### PR TITLE
[static] Use latest secret version when reading dns secret

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -616,7 +616,7 @@
   },
   {
     "custom": true,
-    "id": "projects/da-cn-devnet/secrets/dns01-sa-key-secret/versions/1",
+    "id": "projects/da-cn-devnet/secrets/dns01-sa-key-secret/versions/latest",
     "inputs": {},
     "name": "dns01-sa-key-secret",
     "provider": "",

--- a/cluster/pulumi/infra/src/network.ts
+++ b/cluster/pulumi/infra/src/network.ts
@@ -180,7 +180,7 @@ function clusterCertificate(
 
   gcp.secretmanager.SecretVersion.get(
     'dns01-sa-key-secret',
-    `projects/${GCP_PROJECT}/secrets/${gcpSecretName}/versions/1`
+    `projects/${GCP_PROJECT}/secrets/${gcpSecretName}/versions/latest`
   ).secretData.apply(dns01SaKeySecret => {
     new k8s.core.v1.Secret(
       'clouddns-dns01-solver-svc-acct',


### PR DESCRIPTION
Ensures we don't need to manually update versions

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
