### PR TITLE
Add `cncluster cluster_enable_workload_identity`

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -881,6 +881,7 @@ function subcmd_cluster_set_all_maintenance_windows() {
     fi
 }
 
+# TODO(DACH-NY/canton-network-internal#417) Move this into `cluster` pulumi project
 subcommand_whitelist[cluster_enable_workload_identity]='Enable workload identity for the cluster.'
 
 function subcmd_cluster_enable_workload_identity() {


### PR DESCRIPTION
Needed for https://github.com/DACH-NY/canton-network-internal/issues/798 /https://github.com/hyperledger-labs/splice/pull/1360

Based on https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
