### PR TITLE
Disable token standard sanity check in preflights

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/reonboard/PrepareSvReonboardPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/reonboard/PrepareSvReonboardPreflightIntegrationTest.scala
@@ -13,6 +13,7 @@ class PrepareSvReonboardPreflightIntegrationTest
     with WalletFrontendTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/reonboard/SvReOnboardPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/reonboard/SvReOnboardPreflightIntegrationTest.scala
@@ -27,6 +27,7 @@ class SvReOnboardPreflightIntegrationTest
     with WalletFrontendTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/CometBftPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/CometBftPreflightIntegrationTest.scala
@@ -10,6 +10,7 @@ import scala.util.Using
 class CometBftPreflightIntegrationTest extends IntegrationTestWithSharedEnvironment {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DockerComposeValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DockerComposeValidatorPreflightIntegrationTest.scala
@@ -12,6 +12,7 @@ class DockerComposeValidatorPreflightIntegrationTest
     with FrontendLoginUtil
     with WalletFrontendTestUtil {
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(this.getClass.getSimpleName)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
@@ -13,6 +13,7 @@ class DsoPreflightIntegrationTest
     with SvUiPreflightIntegrationTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/NonDsoNonDevNetPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/NonDsoNonDevNetPreflightIntegrationTest.scala
@@ -13,6 +13,7 @@ final class NonDsoNonDevNetPreflightIntegrationTest
     with DataExportTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   // For now treating this as a non-SV app since it is really run directly as the DSO
   // rather than as SV-1. It just happens to be in SV-1's namespace.

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvCometBftPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvCometBftPreflightIntegrationTest.scala
@@ -12,6 +12,7 @@ import scala.util.Using
 class RunbookSvCometBftPreflightIntegrationTest extends IntegrationTestWithSharedEnvironment {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.svPreflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
@@ -25,6 +25,7 @@ abstract class RunbookSvPreflightIntegrationTestBase
     with SvTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.svPreflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvSequencerInfoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvSequencerInfoPreflightIntegrationTest.scala
@@ -12,6 +12,7 @@ import scala.jdk.OptionConverters.*
 class RunbookSvSequencerInfoPreflightIntegrationTest extends IntegrationTestWithSharedEnvironment {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.svPreflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvNonDevNetPreflightintegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvNonDevNetPreflightintegrationTest.scala
@@ -15,6 +15,7 @@ abstract class SvNonDevNetPreflightIntegrationTestBase
     with FrontendLoginUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition.preflightTopology(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorNonDevNetPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorNonDevNetPreflightIntegrationTest.scala
@@ -11,6 +11,7 @@ abstract class ValidatorNonDevNetPreflightIntegrationTestBase
     with WalletFrontendTestUtil {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   protected val validatorName: String
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -35,6 +35,7 @@ abstract class ValidatorPreflightIntegrationTestBase
     with WithAuth0Support {
 
   override lazy val resetRequiredTopologyState: Boolean = false
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
 
   protected val auth0Users: mutable.Map[String, Auth0User] = mutable.Map.empty[String, Auth0User]
 


### PR DESCRIPTION
It doesn't do anything there anyway. Probably should add a baseclass for preflights as we duplicate a bunch of stuff but keeping as is for now.

[static]

fixes https://github.com/DACH-NY/cn-test-failures/issues/4564#issuecomment-2966019774



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
