### PR TITLE
Query state first in migrationInfo

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
@@ -1968,10 +1968,15 @@ class UpdateHistory(
       override def migrationInfo(
           migrationId: Long
       )(implicit tc: TraceContext): Future[Option[SourceMigrationInfo]] = for {
+        // Note: As the following queries are not wrapped in a REPEATABLE_READ transaction,
+        // the individual results do not form a consistent snapshot of the migration metadata.
+        // This is fine because update history is append-only,
+        // but we have to make sure to query the state first to avoid returning record time ranges
+        // from before the update history was initialized.
+        state <- getBackfillingState()
         previousMigrationId <- getPreviousMigrationId(migrationId)
         recordTimeRange <- getRecordTimeRange(migrationId)
         lastImportUpdateId <- getLastImportUpdateId(migrationId)
-        state <- getBackfillingState()
       } yield {
         state match {
           case BackfillingState.NotInitialized =>


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4846

Alternative would be to refactor the individual calls like `getPreviousMigrationId(migrationId)` to return a `DBIOAction` instead of a `Future`, and combine them here `.transactionally` with `REPEATABLE_READ` isolation level. I don't think this is necessary here though.