### PR TITLE
Fix package version check for merge validator license trigger

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeDuplicatedValidatorLicenseIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeDuplicatedValidatorLicenseIntegrationTest.scala
@@ -30,13 +30,15 @@ class SvMergeDuplicatedValidatorLicenseIntegrationTest
   "Duplicated validator licenses for the same validator get merged" in { implicit env =>
     val dso = sv1Backend.getDsoInfo().dsoParty
 
+    val aliceValidator = aliceValidatorBackend.getValidatorPartyId()
+
     def getValidatorLicenses() =
       sv1Backend.participantClientWithAdminToken.ledger_api_extensions.acs
         .filterJava(ValidatorLicense.COMPANION)(
           dso,
           _ => true,
         )
-        .filter(_.data.validator.contains("digital-asset-2"))
+        .filter(_.data.validator == aliceValidator.toProtoPrimitive)
 
     val validatorLicenses = getValidatorLicenses()
     validatorLicenses should have size 1

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
@@ -12,7 +12,7 @@ import org.lfdecentralizedtrust.splice.automation.{
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules_MergeValidatorLicense
 import org.lfdecentralizedtrust.splice.codegen.java.splice.validatorlicense.ValidatorLicense
 import org.lfdecentralizedtrust.splice.store.PageLimit
-import org.lfdecentralizedtrust.splice.util.{AssignedContract, Codec, Contract}
+import org.lfdecentralizedtrust.splice.util.{AssignedContract, Contract}
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
@@ -50,7 +50,6 @@ class MergeValidatorLicenseContractsTrigger(
           Seq(
             store.key.svParty,
             store.key.dsoParty,
-            Codec.tryDecode(Codec.Party)(validator),
           ),
           context.clock.now.minus(context.config.clockSkewAutomationDelay.asJava),
         )


### PR DESCRIPTION
[ci]

Tested that the adjusted test fails without this and succeeds with this.

Just omitting the validator is sound as all the logic is in dso-governance. We don't need any specific version of splice-amulet for this to work, it just calls `Archive`.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
