### PR TITLE
[static] Increase pulumi workspace termination seconds

### DIFF
--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -175,6 +175,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "canton-network",
             "namespace": "operator"
           },
@@ -250,6 +251,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -502,6 +504,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "infra",
             "namespace": "operator"
           },
@@ -577,6 +580,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -779,6 +783,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "multi-validator",
             "namespace": "operator"
           },
@@ -854,6 +859,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -1471,6 +1477,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "splitwell",
             "namespace": "operator"
           },
@@ -1546,6 +1553,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -1748,6 +1756,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-1-migration-1",
             "namespace": "operator"
           },
@@ -1823,6 +1832,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -2025,6 +2035,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-1-migration-2",
             "namespace": "operator"
           },
@@ -2100,6 +2111,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -2314,6 +2326,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-1-migration-3",
             "namespace": "operator"
           },
@@ -2389,6 +2402,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -2603,6 +2617,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-1-migration-4",
             "namespace": "operator"
           },
@@ -2678,6 +2693,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -2882,6 +2898,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-migration-1",
             "namespace": "operator"
           },
@@ -2957,6 +2974,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -3161,6 +3179,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-migration-2",
             "namespace": "operator"
           },
@@ -3236,6 +3255,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -3452,6 +3472,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-migration-3",
             "namespace": "operator"
           },
@@ -3527,6 +3548,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -3743,6 +3765,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-canton-sv-migration-4",
             "namespace": "operator"
           },
@@ -3818,6 +3841,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -4022,6 +4046,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "sv-runbook",
             "namespace": "operator"
           },
@@ -4097,6 +4122,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -4301,6 +4327,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "validator-runbook",
             "namespace": "operator"
           },
@@ -4376,6 +4403,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",
@@ -4578,6 +4606,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "validator1",
             "namespace": "operator"
           },
@@ -4653,6 +4682,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -209,6 +209,7 @@
         "useLocalStackOnly": true,
         "workspaceTemplate": {
           "metadata": {
+            "deletionGracePeriodSeconds": 1800,
             "name": "deployment",
             "namespace": "operator"
           },
@@ -284,6 +285,7 @@
                     ]
                   }
                 ],
+                "terminationGracePeriodSeconds": 1800,
                 "tolerations": [
                   {
                     "effect": "NoSchedule",

--- a/cluster/pulumi/common/src/operator/config.ts
+++ b/cluster/pulumi/common/src/operator/config.ts
@@ -18,3 +18,5 @@ export type Config = z.infer<typeof OperatorDeploymentConfigSchema>;
 // @ts-ignore
 const fullConfig = OperatorDeploymentConfigSchema.parse(clusterYamlConfig);
 export const operatorDeploymentConfig = fullConfig.operatorDeployment;
+
+export const PulumiOperatorGracePeriod = 1800;

--- a/cluster/pulumi/common/src/operator/stack.ts
+++ b/cluster/pulumi/common/src/operator/stack.ts
@@ -13,7 +13,7 @@ import {
 } from 'splice-pulumi-common';
 
 import { spliceEnvConfig } from '../config/envConfig';
-import { operatorDeploymentConfig } from './config';
+import { operatorDeploymentConfig, PulumiOperatorGracePeriod } from './config';
 import { GitFluxRef } from './flux-source';
 
 export type EnvRefs = { [key: string]: unknown };
@@ -360,6 +360,7 @@ function createStackCRV2(
             metadata: {
               name: `${name.replaceAll('.', '-')}`,
               namespace: namespaceName,
+              deletionGracePeriodSeconds: PulumiOperatorGracePeriod,
             },
             spec: {
               image: `pulumi/pulumi:${semver.gt(pulumiVersion, minimumPulumiVersionRequired) ? pulumiVersion : minimumPulumiVersionRequired}-nonroot`,
@@ -408,6 +409,7 @@ function createStackCRV2(
               podTemplate: {
                 spec: {
                   ...infraAffinityAndTolerations,
+                  terminationGracePeriodSeconds: PulumiOperatorGracePeriod,
                   volumes: [
                     {
                       name: 'gcp-credentials',

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -9,6 +9,7 @@ import {
   infraAffinityAndTolerations,
 } from 'splice-pulumi-common';
 
+import { PulumiOperatorGracePeriod } from '../../common/src/operator/config';
 import { namespace } from './namespace';
 
 export const imagePullDeps = imagePullSecret(namespace);
@@ -38,7 +39,7 @@ export const operator = new k8s.helm.v3.Release(
         },
       },
       imagePullSecrets: [{ name: secretName }],
-      terminationGracePeriodSeconds: 1800,
+      terminationGracePeriodSeconds: PulumiOperatorGracePeriod,
       image: {
         pullPolicy: 'Always',
       },


### PR DESCRIPTION
part of https://github.com/hyperledger-labs/splice/issues/689

should improve handling of updates by the workspace during resets

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
