### PR TITLE
[static] Remove some repeated env reads from pulumi code

### DIFF
--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -601,13 +601,9 @@
         ],
         "maxHistory": 10,
         "resources": {
-          "limits": {
-            "cpu": 2,
-            "memory": "4G"
-          },
           "requests": {
-            "cpu": 1,
-            "memory": "2G"
+            "cpu": 0.2,
+            "memory": "1G"
           }
         },
         "serviceMonitor": {

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_AUDIENCE,
   ExactNamespace,
   exactNamespace,
+  failOnAppVersionMismatch,
   fetchAndInstallParticipantBootstrapDump,
   imagePullSecret,
   initialPackageConfigJson,
@@ -55,7 +56,6 @@ import { spliceConfig } from 'splice-pulumi-common/src/config/config';
 import { initialAmuletPrice } from 'splice-pulumi-common/src/initialAmuletPrice';
 import { jmxOptions } from 'splice-pulumi-common/src/jmx';
 import { Postgres } from 'splice-pulumi-common/src/postgres';
-import { failOnAppVersionMismatch } from 'splice-pulumi-common/src/upgrades';
 
 import {
   delegatelessAutomation,
@@ -459,7 +459,7 @@ function installSvApp(
       enable: true,
     },
     additionalJvmOptions: jmxOptions(),
-    failOnAppVersionMismatch: failOnAppVersionMismatch(),
+    failOnAppVersionMismatch: failOnAppVersionMismatch,
     participantAddress: participant.internalClusterAddress,
     onboardingPollingInterval: config.onboardingPollingInterval,
     enablePostgresMetrics: true,
@@ -522,7 +522,7 @@ function installScan(
     isFirstSv: isFirstSv,
     persistence: persistenceConfig(postgres, scanDbName),
     additionalJvmOptions: jmxOptions(),
-    failOnAppVersionMismatch: failOnAppVersionMismatch(),
+    failOnAppVersionMismatch: failOnAppVersionMismatch,
     sequencerAddress: decentralizedSynchronizerNode.namespaceInternalSequencerAddress,
     participantAddress: participant.internalClusterAddress,
     migration: {

--- a/cluster/pulumi/common-validator/src/validator.ts
+++ b/cluster/pulumi/common-validator/src/validator.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_AUDIENCE,
   DomainMigrationIndex,
   ExactNamespace,
+  failOnAppVersionMismatch,
   fetchAndInstallParticipantBootstrapDump,
   installAuth0Secret,
   installAuth0UISecret,
@@ -30,7 +31,6 @@ import {
   ValidatorTopupConfig,
 } from 'splice-pulumi-common';
 import { jmxOptions } from 'splice-pulumi-common/src/jmx';
-import { failOnAppVersionMismatch } from 'splice-pulumi-common/src/upgrades';
 
 import { SweepConfig } from './sweep';
 
@@ -214,7 +214,7 @@ export async function installValidatorApp(
       },
       participantAddress: config.participantAddress,
       additionalJvmOptions: jmxOptions(),
-      failOnAppVersionMismatch: failOnAppVersionMismatch(),
+      failOnAppVersionMismatch: failOnAppVersionMismatch,
       enablePostgresMetrics: true,
       auth: {
         audience:

--- a/cluster/pulumi/common/src/config/index.ts
+++ b/cluster/pulumi/common/src/config/index.ts
@@ -28,3 +28,7 @@ export const publicPrometheusRemoteWrite = spliceEnvConfig.envFlag(
   'PUBLIC_PROMETHEUS_REMOTE_WRITE',
   false
 );
+export const failOnAppVersionMismatch: boolean = spliceEnvConfig.envFlag(
+  'FAIL_ON_APP_VERSION_MISMATCH',
+  true
+);

--- a/cluster/pulumi/common/src/secrets.ts
+++ b/cluster/pulumi/common/src/secrets.ts
@@ -8,7 +8,6 @@ import { DockerConfig } from 'splice-pulumi-common/src/dockerConfig';
 
 import { installAuth0Secret, installAuth0UiSecretWithClientId } from './auth0';
 import { Auth0Client } from './auth0types';
-import { config } from './config';
 import { CnInput } from './helm';
 import { btoa, ExactNamespace } from './utils';
 
@@ -84,7 +83,8 @@ export function imagePullSecretByNamespaceNameForServiceAccount(
   serviceAccountName: string,
   dependsOn: pulumi.Resource[] = []
 ): pulumi.Resource[] {
-  const kubecfg = config.optionalEnv('KUBECONFIG');
+  // eslint-disable-next-line no-process-env
+  const kubecfg = process.env['KUBECONFIG'];
   // k8sProvider saves the absolute path to kubeconfig if it's defined in KUBECONFIG env var, which makes
   // it not portable between machines, so we temporarily remove this env var to avoid that.
   // eslint-disable-next-line no-process-env

--- a/cluster/pulumi/common/src/upgrades.ts
+++ b/cluster/pulumi/common/src/upgrades.ts
@@ -1,7 +1,0 @@
-// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { config } from './config';
-
-export function failOnAppVersionMismatch(): boolean {
-  return config.envFlag('FAIL_ON_APP_VERSION_MISMATCH', true);
-}

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -28,13 +28,9 @@ export const operator = new k8s.helm.v3.Release(
     namespace: namespace.ns.metadata.name,
     values: {
       resources: {
-        limits: {
-          cpu: 2,
-          memory: config.optionalEnv('OPERATOR_MEMORY_LIMIT') || '4G',
-        },
         requests: {
-          cpu: 1,
-          memory: config.optionalEnv('OPERATOR_MEMORY_REQUESTS') || '2G',
+          cpu: 0.2,
+          memory: config.optionalEnv('OPERATOR_MEMORY_REQUESTS') || '1G',
         },
       },
       imagePullSecrets: [{ name: secretName }],

--- a/cluster/pulumi/splitwell/src/splitwell.ts
+++ b/cluster/pulumi/splitwell/src/splitwell.ts
@@ -19,10 +19,10 @@ import {
   CnInput,
   activeVersion,
   ansDomainPrefix,
+  failOnAppVersionMismatch,
 } from 'splice-pulumi-common';
 import { installParticipant } from 'splice-pulumi-common-validator';
 import { installValidatorApp } from 'splice-pulumi-common-validator/src/validator';
-import { failOnAppVersionMismatch } from 'splice-pulumi-common/src/upgrades';
 
 export async function installSplitwell(
   auth0Client: Auth0Client,
@@ -104,7 +104,7 @@ export async function installSplitwell(
         user: pulumi.Output.create('cnadmin'),
         port: pulumi.Output.create(5432),
       },
-      failOnAppVersionMismatch: failOnAppVersionMismatch(),
+      failOnAppVersionMismatch: failOnAppVersionMismatch,
     },
     activeVersion,
     { dependsOn: imagePullDeps }

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -45,10 +45,10 @@ import {
   SvCometBftGovernanceKey,
   svCometBftGovernanceKeySecret,
   svCometBftGovernanceKeyFromSecret,
+  failOnAppVersionMismatch,
 } from 'splice-pulumi-common';
 import { spliceConfig } from 'splice-pulumi-common/src/config/config';
 import { CloudPostgres, SplicePostgres } from 'splice-pulumi-common/src/postgres';
-import { failOnAppVersionMismatch } from 'splice-pulumi-common/src/upgrades';
 
 import { SvAppConfig, ValidatorAppConfig } from './config';
 import { installCanton } from './decentralizedSynchronizer';
@@ -278,7 +278,7 @@ async function installSvAndValidator(
     extraBeneficiaries,
     onboardingPollingInterval: svOnboardingPollingInterval,
     disableOnboardingParticipantPromotionDelay,
-    failOnAppVersionMismatch: failOnAppVersionMismatch(),
+    failOnAppVersionMismatch: failOnAppVersionMismatch,
     initialAmuletPrice,
   };
 

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -38,10 +38,10 @@ import {
   ValidatorTopupConfig,
   InstalledHelmChart,
   ansDomainPrefix,
+  failOnAppVersionMismatch,
 } from 'splice-pulumi-common';
 import { installParticipant } from 'splice-pulumi-common-validator';
 import { SplicePostgres } from 'splice-pulumi-common/src/postgres';
-import { failOnAppVersionMismatch } from 'splice-pulumi-common/src/upgrades';
 
 import {
   VALIDATOR_MIGRATE_PARTY,
@@ -246,7 +246,7 @@ async function installValidator(validatorConfig: ValidatorConfig): Promise<Insta
     },
     participantAddress,
     participantIdentitiesDumpPeriodicBackup: backupConfig,
-    failOnAppVersionMismatch: failOnAppVersionMismatch(),
+    failOnAppVersionMismatch: failOnAppVersionMismatch,
     validatorPartyHint: VALIDATOR_PARTY_HINT || 'digitalasset-testValidator-1',
     migrateValidatorParty: VALIDATOR_MIGRATE_PARTY,
     participantIdentitiesDumpImport: participantBootstrapDumpSecret


### PR DESCRIPTION
Cleaning up the pulumi output for easier debugging

eg of a single stack update 
![image](https://github.com/user-attachments/assets/237fa0e8-3545-470f-9dc7-a970918ba974)


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
