### PR TITLE
note each validator needs a separate k8s namespace

### DIFF
--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -64,6 +64,11 @@ Create the application namespace within Kubernetes.
 
     kubectl create ns validator
 
+.. note::
+
+    The validator deployment assumes one validator per namespace.
+    If you wish to run multiple validators in the same cluster, please create a separate namespace for each.
+
 .. _validator-postgres-auth:
 
 Configuring PostgreSQL authentication


### PR DESCRIPTION
As @isegall-da [noted](https://github.com/global-synchronizer-foundation/docs/discussions/15#discussioncomment-13172778),

> I think that "a single validator per namespace" is an assumption in many other places, and should just be documented as a requirement instead.

Tested `docs/bundle` locally.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
