### PR TITLE
Always expose sv runbook cometbft port

### DIFF
--- a/cluster/pulumi/infra/package.json
+++ b/cluster/pulumi/infra/package.json
@@ -5,7 +5,8 @@
     "@pulumi/auth0": "3.21.0",
     "@pulumi/kubernetes-cert-manager": "0.2.0",
     "@pulumiverse/grafana": "0.16.3",
-    "splice-pulumi-common": "1.0.0"
+    "splice-pulumi-common": "1.0.0",
+    "splice-pulumi-common-sv": "1.0.0"
   },
   "overrides": {
     "@pulumi/kubernetes-cert-manager": {

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -10,7 +10,6 @@ import { PodMonitor, ServiceMonitor } from 'splice-pulumi-common/src/metrics';
 import {
   activeVersion,
   DecentralizedSynchronizerUpgradeConfig,
-  DeploySvRunbook,
   ExactNamespace,
   getDnsNames,
   HELM_MAX_HISTORY_SIZE,
@@ -160,16 +159,17 @@ function configureInternalGatewayService(
   // see notes when installing a CometBft node in the full deployment
   const cometBftIngressPorts = DecentralizedSynchronizerUpgradeConfig.runningMigrations()
     .map(migrationInfo => migrationInfo.id)
-    .flatMap((domain: number) => {
-      return (DeploySvRunbook ? [0] : [])
-        .concat(Array.from(Array(dsoSize).keys()).map(n => n + 1))
-        .map(node => {
-          return ingressPort(
+    .flatMap((domain: number) =>
+        // node = 0 is the sv runbook. We always include that as relying on SPLICE_DEPLOY_SV_RUNBOOK doesn't work well
+        // for jobs where we deploy the sv runbook in a separate step so the core infra stack still runs with SPLICE_DEPLOY_SV_RUNBOOK=false.
+        Array.from(Array(dsoSize + 1).keys())
+        .map(node =>
+          ingressPort(
             `cometbft-${domain}-${node}-gw`,
             istioCometbftExternalPort(domain, node)
-          );
-        });
-    });
+          )
+        )
+    );
   return configureGatewayService(
     ingressNs,
     ingressIp,

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -162,7 +162,8 @@
                 "@pulumi/auth0": "3.21.0",
                 "@pulumi/kubernetes-cert-manager": "0.2.0",
                 "@pulumiverse/grafana": "0.16.3",
-                "splice-pulumi-common": "1.0.0"
+                "splice-pulumi-common": "1.0.0",
+                "splice-pulumi-common-sv": "1.0.0"
             }
         },
         "multi-validator": {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/4702

[static]

Probably could be more clever here but doesn't seem worth the
complexity and potential breakage.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
