### PR TITLE
upgrade self-hosted runners helm chart versions

### DIFF
--- a/cluster/pulumi/circleci/src/index.ts
+++ b/cluster/pulumi/circleci/src/index.ts
@@ -78,7 +78,7 @@ const persistentVolumeClaim = new k8s.core.v1.PersistentVolumeClaim(cachePvc, {
 new k8s.helm.v3.Release('container-agent', {
   name: 'container-agent',
   chart: 'container-agent',
-  version: '101.1.1',
+  version: '101.1.3',
   namespace: circleCiNamespace.metadata.name,
   repositoryOpts: {
     repo: 'https://packagecloud.io/circleci/container-agent/helm',

--- a/cluster/pulumi/gha/src/controller.ts
+++ b/cluster/pulumi/gha/src/controller.ts
@@ -13,7 +13,7 @@ export function installController(): k8s.helm.v3.Release {
 
   return new k8s.helm.v3.Release('gha-runner-scale-set-controller', {
     chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
-    version: '0.10.1',
+    version: '0.11.0',
     namespace: controllerNamespace.metadata.name,
     values: {
       ...infraAffinityAndTolerations,

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -139,7 +139,7 @@ function installDockerRunnerScaleSet(
     name,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
-      version: '0.10.1',
+      version: '0.11.0',
       namespace: runnersNamespace.metadata.name,
       values: {
         githubConfigUrl: repo,
@@ -474,7 +474,7 @@ function installK8sRunnerScaleSet(
     name,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
-      version: '0.10.1',
+      version: '0.11.0',
       namespace: runnersNamespace.metadata.name,
       values: {
         githubConfigUrl: repo,


### PR DESCRIPTION
For both CCI and GHA

These ones it seems like the easiest way to test is just yolo it: apply to the runner clusters and see if it still works.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
