### PR TITLE
fix TimeBasedTestNetPreviewIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
@@ -40,7 +40,7 @@ class TimeBasedTestNetPreviewIntegrationTest
       _ => {
         sv1WalletClient.balance().unlockedQty should be > BigDecimal(0)
         forAll(Seq(1,2)) { round =>
-            ensureNoSvRewardCouponExistsForRound(round, sv1WalletClient)
+            ensureNoSvRewardCouponExistsForRound(round.toLong, sv1WalletClient)
         }
       },
     )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
@@ -36,11 +36,11 @@ class TimeBasedTestNetPreviewIntegrationTest
         }
       },
     )(
-      "Wait for SV rewards for rounds 1&2 to be collected",
+      "Wait for SV rewards for rounds 0&1 to be collected",
       _ => {
         sv1WalletClient.balance().unlockedQty should be > BigDecimal(0)
-        forAll(Seq(1,2)) { round =>
-            ensureNoSvRewardCouponExistsForRound(round.toLong, sv1WalletClient)
+        forAll(Seq(0, 1)) { round =>
+          ensureNoSvRewardCouponExistsForRound(round.toLong, sv1WalletClient)
         }
       },
     )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
@@ -36,9 +36,14 @@ class TimeBasedTestNetPreviewIntegrationTest
         }
       },
     )(
-      "Wait for SV rewards to be collected",
+      "Wait for SV rewards for rounds 1&2 to be collected",
       _ => {
         sv1WalletClient.balance().unlockedQty should be > BigDecimal(0)
+        (1 to 2).foreach { _ =>
+          eventually() {
+            ensureNoSvRewardCouponExistsForRound(_, sv1WalletClient)
+          }
+        }
       },
     )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TimeBasedTestNetPreviewIntegrationTest.scala
@@ -39,10 +39,8 @@ class TimeBasedTestNetPreviewIntegrationTest
       "Wait for SV rewards for rounds 1&2 to be collected",
       _ => {
         sv1WalletClient.balance().unlockedQty should be > BigDecimal(0)
-        (1 to 2).foreach { _ =>
-          eventually() {
-            ensureNoSvRewardCouponExistsForRound(_, sv1WalletClient)
-          }
+        forAll(Seq(1,2)) { round =>
+            ensureNoSvRewardCouponExistsForRound(round, sv1WalletClient)
         }
       },
     )


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4739

Quite amazing that we still have corner cases in these tests....
I believe what happened is that there's two rounds to collect rewards for. As soon as one is collected, balance > 0 and we proceed, so we query the balance, do a transfer, and assert that new balance is previous one - transfered amount, but in this run the second collection came after we queried the balance, thus the balance was higher than expected after the transfer.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
