### PR TITLE
canton, docker image: Add libjemalloc2

### DIFF
--- a/cluster/images/canton/Dockerfile
+++ b/cluster/images/canton/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGETPLATFORM
 
 # Install screen for running the console in a headless server
 RUN xx-apt-get update \
-   && DEBIAN_FRONTEND=noninteractive xx-apt-get install -y screen tini \
+   && DEBIAN_FRONTEND=noninteractive xx-apt-get install -y screen tini libjemalloc2 \
    && xx-apt-get clean \
    && rm -rf /var/cache/apt/archives
 


### PR DESCRIPTION
Allow operators to use an efficient memory allocator libjemalloc2 without necessity to rebuild images