### PR TITLE
Isegall/revert istio metrics

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1710,6 +1710,12 @@
                 ]
               },
               {
+                "action": "keep",
+                "sourceLabels": [
+                  "__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"
+                ]
+              },
+              {
                 "action": "replace",
                 "regex": "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})",
                 "replacement": "[$2]:$1",
@@ -1734,15 +1740,18 @@
                 "regex": "__meta_kubernetes_pod_label_(.+)"
               },
               {
-                "action": "labeldrop",
-                "regex": "instance"
-              },
-              {
                 "action": "replace",
                 "sourceLabels": [
                   "__meta_kubernetes_namespace"
                 ],
                 "targetLabel": "namespace"
+              },
+              {
+                "action": "replace",
+                "sourceLabels": [
+                  "__meta_kubernetes_pod_name"
+                ],
+                "targetLabel": "pod"
               }
             ]
           }
@@ -1870,26 +1879,6 @@
               "operator": "Exists"
             }
           ]
-        },
-        "telemetry": {
-          "enabled": true,
-          "v2": {
-            "enabled": true,
-            "prometheus": {
-              "configOverride": {
-                "gateway": {
-                  "disable_host_header_fallback": true
-                },
-                "inboundSidecar": {
-                  "disable_host_header_fallback": true
-                },
-                "outboundSidecar": {
-                  "disable_host_header_fallback": true
-                }
-              },
-              "enabled": true
-            }
-          }
         }
       },
       "version": "1.26.1"

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1843,13 +1843,6 @@
           "defaultHttpRetryPolicy": {
             "attempts": 0
           },
