### PR TITLE
Add missing dependency on splice-pulumi-common-sv

### DIFF
--- a/cluster/pulumi/infra/package.json
+++ b/cluster/pulumi/infra/package.json
@@ -6,7 +6,8 @@
     "@pulumi/command": "1.1.0",
     "@pulumi/kubernetes-cert-manager": "0.2.0",
     "@pulumiverse/grafana": "0.16.3",
-    "splice-pulumi-common": "1.0.0"
+    "splice-pulumi-common": "1.0.0",
+    "splice-pulumi-common-sv": "1.0.0"
   },
   "overrides": {
     "@pulumi/kubernetes-cert-manager": {

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -160,7 +160,8 @@
                 "@pulumi/command": "1.1.0",
                 "@pulumi/kubernetes-cert-manager": "0.2.0",
                 "@pulumiverse/grafana": "0.16.3",
-                "splice-pulumi-common": "1.0.0"
+                "splice-pulumi-common": "1.0.0",
+                "splice-pulumi-common-sv": "1.0.0"
             }
         },
         "multi-validator": {


### PR DESCRIPTION
[static]

I hope this makes the pulumi operator happy again and fixes this

```
src/istio.ts(4,52): error TS2307: Cannot find module
'splice-pulumi-common-sv' or its corresponding type declarations.
```



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
