### PR TITLE
Check both amulet and dso governance in merge validator license trigger

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
@@ -45,12 +45,18 @@ trait PackageVersionSupport {
     )
   }
 
-  def supportsMergeDuplicatedValidatorLicense(parties: Seq[PartyId], now: CantonTimestamp)(implicit
+  def supportsMergeDuplicatedValidatorLicense(
+      dsoGovernanceParties: Seq[PartyId],
+      amuletParties: Seq[PartyId],
+      now: CantonTimestamp,
+  )(implicit
       tc: TraceContext
   ): Future[FeatureSupport] = {
     isDarSupported(
-      parties,
-      PackageIdResolver.Package.SpliceDsoGovernance,
+      Seq(
+        (PackageIdResolver.Package.SpliceDsoGovernance -> dsoGovernanceParties),
+        (PackageIdResolver.Package.SpliceAmulet -> amuletParties),
+      ),
       now,
       DarResources.dsoGovernance_0_1_8,
     )
@@ -136,15 +142,21 @@ trait PackageVersionSupport {
       packageId: PackageIdResolver.Package,
       at: CantonTimestamp,
       dar: DarResource,
-  )(implicit tc: TraceContext) = {
-    require(packageId.packageName == dar.metadata.name)
-    require(parties.nonEmpty)
-    isPackageSupported(parties, packageId, at, dar.metadata)
+  )(implicit tc: TraceContext): Future[FeatureSupport] =
+    isDarSupported(Seq(packageId -> parties), at, dar)
+
+  private def isDarSupported(
+      packageRequirements: Seq[(PackageIdResolver.Package, Seq[PartyId])],
+      at: CantonTimestamp,
+      dar: DarResource,
+  )(implicit tc: TraceContext): Future[FeatureSupport] = {
+    require(packageRequirements.exists(_._1.packageName == dar.metadata.name))
+    require(packageRequirements.forall(_._2.nonEmpty))
+    isPackageSupported(packageRequirements, at, dar.metadata)
   }
 
   def isPackageSupported(
-      parties: Seq[PartyId],
-      packageId: PackageIdResolver.Package,
+      packageRequirements: Seq[(PackageIdResolver.Package, Seq[PartyId])],
       at: CantonTimestamp,
       metadata: Ast.PackageMetadata,
   )(implicit
@@ -160,25 +172,25 @@ class TopologyAwarePackageVersionSupport private[environment] (
     extends PackageVersionSupport {
 
   override def isPackageSupported(
-      parties: Seq[PartyId],
-      packageId: PackageIdResolver.Package,
+      packageRequirements: Seq[(PackageIdResolver.Package, Seq[PartyId])],
       at: CantonTimestamp,
       metadata: Ast.PackageMetadata,
   )(implicit tc: TraceContext): Future[FeatureSupport] = {
     connection
       .getSupportedPackageVersion(
         synchronizerId,
-        parties,
-        packageId.packageName,
+        packageRequirements.map({ case (k, v) => k.packageName -> v }),
         at,
       )
-      .map { optionalPackageReference =>
-        val isFeatureSupported = optionalPackageReference.exists { packageReference =>
-          PackageVersion.assertFromString(packageReference.packageVersion) >= metadata.version
+      .map { packageReferences =>
+        val isFeatureSupported = packageReferences.exists { packageReference =>
+          PackageVersion.assertFromString(
+            packageReference.packageVersion
+          ) >= metadata.version && packageReference.packageName == metadata.name
         }
         FeatureSupport(
           supported = isFeatureSupported,
-          optionalPackageReference.map(_.packageId).toList,
+          packageReferences.map(_.packageId).toList,
         )
       }
   }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -604,17 +604,15 @@ class BaseLedgerConnection(
 
   def getSupportedPackageVersion(
       synchronizerId: SynchronizerId,
-      parties: Seq[PartyId],
-      packageName: String,
+      packageRequirements: Seq[(String, Seq[PartyId])],
       vettingAsOfTime: CantonTimestamp,
-  )(implicit tc: TraceContext): Future[Option[PackageReference]] = {
+  )(implicit tc: TraceContext): Future[Seq[PackageReference]] = {
     retryProvider.retryForClientCalls(
       "get_supported_package_version",
-      s"Get the supported package version for package $packageName on synchronizer $synchronizerId and parties $parties with vetting time ${vettingAsOfTime}",
+      s"Get the supported package version for packageRequirements $packageRequirements on synchronizer $synchronizerId with vetting time ${vettingAsOfTime}",
       client.getSupportedPackageVersion(
         synchronizerId,
-        parties,
-        packageName,
+        packageRequirements,
         vettingAsOfTime,
       ),
       logger,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
@@ -13,6 +13,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules_Mer
 import org.lfdecentralizedtrust.splice.codegen.java.splice.validatorlicense.ValidatorLicense
 import org.lfdecentralizedtrust.splice.store.PageLimit
 import org.lfdecentralizedtrust.splice.util.{AssignedContract, Contract}
+import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
@@ -47,9 +48,12 @@ class MergeValidatorLicenseContractsTrigger(
     for {
       pruneAmuletConfigScheduleFeatureSupport <- svTaskContext.packageVersionSupport
         .supportsMergeDuplicatedValidatorLicense(
-          Seq(
+          dsoGovernanceParties = Seq(
             store.key.svParty,
             store.key.dsoParty,
+          ),
+          amuletParties = Seq(
+            PartyId.tryFromProtoPrimitive(validator)
           ),
           context.clock.now.minus(context.config.clockSkewAutomationDelay.asJava),
         )


### PR DESCRIPTION
Couldn't quite justify an integration test for that but I did add a unit test for the extra filtering and I manually checked that the LAPI endpoint behaves as expected.

[ci]

fixes #1336



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
