### PR TITLE
Update Splice main to version 0.3.1-snapshot.20241127.7721.0.v26811473 (automatic PR)

### DIFF
--- a/canton/community/app/src/main/scala/com/digitalasset/canton/cli/Cli.scala
+++ b/canton/community/app/src/main/scala/com/digitalasset/canton/cli/Cli.scala
@@ -50,7 +50,7 @@ final case class Cli(
     logFileName: Option[String] = None,
     kmsLogFileName: Option[String] = None,
     logEncoder: LogEncoder = LogEncoder.Plain,
-    logLastErrors: Boolean = true,
+    logLastErrors: Boolean = false,
     logLastErrorsFileName: Option[String] = None,
     logImmediateFlush: Option[Boolean] = None,
     kmsLogImmediateFlush: Option[Boolean] = None,

--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -56,6 +56,19 @@ spec:
         - name: CANTON_PARTICIPANT_POSTGRES_DB
           value: {{ .Values.persistence.databaseName }}
         {{- end }}
+        {{- if .Values.kms }}
+        - name: ADDITIONAL_CONFIG_SPLICE_PARTICIPANT_CRYPTO_PROVIDER_KMS
+          value: |
+            canton.participants.participant.crypto {
+              provider = kms
+              kms = {
+                type = {{ .Values.kms.type }}
+                location-id = {{ .Values.kms.locationId }}
+                project-id = {{ .Values.kms.projectId }}
+                key-ring-id = {{ .Values.kms.keyRingId }}
+              }
+            }
+        {{- end }}
         {{- include "splice-util-lib.additional-env-vars" .Values.additionalEnvVars | indent 8}}
         {{- include "splice-util-lib.log-level" .Values | indent 8}}
         ports:
@@ -91,6 +104,19 @@ spec:
         {{- with .Values.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if and .Values.extraVolumeMounts (gt (len .Values.extraVolumeMounts) 0) }}
+        volumeMounts:
+          {{- range .Values.extraVolumeMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
+            {{- if .subPath }}
+            subPath: {{ .subPath }}
+            {{- end }}
+            {{- if .readOnly }}
+            readOnly: {{ .readOnly }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
       initContainers:
         - name: pg-init
           image: postgres:14
@@ -124,6 +150,16 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.extraVolumes (gt (len .Values.extraVolumes) 0) }}
+      volumes:
+        {{- range .Values.extraVolumes }}
+        - name: {{ .name }}
+          {{- if .secret }}
+          secret:
+            secretName: {{ .secret.secretName }}
+          {{- end }}
+        {{- end }}
       {{- end }}
 ---
 apiVersion: v1

--- a/nix/README.md
+++ b/nix/README.md
@@ -27,6 +27,9 @@ To disable this behaviour we have set `PULUMI_HOME` to the nix pulumi path. The 
 The `extra-pulumi-packages.nix` defines a list of plugins that will be installed on top of the ones comes with the nix version.
 The file is based on the default [pulumi setup](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/pulumi-bin/data.nix) and is generated using `generate_pulumi_packages.sh`.
 
+If you need to add a new plugin, you can do so by adding the plugin name and version to the `generate_pulumi_packages.sh` script and then run it.
+Examine the `extra-pulumi-packages.nix` to ensure that the plugin is correctly added.
+
 We have a number of older plugins in our extra packages. These are either plugins that are not yet in the official nix package (eg: command) or packages
 that require multiple versions while we upgrade the pulumi stack to the latest version.
 

--- a/nix/extra-pulumi-packages.nix
+++ b/nix/extra-pulumi-packages.nix
@@ -4,27 +4,27 @@
   packages = {
     x86_64-linux = [
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.1.0-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.1.0/pulumi-resource-auth0-v3.1.0-linux-amd64.tar.gz";
         sha256 = "5199462923cd1431fe0457425696e7a93b979a864f7a106bc9d3c64a5cdcb016";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.1-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-linux-amd64.tar.gz";
         sha256 = "008f8afbe723cc38ac5f557031dadc6324435d1c8dcb4037f32be856d87d0425";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.2-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-linux-amd64.tar.gz";
         sha256 = "f9175cc253c4db42dac07a2a8242f036f248af9981cff2d9700ca3e33f70be9d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-command-v0.9.2-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-linux-amd64.tar.gz";
         sha256 = "1fb8955dabbe81a767791e9769a32bd895dfee68d2bcc8ffd3dbd560cd5bcf0d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v6.67.0-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v6.67.0/pulumi-resource-gcp-v6.67.0-linux-amd64.tar.gz";
         sha256 = "4bdff1a687c8ddf0aa19d09011f4f6b18615cf221e5510e2c3b880aa25781a91";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v7.2.1-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-linux-amd64.tar.gz";
         sha256 = "2c5f29ac9bc058bb9377b906e7630947add587b69040c63af5a8fd4ff95c9e52";
       }
       {
@@ -32,45 +32,49 @@
         sha256 = "ad6675574e75c6984ab79a2ff9f4ee6c4859d46a41a7d73ef35c84f05a00b407";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.11.0-linux-amd64.tar.gz";
-        sha256 = "1b8f5e6a2691c9b58fff4b8c434731b7aa7c13e46e9ba217705353a9532254b2";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.11.0/pulumi-resource-kubernetes-v4.11.0-linux-amd64.tar.gz";
+        sha256 = "659ba41363c23cea895e6e8425f7f20e2165d24effe7a7aaa37c545b5eccc5e2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.7.1-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.7.1/pulumi-resource-kubernetes-v4.7.1-linux-amd64.tar.gz";
         sha256 = "4f71421b353159067f8864fdad3a28dbd799ec8de213a4bfd23826aaddb49b86";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-amd64.tar.gz";
         sha256 = "449d19d54d606cf723bed76f24c821e2c963a04297e6d12f35b91576254aed2f";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.14.0-linux-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-linux-amd64.tar.gz";
         sha256 = "af44caea25e0e0a94307264ee36f927cb182d2b29f74d1d62e4de54c2a98a9ec";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-linux-amd64.tar.gz";
+        sha256 = "44f937ce4ab4662f7b335e0677797539caebb083a23479b6df95072a503f2995";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.1.0-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.1.0/pulumi-resource-auth0-v3.1.0-darwin-amd64.tar.gz";
         sha256 = "fab4e2e5324dd90b4d01f5e21db1eed99a3cfa4cf9f46e25761de10e88dad89b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.1-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-darwin-amd64.tar.gz";
         sha256 = "c02df58f6a43d18fd7d275d28d46bf527a087d290a62b252a1da74e129ddc90c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.2-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-darwin-amd64.tar.gz";
         sha256 = "f3518d84aa024fabba4e4ed6757c5a1349814792d798ca43262245978269991b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-command-v0.9.2-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-darwin-amd64.tar.gz";
         sha256 = "0b33689487f8297642336bab2e7fe6c83813d2f694a21ba397e851a5a3215696";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v6.67.0-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v6.67.0/pulumi-resource-gcp-v6.67.0-darwin-amd64.tar.gz";
         sha256 = "9244994c49c2cfa0509ea84b2cdbc679c4db1e24f91f46906fcc906924ec605c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v7.2.1-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-darwin-amd64.tar.gz";
         sha256 = "08ee93595be215736c834d75012704713738b6a1452cc21813a84612c950e424";
       }
       {
@@ -78,45 +82,49 @@
         sha256 = "f4d065bd98b30b0f1ea2185ccb2f4c447c80f71992779ad820fc524f011d403d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.11.0-darwin-amd64.tar.gz";
-        sha256 = "3966f34f1c01e295fca8d1ad30c492d09b876085128009fa25e96aa858d93e68";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.11.0/pulumi-resource-kubernetes-v4.11.0-darwin-amd64.tar.gz";
+        sha256 = "efab48604cb1942572afe83e951fe42cb77cbbe1ff23022c8d71c6fe0968e1de";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.7.1-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.7.1/pulumi-resource-kubernetes-v4.7.1-darwin-amd64.tar.gz";
         sha256 = "bf347c4996dfee24083fc4256032632e4aad978f0c545282d465b30ca271ba0c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-amd64.tar.gz";
         sha256 = "0cdd4ae517668d364a2c7beed21d838fd25921e4b615fe2e2cbbc628c5308a83";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.14.0-darwin-amd64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-darwin-amd64.tar.gz";
         sha256 = "bcb16a5d53cf7eddeb35e54050a19541342a5a07d8b81705b6bb85316ac3e3c9";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-darwin-amd64.tar.gz";
+        sha256 = "782e620c8587bd13ece55b298652009609d4892258d513462dc07720ea77e930";
       }
     ];
     aarch64-linux = [
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.1.0-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.1.0/pulumi-resource-auth0-v3.1.0-linux-arm64.tar.gz";
         sha256 = "50d37a8c053150ac18c33ea018069cfa34c0b141e31733cd7786ed1659a87347";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.1-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-linux-arm64.tar.gz";
         sha256 = "c2b1d68b75ad613a7ed01c322609d03a9fa727d5833a0f4bb8ab037578502a82";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.2-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-linux-arm64.tar.gz";
         sha256 = "c78c7b172940b43098dae3235a4606cae7fc37795e79f0b5620569258a59eb9b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-command-v0.9.2-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-linux-arm64.tar.gz";
         sha256 = "0ef3b81713728d17c9d55e894c66d2c51658ce3bbe682559d1517fdd49ba126e";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v6.67.0-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v6.67.0/pulumi-resource-gcp-v6.67.0-linux-arm64.tar.gz";
         sha256 = "91f2a6c29c9731273366788d348a4325cc70621a3c929e941663383c5278b793";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v7.2.1-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-linux-arm64.tar.gz";
         sha256 = "4cddd536e4e28caba68919ba2d051442595ef0c0c139a7779108b579bf596901";
       }
       {
@@ -124,45 +132,49 @@
         sha256 = "dbf59982dcd94e50b9241e9501dc531bad2a9faac47aa5ecce8e5bb1bfc2e9ff";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.11.0-linux-arm64.tar.gz";
-        sha256 = "9fa4a9f3e93e839da31e23f26c738184675b2bc8fad7d364e6f476ed033f3108";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.11.0/pulumi-resource-kubernetes-v4.11.0-linux-arm64.tar.gz";
+        sha256 = "6a45ce78cf1e7fbb9ea16ad31ac24083a9f2082ed84dc01f6a17efbef5926399";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.7.1-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.7.1/pulumi-resource-kubernetes-v4.7.1-linux-arm64.tar.gz";
         sha256 = "ffe3fe3847fc6bd9445d5f35503877291e00f3ffd2d68d7e90f2bc4da6f55451";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-arm64.tar.gz";
         sha256 = "33b645af0f32e36a7dc1468a65a4b55c01ccd0c0dc85506e2ff42f8fd69d0082";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.14.0-linux-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-linux-arm64.tar.gz";
         sha256 = "5376484af2484e7f7dac6c61cfa6bf18358eb07d0d0e46565a6827e574c993a3";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-linux-arm64.tar.gz";
+        sha256 = "cc2f838a4df1b8f5466a1192d5f16a51761062ff695aea92fc52d241701a60fe";
       }
     ];
     aarch64-darwin = [
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.1.0-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.1.0/pulumi-resource-auth0-v3.1.0-darwin-arm64.tar.gz";
         sha256 = "0fe7496917d6f842e34d1b7942cce61d16c08b9eb49c232f3bba91244eba140a";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.1-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-darwin-arm64.tar.gz";
         sha256 = "35f76da2d17846c5772b55195c7ace2bd889f03b4b66dfbe78eb910c3e024549";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v3.3.2-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-darwin-arm64.tar.gz";
         sha256 = "240ae83b53065d15c41990ade21284d4c64c1915559d5b2ed2c0fcea0f415b9b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-command-v0.9.2-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-darwin-arm64.tar.gz";
         sha256 = "15b1f11b1d7329733337605f78eaf1612e2c3bf8bb4afbb43146f418dd6f4526";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v6.67.0-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v6.67.0/pulumi-resource-gcp-v6.67.0-darwin-arm64.tar.gz";
         sha256 = "05a931c00b72f087bcfe8dc35ba6c3c6c0e929e7caf83fcae925f4c9d9d5d174";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v7.2.1-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-darwin-arm64.tar.gz";
         sha256 = "4bb52f6d510772d53e0ed88153bd237703610cb1ff7b4e40558c493c45405991";
       }
       {
@@ -170,20 +182,24 @@
         sha256 = "76ff2462fa5b85023948f5e7139b28a08af4a50ae80077e3c24ff8723203a603";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.11.0-darwin-arm64.tar.gz";
-        sha256 = "7ce1f19d8724231e026787e0cc9d7839c640252ecd5246187270291b3ef3ee9c";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.11.0/pulumi-resource-kubernetes-v4.11.0-darwin-arm64.tar.gz";
+        sha256 = "d6b4179aae4549bbb1238469fa600d4035b47f641d7941d79d5230f7434d79df";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.7.1-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.7.1/pulumi-resource-kubernetes-v4.7.1-darwin-arm64.tar.gz";
         sha256 = "d77fc5e7fc98a4d3ac4348343b8056d2570841365444656713e4a69feebbec78";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-arm64.tar.gz";
         sha256 = "8d393dc2d633ed5ad7e291a70d513a340505a3dcb5684b5000c883fb4137dca3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v4.14.0-darwin-arm64.tar.gz";
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-darwin-arm64.tar.gz";
         sha256 = "920f2f3f8fa9ad78d3077d81debd29861afac72cf852ca9605ba2550dcc79422";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-darwin-arm64.tar.gz";
+        sha256 = "cad5c31ed137e6653ab53947fdae6343dd2b41f486790de40535cb36eb76351f";
       }
     ];
   };

