### PR TITLE
Update Splice release-line-0.3.2 to version 0.3.2 (automatic PR)

### DIFF
--- a/cluster/images/common/monitoring.conf
+++ b/cluster/images/common/monitoring.conf
@@ -17,7 +17,8 @@ canton {
         address = "0.0.0.0"
         port = 10013
       }]
-      cardinality = 10000 # Raised to allow for per domain member labels
+      # Raised to allow for per domain member labels (e.g. daml.sequencer.traffic-control.event-delivered-cost, see #16410)
+      cardinality = 20000
       # enable all metric qualifiers
       qualifiers = ["errors", "latency", "saturation", "traffic", "debug"]
       histograms = [

--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0-snapshot.20241128.14513.0.v4a3d4dd7",
+  "version": "3.2.0-snapshot.20241204.14518.0.vfd036cca",
   "tooling_sdk_version": "3.1.0-snapshot.20240717.13187.0.va47ab77f",
-  "sha256": "sha256:07sbn2irdd6q8qfwhd96whxsj1llwjxga2irzkdvmvr07ai2wb34"
+  "sha256": "sha256:01zymj1f8y10anc062qn9p3031f2ky06l1rk9ismrfl52zn0r1x2"
 }


### PR DESCRIPTION
This PR updates branch release-line-0.3.2 of Splice from the latest changes as of version 0.3.2, commit DACH-NY/canton-network-node@c8a403205b