### PR TITLE
prepare for DevNet BigQuery activation, then later deactivation

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -311,8 +311,24 @@ function createPostgresReplicatorUser(
   postgres: CloudPostgres,
   password: PostgresPassword
 ): gcp.sql.User {
+    const schemaName = scanAppDatabaseName(postgres);
+    const name = `${postgres.namespace.logicalName}-user-${replicatorUserName}`;
+    const {header, footer} = databaseCommandBracket(postgres);
+    const cleanup = new command.local.Command(
+        `${name}-cleanup`,
+        {delete: pulumi.interpolate`
+        ${header}
+          ALTER DEFAULT PRIVILEGES IN SCHEMA ${schemaName}
+            REVOKE SELECT ON TABLES TO ${replicatorUserName};
+          REVOKE USAGE ON SCHEMA ${schemaName} TO ${replicatorUserName};
+          REVOKE SELECT ON ALL TABLES
+            IN SCHEMA ${schemaName} TO ${replicatorUserName};
+          ALTER USER ${replicatorUserName} WITH NOREPLICATION;
+          COMMIT;
+        ${footer}
+    `});
   return new gcp.sql.User(
-    `${postgres.namespace.logicalName}-user-${replicatorUserName}`,
+    name,
     {
       instance: postgres.databaseInstance.name,
       name: replicatorUserName,

--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -311,7 +311,7 @@ function createPostgresReplicatorUser(
   postgres: CloudPostgres,
   password: PostgresPassword
 ): gcp.sql.User {
-    const name = `${postgres.namespace.logicalName}-user-${replicatorUserName}`;
+  const name = `${postgres.namespace.logicalName}-user-${replicatorUserName}`;
   return new gcp.sql.User(
     name,
     {
@@ -331,7 +331,7 @@ function createPostgresReplicatorUser(
 
 function databaseCommandBracket(postgres: CloudPostgres) {
   return {
-      header: pulumi.interpolate`
+    header: pulumi.interpolate`
         set -e
         TMP_BUCKET="da-cn-tmp-sql-$(date +%s)-$RANDOM"
         TMP_SQL_FILE="$(mktemp tmp_pub_rep_slots_XXXXXXXXXX.sql --tmpdir)"
@@ -347,7 +347,7 @@ function databaseCommandBracket(postgres: CloudPostgres) {
 
         cat > "$TMP_SQL_FILE" <<'EOT'
   `,
-      footer: pulumi.interpolate`
+    footer: pulumi.interpolate`
 EOT
 
         # upload SQL to temporary bucket
@@ -379,7 +379,7 @@ function createPublicationAndReplicationSlots(
 ) {
   const dbName = scanAppDatabaseName(postgres);
   const schemaName = dbName;
-  const {header, footer} = databaseCommandBracket(postgres);
+  const { header, footer } = databaseCommandBracket(postgres);
   return new command.local.Command(
     `${postgres.namespace.logicalName}-${replicatorUserName}-pub-replicate-slots`,
     {

--- a/cluster/pulumi/common-sv/src/svConfigs.ts
+++ b/cluster/pulumi/common-sv/src/svConfigs.ts
@@ -15,6 +15,8 @@ import { StaticSvConfig } from './config';
 import { dsoSize } from './dsoConfig';
 import { cometbftRetainBlocks } from './synchronizer/cometbftConfig';
 
+const sv1ScanBigQuery = spliceEnvConfig.envFlag('SV1_SCAN_BIGQUERY', false);
+
 const svCometBftSecrets: pulumi.Output<SvCometBftKeys>[] = isMainNet
   ? [svCometBftKeysFromSecret('sv1-cometbft-keys')]
   : [
@@ -58,6 +60,9 @@ export const svConfigs: StaticSvConfig[] = isMainNet
           },
         },
         sweep: sweepConfigFromEnv('SV1'),
+        ...(sv1ScanBigQuery
+          ? { scanBigQuery: { dataset: 'mainnet_da2_scan', prefix: 'da2' } }
+          : {}),
       },
     ]
   : [
@@ -83,6 +88,7 @@ export const svConfigs: StaticSvConfig[] = isMainNet
           },
         },
         sweep: sweepConfigFromEnv('SV1'),
+        ...(sv1ScanBigQuery ? { scanBigQuery: { dataset: 'devnet_da2_scan', prefix: 'da2' } } : {}),
       },
       {
         // TODO(#12169): consider making nodeName and ingressName the same (also for all other SVs)


### PR DESCRIPTION
Ensuring we can flip it on and then flip it off later without resetting DevNet.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