-          "defaultProviders": {
-            "metrics": [
-              {
-                "name": "prometheus"
-              }
-            ]
-          },
           "enablePrometheusMerge": false
         },
         "pilot": {
@@ -1883,6 +1876,17 @@
           "v2": {
             "enabled": true,
             "prometheus": {
+              "configOverride": {
+                "gateway": {
+                  "disable_host_header_fallback": true
+                },
+                "inboundSidecar": {
+                  "disable_host_header_fallback": true
+                },
+                "outboundSidecar": {
+                  "disable_host_header_fallback": true
+                }
+              },
               "enabled": true
             }
           }

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1261,21 +1261,46 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "PodMonitor",
       "metadata": {
-        "labels": {
-          "monitoring": "istio-proxies",
-          "release": "prometheus-grafana-monitoring"
-        },
-        "name": "istio-gateway-monitor",
+        "name": "istio-gateway-monitor-public",
         "namespace": "cluster-ingress"
       },
       "spec": {
-        "jobLabel": "app",
         "namespaceSelector": {
           "any": true
         },
         "podMetricsEndpoints": [
           {
-            "honorLabels": true,
+            "path": "/stats/prometheus",
+            "port": "http-envoy-prom"
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "istio": "ingress"
+          }
+        }
+      }
+    },
+    "name": "istio-gateway-monitor-public",
+    "provider": "",
+    "type": "kubernetes:monitoring.coreos.com/v1:PodMonitor"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PodMonitor",
+      "metadata": {
+        "name": "istio-gateway-monitor",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "namespaceSelector": {
+          "any": true
+        },
+        "podMetricsEndpoints": [
+          {
             "path": "/stats/prometheus",
             "port": "http-envoy-prom"
           }
@@ -1684,76 +1709,48 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "PodMonitor",
       "metadata": {
-        "labels": {
-          "monitoring": "istio-proxies",
-          "release": "prometheus-grafana-monitoring"
-        },
-        "name": "istio-sidecar-monitor",
+        "name": "istio-sidecar-monitor-public",
         "namespace": "cluster-ingress"
       },
       "spec": {
-        "jobLabel": "app",
         "namespaceSelector": {
           "any": true
         },
         "podMetricsEndpoints": [
           {
-            "honorLabels": true,
             "path": "/stats/prometheus",
-            "port": "http-envoy-prom",
-            "relabelings": [
-              {
-                "action": "keep",
-                "regex": "istio-proxy",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_container_name"
-                ]
-              },
-              {
-                "action": "keep",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"
-                ]
-              },
-              {
-                "action": "replace",
-                "regex": "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})",
-                "replacement": "[$2]:$1",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_annotation_prometheus_io_port",
-                  "__meta_kubernetes_pod_ip"
-                ],
-                "targetLabel": "__address__"
-              },
-              {
-                "action": "replace",
-                "regex": "(\\d+);((([0-9]+?)(\\.|$)){4})",
-                "replacement": "$2:$1",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_annotation_prometheus_io_port",
-                  "__meta_kubernetes_pod_ip"
-                ],
-                "targetLabel": "__address__"
-              },
-              {
-                "action": "labeldrop",
-                "regex": "__meta_kubernetes_pod_label_(.+)"
-              },
-              {
-                "action": "replace",
-                "sourceLabels": [
-                  "__meta_kubernetes_namespace"
-                ],
-                "targetLabel": "namespace"
-              },
-              {
-                "action": "replace",
-                "sourceLabels": [
-                  "__meta_kubernetes_pod_name"
-                ],
-                "targetLabel": "pod"
-              }
-            ]
+            "port": "http-envoy-prom"
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "security.istio.io/tlsMode": "istio"
+          }
+        }
+      }
+    },
+    "name": "istio-sidecar-monitor-public",
+    "provider": "",
+    "type": "kubernetes:monitoring.coreos.com/v1:PodMonitor"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PodMonitor",
+      "metadata": {
+        "name": "istio-sidecar-monitor",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "namespaceSelector": {
+          "any": true
+        },
+        "podMetricsEndpoints": [
+          {
+            "path": "/stats/prometheus",
+            "port": "http-envoy-prom"
           }
         ],
         "selector": {
@@ -1788,16 +1785,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "istiod-service-monitor",
         "namespace": "cluster-ingress"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "http-monitoring"
           }
         ],

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -174,16 +174,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-participant-0-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -607,16 +603,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-participant-1-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -1040,16 +1032,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-participant-2-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -1473,16 +1461,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-participant-3-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -1906,16 +1890,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-participant-4-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -2339,16 +2319,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-validator-0-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -2721,16 +2697,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-validator-1-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -3103,16 +3075,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-validator-2-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -3485,16 +3453,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-validator-3-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],
@@ -3867,16 +3831,12 @@
       "apiVersion": "monitoring.coreos.com/v1",
       "kind": "ServiceMonitor",
       "metadata": {
-        "labels": {
-          "release": "prometheus-grafana-monitoring"
-        },
         "name": "multi-validator-4-service-monitor",
         "namespace": "multi-validator"
       },
       "spec": {
         "endpoints": [
           {
-            "honorLabels": true,
             "port": "metrics"
           }
         ],

--- a/cluster/pulumi/common/src/metrics.ts
+++ b/cluster/pulumi/common/src/metrics.ts
@@ -4,17 +4,11 @@ import * as pulumi from '@pulumi/pulumi';
 import { CustomResource } from '@pulumi/kubernetes/apiextensions';
 import { Input, Inputs } from '@pulumi/pulumi';
 
-import { ObservabilityReleaseName } from './utils';
-
 export class PodMonitor extends CustomResource {
   constructor(
     name: string,
     matchLabels: Inputs,
-    podMetricsEndpoints: Array<{
-      port: string;
-      path: string;
-      relabelings?: Array<unknown>;
-    }>,
+    podMetricsEndpoints: Array<{ port: string; path: string }>,
     namespace: Input<string>,
     opts?: pulumi.CustomResourceOptions
   ) {
@@ -26,25 +20,15 @@ export class PodMonitor extends CustomResource {
         metadata: {
           name: name,
           namespace: namespace,
-          labels: {
-            monitoring: 'istio-proxies',
-            release: ObservabilityReleaseName,
-          },
         },
         spec: {
-          jobLabel: 'app',
           selector: {
             matchLabels: matchLabels,
           },
           namespaceSelector: {
             any: true,
           },
-          podMetricsEndpoints: podMetricsEndpoints.map(endpoint => {
-            return {
-              honorLabels: true,
-              ...endpoint,
-            };
-          }),
+          podMetricsEndpoints: podMetricsEndpoints,
         },
       },
       opts
@@ -68,9 +52,6 @@ export class ServiceMonitor extends CustomResource {
         metadata: {
           name: name,
           namespace: namespace,
-          labels: {
-            release: ObservabilityReleaseName,
-          },
         },
         spec: {
           selector: {
@@ -82,7 +63,6 @@ export class ServiceMonitor extends CustomResource {
           endpoints: [
             {
               port: port,
-              honorLabels: true,
             },
           ],
         },

--- a/cluster/pulumi/common/src/utils.ts
+++ b/cluster/pulumi/common/src/utils.ts
@@ -27,8 +27,6 @@ export const PRIVATE_CONFIGS_PATH = config.optionalEnv('PRIVATE_CONFIGS_PATH');
 export const HELM_REPO = spliceEnvConfig.requireEnv('OCI_DEV_HELM_REGISTRY');
 export const DOCKER_REPO = spliceEnvConfig.requireEnv('CACHE_DEV_DOCKER_REGISTRY');
 
-export const ObservabilityReleaseName = 'prometheus-grafana-monitoring';
-
 export function getDnsNames(): { daDnsName: string; cantonDnsName: string } {
   const daUrlScheme = 'global.canton.network.digitalasset.com';
   const cantonUrlScheme = 'network.canton.global';

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -123,27 +123,6 @@ function configureIstiod(
             attempts: 0,
           },
         },
-        telemetry: {
-          enabled: true,
-          v2: {
-            enabled: true,
-            prometheus: {
-              enabled: true,
-              //Prometheus goes brrrr https://github.com/istio/istio/issues/35414
-              configOverride: {
-                inboundSidecar: {
-                  disable_host_header_fallback: true,
-                },
-                outboundSidecar: {
-                  disable_host_header_fallback: true,
-                },
-                gateway: {
-                  disable_host_header_fallback: true,
-                },
-              },
-            },
-          },
-        },
       },
       maxHistory: HELM_MAX_HISTORY_SIZE,
     },
@@ -545,6 +524,10 @@ export function istioMonitoring(
             regex: 'istio-proxy',
           },
           {
+            action: 'keep',
+            sourceLabels: ['__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape'],
+          },
+          {
             action: 'replace',
             regex: '(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})',
             replacement: '[$2]:$1',
@@ -569,13 +552,14 @@ export function istioMonitoring(
             regex: '__meta_kubernetes_pod_label_(.+)',
           },
           {
-            action: 'labeldrop',
-            regex: 'instance',
-          },
-          {
             sourceLabels: ['__meta_kubernetes_namespace'],
             action: 'replace',
             targetLabel: 'namespace',
+          },
+          {
+            sourceLabels: ['__meta_kubernetes_pod_name'],
+            action: 'replace',
+            targetLabel: 'pod',
           },
         ],
       },

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -122,9 +122,6 @@ function configureIstiod(
           defaultHttpRetryPolicy: {
             attempts: 0,
           },
-          defaultProviders: {
-            metrics: [{ name: 'prometheus' }],
-          },
         },
         telemetry: {
           enabled: true,
@@ -132,6 +129,18 @@ function configureIstiod(
             enabled: true,
             prometheus: {
               enabled: true,
+              //Prometheus goes brrrr https://github.com/istio/istio/issues/35414
+              configOverride: {
+                inboundSidecar: {
+                  disable_host_header_fallback: true,
+                },
+                outboundSidecar: {
+                  disable_host_header_fallback: true,
+                },
+                gateway: {
+                  disable_host_header_fallback: true,
+                },
+              },
             },
           },
         },

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -21,7 +21,6 @@ import {
   isMainNet,
   loadTesterConfig,
   MOCK_SPLICE_ROOT,
-  ObservabilityReleaseName,
   publicPrometheusRemoteWrite,
   SPLICE_ROOT,
 } from 'splice-pulumi-common';
@@ -149,7 +148,7 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
   const prometheusStack = new k8s.helm.v3.Release(
     'observability-metrics',
     {
-      name: ObservabilityReleaseName,
+      name: 'prometheus-grafana-monitoring',
       chart: 'kube-prometheus-stack',
       version: stackVersion,
       namespace: namespaceName,


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/4884

I tried finding a subset that I can revert, but failed. So reverting all of this for now, and letting @nicu-da  sort it out tomorrow.
cluster test for this: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/19097/workflows/955135c6-74a7-455b-a475-9623ea8034a6

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
