### PR TITLE
upgrade chaos-mesh

### DIFF
--- a/cluster/pulumi/canton-network/src/chaosMesh.ts
+++ b/cluster/pulumi/canton-network/src/chaosMesh.ts
@@ -146,7 +146,7 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
     {
       name: 'chaos-mesh',
       chart: 'chaos-mesh',
-      version: '2.6.3',
+      version: '2.7.2',
       namespace: ns.metadata.name,
       repositoryOpts: {
         repo: 'https://charts.chaos-mesh.org',
@@ -165,11 +165,6 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
           ...infraAffinityAndTolerations,
         },
         dnsServer: {
-          // Unfortunatly, in the latest release (2.6.3) of chaos-mesh helm charts, affinity for dns-server is not supported
-          // (support was added in https://github.com/chaos-mesh/chaos-mesh/commit/ee642585de38e1fa9b4e99787437498f16029eea, but not included in v2.6.3)
-          // This means that the dns server pod may get scheduled to the default pool if it exists, but its
-          // tolerance would also allow it to be scheduled to the infra pool, and k8s will prefer to do that
-          // rather than scale up the default pool from 0, so we just accept that for now.
           ...infraAffinityAndTolerations,
         },
         maxHistory: HELM_MAX_HISTORY_SIZE,


### PR DESCRIPTION
Part of #1091 

Confirmed that `ENABLE_CHAOS_MESH=1 cncluster apply` succeeds and installs stuff in chaos-mesh namespace. 

Not sure how to see if chaos-mesh actually does anything. @moritzkiefer-da any suggestions? Or should I just take the seemingly successful as a good enough signal, and merge this and see if it explodes on cilr? (also there I'd be happy to know how to confirm that it's working).


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
