### PR TITLE
Bump Canton to consume DAR vetting bugfix

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.0-snapshot.20250619.15981.0.v46bd2c05",
+  "version": "3.3.0-snapshot.20250625.15986.0.v6a165324",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
-  "sha256": "sha256:1s6n5dlrlxrcbgpbn7j5s93airkgg4ldp7rvbcn8xprnc1ica5jh"
+  "sha256": "sha256:10yxfyknjlh1psyg79wd7nfqlqmwkdbrylm0qdbx8kr3pffb5yf8"
 }


### PR DESCRIPTION
includes the fix for
https://github.com/DACH-NY/canton/commit/6a1653240378542fc0690357e3c706bc6a71e864

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
