### PR TITLE
Bump istio maxReplicas

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1218,7 +1218,7 @@
           }
         },
         "autoscaling": {
-          "maxReplicas": 10
+          "maxReplicas": 15
         },
         "podDisruptionBudget": {
           "maxUnavailable": 1
@@ -1303,7 +1303,7 @@
           }
         },
         "autoscaling": {
-          "maxReplicas": 10
+          "maxReplicas": 15
         },
         "podDisruptionBudget": {
           "maxUnavailable": 1

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -319,7 +319,7 @@ function configureGatewayService(
           },
         },
         autoscaling: {
-          maxReplicas: 10,
+          maxReplicas: 15,
         },
         podDisruptionBudget: {
           maxUnavailable: 1,


### PR DESCRIPTION
```
 KubeHpaMaxedOut
 HPA is running at max replicas
 HPA cluster-ingress/istio-ingress has been running at max replicas for longer than 15 minutes.ksm
```
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
