### PR TITLE
fix checks in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,14 +45,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Checkout the PR head commit to get the commit message first
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check if static only
         uses: ./.github/actions/tests/skip_on_static
         id: static_only
       - name: Cancel if not opted in
         shell: bash
         run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}
-          last_commit_msg=$(git log -1 --pretty=%B ${{ github.event.pull_request.head.sha }})
+          last_commit_msg=$(git log -1 --pretty=%B)
           echo "Last commit message: $last_commit_msg"
           if [[ $last_commit_msg != *"[ci]"* ]] && [[ "${{ steps.static_only.outputs.skip }}" == "false" ]] ; then
             echo "Cancelling the entire workflow because the current commit does not opt in for CI."


### PR DESCRIPTION
- For forks, we are now skipping `cancel_if_not_opt_in`, so it definitely cannot be required for forks ( see e.g. [here](https://github.com/hyperledger-labs/splice/actions/runs/15670286512) for a failure). Not much value in depending on it for non-forks either, so I just completely removed it as a dependency.
- The check for contributors is also broken by checking the commit message in the merge commit, not the original in the PR branch

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
