### PR TITLE
Revert "Upgrade Canton binary to get sequencer DB migration (#1403)"

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.3.0-snapshot.20250709.16004.0.v1936a2aa",
+  "version": "3.3.0-snapshot.20250630.15992.0.vb8ce8c94",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "1l8p6bd70c4d6lm6x9vxvgx1prxb13941pkamhk43ycv10ba5lkx",
-  "oss_sha256": "0b69lk3459fi49s7aivy0bw9k1h6wy8v2ak604mndl1phxmqszd4"
+  "enterprise_sha256": "sha256-/2lopA64QFZQn7Gl4pwHxwXEDiB7EfdlXWtlITff6BU=",
+  "oss_sha256": "sha256-946C3hrpGJzS9q11ezcKw+Qgq2P3KVTuh/6MSkIiFYA="
 }


### PR DESCRIPTION
This reverts commit 0e223b2a33967825288b2c0767a53d1c8a4a308a.

Signed-off-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
