### PR TITLE
YAML-configurable GCP log alerts

### DIFF
--- a/cluster/deployment/config.yaml
+++ b/cluster/deployment/config.yaml
@@ -49,3 +49,54 @@ monitoring:
         expectedMaxBlocksPerSecond: 3.5
       loadTester:
         minRate: 0.95
+    logAlerts:
+      shared: |
+        severity>=WARNING
+        resource.type="k8s_container"
+        -- Note that we ignore the validator runbook. This is because we reset it periodically, which sometimes produces noise.
+        resource.labels.namespace_name=~"sv|validator1|multi-validator|splitwell"
+        -(resource.labels.container_name=~"participant" AND jsonPayload.message=~"Instrument .* has recorded multiple values for the same attributes.")
+        -- https://github.com/DACH-NY/canton-network-node/issues/10475
+        -(resource.labels.container_name="cometbft" AND
+          (   jsonPayload.err=~"\Aerror adding vote\z|\Aalready stopped\z|use of closed network connection"
+           OR jsonPayload._msg=~"\A(Stopping peer for error|Stopped accept routine, as transport is closed|Failed to write PacketMsg|Connection failed @ sendRoutine)\z"
+           OR jsonPayload.error="already stopped"
+           OR textPayload="cp: not replacing '/cometbft/data/priv_validator_state.json'"
+           OR (jsonPayload._msg="Error stopping connection" AND jsonPayload.err="already stopped")
+           OR jsonPayload._msg="Error adding peer to new bucket"))
+        -- execution context overload
+        -jsonPayload.message=~"Task runner canton-env-ec is .* overloaded"
+        -- on startup
+        -textPayload=~"Picked up JAVA_TOOL_OPTIONS:"
+        -- \A and \z anchor a search (=~) at beginning/end of string, respectively
+        -- regex is significantly faster than OR; gcp docs themselves recommend
+        -- regex-based factoring
+        -resource.labels.container_name=~"\A(ans|wallet|scan|sv|splitwell)-web-ui\z"
+        -- sequencer down
+        -(resource.labels.namespace_name=~"validator|splitwell"
+          AND resource.labels.container_name=~"participant"
+          AND jsonPayload.message=~"SEQUENCER_SUBSCRIPTION_LOST|Request failed for sequencer|Sequencer shutting down|Submission timed out|Response message for request .* timed out |periodic acknowledgement failed|Token refresh failed with Status{code=UNAVAILABLE")
+        -(resource.labels.container_name="postgres-exporter" AND jsonPayload.msg=~"Error loading config|Excluded databases")
+        -jsonPayload.message=~"UnknownHostException"
+        -(resource.labels.container_name=~"participant|mediator" AND jsonPayload.message=~"Late processing \(or clock skew\) of batch")
+        -(resource.labels.container_name="sequencer" AND jsonPayload.stack_trace=~"UnresolvedAddressException")
+        -(resource.labels.container_name="sequencer-pg" AND
+          ("checkpoints are occurring too frequently" OR "Consider increasing the configuration parameter \"max_wal_size\"."))
+        -(resource.labels.container_name=~"participant" AND
+          jsonPayload.message=~"SYNC_SERVICE_ALARM.*Received a request.*where the view.*has (missing|extra) recipients|LOCAL_VERDICT_MALFORMED_PAYLOAD.*Rejected transaction due to malformed payload within views.*WrongRecipients|channel.*shutdown did not complete gracefully in allotted|LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*: UnvettedPackages")
+        -(resource.labels.container_name="mediator" AND
+          jsonPayload.message=~"MEDIATOR_RECEIVED_MALFORMED_MESSAGE.*(Reason: (Missing root hash message for informee participants|Superfluous root hash message)|Received a (mediator|confirmation) response.*with an invalid root hash)")
+        -(jsonPayload.logger_name=~"c.d.n.a.AdminAuthExtractor:" AND jsonPayload.message=~"Authorization Failed")
+        -(jsonPayload.level="error" AND jsonPayload.msg=~"/readyz")
+        -- The prometheus export server does not wait for any ongoing requests when shutting down https://github.com/prometheus/client_java/issues/938
+        -jsonPayload.message="The Prometheus metrics HTTPServer caught an Exception while trying to send the metrics response."
+        -- istio-proxy is spammy with warnings
+        -(resource.labels.container_name="istio-proxy" AND severity<ERROR)
+        -resource.labels.container_name="postgres"
+        -(resource.labels.container_name=~"postgres" AND resource.labels.namespace_name="multi-validator")
+        -- TODO(DACH-NY/canton-network-internal#412): Remove this once we have improved our sv onboarding logic
+        -(resource.labels.container_name="sv-app" AND jsonPayload.stack_trace=~"io.grpc.StatusRuntimeException: FAILED_PRECONDITION: UNHANDLED_EXCEPTION.*SV party has not yet operated a node")
+        -- TODO(#695): Don't just ignore this - investigate!
+        -(resource.labels.container_name="splitwell-app" AND jsonPayload.message=~"Waiting for domain Domain 'global' to be connected has not completed after")
+        -- TODO(#911): Our apps can't handle ingesting bursts of transactions after delays due to the record order publisher
+        -(jsonPayload.message=~"signalWhenIngested.* has not completed after .* milliseconds")

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -38,6 +38,10 @@ const MonitoringConfigSchema = z.object({
         minRate: z.number(),
       }),
     }),
+    logAlerts: z.object({
+      shared: z.string(),
+      clusterSpecific: z.string().optional(),
+    }),
   }),
 });
 export const InfraConfigSchema = z.object({

--- a/cluster/pulumi/infra/src/gcpAlerts.ts
+++ b/cluster/pulumi/infra/src/gcpAlerts.ts
@@ -12,6 +12,7 @@ import {
 } from 'splice-pulumi-common';
 
 import { slackToken } from './alertings';
+import { monitoringConfig } from './config';
 
 const enableChaosMesh = config.envFlag('ENABLE_CHAOS_MESH');
 const disableReplayWarnings = config.envFlag('DISABLE_REPLAY_WARNINGS');
@@ -40,56 +41,8 @@ export function installGcpLoggingAlerts(
   const logWarningsMetric = new gcp.logging.Metric('log_warnings', {
     name: `log_warnings_${CLUSTER_BASENAME}`,
     description: 'Logs with a severity level of warning or above',
-    filter: `severity>=WARNING
-resource.type="k8s_container"
-resource.labels.cluster_name="${CLUSTER_NAME}"
--- Note that we ignore the validator runbook. This is because we reset it periodically, which sometimes produces noise.
-resource.labels.namespace_name=~"sv|validator1|multi-validator|splitwell"
--(resource.labels.container_name=~"participant" AND jsonPayload.message=~"Instrument .* has recorded multiple values for the same attributes.")
--- https://github.com/DACH-NY/canton-network-node/issues/10475
--(resource.labels.container_name="cometbft" AND
-  (   jsonPayload.err=~"\\Aerror adding vote\\z|\\Aalready stopped\\z|use of closed network connection"
-   OR jsonPayload._msg=~"\\A(Stopping peer for error|Stopped accept routine, as transport is closed|Failed to write PacketMsg|Connection failed @ sendRoutine)\\z"
-   OR jsonPayload.error="already stopped"
-   OR textPayload="cp: not replacing '/cometbft/data/priv_validator_state.json'"
-   OR (jsonPayload._msg="Error stopping connection" AND jsonPayload.err="already stopped")
-   OR jsonPayload._msg="Error adding peer to new bucket"))
--- execution context overload
--jsonPayload.message=~"Task runner canton-env-ec is .* overloaded"
--- on startup
--textPayload=~"Picked up JAVA_TOOL_OPTIONS:"
--- \\A and \\z anchor a search (=~) at beginning/end of string, respectively
--- regex is significantly faster than OR; gcp docs themselves recommend
--- regex-based factoring
--resource.labels.container_name=~"\\A(ans|wallet|scan|sv|splitwell)-web-ui\\z"
--- sequencer down
--(resource.labels.namespace_name=~"validator|splitwell"
-  AND resource.labels.container_name=~"participant"
-  AND jsonPayload.message=~"SEQUENCER_SUBSCRIPTION_LOST|Request failed for sequencer|Sequencer shutting down|Submission timed out|Response message for request .* timed out |periodic acknowledgement failed|Token refresh failed with Status{code=UNAVAILABLE")
--(resource.labels.container_name="postgres-exporter" AND jsonPayload.msg=~"Error loading config|Excluded databases")
--jsonPayload.message=~"UnknownHostException"
--(resource.labels.container_name=~"participant|mediator" AND jsonPayload.message=~"Late processing \\(or clock skew\\) of batch")
--(resource.labels.container_name="sequencer" AND jsonPayload.stack_trace=~"UnresolvedAddressException")
--(resource.labels.container_name="sequencer-pg" AND
-  ("checkpoints are occurring too frequently" OR "Consider increasing the configuration parameter \\"max_wal_size\\"."))
--(resource.labels.container_name=~"participant" AND
-  jsonPayload.message=~"SYNC_SERVICE_ALARM.*Received a request.*where the view.*has (missing|extra) recipients|LOCAL_VERDICT_MALFORMED_PAYLOAD.*Rejected transaction due to malformed payload within views.*WrongRecipients|channel.*shutdown did not complete gracefully in allotted|LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*: UnvettedPackages")
--(resource.labels.container_name="mediator" AND
-  jsonPayload.message=~"MEDIATOR_RECEIVED_MALFORMED_MESSAGE.*(Reason: (Missing root hash message for informee participants|Superfluous root hash message)|Received a (mediator|confirmation) response.*with an invalid root hash)")
--(jsonPayload.logger_name=~"c.d.n.a.AdminAuthExtractor:" AND jsonPayload.message=~"Authorization Failed")
--(jsonPayload.level="error" AND jsonPayload.msg=~"/readyz")
--- The prometheus export server does not wait for any ongoing requests when shutting down https://github.com/prometheus/client_java/issues/938
--jsonPayload.message="The Prometheus metrics HTTPServer caught an Exception while trying to send the metrics response."
--- istio-proxy is spammy with warnings
--(resource.labels.container_name="istio-proxy" AND severity<ERROR)
--resource.labels.container_name="postgres"
--(resource.labels.container_name=~"postgres" AND resource.labels.namespace_name="multi-validator")
--- TODO(DACH-NY/canton-network-internal#412): Remove this once we have improved our sv onboarding logic
--(resource.labels.container_name="sv-app" AND jsonPayload.stack_trace=~"io.grpc.StatusRuntimeException: FAILED_PRECONDITION: UNHANDLED_EXCEPTION.*SV party has not yet operated a node")
--- TODO(#695): Don't just ignore this - investigate!
--(resource.labels.container_name="splitwell-app" AND jsonPayload.message=~"Waiting for domain Domain 'global' to be connected has not completed after")
--- TODO(#911): Our apps can't handle ingesting bursts of transactions after delays due to the record order publisher
--(jsonPayload.message=~"signalWhenIngested.* has not completed after .* milliseconds")
+    filter: `resource.labels.cluster_name="${CLUSTER_NAME}"
+${monitoringConfig.alerting.logAlerts.shared}
 ${conditionalString(
   isDevNet,
   "-- TODO(DACH-NY/canton-network-internal#475): Failing for all kinds of sequencer and CometBFT-related reasons; let's reevaluate on Canton 3.3\n" +


### PR DESCRIPTION
Refactors `installGcpLoggingAlerts` by introducing the `monitoring.alerting.logAlerts` config, with `shared` in the common file and `clusterSpecific` in the individual cluster configs.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
