### PR TITLE
Decrease memory footprint of JVM-based apps by setting MALLOC_ARENA_MAX

### DIFF
--- a/cluster/images/common/entrypoint.sh
+++ b/cluster/images/common/entrypoint.sh
@@ -57,6 +57,17 @@ if [ -s "/app/additional-config.conf" ]; then
    ARGS+=( --config /app/additional-config.conf )
 fi
 
+# The default maximum for malloc arenas is 8 * num_of_cpu_cores with no respect
+# to container limits.  JVM has it's own memory management, so high number of
+# arenas doesn't provide any significant pefromance improvement, however it
+# does increase the memory footprint of a long running process.  We limit the
+# number of arenas to 2 (main and one additional arena) by setting environment
+# variable MALOC_ARENA_MAX.
+#
+# Setting SPLICE_MALLOC_ARENA_MAX to 0 or '' will disable the limit and use the
+# default value.
+export MALLOC_ARENA_MAX=${SPLICE_MALLOC_ARENA_MAX:-2}
+
 json_log "Starting '${EXE}' with arguments: ${ARGS[*]}" "entrypoint.sh"
 
 exec "$EXE" "${ARGS[@]}"


### PR DESCRIPTION
Set MALLOC_ARENA_MAX to 2 by default and introduce environment variable SPLICE_MALLOC_ARENA_MAX as an option to override this value.  This can decrease resident memory footprint for JVM process reduce unnecessary OOM kills by the OS.

Here are the details:
- By default on 64-bit systems the limit for number of arenas in glibc malloc is determined as 8 * num_of_cores (in our case it is the max arenas becomes 8 *16 = 128)
- Container limits are not respected
- Each Arena allocates one heap of 64 MiB at the time of creation
- A new Arena is created each time when malloc is called and all existing Arenas are locked by other threads
- JVM based software tends to create a lot of threads, at the same time it has it's own memory management so it doesn't call malloc frequently. Memory waste from a large number of arenas is quite significant on machines with many physical cores and this waste is especially noticeable in smaller apps.