### PR TITLE
Fix migrations for SV validators

### DIFF
--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -152,7 +152,8 @@ class ValidatorApp(
           )
         case None =>
           UpdateHistory.getHighestKnownMigrationId(storage).flatMap {
-            case Some(migrationId) if migrationId < config.domainMigrationId =>
+            case Some(migrationId)
+                if !config.svValidator && migrationId < config.domainMigrationId =>
               throw Status.INVALID_ARGUMENT
                 .withDescription(
                   s"Migration ID was incremented (to ${config.domainMigrationId}) but no migration dump for restoring from was specified."


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4829

Bug was introduced in https://github.com/hyperledger-labs/splice/pull/1297

This was not caught in our `DecentralizedSynchronizerMigrationIntegrationTest` because we don't migrate SV2's validator there. Extending the (already slow and complex) test to do so doesn't seem worthwhile to me though; also as we plan to phase out synchronizer migrations entirely in the not-too-long term.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
