### PR TITLE
Update Splice main to version 0.2.5-snapshot.20241017.7280.0.v9b2d9452 (automatic PR)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val `splice-wartremover-extension` = Wartremover.`splice-wartremover-extens
 
 inThisBuild(
   List(
-    pushRemoteCacheTo := Some(MavenCache("local-cache", file("/cache/sbt/sbt-remote-cache"))),
+    pushRemoteCacheTo := Some(MavenCache("local-cache", file("/cache/sbt/sbt-remote-cache-2"))),
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     semanticdbIncludeInJar := true, // cache it in the remote cache
@@ -136,7 +136,7 @@ lazy val root: Project = (project in file("."))
         if !path.startsWith(cantonPath)
       } yield basePath.relativize(path)
       val outputFile = "daml/dars.lock"
-      " " + (Seq(outputFile) ++ darPaths ++ getCommittedDarFiles).mkString(" ")
+      " " + (Seq(outputFile) ++ darPaths).mkString(" ")
     },
     damlDarsLockFileUpdate :=
       Def.taskDyn {


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.2.5-snapshot.20241017.7280.0.v9b2d9452, commit DACH-NY/canton-network-node@9b2d9452d0