### PR TITLE
Only auto-assign PRs from forks if they don't already have assignees

### DIFF
--- a/.github/workflows/assign_fork_prs.yml
+++ b/.github/workflows/assign_fork_prs.yml
@@ -9,14 +9,17 @@ jobs:
     runs-on: self-hosted-docker-tiny
     if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - name: Add labels to PRs from forks
+      - name: Assign PR from fork
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const pr = context.payload.pull_request;
-            await github.rest.issues.addAssignees({
-              issue_number: pr.number,
-              owner: pr.base.repo.owner.login,
-              repo: pr.base.repo.name,
-              assignees: ['isegall-da', 'martinflorian-da', 'ray-roestenburg-da'],
-            });
+            // Only add assignees if the PR isn't already assigned to someone
+            if (!pr.assignee && !pr.assignees.length) {
+              await github.rest.issues.addAssignees({
+                issue_number: pr.number,
+                owner: pr.base.repo.owner.login,
+                repo: pr.base.repo.name,
+                assignees: ['isegall-da', 'martinflorian-da', 'ray-roestenburg-da'],
+              });
+            }


### PR DESCRIPTION
Otherwise it seems like we're added back as assignees whenever a PR is edited.

I prefer to unassign myself from PRs that are already shepherded by someone, so they stop showing up in my `gh status` and other overviews.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