--- a/nix/generate_pulumi_packages.sh
+++ b/nix/generate_pulumi_packages.sh
@@ -24,6 +24,7 @@ plugins=(
   "pulumi/random=4.14.0"
   "pulumi/gcp=7.2.1"
   "pulumi/auth0=3.3.2"
+  "pulumi/std=1.7.3"
   "pulumiverse/grafana=0.4.2"
 )
 
@@ -59,7 +60,7 @@ function genSrcs() {
     # url as defined here
     # https://github.com/pulumi/pulumi/blob/06d4dde8898b2a0de2c3c7ff8e45f97495b89d82/pkg/workspace/plugins.go#L197
     if [ "$src" == "pulumi" ]; then
-      local url="https://api.pulumi.com/releases/plugins/pulumi-resource-${plug}-v${version}-${1}-${2}.tar.gz"
+      local url="https://github.com/pulumi/pulumi-${plug}/releases/download/v${version}/pulumi-resource-${plug}-v${version}-${1}-${2}.tar.gz"
     elif [ "$src" == "pulumiverse" ]; then
       local url="https://github.com/pulumiverse/pulumi-${plug}/releases/download/v${version}/pulumi-resource-${plug}-v${version}-${1}-${2}.tar.gz"
     else


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.3.1-snapshot.20241127.7721.0.v26811473, commit DACH-NY/canton-network-node@2681147326