### PR TITLE
[ci] Handle metrics shutdown cleaner

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceEnvironment.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceEnvironment.scala
@@ -44,6 +44,8 @@ class SpliceEnvironment(
   private lazy val metrics = SpliceMetricsFactory(
     metricsRegistry,
     dbStorageHistograms,
+    loggerFactory,
+    config.parameters.timeouts.processing,
   )
 
   protected def createValidator(

--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/metrics/SpliceMetricsFactory.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/metrics/SpliceMetricsFactory.scala
@@ -4,17 +4,21 @@
 package org.lfdecentralizedtrust.splice.metrics
 
 import com.daml.metrics.api.MetricsContext
+import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.logging.NamedLoggerFactory
+import com.digitalasset.canton.metrics.{DbStorageHistograms, MetricsFactoryProvider}
 import org.lfdecentralizedtrust.splice.scan.metrics.ScanAppMetrics
 import org.lfdecentralizedtrust.splice.splitwell.metrics.SplitwellAppMetrics
 import org.lfdecentralizedtrust.splice.sv.metrics.SvAppMetrics
 import org.lfdecentralizedtrust.splice.validator.metrics.ValidatorAppMetrics
-import com.digitalasset.canton.metrics.{DbStorageHistograms, MetricsFactoryProvider}
 
 import scala.collection.concurrent.TrieMap
 
 case class SpliceMetricsFactory(
     metricsFactoryProvider: MetricsFactoryProvider,
     storageHistograms: DbStorageHistograms,
+    loggerFactory: NamedLoggerFactory,
+    timeouts: ProcessingTimeout,
 ) {
 
   private val validators = TrieMap[String, ValidatorAppMetrics]()
@@ -53,6 +57,8 @@ case class SpliceMetricsFactory(
         new ScanAppMetrics(
           metricsFactoryProvider.generateMetricsFactory(metricsContext),
           storageHistograms,
+          loggerFactory.getTracedLogger(getClass),
+          timeouts,
         )
       },
     )

--- a/apps/metrics-docs/src/main/scala/org/lfdecentralizedtrust/splice/metrics/MetricsDocs.scala
+++ b/apps/metrics-docs/src/main/scala/org/lfdecentralizedtrust/splice/metrics/MetricsDocs.scala
@@ -5,13 +5,15 @@ package org.lfdecentralizedtrust.splice.metrics
 
 import better.files.File
 import com.daml.metrics.api.MetricsContext
+import com.digitalasset.canton.config.ProcessingTimeout
 import com.digitalasset.canton.discard.Implicits.DiscardOps
+import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.metrics.{MetricDoc, MetricsDocGenerator}
 import com.digitalasset.canton.topology.PartyId
 import org.lfdecentralizedtrust.splice.admin.api.client.DamlGrpcClientMetrics
 import org.lfdecentralizedtrust.splice.automation.TriggerMetrics
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanStoreMetrics
-import org.lfdecentralizedtrust.splice.sv.automation.singlesv.{SequencerPruningMetrics}
+import org.lfdecentralizedtrust.splice.sv.automation.singlesv.SequencerPruningMetrics
 import org.lfdecentralizedtrust.splice.sv.automation.ReportSvStatusMetricsExportTrigger
 import org.lfdecentralizedtrust.splice.sv.store.db.DbSvDsoStoreMetrics
 import org.lfdecentralizedtrust.splice.store.{DomainParamsStore, HistoryMetrics, StoreMetrics}
@@ -91,7 +93,11 @@ object MetricsDocs {
     val svMetrics = generator.getAll()
     generator.reset()
     // scan
-    new DbScanStoreMetrics(generator)
+    new DbScanStoreMetrics(
+      generator,
+      NamedLoggerFactory.root.getTracedLogger(getClass),
+      ProcessingTimeout(),
+    )
     val scanMetrics = generator.getAll()
     generator.reset()
     GeneratedMetrics(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanAppMetrics.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanAppMetrics.scala
@@ -4,6 +4,8 @@
 package org.lfdecentralizedtrust.splice.scan.metrics
 
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
+import com.digitalasset.canton.config.ProcessingTimeout
+import com.digitalasset.canton.logging.TracedLogger
 import org.lfdecentralizedtrust.splice.BaseSpliceMetrics
 import com.digitalasset.canton.metrics.DbStorageHistograms
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanStoreMetrics
@@ -15,6 +17,8 @@ import org.lfdecentralizedtrust.splice.scan.store.db.DbScanStoreMetrics
 class ScanAppMetrics(
     metricsFactory: LabeledMetricsFactory,
     storageHistograms: DbStorageHistograms,
+    logger: TracedLogger,
+    timeouts: ProcessingTimeout,
 ) extends BaseSpliceMetrics("scan", metricsFactory, storageHistograms) {
-  val dbScanStore = new DbScanStoreMetrics(metricsFactory)
+  val dbScanStore = new DbScanStoreMetrics(metricsFactory, logger, timeouts)
 }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanAggregatorTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanAggregatorTest.scala
@@ -24,6 +24,7 @@ import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.SynchronizerAlias
+import com.digitalasset.canton.config.ProcessingTimeout
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import org.lfdecentralizedtrust.splice.codegen.java.splice
 import org.lfdecentralizedtrust.splice.migration.DomainMigrationInfo
@@ -918,7 +919,7 @@ class ScanAggregatorTest
       ),
       participantId = mkParticipantId("ScanAggregatorTest"),
       enableImportUpdateBackfill = true,
-      new DbScanStoreMetrics(new NoOpMetricsFactory()),
+      new DbScanStoreMetrics(new NoOpMetricsFactory(), logger, ProcessingTimeout()),
     )(parallelExecutionContext, implicitly, implicitly)
     for {
       _ <- store.multiDomainAcsStore.testIngestionSink.initialize()

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
@@ -2354,7 +2354,7 @@ class DbScanStoreTest
       ),
       participantId = mkParticipantId("ScanStoreTest"),
       enableImportUpdateBackfill = true,
-      new DbScanStoreMetrics(new NoOpMetricsFactory()),
+      new DbScanStoreMetrics(new NoOpMetricsFactory(), logger, timeouts),
     )(parallelExecutionContext, implicitly, implicitly)
 
     for {


### PR DESCRIPTION
also add some more logging

fixes https://github.com/DACH-NY/cn-test-failures/issues/4874 and provides some more logging for future issues

theory:
there was a race condition between shutdown and calling the svnodecache which would've recreated the cache from a stopped scan instance. we now handle shutdown properly.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
