### PR TITLE
Fix ignores related to sending ACS commitments to revoked counterparties

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -90,8 +90,6 @@ INVALID_TRAFFIC_CONTROL_PURCHASED_MESSAGE.* signature threshold not reached
 # In ValidatorReonboardingIntegrationTest, importing the ACS on the new participant may lead to temporary ACS_COMMITMENT_MISMATCH errors.
 # The new participant can be both the sender or the counterParticipant in the error message.
 ACS_COMMITMENT_MISMATCH.*aliceValidatorLocalNewForValidatorReonboardingIT
-# TODO(#897): Remove once it's fixed
-Failed to send commitment message batch for period.*RequestInvalid\(Unregistered recipients: HashSet\(PAR::alice-validatorLocalForValidatorReonboardingIT
 
 # TODO(#970): figure out why this happens, as in principle the confirmations from three of the mediators and counter-participants should be sufficient
 Response message for request.*timed out.*c.d.c.p.p.TransactionProcessor:participant=sv
@@ -100,9 +98,10 @@ Response message for request.*timed out.*c.d.c.p.p.TransactionProcessor:particip
 The operation 'insert block' has failed with an exception
 Now retrying operation 'insert block'
 
-# TODO(#737): investigate why it happens and remove if possible
+# TODO(tech-debt): Remove these once we're on Canton 3.4
+Failed to send commitment message batch for period.*RequestInvalid\(Unregistered recipients:.*Set\(PAR::(?:validatorLocalForValidatorReonboardingIT|da-ComposeValidator-1)
 Failed to send commitment message batch for period CommitmentPeriod.*RequestRefused\(UnknownRecipients
-SEQUENCER_UNKNOWN_RECIPIENTS.*validatorLocalForValidatorReonboardingIT
+SEQUENCER_UNKNOWN_RECIPIENTS.*(?:validatorLocalForValidatorReonboardingIT|da-ComposeValidator-1)
 
 # TODO(#919) Figure out where this is coming from
 Instrument rpc\.server\.duration has exceeded the maximum allowed cardinality


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4828

Main issue is https://github.com/hyperledger-labs/splice/issues/897 - fixed for Canton 3.4 but not backported to 3.3 AFAICT.

The ignore was also only covering one of the tests where this can happen.

Tested changes locally; correctly ignores the new error.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
