### PR TITLE
[canton-3.4] Trim down test sources

### DIFF
--- a/project/BuildCommon.scala
+++ b/project/BuildCommon.scala
@@ -782,6 +782,13 @@ object BuildCommon {
         `canton-ledger-common` % "compile->compile;test->test",
       )
       .settings(
+        removeTestSources,
+        // We only need 3 files out of a lot of test files so add them explicitly
+        Test / managedSources := Seq(
+          (Test / sourceDirectory).value / "scala/com/digitalasset/canton/HasActorSystem.scala",
+          (Test / sourceDirectory).value / "scala/com/digitalasset/canton/store/db/DbTest.scala",
+          (Test / sourceDirectory).value / "scala/com/digitalasset/canton/store/db/DbStorageIdempotency.scala",
+        ),
         disableTests,
         sharedCantonSettings,
         libraryDependencies ++= Seq(
@@ -1181,6 +1188,7 @@ object BuildCommon {
         `canton-ledger-api`,
       )
       .settings(
+        removeTestSources,
         sharedCantonSettings,
         disableTests,
         sharedSettings,
@@ -1255,6 +1263,7 @@ object BuildCommon {
         ScalafmtPlugin,
       ) // to accommodate different daml repo coding style
       .settings(
+        removeTestSources,
         sharedCantonSettings,
         sharedSettings,
         scalacOptions += "-Wconf:src=src_managed/.*:silent",
@@ -1410,6 +1419,10 @@ object BuildCommon {
         `canton-ledger-api`
       )
       .settings(
+        removeTestSources,
+        Test / managedSources := Seq(
+          (Test / sourceDirectory).value / "scala/com/daml/ledger/javaapi/data/Generators.scala"
+        ),
         sharedCantonSettings,
         Test / unmanagedSources :=
           (Test / unmanagedSources).value.filter(_.getName == "Generators.scala"),


### PR DESCRIPTION
A few less things to worry about conflicts or getting to compile on upgrades



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
