### PR TITLE
github: Enable syntax highlighting for Daml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.daml linguist-language=Haskell


### PR DESCRIPTION
This is done by making GitHub believe it's Haskell