### PR TITLE
splice-validator: make sure users (which are OIDC sub values) are quo…

### DIFF
--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -83,7 +83,7 @@ spec:
         {{- range $ii, $user := .Values.validatorWalletUsers }}
         - name: ADDITIONAL_CONFIG_VALIDATOR_WALLET_USER_{{ $ii }}
           value: |
-            canton.validator-apps.validator_backend.validator-wallet-users.{{ $ii }} = {{ $user }}
+            canton.validator-apps.validator_backend.validator-wallet-users.{{ $ii }} = {{ $user | quote }}
         {{- end }}
         {{ if .Values.validatorPartyHint }}
         - name: SPLICE_APP_VALIDATOR_PARTY_HINT


### PR DESCRIPTION
…ted because Okta uses emails and '@' breaks yaml file loading if not quoted



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
