### PR TITLE
fix rst warning in docs/bundle helm-kubernetes-templating-tool.rst

### DIFF
--- a/docs/src/community/helm-kubernetes-templating-tool.rst
+++ b/docs/src/community/helm-kubernetes-templating-tool.rst
@@ -8,15 +8,15 @@
 Automated Helm/Kubernetes Templating Tool
 =========================================
 
-Managing deployments for Validator and Super Validator nodes using Kubernetes, Helm, and Git can be challenging, 
-especially when keeping multiple environments (DevNet, TestNet, MainNet) in sync with evolving configuration files and values. 
-Frequent version bumps, new variables, and hard migrations often require manual, error-prone updates to numerous values-*.yml files. 
-This manual process can lead to inconsistencies, missed configuration changes, and increased operational overhead. 
-The introduced solution provides a templating tool designed to automate and simplify the management of Helm values and environment-specific configurations. 
-This tool is intended as a supplemental resource for users seeking additional automation and templating flexibility alongside the official deployment guides. 
+Managing deployments for Validator and Super Validator nodes using Kubernetes, Helm, and Git can be challenging,
+especially when keeping multiple environments (DevNet, TestNet, MainNet) in sync with evolving configuration files and values.
+Frequent version bumps, new variables, and hard migrations often require manual, error-prone updates to numerous ``values-*.yml`` files.
+This manual process can lead to inconsistencies, missed configuration changes, and increased operational overhead.
+The introduced solution provides a templating tool designed to automate and simplify the management of Helm values and environment-specific configurations.
+This tool is intended as a supplemental resource for users seeking additional automation and templating flexibility alongside the official deployment guides.
 To learn more about officially supported Kubernetes-based deployments, refer to :ref:`Kubernetes-Based Deployment of a Validator node <k8s_validator>` and :ref:`Kubernetes-Based Deployment of a Super Validator node <sv-helm>`.
 
-Thanks to Stéphane Loeuillet for sharing this solution in a community discussion. 
+Thanks to Stéphane Loeuillet for sharing this solution in a community discussion.
 For more details and future updates, see the `kaikodata/canton-tooling <https://github.com/kaikodata/canton-tooling/blob/master/kubernetes/README.md#canton-templating-script>`_ repository.
 
 Key Features of the Solution


### PR DESCRIPTION
```
[error] Warning, treated as error:
[error] /__w/splice/splice/docs/src/community/helm-kubernetes-templating-tool.rst:11:Inline emphasis start-string without end-string.
```

Also removes some trailing spaces. Followup to #1172.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
