### PR TITLE
Retry clearing webdrivers after frontend integration tests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -308,19 +308,21 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
 
   protected def clearWebDrivers(implicit ec: ExecutionContext) = {
     logger.info("Clearing web drivers")
-    webDrivers.values.toList.parTraverse { implicit webDriver =>
-      Future {
-        // Reset session storage so we see the login window again.
-        // You cannot reset session storage of about:blank so
-        // we exclude this.
-        if (currentUrl != "about:blank") {
-          webDriver.getSessionStorage().clear()
-          eventually() {
-            webDriver.getSessionStorage().keySet.asScala shouldBe empty
+    eventually(60.seconds) {
+      webDrivers.values.toList.parTraverse { implicit webDriver =>
+        Future {
+          // Reset session storage so we see the login window again.
+          // You cannot reset session storage of about:blank so
+          // we exclude this.
+          if (currentUrl != "about:blank") {
+            webDriver.getSessionStorage().clear()
+            eventually() {
+              webDriver.getSessionStorage().keySet.asScala shouldBe empty
+            }
           }
         }
-      }
-    }.futureValue
+      }.futureValue
+    }
     logger.info("Cleared web drivers")
   }
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4437

Hard to say why this is timing out; let's attempt to fix via retry.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
