### PR TITLE
Restore relevant `cluster/scripts/`

### DIFF
--- a/cluster/scripts/find-recent-backup.sh
+++ b/cluster/scripts/find-recent-backup.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "${TOOLS_LIB}/libcli.source"
+# shellcheck disable=SC1091
+source "${SPLICE_ROOT}/cluster/scripts/utils.source"
+
+function usage() {
+  _info "Usage: $0 <namespace> <migration_id> <internal (true|false)>"
+}
+
+function is_full_backup_kube() {
+  local component_backup_names=$1
+  local expected_components=$2
+
+  # Check if all expected components can be found in the component_backup_names
+  for component in $expected_components; do
+    count=$(echo "$component_backup_names" | grep -c "$component")
+    if [ "$count" -ne 1 ]; then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+function get_component_backup_names_kube() {
+  local migration_id=$1
+  local run_id=$2
+  component_backup_names=$(kubectl get volumesnapshot -n "$namespace" --sort-by=.metadata.creationTimestamp -o json | jq "[.items[] | select(.metadata.annotations[\"migrationId\"] == \"$migration_id\") | select(.metadata.name | endswith(\"$run_id\"))]" | jq -r '.[].metadata.name // empty' )
+  echo "$component_backup_names"
+}
+
+function latest_full_backup_run_id_kube() {
+  local namespace=$1
+  local migration_id=$2
+  local is_sv=$3
+  local expected_components=$4
+  if [ "$is_sv" == "true" ]; then
+      expected_components="$expected_components cometbft"
+  fi
+
+  local all_run_ids
+  # get all run id postgres
+  all_run_ids=$(kubectl get volumesnapshot -n "$namespace" --sort-by=.metadata.creationTimestamp -o json | jq "[.items[] | select(.metadata.annotations[\"migrationId\"] == \"$migration_id\")]" | jq -r '.[].metadata.name // empty' | grep -o '[^-]*$' | sort -rn | uniq )
+
+  while read -r run_id; do
+    component_backup_names=$(get_component_backup_names_kube "$migration_id" "$run_id")
+    if is_full_backup_kube "$component_backup_names" "$expected_components"; then
+      echo "$run_id"
+      return 0
+    fi
+  done <<< "$all_run_ids"
+  return 1
+}
+
+function latest_full_backup_run_id_gcloud() {
+  local namespace=$1
+  local migration_id=$2
+  local is_sv=$3
+  local expected_components=$4
+  local internal=$5
+  local num_components
+  num_components=$(echo "$expected_components" | wc -w)
+  local stack
+
+  declare -A run_ids_dict
+
+  for component in $expected_components; do
+    stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+    instance="$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")"
+    local full_component_instance="$namespace-$instance-pg"
+
+    local cloudsql_id
+    cloudsql_id=$(get_cloudsql_id "$full_component_instance" "$stack")
+    # We always create backups with a description field while this field could be missing for automated backups done by Google Cloud.
+    # So we filter those out while looking for the most recent backup.
+    mapfile -t run_ids < <(gcloud sql backups list --instance "$cloudsql_id" --filter=type="ON_DEMAND" --format=json | jq -r '.[] | select(has("description")) | .description')
+    run_ids_dict[$component]="${run_ids[*]}"
+  done
+
+  if [ "$is_sv" == "true" ]; then
+    mapfile -t cometbft_run_ids < <(kubectl get volumesnapshot -n "$namespace" --sort-by=.metadata.creationTimestamp -o json | jq "[.items[] | select(.metadata.annotations[\"migrationId\"] == \"$migration_id\") | select(.metadata.name | contains(\"cometbft\"))]" | jq -r '.[].metadata.name // empty' | grep -o '[^-]*$' | sort -rn | uniq )
+    run_ids_dict["cometbft"]="${cometbft_run_ids[*]}"
+    ((num_components++))
+  fi
+
+  declare -A count_dict
+  for key in "${!run_ids_dict[@]}"; do
+    for value in ${run_ids_dict[$key]}; do
+      if [ -z "${count_dict[$value]+_}" ]; then
+        count_dict[$value]=0
+      fi
+      ((count_dict[$value]++))
+    done
+  done
+
+  largest_run_id=$(for key in "${!count_dict[@]}"; do
+    if [ "${count_dict[$key]}" -eq "$num_components" ]; then
+      echo "$key"
+    fi
+  done | sort -n | tail -n 1)
+
+  echo "$largest_run_id"
+}
+
+function main() {
+  if [ "$#" -lt 3 ]; then
+      usage
+      exit 1
+  fi
+
+  local namespace=$1
+  local migration_id=$2
+  local internal=$3
+
+  case "$namespace" in
+      sv-1|sv-2|sv-3|sv-4)
+          is_sv=true
+          full_instance="$namespace-cn-apps-pg"
+          expected_components="cn-apps sequencer participant mediator"
+          stack=$(get_stack_for_namespace_component "$namespace" "cn-apps" "$internal")
+          ;;
+      *)
+          is_sv=false
+          full_instance="$namespace-validator-pg"
+          expected_components="validator participant"
+          stack=$(get_stack_for_namespace_component "$namespace" "participant" "$internal")
+          ;;
+  esac
+
+  type=$(get_postgres_type "$full_instance" "$stack")
+  # We only check the postgres type of one component and assume other components have the same type.
+  if [ "$type" == "canton:network:postgres" ]; then
+    backup_run_id=$(latest_full_backup_run_id_kube "$namespace" "$migration_id" "$is_sv" "$expected_components")
+    echo "$backup_run_id"
+  elif [ "$type" == "canton:cloud:postgres" ]; then
+    backup_run_id=$(latest_full_backup_run_id_gcloud "$namespace" "$migration_id" "$is_sv" "$expected_components" "$internal")
+    echo "$backup_run_id"
+  elif [ -z "$type" ]; then
+    _error "No postgres instance $full_instance found in stack ${stack}. Is the cluster deployed with split DB instances?"
+  else
+    _error "Unknown postgres type: $type"
+  fi
+}
+
+main "$@"

