### PR TITLE
Bump max heap size for local canton runs

### DIFF
--- a/start-canton.sh
+++ b/start-canton.sh
@@ -188,7 +188,7 @@ tmux new-session -d -s "${tmux_session}"
 
 # Numbers chosen such that we don't run out of memory and CI runs are not measurably slower.
 # Feel free to bump if you encounter issues but make sure the nodes don't run out of memory.
-JAVA_TOOL_OPTIONS="-Xms6g -Xmx6g -Dlogback.configurationFile=./scripts/canton-logback.xml"
+JAVA_TOOL_OPTIONS="-Xms6g -Xmx8g -Dlogback.configurationFile=./scripts/canton-logback.xml"
 
 config_overrides=""
 config_overrides_simtime=""


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/3885 (Integration test participant `OutOfMemory encountered: Java heap space`)

I didn't touch the initial heap size for now; we only reach it rarely so seems to be more economical this way.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
