### PR TITLE
backport "SV1_SCAN_BIGQUERY deployment var; allow BQ-only cleanup (#1050)" to 0.4.1

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -311,8 +311,9 @@ function createPostgresReplicatorUser(
   postgres: CloudPostgres,
   password: PostgresPassword
 ): gcp.sql.User {
+  const name = `${postgres.namespace.logicalName}-user-${replicatorUserName}`;
   return new gcp.sql.User(
-    `${postgres.namespace.logicalName}-user-${replicatorUserName}`,
+    name,
     {
       instance: postgres.databaseInstance.name,
       name: replicatorUserName,
@@ -321,31 +322,16 @@ function createPostgresReplicatorUser(
     {
       parent: postgres,
       deletedWith: postgres.databaseInstance,
+      retainOnDelete: true,
       protect: protectCloudSql,
       dependsOn: [postgres.databaseInstance, password.secret],
     }
   );
 }
 
-/*
-For the SQL below to apply, the user/operator applying the pulumi
-needs the 'Cloud SQL Editor' IAM role in the relevant GCP project
- */
-
-function createPublicationAndReplicationSlots(
-  postgres: CloudPostgres,
-  replicatorUser: gcp.sql.User,
-  scan: InstalledHelmChart
-) {
-  const dbName = scanAppDatabaseName(postgres);
-  const schemaName = dbName;
-  return new command.local.Command(
-    `${postgres.namespace.logicalName}-${replicatorUserName}-pub-replicate-slots`,
-    {
-      // TODO (#19809) refactor to invoke external shell script
-      // ----
-      // from https://cloud.google.com/datastream/docs/configure-cloudsql-psql
-      create: pulumi.interpolate`
+function databaseCommandBracket(postgres: CloudPostgres) {
+  return {
+    header: pulumi.interpolate`
         set -e
         TMP_BUCKET="da-cn-tmp-sql-$(date +%s)-$RANDOM"
         TMP_SQL_FILE="$(mktemp tmp_pub_rep_slots_XXXXXXXXXX.sql --tmpdir)"
@@ -360,6 +346,48 @@ function createPublicationAndReplicationSlots(
             "gs://$TMP_BUCKET"
 
         cat > "$TMP_SQL_FILE" <<'EOT'
+  `,
+    footer: pulumi.interpolate`
+EOT
+
+        # upload SQL to temporary bucket
+        gsutil cp "$TMP_SQL_FILE" "$GCS_URI"
+
+        # then import into Cloud SQL
+        gcloud sql import sql ${postgres.databaseInstance.name} "$GCS_URI" \
+          --database="${scanAppDatabaseName(postgres)}" \
+          --user="${postgres.user.name}" \
+          --quiet
+
+        # cleanup: remove the file from GCS, delete the bucket, remove the local file
+        gsutil rm "$GCS_URI"
+        gsutil rb "gs://$TMP_BUCKET"
+        rm "$TMP_SQL_FILE"
+  `,
+  };
+}
+
+/*
+For the SQL below to apply, the user/operator applying the pulumi
+needs the 'Cloud SQL Editor' IAM role in the relevant GCP project
+ */
+
+function createPublicationAndReplicationSlots(
+  postgres: CloudPostgres,
+  replicatorUser: gcp.sql.User,
+  scan: InstalledHelmChart
+) {
+  const dbName = scanAppDatabaseName(postgres);
+  const schemaName = dbName;
+  const { header, footer } = databaseCommandBracket(postgres);
+  return new command.local.Command(
+    `${postgres.namespace.logicalName}-${replicatorUserName}-pub-replicate-slots`,
+    {
+      // TODO (#19809) refactor to invoke external shell script
+      // ----
+      // from https://cloud.google.com/datastream/docs/configure-cloudsql-psql
+      create: pulumi.interpolate`
+        ${header}
           DO $$
           DECLARE
             migration_complete BOOLEAN := FALSE;
@@ -414,21 +442,23 @@ function createPublicationAndReplicationSlots(
           ALTER DEFAULT PRIVILEGES IN SCHEMA ${schemaName}
             GRANT SELECT ON TABLES TO ${replicatorUserName};
           COMMIT;
-EOT
-
-        # upload SQL to temporary bucket
-        gsutil cp "$TMP_SQL_FILE" "$GCS_URI"
-
-        # then import into Cloud SQL
-        gcloud sql import sql ${postgres.databaseInstance.name} "$GCS_URI" \
-          --database="${scanAppDatabaseName(postgres)}" \
-          --user="${postgres.user.name}" \
-          --quiet
-
-        # cleanup: remove the file from GCS, delete the bucket, remove the local file
-        gsutil rm "$GCS_URI"
-        gsutil rb "gs://$TMP_BUCKET"
-        rm "$TMP_SQL_FILE"
+        ${footer}
+      `,
+      delete: pulumi.interpolate`
+        ${header}
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '${replicationSlotName}') THEN
+            PERFORM PG_DROP_REPLICATION_SLOT('${replicationSlotName}');
+          END IF;
+        END $$;
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = '${publicationName}') THEN
+            DROP PUBLICATION ${publicationName};
+          END IF;
+        END $$;
+        ${footer}
       `,
     },
     {

--- a/cluster/pulumi/common-sv/src/svConfigs.ts
+++ b/cluster/pulumi/common-sv/src/svConfigs.ts
@@ -15,6 +15,8 @@ import { StaticSvConfig } from './config';
 import { dsoSize } from './dsoConfig';
 import { cometbftRetainBlocks } from './synchronizer/cometbftConfig';
 
+const sv1ScanBigQuery = spliceEnvConfig.envFlag('SV1_SCAN_BIGQUERY', false);
+
 const svCometBftSecrets: pulumi.Output<SvCometBftKeys>[] = isMainNet
   ? [svCometBftKeysFromSecret('sv1-cometbft-keys')]
   : [
@@ -58,6 +60,9 @@ export const svConfigs: StaticSvConfig[] = isMainNet
           },
         },
         sweep: sweepConfigFromEnv('SV1'),
+        ...(sv1ScanBigQuery
+          ? { scanBigQuery: { dataset: 'mainnet_da2_scan', prefix: 'da2' } }
+          : {}),
       },
     ]
   : [
@@ -83,6 +88,7 @@ export const svConfigs: StaticSvConfig[] = isMainNet
           },
         },
         sweep: sweepConfigFromEnv('SV1'),
+        ...(sv1ScanBigQuery ? { scanBigQuery: { dataset: 'devnet_da2_scan', prefix: 'da2' } } : {}),
       },
       {
         // TODO(#12169): consider making nodeName and ingressName the same (also for all other SVs)


### PR DESCRIPTION
Make it possible to use #1050 on devnet now, which is the fix for #1060.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
