### PR TITLE
[static] Fix istiod helm chart values

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1842,6 +1842,13 @@
           "defaultHttpRetryPolicy": {
             "attempts": 0
           },
+          "defaultProviders": {
+            "metrics": [
+              {
+                "name": "prometheus"
+              }
+            ]
+          },
           "enablePrometheusMerge": false
         },
         "pilot": {
@@ -1875,17 +1882,6 @@
           "v2": {
             "enabled": true,
             "prometheus": {
-              "configOverride": {
-                "gateway": {
-                  "disable_host_header_fallback": true
-                },
-                "inboundSidecar": {
-                  "disable_host_header_fallback": true
-                },
-                "outboundSidecar": {
-                  "disable_host_header_fallback": true
-                }
-              },
               "enabled": true
             }
           }

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -122,6 +122,9 @@ function configureIstiod(
           defaultHttpRetryPolicy: {
             attempts: 0,
           },
+          defaultProviders: {
+            metrics: [{ name: 'prometheus' }],
+          },
         },
         telemetry: {
           enabled: true,
@@ -129,18 +132,6 @@ function configureIstiod(
             enabled: true,
             prometheus: {
               enabled: true,
-              //Prometheus goes brrrr https://github.com/istio/istio/issues/35414
-              configOverride: {
-                inboundSidecar: {
-                  disable_host_header_fallback: true,
-                },
-                outboundSidecar: {
-                  disable_host_header_fallback: true,
-                },
-                gateway: {
-                  disable_host_header_fallback: true,
-                },
-              },
             },
           },
         },


### PR DESCRIPTION
the api was changed, not sure with what it was replaced, there's no release notes, i hate everything

fixes https://github.com/DACH-NY/cn-test-failures/issues/4890

will keep testing out with cilr 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
