### PR TITLE
Fix reconnect logic for sv validators with bft connections

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
@@ -10,9 +10,13 @@ import com.daml.nonempty.NonEmpty
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.data.NodeStatus
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
-import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, Port}
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, Port, PositiveInt}
 import com.digitalasset.canton.networking.Endpoint
-import com.digitalasset.canton.sequencing.{GrpcSequencerConnection, SequencerConnection}
+import com.digitalasset.canton.sequencing.{
+  GrpcSequencerConnection,
+  SequencerConnection,
+  SubmissionRequestAmplification,
+}
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.util.FutureInstances.*
 
@@ -44,13 +48,16 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
       eventually() {
         forAll(Seq(sv1Backend, sv2Backend, sv3Backend, sv4Backend)) { sv =>
           clue(s"sv ${sv.name} is connected to all sequencers") {
-            val synchronizerConfig: Seq[SequencerConnection] = sv.participantClient.synchronizers
+            val synchronizerConfig = sv.participantClient.synchronizers
               .config(decentralizedSynchronizer)
               .value
               .sequencerConnections
-              .connections
-              .forgetNE
-            val endpoints = synchronizerConfig.map { s =>
+            val connections: Seq[SequencerConnection] = synchronizerConfig.connections.forgetNE
+            synchronizerConfig.submissionRequestAmplification shouldBe SubmissionRequestAmplification(
+              PositiveInt.tryCreate(2),
+              NonNegativeFiniteDuration.ofSeconds(10),
+            )
+            val endpoints = connections.map { s =>
               inside(s) { case GrpcSequencerConnection(endpoint, _, _, _) =>
                 endpoint
               }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -182,7 +182,7 @@ class ManualStartIntegrationTest
                 .value
             sequencerConnections.connections.size shouldBe 1
             sequencerConnections.sequencerTrustThreshold shouldBe PositiveInt.tryCreate(1)
-            sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION
+            sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DefaultMediatorSequencerRequestAmplification
             // otherwise we get log warnings
             mediatorConnection.close()
           }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -1,7 +1,6 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.daml.nonempty.NonEmpty
-import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.data.PruningSchedule
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.config.{FullClientConfig, PositiveDurationSeconds}
@@ -183,28 +182,9 @@ class ManualStartIntegrationTest
                 .value
             sequencerConnections.connections.size shouldBe 1
             sequencerConnections.sequencerTrustThreshold shouldBe PositiveInt.tryCreate(1)
-            sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION
+            sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION
             // otherwise we get log warnings
             mediatorConnection.close()
-          }
-        }
-
-        clue("SV1 and SV2 have configured amplification on the participant sequencer connection") {
-          Seq(
-            participantAdminConnection("sv1", sv1Backend.config),
-            participantAdminConnection("sv2", sv2Backend.config),
-          ).map { participantConnection =>
-            val sequencerConnections =
-              participantConnection
-                .lookupSynchronizerConnectionConfig(SynchronizerAlias.tryCreate("global"))
-                .futureValue
-                .value
-                .sequencerConnections
-            sequencerConnections.connections.size shouldBe 1
-            sequencerConnections.sequencerTrustThreshold shouldBe PositiveInt.tryCreate(1)
-            sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION
-            // otherwise we get log warnings
-            participantConnection.close()
           }
         }
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -205,7 +205,7 @@ final case class SvParticipantClientConfig(
     override val adminApi: FullClientConfig,
     override val ledgerApi: LedgerApiClientConfig,
     sequencerRequestAmplification: SubmissionRequestAmplification =
-      SvAppBackendConfig.DEFAULT_PARTICIPANT_SEQUENCER_REQUEST_AMPLIFICATION,
+      SvAppBackendConfig.DefaultParticipantSequencerRequestAmplification,
 ) extends BaseParticipantClientConfig(adminApi, ledgerApi)
 
 case class SvAppBackendConfig(
@@ -285,11 +285,11 @@ case class SvAppBackendConfig(
 
 object SvAppBackendConfig {
   // This is consistent with what the validator sets for a single sequencer connection
-  val DEFAULT_PARTICIPANT_SEQUENCER_REQUEST_AMPLIFICATION = SubmissionRequestAmplification(
+  val DefaultParticipantSequencerRequestAmplification = SubmissionRequestAmplification(
     PositiveInt.tryCreate(1),
     NonNegativeFiniteDuration.ofSeconds(10),
   )
-  val DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION = SubmissionRequestAmplification(
+  val DefaultMediatorSequencerRequestAmplification = SubmissionRequestAmplification(
     PositiveInt.tryCreate(5),
     NonNegativeFiniteDuration.ofSeconds(10),
   )
@@ -348,7 +348,7 @@ final case class SvSequencerConfig(
 final case class SvMediatorConfig(
     adminApi: FullClientConfig,
     sequencerRequestAmplification: SubmissionRequestAmplification =
-      SvAppBackendConfig.DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION,
+      SvAppBackendConfig.DefaultMediatorSequencerRequestAmplification,
 ) {
 
   def toCantonConfig: RemoteMediatorConfig = RemoteMediatorConfig(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -205,7 +205,7 @@ final case class SvParticipantClientConfig(
     override val adminApi: FullClientConfig,
     override val ledgerApi: LedgerApiClientConfig,
     sequencerRequestAmplification: SubmissionRequestAmplification =
-      SvAppBackendConfig.DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION,
+      SvAppBackendConfig.DEFAULT_PARTICIPANT_SEQUENCER_REQUEST_AMPLIFICATION,
 ) extends BaseParticipantClientConfig(adminApi, ledgerApi)
 
 case class SvAppBackendConfig(
@@ -284,7 +284,12 @@ case class SvAppBackendConfig(
 }
 
 object SvAppBackendConfig {
-  val DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION = SubmissionRequestAmplification(
+  // This is consistent with what the validator sets for a single sequencer connection
+  val DEFAULT_PARTICIPANT_SEQUENCER_REQUEST_AMPLIFICATION = SubmissionRequestAmplification(
+    PositiveInt.tryCreate(1),
+    NonNegativeFiniteDuration.ofSeconds(10),
+  )
+  val DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION = SubmissionRequestAmplification(
     PositiveInt.tryCreate(5),
     NonNegativeFiniteDuration.ofSeconds(10),
   )
@@ -343,7 +348,7 @@ final case class SvSequencerConfig(
 final case class SvMediatorConfig(
     adminApi: FullClientConfig,
     sequencerRequestAmplification: SubmissionRequestAmplification =
-      SvAppBackendConfig.DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION,
+      SvAppBackendConfig.DEFAULT_MEDIATOR_SEQUENCER_REQUEST_AMPLIFICATION,
 ) {
 
   def toCantonConfig: RemoteMediatorConfig = RemoteMediatorConfig(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -173,7 +173,9 @@ class SV1Initializer(
             minObservationDuration = config.timeTrackerMinObservationDuration
           ),
         ),
-        RetryFor.WaitingOnInitDependency,
+        overwriteExistingConnection =
+          false, // The validator will manage sequencer connections after initial setup
+        retryFor = RetryFor.WaitingOnInitDependency,
       )
       _ = logger.info("Participant connected to domain")
       (dsoParty, svParty, _) <- (

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -135,6 +135,9 @@ class ValidatorApp(
   override def packagesForJsonDecoding =
     super.packagesForJsonDecoding ++ DarResources.wallet.all ++ DarResources.amuletNameService.all ++ DarResources.dsoGovernance.all
 
+  // We don't want the validator to mess around with things like sequencer connections until the SV app finishes init
+  override def waitForPartyBeforePreinitialize = false
+
   override def preInitializeBeforeLedgerConnection()(implicit
       traceContext: TraceContext
   ): Future[Unit] = for {
@@ -263,7 +266,7 @@ class ValidatorApp(
                   }
                 } yield ()
               case None =>
-                if (config.svValidator)
+                if (config.svValidator && config.disableSvValidatorBftSequencerConnection)
                   appInitStep("Ensuring decentralized synchronizer already registered") {
                     domainConnector.waitForDecentralizedSynchronizerIsRegisteredAndConnected()
                   }

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -115,7 +115,8 @@ class DomainConnector(
     logger.info(s"Ensuring domain $alias registered with config $domainConfig")
     participantAdminConnection.ensureDomainRegisteredAndConnected(
       domainConfig,
-      RetryFor.WaitingOnInitDependency,
+      overwriteExistingConnection = true,
+      retryFor = RetryFor.WaitingOnInitDependency,
     )
   }
 


### PR DESCRIPTION
[ci]

Don't really see a great way of testing this but this ensure that the validator tries to reconfigure the connections on startup already. Otherwise you can end up in in a situation where the existing sequencers are broken and it just waits for a connection instead of fixing it to the current ones.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
