### PR TITLE
[static] Use a slimmer pulumi image for the operator workspaces

### DIFF
--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -220,7 +220,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -549,7 +549,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -828,7 +828,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -1522,7 +1522,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -1801,7 +1801,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -2080,7 +2080,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -2371,7 +2371,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -2662,7 +2662,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -2943,7 +2943,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -3224,7 +3224,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -3517,7 +3517,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -3810,7 +3810,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -4091,7 +4091,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -4372,7 +4372,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {
@@ -4651,7 +4651,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -254,7 +254,7 @@
                 }
               }
             ],
-            "image": "pulumi/pulumi:3.147.0-nonroot",
+            "image": "pulumi/pulumi-nodejs-22:3.147.0-nonroot",
             "podTemplate": {
               "spec": {
                 "affinity": {

--- a/cluster/pulumi/common/src/operator/stack.ts
+++ b/cluster/pulumi/common/src/operator/stack.ts
@@ -289,6 +289,7 @@ function createStackCRV2(
   // required because the docker images are broken
   // TODO(#15978): remove this once pulumi is upgraded
   const minimumPulumiVersionRequired = '3.147.0';
+  const [nodejsVersion] = process.versions.node.split('.');
   return new k8s.apiextensions.CustomResource(
     name,
     {
@@ -363,7 +364,7 @@ function createStackCRV2(
               deletionGracePeriodSeconds: PulumiOperatorGracePeriod,
             },
             spec: {
-              image: `pulumi/pulumi:${semver.gt(pulumiVersion, minimumPulumiVersionRequired) ? pulumiVersion : minimumPulumiVersionRequired}-nonroot`,
+              image: `pulumi/pulumi-nodejs-${nodejsVersion}:${semver.gt(pulumiVersion, minimumPulumiVersionRequired) ? pulumiVersion : minimumPulumiVersionRequired}-nonroot`,
               env: [
                 {
                   name: 'CN_PULUMI_LOAD_ENV_CONFIG_FILE',


### PR DESCRIPTION
nodejs specific, based on our nodejs version

tried to find a way to log json but failed 


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
