### PR TITLE
Remove validator license metadata support

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
@@ -28,12 +28,6 @@ trait PackageVersionSupport {
     )
   }
 
-  def supportsValidatorLicenseMetadata(parties: Seq[PartyId], now: CantonTimestamp)(implicit
-      tc: TraceContext
-  ): Future[FeatureSupport] = {
-    isDarSupported(parties, PackageIdResolver.Package.SpliceAmulet, now, DarResources.amulet_0_1_3)
-  }
-
   def supportsValidatorLicenseActivity(parties: Seq[PartyId], now: CantonTimestamp)(implicit
       tc: TraceContext
   ): Future[FeatureSupport] = {

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/TopologyAwarePackageVersionSupportTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/TopologyAwarePackageVersionSupportTest.scala
@@ -110,12 +110,6 @@ class TopologyAwarePackageVersionSupportTest extends BaseTest with AnyWordSpecLi
   "TopologyAwarePackageVersionSupport" should {
 
     testFeatureSupport(
-      "ValidatorLicenseMetadata",
-      DarResources.amulet_0_1_3,
-      packageVersionSupport.supportsValidatorLicenseMetadata,
-    )
-
-    testFeatureSupport(
       "ValidatorLicenseActivity",
       DarResources.amulet_0_1_3,
       packageVersionSupport.supportsValidatorLicenseActivity,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
@@ -426,8 +426,6 @@ class SvApp(
             config,
             retryProvider,
             logger,
-            clock,
-            packageVersionSupport,
           )
         },
         // Ensure Daml-level invariants for the SV
@@ -528,7 +526,6 @@ class SvApp(
         cometBftClient,
         loggerFactory,
         config.localSynchronizerNode.exists(_.sequencer.isBftSequencer),
-        packageVersionSupport,
       )
 
       adminHandler = new HttpSvAdminHandler(
@@ -1187,8 +1184,6 @@ object SvApp {
       config: SvAppBackendConfig,
       retryProvider: RetryProvider,
       logger: TracedLogger,
-      clock: Clock,
-      packageVersionSupport: PackageVersionSupport,
   )(implicit ec: ExecutionContext, tc: TraceContext): Future[Unit] = {
     val store = dsoStoreWithIngestion.store
     val svParty = store.key.svParty
@@ -1210,31 +1205,22 @@ object SvApp {
             case QueryResult(offset, None) =>
               logger.debug("Trying to create validator license for SV party")
               val dsoParty = store.key.dsoParty
-              for {
-                validatorLicenseMetadataFeatureSupport <- packageVersionSupport
-                  .supportsValidatorLicenseMetadata(
-                    Seq(dsoParty, svParty),
-                    clock.now,
-                  )
-                cmd = dsoRules.exercise(
-                  _.exerciseDsoRules_OnboardValidator(
-                    svParty.toProtoPrimitive,
-                    svParty.toProtoPrimitive,
-                    Some(BuildInfo.compiledVersion)
-                      .filter(_ => validatorLicenseMetadataFeatureSupport.supported)
-                      .toJava,
-                    Some(config.contactPoint)
-                      .filter(_ => validatorLicenseMetadataFeatureSupport.supported)
-                      .toJava,
-                  )
+              val cmd = dsoRules.exercise(
+                _.exerciseDsoRules_OnboardValidator(
+                  svParty.toProtoPrimitive,
+                  svParty.toProtoPrimitive,
+                  Some(BuildInfo.compiledVersion).toJava,
+                  Some(config.contactPoint).toJava,
                 )
+              )
+
+              for {
                 _ <- dsoStoreWithIngestion.connection
                   .submit(
                     actAs = Seq(svParty),
                     readAs = Seq(dsoParty),
                     cmd,
                   )
-                  .withPreferredPackage(validatorLicenseMetadataFeatureSupport.packageIds)
                   .withDedup(
                     commandId = SpliceLedgerConnection.CommandId(
                       "org.lfdecentralizedtrust.splice.sv.createSvValidatorLicense",

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
@@ -209,7 +209,6 @@ class ValidatorAutomationService(
       connection,
       store,
       contactPoint,
-      packageVersionSupport,
     )
   )
 


### PR DESCRIPTION
[ci]

The feature check checks on amulet but in some cases we exercise a dso-governance choice which then doesn't work properly. I considered fixing it but the version that this matters for is so ancient that just deleting it seems like the better option.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
