### PR TITLE
Define new runner type for CircleCI-based deployments and wire up SAs for it

### DIFF
--- a/cluster/pulumi/circleci/src/index.ts
+++ b/cluster/pulumi/circleci/src/index.ts
@@ -18,6 +18,9 @@ const circleCiNamespace = new Namespace('circleci-runner', {
   },
 });
 
+// Below logic assumes that the cluster has workload identity enabled.
+// You can enforce this via `cncluster cluster_enable_workload_identity`.
+
 // Create a GCP SA for CCI (CCI SA) and a k8s service account (CCI KSA) that is connected to the GCP SA.
 const cciGcpServiceAccount = new gcp.serviceaccount.Account('cci-deployments-gcp-sa', {
   accountId: 'cci-deployments-gcp-sa',


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/798 (let's discuss there)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
