### PR TITLE
[ci] Fix issue where multiple caches could've been created in tests

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -87,9 +87,6 @@ unexpected exception: Task slick.*rejected from slick.util.AsyncExecutorWithMetr
 # TODO (#944): investigate what task is it still running and see if we can somehow fix it
 Timeout 10 seconds expired, but tasks still running. Shutting down forcibly
 
-# TODO (#939): we don't close cache metrics created by DbScanStoreMetrics
-Instrument daml.cache.* has recorded multiple values for the same attributes
-
 Consensus not reached.*BftScanConnection:BftScanConnectionTest.*
 
 # internal selenium error. Potentially intermittent


### PR DESCRIPTION
The root cause is that TrieMap.getOrUpdate guarantees that it returns the same element all the time but the function passed to generate the element can be called multiple times. 
This in turn was creating multiple caches, that wouldn't have been an issue but the underlying gauges would have never been GCd because they are referenced by the metrics infra to read the values. 

The new implementation is safe because the gauges are registered only as a final step when creating the cache, so if we use a single instance of CacheMetrics to register it as cache metrics we're safe.


Should fix https://github.com/DACH-NY/cn-test-failures/issues/4843 :crossed_fingers: 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
