### PR TITLE
Add sphinx format check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,3 +81,9 @@ repos:
         entry: "./scripts/check-daml-return-types.sh"
         pass_filenames: false
         always_run: true
+  -  repo: https://github.com/rstcheck/rstcheck
+     rev: v6.2.5
+     hooks:
+     - id: rstcheck
+       name: Check sphinx format
+       additional_dependencies: ['rstcheck[sphinx]']


### PR DESCRIPTION
fixes flakes related to sphinx format

Result of the check for when the title underline is too short:
```
Check all Daml return types.........................................................Passed
Check sphinx format.................................................................Failed
- hook id: rstcheck
- exit code: 1

docs/src/deployment.rst:7: (WARNING/2) Title underline too short.
docs/src/deployment.rst:9: (INFO/1) No directive entry for "todo" in module "docutils.parsers.rst.languages.en".
docs/src/deployment.rst:9: (ERROR/3) Unknown directive type "todo".
Error! Issues detected.
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
