### PR TITLE
use temp functions instead of stored procedures

### DIFF
--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -11,10 +11,6 @@ DECLARE
   current_supply_total,
   allowed_mint,
   burned bignumeric;
-DECLARE
-  TransferResult_summary string;
-SET
-    TransferResult_summary = '$.record.fields[1].value.record.fields';
 
 CREATE TEMP FUNCTION
   iso_timestamp(iso8601_string string)
@@ -95,6 +91,10 @@ CREATE TEMP FUNCTION unminted(
     migration_id));
 
 
+CREATE TEMP FUNCTION TransferResult_summary(suffix string)
+    RETURNS string AS ('$.record.fields[1].value.record.fields' || suffix);
+
+
 -- All Amulet that was ever minted.
 CREATE TEMP FUNCTION minted(
     as_of_record_time timestamp,
@@ -103,13 +103,13 @@ CREATE TEMP FUNCTION minted(
 SELECT
   SUM(PARSE_BIGNUMERIC(JSON_VALUE(e.result,
                                   -- .inputAppRewardAmount
-                                  TransferResult_summary || '[0].value.numeric'))
+                                  TransferResult_summary('[0].value.numeric')))
     + PARSE_BIGNUMERIC(JSON_VALUE(e.result,
                                   -- .inputValidatorRewardAmount
-                                  TransferResult_summary || '[1].value.numeric'))
+                                  TransferResult_summary('[1].value.numeric')))
     + PARSE_BIGNUMERIC(JSON_VALUE(e.result,
                                   -- .inputSvRewardAmount
-                                  TransferResult_summary || '[2].value.numeric')))
+                                  TransferResult_summary('[2].value.numeric'))))
 FROM
   mainnet_da2_scan.scan_sv_1_update_history_exercises e
 WHERE

--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -123,7 +123,7 @@ WHERE
 
 -- fees from a Splice.AmuletRules:TransferResult
 CREATE TEMP FUNCTION
