### PR TITLE
bump observability charts

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2748,7 +2748,7 @@
           ]
         }
       },
-      "version": "67.3.1"
+      "version": "75.9.0"
     },
     "name": "observability-metrics",
     "provider": "",
@@ -3847,9 +3847,9 @@
     "id": "",
     "inputs": {
       "addPreviousOutputInEnv": true,
-      "create": "bash SPLICE_ROOT/cluster/pulumi/infra/prometheus-crd-update.sh 0.79.0"
+      "create": "bash SPLICE_ROOT/cluster/pulumi/infra/prometheus-crd-update.sh 0.83.0"
     },
-    "name": "update-prometheus-crd-0.79.0",
+    "name": "update-prometheus-crd-0.83.0",
     "provider": "",
     "type": "command:local:Command"
   },

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -145,8 +145,8 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
   );
   const namespaceName = namespace.metadata.name;
   // If the stack version is updated the crd version might need to be upgraded as well, check the release notes https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
-  const stackVersion = '67.3.1';
-  const prometheusStackCrdVersion = '0.79.0';
+  const stackVersion = '75.9.0';
+  const prometheusStackCrdVersion = '0.83.0';
   const adminPassword = grafanaKeysFromSecret().adminPassword;
   const prometheusStack = new k8s.helm.v3.Release(
     'observability-metrics',


### PR DESCRIPTION
Part of #1091 

Applied on scratchB, confirmed that it doesn't explode, and manually checked a few dashboards there.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/DACH-NY/canton-network-node/blob/main/cluster/images/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/DACH-NY/canton-network-node#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
