### PR TITLE
Update Splice main to version 0.3.2-snapshot.20241129.7753.0.v203312b6 (automatic PR)

### DIFF
--- a/cluster/helm/local.mk
+++ b/cluster/helm/local.mk
@@ -27,7 +27,7 @@ IMAGE_DIGESTS := cluster/helm/.image-digests
 .PHONY: cluster/helm/push
 cluster/helm/push:
 	@for file in cluster/helm/target/*.tgz; do \
-		helm push $$file oci://us-central1-docker.pkg.dev/da-cn-shared/cn-images; \
+	    publish_helm_chart.sh $$file;\
 	done
 
 .PHONY: cluster/helm/write-version

--- a/cluster/images/canton/Dockerfile
+++ b/cluster/images/canton/Dockerfile
@@ -29,7 +29,7 @@ COPY target/monitoring.conf target/parameters.conf target/entrypoint.sh target/b
 
 RUN ln -s bin/canton splice-image-bin
 
-FROM fullstorydev/grpcurl:v1.9.1 AS grpcurl
+FROM fullstorydev/grpcurl:v1.9.2 AS grpcurl
 
 FROM eclipse-temurin:17-jdk-jammy
 COPY --from=build /usr/bin/tini /usr/bin/tini

--- a/cluster/images/splice-debug/Dockerfile
+++ b/cluster/images/splice-debug/Dockerfile
@@ -5,4 +5,4 @@
 # so we're hard-coding amd64, and accepting that this will break on arm64.
 FROM --platform=linux/amd64 ubuntu:latest
 RUN apt-get update && apt-get install -y postgresql-client curl
-RUN curl -sSLO https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_amd64.deb && dpkg -i grpcurl_1.9.1_linux_amd64.deb && rm grpcurl_1.9.1_linux_amd64.deb
+RUN curl -sSLO https://github.com/fullstorydev/grpcurl/releases/download/v1.9.2/grpcurl_1.9.2_linux_amd64.deb && dpkg -i grpcurl_1.9.2_linux_amd64.deb && rm grpcurl_1.9.2_linux_amd64.deb

--- a/cluster/local.mk
+++ b/cluster/local.mk
@@ -16,11 +16,8 @@ docker-build: $(foreach image,$(images),cluster/images/$(image)/$(docker-build))
 .PHONY: docker-push
 docker-push: $(foreach image,$(images),cluster/images/$(image)/$(docker-push))
 
-.PHONY: docker-promote
-docker-promote: $(foreach image,$(images),cluster/images/$(image)/$(docker-promote))
-
-.PHONY: docker-check
-docker-check: $(foreach image,$(images),cluster/images/$(image)/docker-check)
+.PHONY: docker-image-reference-exists
+docker-image-reference-exists: $(foreach image,$(images),cluster/images/$(image)/docker-image-reference-exists)
 
 .PHONY: cluster/images/clean
 cluster/images/clean: $(foreach image,$(images),cluster/images/$(image)/clean)


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.3.2-snapshot.20241129.7753.0.v203312b6, commit DACH-NY/canton-network-node@203312b647