--- a/cluster/scripts/node-backup.sh
+++ b/cluster/scripts/node-backup.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "${TOOLS_LIB}/libcli.source"
+# shellcheck disable=SC1091
+source "${SPLICE_ROOT}/cluster/scripts/utils.source"
+
+RUN_ID=$(date +%s)
+
+##### PVC Backup & Restore
+
+function backup_pvc() {
+  local description=$1
+  local namespace=$2
+  local pvc_name=$3
+  local migration_id=$4
+
+  local backupName="${pvc_name}-$RUN_ID"
+
+  _info "Backing up PVC $description"
+
+  kubectl apply -n "$namespace" -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: "$backupName"
+  annotations:
+    migrationId: "$migration_id"
+spec:
+  volumeSnapshotClassName: dev-vsc
+  source:
+    persistentVolumeClaimName: "$pvc_name"
+EOF
+}
+
+function wait_for_pvc_backup() {
+  local description=$1
+  local namespace=$2
+  local pvc_name=$3
+
+  local backupName="${pvc_name}-$RUN_ID"
+
+  local -i i=0
+
+  _info "Waiting for $description PVC backup to complete..."
+  while true; do
+    ready=$(kubectl get volumesnapshot -n "$namespace" -o json "$backupName" | jq .status.readyToUse)
+    if [ "$ready" == "true" ]; then
+      _info "Backup of $description PVC ready!"
+      break
+    else
+      (( i++ )) && (( i > 300 )) && _error "Timed out waiting for backup of $description PVC"
+      sleep 5
+      _info "still waiting..."
+    fi
+  done
+}
+
+function backup_pvc_postgres() {
+  local description=$1
+  local namespace=$2
+  local instance=$3
+  local migration_id=$4
+
+  _info "** Backup up pvc-based postgres $description **"
+
+  # Since we only have one replica, it's always 0.
+  replica_index="0"
+  local pvc_name="pg-data-$instance-$replica_index"
+  backup_pvc "$description" "$namespace" "$pvc_name" "$migration_id"
+}
+
+#### CloudSQL Backup & Restore
+
+function backup_cloudsql() {
+  local description=$1
+  local instance=$2
+  local stack=$3
+  MAX_RETRIES=20
+  retry_count=0
+
+  _info "** Backing up $description **"
+
+  _info "Looking for $description db"
+
+  db_id=$(get_cloudsql_id "$instance" "$stack")
+
+  if [ -z "$db_id" ]; then
+    _error "No CloudSQL instance $instance found"
+  fi
+
+  echo "Waiting for any operations on $instance to finish"
+
+  # Wait for any existing operations to finish (to avoid e.g. conflicting with automated periodic backups)
+  gcloud sql operations list --instance="$db_id" --filter='NOT status:done' --format='value(name)' | xargs -r gcloud sql operations wait
+
+  echo "All operations finished"
+
+  _info "Starting backup of $description db ($db_id)"
+  until [ $retry_count -gt $MAX_RETRIES ]; do
+    # disabling exit on error to allow for retries
+    set +e
+    output=$(gcloud sql backups create --instance "$db_id" --description "$RUN_ID" 2>&1)
+    backup_exit_code=$?
+    set -e
+
+    if [ $backup_exit_code -ne 0 ]; then
+      if [[ $output == *"another operation was already in progress"* ]]; then
+        _error_msg "Backup failed due to another operation in progress, retrying: $output"
+      else
+        _error_msg "$output"
+      fi
+      retry_count=$((retry_count+1))
+      sleep 10
+    else
+      echo "Backup succeeded"
+      return 0
+    fi
+
+    if [ $retry_count -gt $MAX_RETRIES ]; then
+      _error "Backup of $description db exceeded max retries"
+      return 1
+    fi
+  done
+}
+
+function wait_for_cloudsql_backup() {
+  local description=$1
+  local instance=$2
+  local stack=$3
+
+  db_id=$(get_cloudsql_id "$instance" "$stack")
+
+  local -i i=0
+
+  _info "Waiting for $description db backup to complete for $db_id..."
+  while true; do
+    backup=$(gcloud sql backups list --instance "$db_id" --filter="description=\"$RUN_ID\"" --format=json)
+    status=$(echo "$backup" | jq -r '.[].status')
+    id=$(echo "$backup" | jq -r '.[].id')
+
+    if [ "$status" == "SUCCESSFUL" ]; then
+      _info "Backup of $description ready! Backup ID: $id "
+      break
+    else
+      (( i++ ))&& (( i > 300 )) &&_error "Timed out waiting for backup of $description db"
+      sleep 5
+      _info "still waiting..."
+    fi
+  done
+}
+
+### Generic Postgres (Local or CloudSQL)
+
+function backup_postgres() {
+  local description=$1
+  local namespace=$2
+  local instance=$3
+  local migration_id=$4
+  local stack=$5
+
+  local full_instance="$namespace-$instance"
+
+  type=$(get_postgres_type "$full_instance" "$stack")
+
+  if [ "$type" == "canton:network:postgres" ]; then
+    backup_pvc_postgres "$description" "$namespace" "$instance" "$migration_id"
+  elif [ "$type" == "canton:cloud:postgres" ]; then
+    backup_cloudsql "$description" "$full_instance" "$stack"
+  elif [ -z "$type" ]; then
+    _error "No postgres instance $full_instance found. Is the cluster deployed with split DB instances?"
+  else
+    _error "Unknown postgres type: $type"
+  fi
+}
+
+function wait_for_postgres_backup() {
+  local description=$1
+  local namespace=$2
+  local instance=$3
+  local migration_id=$4
+  local stack=$5
+
+  local full_instance="$namespace-$instance"
+
+  type=$(get_postgres_type "$full_instance" "$stack")
+
+  if [ "$type" == "canton:network:postgres" ]; then
+    # Since we only have one replica, it's always 0.
+    replica_index="0"
+    local pvc_name="pg-data-$instance-$replica_index"
+    wait_for_pvc_backup "$description" "$namespace" "$pvc_name"
+  elif [ "$type" == "canton:cloud:postgres" ]; then
+    wait_for_cloudsql_backup "$description" "$full_instance" "$stack"
+  else
+    _error "Unknown postgres type: $type"
+  fi
+
+}
+
+function backup_component() {
+  local namespace=$1
+  local component=$2
+  local requested_component=$3
+  local migration_id=$4
+  local internal=$5
+
+  local stack
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+
+  if [ "$component" == "$requested_component" ] || [ -z "$requested_component" ]; then
+    if [ "$component" == "cometbft-$migration_id" ]; then
+      backup_pvc "cometBFT" "$namespace" "global-domain-$migration_id-cometbft-cometbft-data" "$migration_id"
+    else
+      local db_name
+      db_name=$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")
+      SPLICE_SV=$namespace SPLICE_MIGRATION_ID=$migration_id backup_postgres "$component" "$namespace" "$db_name-pg" "$migration_id" "$stack"
+    fi
+  else
+    _info "Skipping backup of $component, not requested"
+  fi
+}
+
+function wait_for_backup() {
+  local namespace=$1
+  local component=$2
+  local requested_component=$3
+  local migration_id=$4
+  local internal=$5
+
+  local stack
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+
+  if [ "$component" == "$requested_component" ] || [ -z "$requested_component" ]; then
+    if [ "$component" == "cometbft-$migration_id" ]; then
+      wait_for_pvc_backup "cometBFT" "$namespace" "global-domain-$migration_id-cometbft-cometbft-data"
+    else
+      instance=$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")
+      wait_for_postgres_backup "$component" "$namespace" "$instance-pg" "$migration_id" "$stack"
+    fi
+  else
+    _info "Skipping waiting for backup of $component, not requested"
+  fi
+}
+
+function usage() {
+  echo "Usage: $0 <sv|validator> <namespace> <migration id> <internal (true|false)> [<component_name>]"
+}
+
+function main() {
+  if [ "$#" -lt 4 ]; then
+      usage
+      exit 1
+  fi
+
+  local namespace=$2
+  local migration_id=$3
+  local internal=$4 # "true" for internal stack, "false" for external stack
+  local requested_component="${5:-}"
+
+  # TODO(#9361): support multiple domains / non-default-ID'd ones
+  if [ "$1" == "validator" ]; then
+    _info "Backing up validator $namespace"
+    backup_component "$namespace" "validator" "$requested_component" "$migration_id" "$internal"
+    wait_for_backup "$namespace" "validator" "$requested_component" "$migration_id" "$internal"
+    # CN apps must be strictly before participant, so we sync on apps before starting the participant backup
+    backup_component "$namespace" "participant" "$requested_component" "$migration_id" "$internal"
+    wait_for_backup "$namespace" "participant" "$requested_component" "$migration_id" "$internal"
+  elif [ "$1" == "sv" ]; then
+    _info "Backing up SV node $namespace"
+
+    backup_component "$namespace" "cn-apps" "$requested_component" "$migration_id" "$internal"
+    backup_component "$namespace" "mediator" "$requested_component" "$migration_id" "$internal"
+    backup_component "$namespace" "sequencer" "$requested_component" "$migration_id" "$internal"
+    backup_component "$namespace" "cometbft-$migration_id" "$requested_component" "$migration_id" "$internal"
+
+    wait_for_backup "$namespace" "cn-apps" "$requested_component" "$migration_id" "$internal"
+
+    # CN apps must be strictly before participant, so we sync on apps before starting the participant backup
+    backup_component "$namespace" "participant" "$requested_component" "$migration_id" "$internal"
+
+    wait_for_backup "$namespace" "participant" "$requested_component" "$migration_id" "$internal"
+    wait_for_backup "$namespace" "mediator" "$requested_component" "$migration_id" "$internal"
+    wait_for_backup "$namespace" "sequencer" "$requested_component" "$migration_id" "$internal"
+    wait_for_backup "$namespace" "cometbft-$migration_id" "$requested_component" "$migration_id" "$internal"
+  else
+    usage
+    exit 1
+  fi
+
+  _info "Completed all backups for namespace $namespace, RUN_ID = $RUN_ID"
+}
+
+main "$@"

