### PR TITLE
auto-assign PR from forks to Martin, Ray and Itai for triaging

### DIFF
--- a/.github/workflows/assign_fork_prs.yml
+++ b/.github/workflows/assign_fork_prs.yml
@@ -3,23 +3,20 @@ name: Auto-assign PRs from forks
 on:
   pull_request_target:
     types: [opened, reopened, edited]
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
 
 jobs:
-  add_labels:
+  assign:
     runs-on: self-hosted-docker-tiny
-    # if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Add labels to PRs from forks
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const pr = context.payload.pull_request;
-            // Auto-assign the PR to isegall-da
             await github.rest.issues.addAssignees({
               issue_number: pr.number,
               owner: pr.base.repo.owner.login,
               repo: pr.base.repo.name,
-              assignees: ['isegall-da'],
+              assignees: ['isegall-da', 'martinflorian-da', 'ray-roestenburg-da'],
             });

--- a/.github/workflows/assign_fork_prs.yml
+++ b/.github/workflows/assign_fork_prs.yml
@@ -1,23 +1,25 @@
-name: Add labels to PRs from forks
+name: Auto-assign PRs from forks
 
 on:
   pull_request_target:
     types: [opened, reopened, edited]
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   add_labels:
     runs-on: self-hosted-docker-tiny
-    if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    # if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Add labels to PRs from forks
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const pr = context.payload.pull_request;
-            const labels = ['fork'];
-            await github.rest.issues.addLabels({
+            // Auto-assign the PR to isegall-da
+            await github.rest.issues.addAssignees({
               issue_number: pr.number,
               owner: pr.base.repo.owner.login,
               repo: pr.base.repo.name,
-              labels: labels,
+              assignees: ['isegall-da'],
             });


### PR DESCRIPTION
I'm hopeful that this does trigger realtime Slack alerts...

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
