### PR TITLE
Add back some resource limits for operator

### DIFF
--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -599,6 +599,10 @@
             "name": "docker-reg-cred"
           }
         ],
+        "limits": {
+          "cpu": 1,
+          "memory": "2G"
+        },
         "maxHistory": 10,
         "resources": {
           "requests": {

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -27,6 +27,10 @@ export const operator = new k8s.helm.v3.Release(
     version: '2.1.0',
     namespace: namespace.ns.metadata.name,
     values: {
+      limits: {
+        cpu: 1,
+        memory: config.optionalEnv('OPERATOR_MEMORY_LIMIT') || '2G',
+      },
       resources: {
         requests: {
           cpu: 0.2,


### PR DESCRIPTION
Fixes operator deployments:

```
Deployment.apps "pulumi-kubernetes-operator-controller-manager" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "1G": must be less than or equal to memory limit of 128Mi
```

Fixes https://github.com/DACH-NY/cn-test-failures/issues/4535

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