--- a/cluster/scripts/node-restore.sh
+++ b/cluster/scripts/node-restore.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "${TOOLS_LIB}/libcli.source"
+# shellcheck disable=SC1091
+source "${SPLICE_ROOT}/cluster/scripts/utils.source"
+
+function component_to_deployments() {
+  local -r component=$1
+  local -r migration_id=$2
+  if [[ "$component" == "sequencer" ]]; then
+    echo "global-domain-$migration_id-sequencer"
+  elif [[ "$component" == "mediator" ]]; then
+    echo "global-domain-$migration_id-mediator"
+  elif [[ "$component" == "participant" ]]; then
+    echo "participant-$migration_id"
+  elif [[ "$component" == "cometbft" ]]; then
+    echo "global-domain-$migration_id-cometbft"
+  elif [[ "$component" == "cn-apps" ]]; then
+    echo "validator-app scan-app sv-app"
+  elif [[ "$component" == "validator" ]]; then
+    echo "validator-app"
+  else
+    _error "Unknown component: $component"
+  fi
+}
+
+function create_pvc_from_snapshot() {
+  local -r namespace=$1
+  local -r snapshot_name=$2
+  local -r pvc_name=$3
+  local -r storage_class_name=$4
+
+  vs=$(kubectl get volumesnapshot -n "$namespace" -o json "$snapshot_name")
+  status=$(echo "$vs" | jq -r .status.readyToUse)
+  if [ "$status" != "true" ]; then
+    _error "Snapshot $snapshot_name is not ready to use"
+  fi
+  restore_size=$(echo "$vs" | jq -r .status.restoreSize)
+
+  _info "Creating PVC $pvc_name from snapshot $snapshot_name"
+  kubectl apply -n "$namespace" -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "$pvc_name"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "$restore_size"
+  storageClassName: "$storage_class_name"
+  volumeMode: Filesystem
+  dataSource:
+    name: "$snapshot_name"
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+EOF
+}
+
+function restore_pvc_from_snapshot() {
+  local -r namespace=$1
+  local -r snapshot_name=$2
+  local -r pvc_name=$3
+  local -r storage_class_name=${4:-"standard-rwo"}
+
+  _warning "This operation will delete pvc $pvc_name, and restore it from backup."
+  _warning "Please consider backing up and/or cloning the DB instance before continuing."
+  await_confirmation
+
+  _info "Patching and deleting postgres PVC"
+  local -r pv=$(kubectl get pvc -n "$namespace" "$pvc_name" -o=json | jq -r .spec.volumeName)
+  # remove the finalizers on the pvc and pv to allow fully deleting them
+  kubectl patch -n "$namespace" pvc "$pvc_name" -p '{"metadata":{"finalizers": []}}' --type=merge
+  kubectl patch -n "$namespace" pv "$pv" -p '{"metadata":{"finalizers": []}}' --type=merge
+  kubectl delete -n "$namespace" pvc "$pvc_name"
+
+  _info "Recreating PVC from snapshot"
+  create_pvc_from_snapshot "$namespace" "$snapshot_name" "$pvc_name" "$storage_class_name"
+}
+
+function down() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r migration_id=$3
+  local -r deployment_names=$(component_to_deployments "$component" "$migration_id")
+
+  for deployment_name in $deployment_names; do
+    _info "Scaling down $component deployment $deployment_name"
+    kubectl scale deployment -n "$namespace" "$deployment_name" --replicas=0
+  done
+}
+
+function wait_down() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r migration_id=$3
+  local -r deployment_names=$(component_to_deployments "$component" "$migration_id")
+
+  for deployment_name in $deployment_names; do
+    _info "Waiting for all pods of $deployment_name to get deleted"
+    kubectl wait pods -n "$namespace" -l "app=$deployment_name" --for delete --timeout=180s
+  done
+}
+
+function up() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r migration_id=$3
+  local -r deployment_names=$(component_to_deployments "$component" "$migration_id")
+
+  for deployment_name in $deployment_names; do
+    up_one_with_retries "$namespace" "$component" "$deployment_name"
+  done
+}
+
+function up_one_with_retries() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r deployment_name=$3
+  MAX_RETRIES=5
+  retry_count=0
+
+  until [ $retry_count -gt $MAX_RETRIES ]; do
+    _info "Scaling up $component deployment $deployment_name"
+
+    # disabling exit on error to allow for retries
+    set +e
+    output=$(kubectl scale deployment -n "$namespace" "$deployment_name" --replicas=1 2>&1)
+    restore_exit_code=$?
+    set -e
+
+    if [ $restore_exit_code -ne 0 ]; then
+      _error_msg "$output"
+      retry_count=$((retry_count+1))
+      sleep 10
+    else
+      return 0
+    fi
+
+    if [ $retry_count -gt $MAX_RETRIES ]; then
+      _error "Scaling up $component deployment $deployment_name exceeded max retries"
+      return 1
+    fi
+  done
+}
+
+function restore_pvc_postgres() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r run_id=$3
+
+  local -r template_name="pg-data"
+  local -r ss_name="$component-pg"
+  local -r pg_pod_name="$ss_name-0"
+  local -r pvc_name="$template_name-$pg_pod_name"
+  local -r snapshot_name="$pvc_name-$run_id"
+
+  _info "Scaling down postgres StatefulSet"
+  kubectl scale statefulset -n "$namespace" "$ss_name" --replicas=0
+
+  restore_pvc_from_snapshot "$namespace" "$snapshot_name" "$pvc_name"
+
+  _info "Scaling up postgres StatefulSet"
+  kubectl scale statefulset -n "$namespace" "$ss_name" --replicas=1
+}
+
+function await_confirmation() {
+  local ok=0
+  while [ "$ok" -eq 0 ] && [ "$force" -eq 0 ]; do
+    read -r -p "Type \"I know what I'm doing\" to continue: " confirmation
+
+    if [ "$confirmation" != "I know what I'm doing" ]; then
+      _warning "Are you sure you know what you're doing? Please try again."
+    else
+      ok=1
+    fi
+  done
+}
+
+function restore_cloudsql_postgres() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r run_id=$3
+  local -r migration_id=$4
+  local -r internal=$5
+  local -r restore_cluster=$6 # optional, cluster to restore into (if different than current)
+  MAX_RETRIES=20
+  retry_count=0
+
+  local stack
+
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+  instance="$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")"
+
+  cloudsql_backup_instance_id=$(get_cloudsql_id "$namespace-$instance-pg" "$stack")
+  cloudsql_restore_instance_id=$cloudsql_backup_instance_id
+
+  if [ -n "$restore_cluster" ]; then
+    cloudsql_restore_instance_id=$(get_cloudsql_id "$namespace-$instance-pg" "$stack" "$restore_cluster")
+    _info "Using restoring from $cloudsql_backup_instance_id into $cloudsql_restore_instance_id"
+  fi
+
+  backup_id=$(gcloud sql backups list --instance "$cloudsql_backup_instance_id" --filter="description=\"$run_id\"" --format=json | jq -r '.[].id')
+
+  _warning "This operation will restore the CloudSQL DB instance $cloudsql_restore_instance_id from backup, overwriting its current data."
+  _warning "Please consider backing up and/or cloning the DB instance before continuing."
+  await_confirmation
+
+  echo "Waiting for any operations on $cloudsql_restore_instance_id to finish"
+
+  # Wait for any existing operations to finish (to avoid e.g. conflicting with automated periodic backups)
+  gcloud sql operations list --instance="$cloudsql_restore_instance_id" --filter='NOT status:done' --format='value(name)' | xargs -r gcloud sql operations wait
+
+  echo "All operations finished"
+
+  _info "Restoring CloudSQL DB instance $cloudsql_backup_instance_id from backup $backup_id to $cloudsql_restore_instance_id"
+
+  until [ $retry_count -gt $MAX_RETRIES ]; do
+    # disabling exit on error to allow for retries
+    set +e
+    output=$(gcloud sql backups restore "$backup_id" --restore-instance="$cloudsql_restore_instance_id" --backup-instance="$cloudsql_backup_instance_id" --quiet 2>&1)
+    restore_exit_code=$?
+    set -e
+
+    if [ $restore_exit_code -ne 0 ]; then
+      if [[ $output == *"another operation was already in progress"* ]]; then
+        _error_msg "Restore failed due to another operation in progress, retrying: $output"
+      else
+        _error_msg "$output"
+      fi
+      retry_count=$((retry_count+1))
+      sleep 10
+    else
+      echo "Restore succeeded"
+      return 0
+    fi
+
+
+    if [ $retry_count -gt $MAX_RETRIES ]; then
+      _error "Restore of DB instance $cloudsql_restore_instance_id from backup $backup_id ($cloudsql_backup_instance_id) exceeded max retries"
+      return 1
+    fi
+  done
+}
+
+function restore_component() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r migration_id=$3
+  local -r run_id=$4
+  local -r internal=$5
+  local -r restore_cluster=$6 # cluster to restore into (if different from current)
+  local -r deployment_names=$(component_to_deployments "$component" "$migration_id")
+  local stack
+
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+
+  if [ "$component" == "cometbft" ]; then
+    _info "Restoring cometbft"
+    kubectl scale deployment -n "$namespace" "${deployment_names}" --replicas=0
+    restore_pvc_from_snapshot "$namespace" "global-domain-$migration_id-cometbft-cometbft-data-$run_id" "global-domain-$migration_id-cometbft-cometbft-data" "premium-rwo"
+    kubectl scale deployment -n "$namespace" "${deployment_names}" --replicas=1
+  else
+    _info "Restoring $component"
+    instance="$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")"
+    type=$(get_postgres_type "$namespace-$instance-pg" "$stack")
+    case "$type" in
+      "canton:network:postgres")
+        restore_pvc_postgres "$namespace" "$instance" "$run_id"
+        ;;
+      "canton:cloud:postgres")
+        restore_cloudsql_postgres "$namespace" "$component" "$run_id" "$migration_id" "$internal" "$restore_cluster"
+        ;;
+      *)
+        _error "Unknown postgres type: $type"
+        ;;
+    esac
+  fi
+}
+
+function wait_cloudsql_restore() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r internal=$3
+
+  local stack
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+  instance="$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")"
+  cloudsql_restore_instance_id=$(get_cloudsql_id "$namespace-$instance-pg" "$stack")
+
+  local -i i=0
+  _info "Waiting for restore of $component to finish..."
+
+  # Sleeping for 30 here because it's possible we are being rate limited
+  retry_sleep_time=30
+  should_not_retry=0
+  while [[ $should_not_retry = 0 ]]; do
+
+    # Using conditional execution to prevent automatic exit
+    if ! gcloud_output=$(gcloud sql operations list --instance="$cloudsql_restore_instance_id" --filter="(operationType=RESTORE_VOLUME AND status!=DONE)" --format=json 2>&1); then
+      _error "Error fetching SQL operations: $gcloud_output" >&2
+      sleep "$retry_sleep_time"
+      continue 1
+    fi
+
+    if ! echo "$gcloud_output" | jq empty &>/dev/null; then
+      _error "Error: Invalid JSON output from gcloud command"
+      _error "Output was: $gcloud_output"
+      sleep "$retry_sleep_time"
+      continue 1
+    fi
+
+    num_running=$(echo "$gcloud_output" | jq length)
+
+    if [ "$num_running" == 0 ]; then
+      _info "Restore of instance $component done"
+      should_not_retry=1
+    else
+      ((i++)) && ((i > 300)) && _error "Timed out waiting for backup restore of $component"
+      sleep "$retry_sleep_time"
+      _info "still waiting..."
+    fi
+  done
+}
+
+function wait_restore_component() {
+  local -r namespace=$1
+  local -r component=$2
+  local -r internal=$3
+  local stack
+  stack=$(get_stack_for_namespace_component "$namespace" "$component" "$internal")
+
+  if [ "$component" == "cometbft" ]; then
+    _info "Nothing to do, cometbft restore is currently synchronous"
+  else
+    instance="$(create_component_instance "$component" "$migration_id" "$namespace" "$internal")"
+    type=$(get_postgres_type "$namespace-$instance-pg" "$stack")
+    case "$type" in
+      "canton:network:postgres")
+        _info "Nothing to do, self-hosted postgres restore is currently synchronous"
+        ;;
+      "canton:cloud:postgres")
+        wait_cloudsql_restore "$namespace" "$component" "$internal"
+        ;;
+      *)
+        _error "Unknown postgres type: $type"
+        ;;
+    esac
+  fi
+}
+
+function usage() {
+  echo "Usage: $0 [-r <restore_cluster>] <namespace> <run_id> <component>..."
+}
+
+function main() {
+  if [ "$#" -lt 5 ]; then
+    usage
+    exit 1
+  fi
+
+  force=0
+  POSITIONAL_ARGS=()
+  restore_cluster=""
+  while [[ $# -gt 0 ]]; do
+      case $1 in
+          --force)
+              force=1
+              shift
+              ;;
+          -r)
+              restore_cluster=$2
+              shift 2
+              ;;
+          -*)
+              _error "Unknown option $1"
+              ;;
+          *)
+              POSITIONAL_ARGS+=("$1")
+              shift
+              ;;
+      esac
+  done
+  set -- "${POSITIONAL_ARGS[@]}"
+
+  local -r namespace=$1
+  local -r migration_id=$2
+  local -r run_id=$3
+  local -r internal=$4
+
+  for component in "${@:5}"; do
+    # verify all components exist and have a mapping
+    component_to_deployments "$component" "$migration_id"
+  done
+
+  _info " ** Scaling down ** "
+  for component in "${@:5}"; do
+    down "$namespace" "$component" "$migration_id"
+  done
+
+  for component in "${@:5}"; do
+    wait_down "$namespace" "$component" "$migration_id"
+  done
+
+  _info " ** Restoring ** "
+  for component in "${@:5}"; do
+    restore_component "$namespace" "$component" "$migration_id" "$run_id" "$internal" "$restore_cluster"
+  done
+
+  _info " ** Waiting for all restore operations to finish ** "
+  for component in "${@:5}"; do
+    wait_restore_component "$namespace" "$component" "$internal"
+  done
+
+
+  _info " ** Scaling up ** "
+  for component in "${@:5}"; do
+    up "$namespace" "$component" "$migration_id"
+  done
+
+
+}
+
+main "$@"

