### PR TITLE
Fix transfer preapproval send for featured receiver providers

### DIFF
--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandler.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandler.scala
@@ -825,7 +825,10 @@ class HttpWalletHandler(
               (_: amuletoperationoutcome.COO_TransferPreapprovalSend) =>
                 r0.TransferPreapprovalSendResponse.OK,
               extraDisclosedContracts = wallet.connection.disclosedContracts(
-                preapproval
+                preapproval,
+                // Approximating the state of featured app right to be the same as the preapproval
+                // as scan currently does not return a ContractWithState.
+                featuredAppRight.map(c => ContractWithState(c, preapproval.state)).toList*
               ),
               dedupConfig = Some(
                 AmuletOperationDedupConfig(

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,14 @@
 Release Notes
 =============
 
+Upcoming
+--------
+
+- Validator
+
+  - Fix a bug where sends through transfer preapprovals failed with a ``CONTRACT_NOT_FOUND`` ERROR
+    if the receiver's provider party was featured.
+
 0.4.2
 -----
 


### PR DESCRIPTION
fixes #1216

[ci]

Verified that the test fails without this.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