-    transferresult_fees(tr_json string)
+    transferresult_fees(tr_json json)
                        RETURNS bignumeric AS (-- .summary.holdingFees
     PARSE_BIGNUMERIC(JSON_VALUE(tr_json, '$.record.fields[1].value.record.fields[5].value.numeric'))
     -- .summary.senderChangeFee
@@ -137,7 +137,7 @@ CREATE TEMP FUNCTION
 
 CREATE TEMP FUNCTION
     result_burn(choice string,
-                   result string)
+                result json)
                RETURNS bignumeric AS (CASE choice
       WHEN 'AmuletRules_BuyMemberTraffic' THEN -- Coin Burnt for Purchasing Traffic on the Synchronizer
     -- AmuletRules_BuyMemberTrafficResult

--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -34,13 +34,13 @@ SET
   SELECT
     COALESCE(SUM(PARSE_BIGNUMERIC(JSON_VALUE(c.create_arguments, path))), 0)
   FROM
-    experiment_dataset.creates c
+    mainnet_da2_scan.scan_sv_1_update_history_creates c
   WHERE
     NOT EXISTS (
     SELECT
       TRUE
     FROM
-      experiment_dataset.exercises e
+      mainnet_da2_scan.scan_sv_1_update_history_exercises e
     WHERE
       (e.migration_id < migration_id
         OR (e.migration_id = migration_id
@@ -138,7 +138,7 @@ SET
     + PARSE_BIGNUMERIC(JSON_VALUE(e.result, inputValidatorRewardAmount))
     + PARSE_BIGNUMERIC(JSON_VALUE(e.result, inputSvRewardAmount)))
 FROM
-  experiment_dataset.exercises e
+  mainnet_da2_scan.scan_sv_1_update_history_exercises e
 WHERE
   e.choice = 'AmuletRules_Transfer'
   AND e.template_id_module_name = 'Splice.AmuletRules'
@@ -209,7 +209,7 @@ CREATE TEMP FUNCTION burned(
                   SUM(result_burn(e.choice,
                                   e.result)) fees
               FROM
-                  experiment_dataset.exercises e
+                  mainnet_da2_scan.scan_sv_1_update_history_exercises e
               WHERE
                   ((e.choice IN ('AmuletRules_BuyMemberTraffic',
                                  'AmuletRules_Transfer',
@@ -226,8 +226,8 @@ CREATE TEMP FUNCTION burned(
               SELECT
                   SUM(PARSE_BIGNUMERIC(JSON_VALUE(c.create_arguments, '$.record.fields[2].value.record.fields[0].value.numeric'))) fees -- .amount.initialAmount
               FROM
-                  experiment_dataset.exercises e,
-                  experiment_dataset.creates c
+                  mainnet_da2_scan.scan_sv_1_update_history_exercises e,
+                  mainnet_da2_scan.scan_sv_1_update_history_creates c
               WHERE
                   ((e.choice = 'SubscriptionInitialPayment_Collect'
                       AND e.template_id_entity_name = 'SubscriptionInitialPayment'

--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -244,13 +244,13 @@ CREATE TEMP FUNCTION burned(
 
 
 -- using the functions
-SET as_of_record_time = iso_timestamp('2025-03-10T00:00:00Z');
-SET migration_id = 4;
-CALL experiment_dataset.locked(locked, as_of_record_time, migration_id);
-CALL experiment_dataset.unlocked(unlocked, as_of_record_time, migration_id);
-CALL experiment_dataset.unminted(unminted, as_of_record_time, migration_id);
-CALL experiment_dataset.minted(minted, as_of_record_time, migration_id);
-CALL experiment_dataset.burned(burned, as_of_record_time, migration_id);
+SET as_of_record_time = iso_timestamp('2025-07-01T00:00:00Z');
+SET migration_id = 3;
+SET locked = locked(as_of_record_time, migration_id);
+SET unlocked = unlocked(as_of_record_time, migration_id);
+SET unminted = unminted(as_of_record_time, migration_id);
+SET minted = minted(as_of_record_time, migration_id);
+SET burned = burned(as_of_record_time, migration_id);
 SET current_supply_total = locked + unlocked;
 SET allowed_mint = unminted + minted;
 SELECT

--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -169,7 +169,7 @@ CREATE TEMP FUNCTION
 -- Amulet burned via fees.
 CREATE TEMP FUNCTION burned(
     as_of_record_time timestamp,
-                              migration_id int64
+                              migration_id_arg int64
   ) RETURNS bignumeric AS ((
     SELECT
         SUM(fees)
@@ -188,8 +188,8 @@ CREATE TEMP FUNCTION burned(
                       OR (e.choice = 'TransferPreapproval_Renew'
                           AND e.template_id_entity_name = 'TransferPreapproval'))
                 AND e.template_id_module_name = 'Splice.AmuletRules'
-                AND (e.migration_id < migration_id
-                  OR (e.migration_id = migration_id
+                AND (e.migration_id < migration_id_arg
+                  OR (e.migration_id = migration_id_arg
                       AND e.record_time <= UNIX_MICROS(as_of_record_time))))
           UNION ALL (-- Purchasing ANS Entries
               SELECT
@@ -207,8 +207,8 @@ CREATE TEMP FUNCTION burned(
                 AND e.template_id_module_name = 'Splice.Wallet.Subscriptions'
                 AND c.template_id_module_name = 'Splice.Amulet'
                 AND c.template_id_entity_name = 'Amulet'
-                AND (e.migration_id < migration_id
-                  OR (e.migration_id = migration_id
+                AND (e.migration_id < migration_id_arg
+                  OR (e.migration_id = migration_id_arg
                       AND e.record_time <= UNIX_MICROS(as_of_record_time)))))));
 
 


### PR DESCRIPTION
Fixes #1265. Also changes the dataset and table names to match Pulumi, so you can actually run these as-is, and cleans up the indentation as the auto-indent in Studio has some weird cases.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