--- a/cluster/scripts/utils.source
+++ b/cluster/scripts/utils.source
@@ -1,0 +1,65 @@
+function get_postgres_type() {
+  local instance=$1
+  local stack=$2
+
+  _debug "Getting postgres type for instance $instance in stack $stack"
+
+  cncluster pulumi "$stack" stack export | grep -v "Running Pulumi Command" | jq -r ".deployment.resources[] | select(.urn | test(\".*canton:.*:postgres::${instance}\")) | .type"
+}
+
+function get_cloudsql_id() {
+  local instance=$1
+  local stack=$2
+  local cluster=${3:-""} # optional, defaults to CWD
+
+  if [ -n "$cluster" ]; then
+    local path="$SPLICE_ROOT/cluster/deployment/$cluster"
+    local cwd; cwd="$(pwd)"
+
+    cd "$path" || _error "Failed to enter deployment directory $cluster"
+    direnv exec . cncluster pulumi "$stack" stack export | grep -v "Running Pulumi Command" | jq -r ".deployment.resources[] | select(.urn | test(\".*DatabaseInstance::${instance}\")) | .id"
+    cd "$cwd" || _error "Failed to return to original directory"
+  else
+    cncluster pulumi "$stack" stack export | grep -v "Running Pulumi Command" | jq -r ".deployment.resources[] | select(.urn | test(\".*DatabaseInstance::${instance}\")) | .id"
+  fi
+}
+
+function get_stack_for_namespace_component() {
+  local namespace=$1
+  local component=$2
+  local internal=$3
+
+  local stack=""
+  if [[ "${namespace}" =~ sv.* ]]; then
+    if [[ "${component}" == "participant" && "${internal}" != "true" ]]; then
+      stack="sv-canton"
+    elif [[ "${component}" == "sequencer" && "${internal}" != "true" ]]; then
+      stack="sv-canton"
+    elif [[ "${component}" == "mediator" && "${internal}" != "true" ]]; then
+      stack="sv-canton"
+    else
+      stack="canton-network"
+    fi
+  else
+    stack="$namespace"
+  fi
+
+  echo $stack
+}
+
+create_component_instance() {
+    local component="$1"
+    local migration_id="$2"
+    local namespace="$3"
+    local internal="$4"
+
+    if [[ ("$component" == "sequencer" || "$component" == "mediator" || "$component" == "participant")
+       && ("$namespace" != "splitwell" && "$namespace" != "validator1" && "$namespace" != "sv")
+       && ("$internal" != "true") ]]; then
+        component_instance="${component}-${migration_id}"
+    else
+        component_instance="${component}"
+    fi
+
+    echo "$component_instance"
+}

