### PR TITLE
[static] Disable istio metrics host header fallback

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1709,12 +1709,6 @@
                 ]
               },
               {
-                "action": "keep",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"
-                ]
-              },
-              {
                 "action": "replace",
                 "regex": "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})",
                 "replacement": "[$2]:$1",
@@ -1739,18 +1733,15 @@
                 "regex": "__meta_kubernetes_pod_label_(.+)"
               },
               {
+                "action": "labeldrop",
+                "regex": "instance"
+              },
+              {
                 "action": "replace",
                 "sourceLabels": [
                   "__meta_kubernetes_namespace"
                 ],
                 "targetLabel": "namespace"
-              },
-              {
-                "action": "replace",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_name"
-                ],
-                "targetLabel": "pod"
               }
             ]
           }
@@ -1878,6 +1869,26 @@
               "operator": "Exists"
             }
           ]
+        },
+        "telemetry": {
+          "enabled": true,
+          "v2": {
+            "enabled": true,
+            "prometheus": {
+              "configOverride": {
+                "gateway": {
+                  "disable_host_header_fallback": true
+                },
+                "inboundSidecar": {
+                  "disable_host_header_fallback": true
+                },
+                "outboundSidecar": {
+                  "disable_host_header_fallback": true
+                }
+              },
+              "enabled": true
+            }
+          }
         }
       },
       "version": "1.26.1"

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -123,6 +123,27 @@ function configureIstiod(
             attempts: 0,
           },
         },
+        telemetry: {
+          enabled: true,
+          v2: {
+            enabled: true,
+            prometheus: {
+              enabled: true,
+              //Prometheus goes brrrr https://github.com/istio/istio/issues/35414
+              configOverride: {
+                inboundSidecar: {
+                  disable_host_header_fallback: true,
+                },
+                outboundSidecar: {
+                  disable_host_header_fallback: true,
+                },
+                gateway: {
+                  disable_host_header_fallback: true,
+                },
+              },
+            },
+          },
+        },
       },
       maxHistory: HELM_MAX_HISTORY_SIZE,
     },
@@ -524,10 +545,6 @@ export function istioMonitoring(
             regex: 'istio-proxy',
           },
           {
-            action: 'keep',
-            sourceLabels: ['__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape'],
-          },
-          {
             action: 'replace',
             regex: '(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})',
             replacement: '[$2]:$1',
@@ -552,14 +569,13 @@ export function istioMonitoring(
             regex: '__meta_kubernetes_pod_label_(.+)',
           },
           {
+            action: 'labeldrop',
+            regex: 'instance',
+          },
+          {
             sourceLabels: ['__meta_kubernetes_namespace'],
             action: 'replace',
             targetLabel: 'namespace',
-          },
-          {
-            sourceLabels: ['__meta_kubernetes_pod_name'],
-            action: 'replace',
-            targetLabel: 'pod',
           },
         ],
       },


### PR DESCRIPTION
Creates too many series in cilr and eventually prometheus crashes with 100gb memory usage



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
