### PR TITLE
support shells without $RANDOM in bigquery setup

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -333,7 +333,7 @@ function databaseCommandBracket(postgres: CloudPostgres) {
   return {
     header: pulumi.interpolate`
         set -e
-        TMP_BUCKET="da-cn-tmp-sql-$(date +%s)-$RANDOM"
+        TMP_BUCKET="da-cn-tmpsql-$(date +%s)-$RANDOM-b"
         TMP_SQL_FILE="$(mktemp tmp_pub_rep_slots_XXXXXXXXXX.sql --tmpdir)"
         GCS_URI="gs://$TMP_BUCKET/$(basename "$TMP_SQL_FILE")"
 


### PR DESCRIPTION
The better solution is #455, but just to get things going for now.

Fixes pulumi operator error in `sv-1-bqdatastream-pub-replicate-slots`

```
    InvalidUrlError: Invalid bucket name in URL "da-cn-tmp-sql-1749763865-".
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