--- a/cluster/scripts/versions-from-dump.py
+++ b/cluster/scripts/versions-from-dump.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+
+j = json.load(sys.stdin)
+
+result = {}
+resources = j["deployment"]["resources"]
+releases = [r for r in resources if r["type"] == "kubernetes:helm.sh/v3:Release"]
+for release in releases:
+    outputs = release["outputs"]
+    status = outputs["status"]
+    namespace = status["namespace"]
+    chart = status["chart"]
+    appVersion = outputs["version"]
+    value = result.get(namespace, {})
+    value[chart] = appVersion
+    result[namespace] = value
+
+print(json.dumps(result, sort_keys=True, indent=2))

--- a/cluster/scripts/vote-for-migration.sh
+++ b/cluster/scripts/vote-for-migration.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+# Schedules a global domain upgrade in a CI cluster.
+# Used to be implemented as a preflight test, but loading all the environment for it took forever.
+# See #14665
+
+# curl uses --retry-all-errors because some 4xx returned by canton are transient errors that must be retried
+
+function usage() {
+  echo "Usage: ./vote-for-migration.sh <migration_id>"
+}
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+migration_id=$1
+
+echo "Creating vote request for migration id $migration_id"
+
+sv1_token=$(cncluster get_token sv-1 sv)
+
+current_dso_config=$(curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/dso")
+echo "DSO: $current_dso_config"
+current_config=$(echo "$current_dso_config" | jq -r '.dso_rules.contract.payload.config')
+echo "Current config: $current_config"
+
+requester=$(echo "$current_dso_config" | jq '.sv_party_id')
+scheduled_time=$(date -u -d '+80 seconds' '+%Y-%m-%dT%H:%M:%SZ')
+expiration_microseconds='60000000'
+new_config=$(echo "$current_config" | jq '.nextScheduledSynchronizerUpgrade = {"time": "'"$scheduled_time"'", "migrationId": "'"$migration_id"'"}')
+
+data='
+{
+  "requester": '$requester',
+  "action": {
+    "tag": "ARC_DsoRules",
+    "value": {
+      "dsoAction": {
+        "tag": "SRARC_SetConfig",
+        "value": {
+          "newConfig": '"$new_config"'
+        }
+      }
+    }
+  },
+  "url": "No URL",
+  "description": "Triggered via trigger-migration script.",
+  "expiration": {
+    "microseconds": "'$expiration_microseconds'"
+  }
+}
+'
+
+echo "Sending vote request: $data"
+
+curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+  -X POST "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/voterequest/create" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $sv1_token" \
+  --data-raw "$data"
+
+vote_requests=$(curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+  -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/voterequests" \
+  -H "Authorization: Bearer $sv1_token")
+echo "Found vote requests: $vote_requests"
+
+vote_request_cid=$(echo "$vote_requests" | jq -r '.dso_rules_vote_requests[0].contract_id')
+
+vote_data='{
+  "vote_request_contract_id":"'"$vote_request_cid"'",
+  "is_accepted":true,
+  "reason_url":"No URL",
+  "reason_description":"Accepted via trigger-migration script"
+}'
+echo "Casting votes on $vote_request_cid with: $vote_data"
+
+
+DSO_SIZE=${DSO_SIZE:-4}
+other_svs=()
+for ((i=2; i<=DSO_SIZE; i++)); do
+  other_svs+=("sv-$i")
+done
+
+for sv in "${other_svs[@]}"
+do
+  token=$(cncluster get_token "$sv" sv)
+  echo "Casting vote on $sv"
+  curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+    -X POST "https://sv.$sv-eng.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/votes" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer $token" \
+    --data-raw "$vote_data"
+done
+
+# poll until the vote has gone through
+# 300 to account for
+# - 60s expiration time of the vote request
+# - 60s buffer because we only set minutes not seconds
+# - 30s polling interval for the trigger to kick in
+# - general slowness
+MAX_RETRIES=300
+retry_count=0
+until [ $retry_count -gt $MAX_RETRIES ]; do
+  echo "Checking whether DSO info has been updated"
+  retry_count=$((retry_count+1))
+
+  # disabling exit on error to allow for retries
+  set +e
+  new_dso_config=$(curl -s -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/dso")
+  echo "DSO info: $new_dso_config"
+  next_migration_id=$(echo "$new_dso_config" | jq -r '.dso_rules.contract.payload.config.nextScheduledSynchronizerUpgrade.migrationId')
+  set -e
+  echo "Migration id: $next_migration_id"
+
+  if [ "$next_migration_id" == "$migration_id" ]; then
+    echo "Migration has been successfully scheduled"
+    break
+  fi
+
+  if [ $retry_count -gt $MAX_RETRIES ]; then
+    echo "DSO info was not updated after $MAX_RETRIES retries"
+    exit 1
+  fi
+
+  sleep 1
+done

--- a/cluster/scripts/vote-for-offboard-sv-runbook.sh
+++ b/cluster/scripts/vote-for-offboard-sv-runbook.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+# Offboards the sv runbook, used for testing.
+
+# curl uses --retry-all-errors because some 4xx returned by canton are transient errors that must be retried
+
+# SV1 creates the vote request to offboard the sv runbook
+sv1_token=$(cncluster get_token sv-1 sv)
+
+current_dso_config=$(curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/dso")
+echo "DSO: $current_dso_config"
+
+requester=$(echo "$current_dso_config" | jq '.sv_party_id')
+offboarded=$(echo "$current_dso_config" | jq -r '.dso_rules.contract.payload.svs | map(select(.[1].name == "DA-Helm-Test-Node"))[0][0]')
+expiration_microseconds='60000000'
+
+data='
+{
+    "requester": '$requester',
+    "action": {
+        "tag": "ARC_DsoRules",
+        "value": {
+            "dsoAction": {
+                "tag": "SRARC_OffboardSv",
+                "value": {
+                    "sv": "'$offboarded'"
+                }
+            }
+        }
+    },
+    "url": "http://example.com",
+    "description": "Offboarding test",
+    "expiration": {
+        "microseconds": "'$expiration_microseconds'"
+    }
+}
+'
+
+echo "Sending vote request: $data"
+
+curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+  -X POST "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/voterequest/create" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $sv1_token" \
+  --data-raw "$data"
+
+vote_requests=$(curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+  -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/voterequests" \
+  -H "Authorization: Bearer $sv1_token")
+echo "Found vote requests: $vote_requests"
+
+vote_request_cid=$(echo "$vote_requests" | jq -r '.dso_rules_vote_requests[0].contract_id')
+
+vote_data='{
+  "vote_request_contract_id":"'"$vote_request_cid"'",
+  "is_accepted":true,
+  "reason_url":"No URL",
+  "reason_description":"Accepted via offboard-sv-runbook script"
+}'
+echo "Casting votes on $vote_request_cid with: $vote_data"
+
+# The other SVs vote in favor of the offboarding
+
+DSO_SIZE=${DSO_SIZE:-4}
+other_svs=()
+for ((i=2; i<=DSO_SIZE; i++)); do
+  other_svs+=("sv-$i")
+done
+
+for sv in "${other_svs[@]}"
+do
+  token=$(cncluster get_token "$sv" sv)
+  echo "Casting vote on $sv"
+  curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
+    -X POST "https://sv.$sv-eng.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/votes" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer $token" \
+    --data-raw "$vote_data"
+done
+
+# Wait for SV runbook to be offboarded
+
+MAX_RETRIES=300
+retry_count=0
+until [ $retry_count -gt $MAX_RETRIES ]; do
+  echo "Checking whether DSO info has been updated"
+  retry_count=$((retry_count+1))
+
+  new_dso_config=$(curl -s -X GET "https://sv.sv-2.$GCP_CLUSTER_HOSTNAME/api/sv/v0/dso")
+  echo "DSO info: $new_dso_config"
+  offboarded_status=$(echo "$new_dso_config" | jq -r '.dso_rules.contract.payload.svs | map(select(.[1].name == "DA-Helm-Test-Node")) | length')
+
+  echo "Length of array when searching for the sv runbook: $offboarded_status"
+
+  if [ "$offboarded_status" == "0" ]; then
+    echo "Success, the SV runbook has been offboarded"
+    break
+  fi
+
+  echo "SV runbook has not been offboarded yet. Current SVs in dso_config:"
+  echo "$new_dso_config" | jq -r '.dso_rules.contract.payload.svs'
+
+  if [ $retry_count -gt $MAX_RETRIES ]; then
+    echo "SV runbook has not been offboarded after $MAX_RETRIES retries"
+    exit 1
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
We still reference those in places, such as `cncluster` and CircleCI flows...

And they don't look secret to me; so let's push now to fix things and clean up later.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/4472

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
