### PR TITLE
Fix `cncluster debug_shell` version selection

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -1422,10 +1422,13 @@ subcommand_whitelist[debug_shell]='Spin up a debug container on the cluster, and
 function subcmd_debug_shell() {
   _cluster_must_exist
 
-  VERSION_NUMBER=$(get-snapshot-version)
+  VERSION_NUMBER=${OVERRIDE_VERSION:-$(yq ".synchronizerMigration.active.version" < config.yaml)}
+  if [ -z "$VERSION_NUMBER" ] || [ "$VERSION_NUMBER" = "null" ]; then
+    VERSION_NUMBER=$(get-snapshot-version)
+  fi
   repo="ghcr.io/digital-asset/decentralized-canton-sync-dev/docker"
 
-  _info "Deploying debug pod"
+  _info "Deploying debug pod on version $VERSION_NUMBER"
   kubectl apply --wait -f - <<EOF
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Current cluster version is a better default than `get-snapshot-version` version.

Keeping the snapshot version for clusters with no useful `config.yaml`.

Tested locally.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
