### PR TITLE
0.4.1: Essentially empty commit to fix upgrade tests

### DIFF
--- a/build-tools/get-release-if-on-release-branch.sh
+++ b/build-tools/get-release-if-on-release-branch.sh
@@ -17,6 +17,7 @@ fi
 
 # Check if we are on a commit that is on a release branch but not on the main branch.
 # (when checking out Splice as a submodule, we might be losing the branch information).
+#
 sha=$(git rev-parse HEAD)
 if ! (git branch -r --contains "$sha" | grep -q "\borigin/main\b"); then
     if [[ $(git branch -r --contains "$sha") =~ origin/release-line-[0-9]+\.[0-9]+\.[0-9]+ ]]; then


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4495

This will produce a new commit on the release line branch that will not be on main, and so `get-snapshot-version` will correctly report `0.4.1` as the version to deploy.

Future release-line branches will be fine, this is just broken due to the repo migration.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
