### PR TITLE
Fix broken retry logic when synchroniser is disconnected

### DIFF
--- a/apps/common/frontend/src/contexts/LedgerApiContext.tsx
+++ b/apps/common/frontend/src/contexts/LedgerApiContext.tsx
@@ -10,20 +10,14 @@ import { Choice, ContractId, Template, TemplateOrInterface } from '@daml/types';
 
 const ANS_LEDGER_NAME = 'ans-ledger';
 
+interface JsonApiErrorBody {
+  error: string;
+}
+
 interface JsonApiErrorResponse {
   status: number;
   statusText: string;
   body: JsonApiErrorBody;
-}
-
-interface JsCantonError {
-  code: string;
-  cause: string;
-  correlationId: string;
-}
-
-interface JsonApiErrorBody {
-  error: JsCantonError;
 }
 
 export class JsonApiError extends Error {
@@ -175,7 +169,7 @@ export class LedgerApiClient {
           console.debug(`${describeChoice} succeeded.`);
           return r.json();
         } else {
-          const body = JSON.parse(await r.text());
+          const body = await r.text();
           throw new JsonApiError({
             status: r.status,
             body: { error: body },

--- a/apps/common/frontend/src/contexts/LedgerApiContext.tsx
+++ b/apps/common/frontend/src/contexts/LedgerApiContext.tsx
@@ -16,8 +16,14 @@ interface JsonApiErrorResponse {
   body: JsonApiErrorBody;
 }
 
+interface JsCantonError {
+  code: string;
+  cause: string;
+  correlationId: string;
+}
+
 interface JsonApiErrorBody {
-  error: string;
+  error: JsCantonError;
 }
 
 export class JsonApiError extends Error {
@@ -169,7 +175,7 @@ export class LedgerApiClient {
           console.debug(`${describeChoice} succeeded.`);
           return r.json();
         } else {
-          const body = await r.text();
+          const body = JSON.parse(await r.text());
           throw new JsonApiError({
             status: r.status,
             body: { error: body },

--- a/apps/common/frontend/src/utils/helpers.ts
+++ b/apps/common/frontend/src/utils/helpers.ts
@@ -53,12 +53,13 @@ export const unitToCurrency = (unit: Unit): string => {
   return unitStringToCurrency(unit.toUpperCase());
 };
 
-export const retrySynchronizerError = (failureCount: number, error: Error): boolean => {
-  // We only retry certain JSON API errors. Retrying everything is more confusing than helpful
-  // because that then also retries on invalid user input.
+export const isDomainConnectionError: (error: Error) => boolean = (error: Error) => {
   const errResponse = error as JsonApiError;
   const keywords = ['NOT_CONNECTED_TO_SYNCHRONIZER', 'NOT_CONNECTED_TO_ANY_SYNCHRONIZER'];
-  const isDomainConnectionError = keywords.some(k => errResponse.body?.error?.includes(k));
 
-  return isDomainConnectionError && failureCount < 10;
+  return keywords.some(k => errResponse.body?.error?.code.includes(k));
+};
+
+export const retrySynchronizerError = (failureCount: number, error: Error): boolean => {
+  return isDomainConnectionError(error) && failureCount < 10;
 };

--- a/apps/common/frontend/src/utils/helpers.ts
+++ b/apps/common/frontend/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export const isDomainConnectionError: (error: Error) => boolean = (error: Error)
   const errResponse = error as JsonApiError;
   const keywords = ['NOT_CONNECTED_TO_SYNCHRONIZER', 'NOT_CONNECTED_TO_ANY_SYNCHRONIZER'];
 
-  return keywords.some(k => errResponse.body?.error?.code.includes(k));
+  return keywords.some(k => errResponse.body?.error?.includes(k));
 };
 
 export const retrySynchronizerError = (failureCount: number, error: Error): boolean => {

--- a/apps/splitwell/frontend/src/App.tsx
+++ b/apps/splitwell/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   AuthProvider,
   UserProvider,
   theme,
+  isDomainConnectionError,
   PackageIdResolver,
   JsonApiError,
 } from '@lfdecentralizedtrust/splice-common-frontend';
@@ -60,11 +61,9 @@ const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
           // We only retry certain JSON API errors. Retrying everything is more confusing than helpful
           // because that then also retries on invalid user input.
           const errResponse = error as JsonApiError;
-          const keywords = ['NOT_CONNECTED_TO_ANY_DOMAIN', 'NOT_CONNECTED_TO_DOMAIN'];
-          const isDomainConnectionError = keywords.some(k => errResponse.body?.error?.includes(k));
           const is404or409 = [404, 409].includes(errResponse.status);
 
-          return (is404or409 || isDomainConnectionError) && failureCount < 10;
+          return (is404or409 || isDomainConnectionError(error)) && failureCount < 10;
         },
         // Exponential backoff up to a maximum of 30 seconds
         retryDelay: attemptIndex => Math.min(1000 * 1.5 ** attemptIndex, 30000),


### PR DESCRIPTION
Making the type more specific and change DOMAIN -> SYNCHRONIZER



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
