### PR TITLE
Update Splice main to version 0.4.0-snapshot.20250429.9182.0.v500570b1 (automatic PR)

### DIFF
--- a/.envrc.vars
+++ b/.envrc.vars
@@ -26,6 +26,7 @@ export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres
 
 export DEPLOYMENT_DIR="${SPLICE_ROOT}/cluster/deployment"
+export PULUMI_TEST_DIR=${SPLICE_ROOT}/cluster/pulumi
 
 export GHCR=ghcr.io
 export DEV_REGISTRY=$GHCR/digital-asset/decentralized-canton-sync-dev


### PR DESCRIPTION
This PR updates branch main of Splice from the latest changes as of version 0.4.0-snapshot.20250429.9182.0.v500570b1, commit DACH-NY/canton-network-node@500570b134