### PR TITLE
Enable delegateless automation by default once dsoGovernance 0.1.13 is vetted

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -723,7 +723,7 @@
           "enabled": true
         },
         "contactPoint": "sv-support@digitalasset.com",
-        "delegatelessAutomation": false,
+        "delegatelessAutomation": true,
         "disableOnboardingParticipantPromotionDelay": false,
         "domain": {
           "mediatorAddress": "global-domain-3-mediator",

--- a/cluster/pulumi/common/src/automation.ts
+++ b/cluster/pulumi/common/src/automation.ts
@@ -3,16 +3,17 @@
 import { clusterYamlConfig } from 'splice-pulumi-common/src/config/configLoader';
 import { z } from 'zod';
 
+// TODO(#459): remove unused flags
 export const AutomationSchema = z.object({
   automation: z
     .object({
-      delegatelessAutomation: z.boolean().default(false),
+      delegatelessAutomation: z.boolean().default(true),
       expectedTaskDuration: z.number().default(5000),
       expiredRewardCouponBatchSize: z.number().default(100),
     })
     .optional()
     .default({
-      delegatelessAutomation: false,
+      delegatelessAutomation: true,
       expectedTaskDuration: 5000,
       expiredRewardCouponBatchSize: 100,
     }),


### PR DESCRIPTION
fixes #609 

Let's only fully remove the feature flag in #459 to allow us to re-enable elections if needed

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
