### PR TITLE
Ignore lukka validator acs commitment mismatches

### DIFF
--- a/cluster/pulumi/infra/src/gcpAlerts.ts
+++ b/cluster/pulumi/infra/src/gcpAlerts.ts
@@ -124,6 +124,7 @@ ${conditionalString(
   AND (
     jsonPayload.remote=~"sender = PAR::tw-cn-mainnet-participant-1::1220bc64ba15"
     OR jsonPayload.remote=~"sender = PAR::northisland-prod1::12204ef1928f"
+    OR jsonPayload.remote=~"sender = PAR::Lukka-Inc-prod-2::1220728cfb80"
   )
   AND timestamp <= "2025-07-14T00:00:00.000Z")
 `


### PR DESCRIPTION
Related to
https://github.com/DACH-NY/canton-network-internal/issues/803#issuecomment-3043813517 it seems like their restore from key caused some issues and they are now spamming our logs. Will ping them to see what they want to do.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
