### PR TITLE
Bump base version for ciperiodic migration tests

### DIFF
--- a/build-tools/find_latest_hard_migration_base_version.sh
+++ b/build-tools/find_latest_hard_migration_base_version.sh
@@ -8,5 +8,6 @@
 
 set -euo pipefail
 
-latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
-echo "release-line-${latest_release}"
+# TODO(DACH-NY/canton-network-interna#713) Reset back to latest_release after the release is cut
+# latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
+echo "release-line-0.4.4-snapshot.20250630.283.0.v06bbc9ce"


### PR DESCRIPTION
Needed due to the acs export/import change.

creating the release branch from the commit which hopefully wroks

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
