### PR TITLE
Make data restore logic after a migration more resistant to crashes

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -1240,8 +1240,6 @@ object BaseLedgerConnection {
 
   val SV_NAME_USER_METADATA_KEY: String = "sv.app.network.canton.global/sv_name"
 
-  val INITIAL_ACS_IMPORT_METADATA_KEY: String = "network.canton.global/initial_acs_import"
-
   val SV1_INITIAL_PACKAGE_UPLOAD_METADATA_KEY: String =
     "network.canton.global/sv1_initial_package_upload"
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainDataRestorer.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainDataRestorer.scala
@@ -3,11 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.migration
 
-import org.lfdecentralizedtrust.splice.environment.{
-  BaseLedgerConnection,
-  ParticipantAdminConnection,
-  RetryFor,
-}
+import org.lfdecentralizedtrust.splice.environment.{ParticipantAdminConnection, RetryFor}
 import org.lfdecentralizedtrust.splice.util.UploadablePackage
 import com.digitalasset.canton.config.{SynchronizerTimeTrackerConfig, NonNegativeFiniteDuration}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
@@ -30,8 +26,6 @@ class DomainDataRestorer(
   /** We assume the domain was not register prior to trying to restore the data.
     */
   def connectDomainAndRestoreData(
-      ledgerConnection: BaseLedgerConnection,
-      userId: String,
       synchronizerAlias: SynchronizerAlias,
       synchronizerId: SynchronizerId,
       sequencerConnections: SequencerConnections,
@@ -40,52 +34,53 @@ class DomainDataRestorer(
   )(implicit
       tc: TraceContext
   ): Future[Unit] = {
-    logger.info("Registering and connecting to new domain")
+    def restoreData() = {
+      val domainConnectionConfig = SynchronizerConnectionConfig(
+        synchronizerAlias,
+        synchronizerId = Some(synchronizerId),
+        sequencerConnections = sequencerConnections,
+        manualConnect = true,
+        initializeFromTrustedSynchronizer = true,
+        timeTracker = SynchronizerTimeTrackerConfig(
+          timeTrackerMinObservationDuration
+        ),
+      )
+      // We rely on the calls here being idempotent
+      for {
+        // Disconnect
+        _ <- participantAdminConnection.disconnectFromAllDomains()
+        _ <- importDars(dars)
+        _ = logger.info("Imported all the dars.")
+        _ <-
+          participantAdminConnection
+            .ensureDomainRegistered(
+              domainConnectionConfig,
+              RetryFor.ClientCalls,
+            )
+        _ = logger.info("Importing the ACS")
+        _ <- importAcs(acsSnapshot)
+        _ = logger.info("Imported the ACS")
+        _ <- participantAdminConnection.modifySynchronizerConnectionConfigAndReconnect(
+          synchronizerAlias,
+          config => Some(config.copy(manualConnect = false)),
+        )
+      } yield ()
+    }
 
     // We use user metadata as a dumb storage to track whether we already imported the ACS.
-    ledgerConnection
-      .lookupUserMetadata(
-        userId,
-        BaseLedgerConnection.INITIAL_ACS_IMPORT_METADATA_KEY,
+    participantAdminConnection
+      .lookupSynchronizerConnectionConfig(
+        synchronizerAlias
       )
       .flatMap {
         case None =>
-          val domainConnectionConfig = SynchronizerConnectionConfig(
-            synchronizerAlias,
-            synchronizerId = Some(synchronizerId),
-            sequencerConnections = sequencerConnections,
-            manualConnect = true,
-            initializeFromTrustedSynchronizer = true,
-            timeTracker = SynchronizerTimeTrackerConfig(
-              timeTrackerMinObservationDuration
-            ),
+          logger.info("Synchronizer not yet registered, registering and restoring data")
+          restoreData()
+        case Some(conf) if conf.manualConnect == true =>
+          logger.info(
+            "Synchronizer registered but manualConnect=true, assuming we crashed during a prior attempt and trying again"
           )
-          // We rely on the calls here being idempotent
-          for {
-            // Disconnect
-            _ <- participantAdminConnection.disconnectFromAllDomains()
-            _ <- importDars(dars)
-            _ = logger.info("Imported all the dars.")
-            _ <-
-              participantAdminConnection
-                .ensureDomainRegistered(
-                  domainConnectionConfig,
-                  RetryFor.ClientCalls,
-                )
-            _ = logger.info("Importing the ACS")
-            _ <- importAcs(acsSnapshot)
-            _ = logger.info("Imported the ACS")
-            _ <- participantAdminConnection.modifySynchronizerConnectionConfigAndReconnect(
-              synchronizerAlias,
-              config => Some(config.copy(manualConnect = false)),
-            )
-            _ <- ledgerConnection.ensureUserMetadataAnnotation(
-              userId,
-              BaseLedgerConnection.INITIAL_ACS_IMPORT_METADATA_KEY,
-              "true",
-              RetryFor.ClientCalls,
-            )
-          } yield ()
+          restoreData()
         case Some(_) =>
           logger.info("Domain is already registered and ACS is imported")
           participantAdminConnection.connectDomain(synchronizerAlias)

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/domainmigration/DomainMigrationInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/domainmigration/DomainMigrationInitializer.scala
@@ -265,8 +265,6 @@ class DomainMigrationInitializer(
         ),
       )
       _ <- domainDataRestorer.connectDomainAndRestoreData(
-        readOnlyConnection,
-        config.ledgerApiUser,
         synchronizerAlias,
         domainMigrationDump.nodeIdentities.synchronizerId,
         SequencerConnections.single(localSynchronizerNode.sequencerConnection),

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -226,8 +226,6 @@ class ValidatorApp(
                       loggerFactory,
                     )
                     decentralizedSynchronizerInitializer.connectDomainAndRestoreData(
-                      connection,
-                      config.ledgerApiUser,
                       config.domains.global.alias,
                       migrationDump.domainId,
                       sequencerConnections,

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -16,6 +16,12 @@ Upcoming
   - Fix a bug where sends through transfer preapprovals failed with a ``CONTRACT_NOT_FOUND`` ERROR
     if the receiver's provider party was featured.
 
+- Synchronizer Migrations
+
+  - Fix a rare bug where a crash of the validator or SV while trying
+    to restore the data after a migration could result in an
+    inconsistent state being restore.
+
 0.4.2
 -----
 


### PR DESCRIPTION
fixes #465

Ended up just relying on manualConnect and dropping the user metadata. I don't really see what we gain from going through user metadata here. It just seems to make the code more complex and harder to reason about.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
