### PR TITLE
Fix container rename in participant Helm chart

### DIFF
--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       {{- include "splice-util-lib.service-account" .Values | nindent 6 }}
       containers:
-      - name: participant-1
+      - name: participant
         image: "{{ .Values.imageRepo }}/canton-participant:{{ .Chart.AppVersion }}{{ ((.Values.imageDigests).canton_participant) }}"
         {{- with .Values.imagePullPolicy }}
         imagePullPolicy: {{ . }}

--- a/cluster/helm/splice-participant/tests/participant_test.yaml
+++ b/cluster/helm/splice-participant/tests/participant_test.yaml
@@ -37,7 +37,7 @@ tests:
       # Sanity check
       - equal:
           path: spec.template.spec.containers[0].name
-          value: participant-1
+          value: participant
       # Labels on deployment
       - isSubset:
           path: metadata.labels
@@ -99,7 +99,7 @@ tests:
       # Sanity check
       - equal:
           path: spec.template.spec.containers[0].name
-          value: participant-1
+          value: participant
       # KMS config
       - contains:
           path: spec.template.spec.containers[0].env
@@ -139,7 +139,7 @@ tests:
       # Sanity check
       - equal:
           path: spec.template.spec.containers[0].name
-          value: participant-1
+          value: participant
       # multi-line env var
       - contains:
           path: spec.template.spec.containers[0].env

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,13 @@
 Release Notes
 =============
 
+Upcoming
+--------
+
+- Deployment
+
+  - Fix a typo in the `splice-participant` Helm chart that caused the participant container to be named `participant-1` instead of `participant`.
+
 0.4.1
 -----
 


### PR DESCRIPTION
So this would have been caught by our Helm unit tests, if only they were testing the right value...

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
