### PR TITLE
[release-line-0.3.21] Limit cometbft load balancer ports to only thos…

### DIFF
--- a/cluster/pulumi/common-sv/src/synchronizer/cometBftNodeConfigs.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometBftNodeConfigs.ts
@@ -35,7 +35,7 @@ export class CometBftNodeConfigs {
       privateKey: staticConf.privateKey,
       identifier: this.nodeIdentifier,
       externalAddress: this.p2pExternalAddress(staticConf.nodeIndex),
-      istioPort: this.istioExternalPort(staticConf.nodeIndex),
+      istioPort: istioCometbftExternalPort(this._domainMigrationId, staticConf.nodeIndex),
       retainBlocks: staticConf.retainBlocks,
       validator: staticConf.validator,
     };
@@ -80,13 +80,13 @@ export class CometBftNodeConfigs {
   }
 
   private p2pExternalAddress(nodeIndex: number): string {
-    return `${CLUSTER_HOSTNAME}:${this.istioExternalPort(nodeIndex)}`;
-  }
-
-  private istioExternalPort(nodeIndex: number) {
-    // TODO(#10482) Revisit port scheme
-    return nodeIndex >= 10
-      ? Number(`26${this._domainMigrationId}${nodeIndex}`)
-      : Number(`26${this._domainMigrationId}${nodeIndex}6`);
+    return `${CLUSTER_HOSTNAME}:${istioCometbftExternalPort(this._domainMigrationId, nodeIndex)}`;
   }
 }
+
+export const istioCometbftExternalPort = (migrationId: number, nodeIndex: number): number => {
+  // TODO(DACH-NY/canton-network-node#10482) Revisit port scheme
+  return nodeIndex >= 10
+    ? Number(`26${migrationId}${nodeIndex}`)
+    : Number(`26${migrationId}${nodeIndex}6`);
+};


### PR DESCRIPTION
…e actually used

backport from #1190

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
