### PR TITLE
Add DAR upload back to SvIntegrationTestBase

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvIntegrationTestBase.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvIntegrationTestBase.scala
@@ -1,18 +1,24 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
-import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
+import org.lfdecentralizedtrust.splice.environment.DarResources
+import org.lfdecentralizedtrust.splice.integration.{EnvironmentDefinition, InitialPackageVersions}
 import SpliceTests.IntegrationTest
 import org.lfdecentralizedtrust.splice.util.SvTestUtil
 
 trait SvIntegrationTestBase extends IntegrationTest with SvTestUtil {
 
   protected val amuletDarPath =
-    "daml/splice-amulet/.daml/dist/splice-amulet-current.dar"
+    s"daml/dars/splice-amulet-${InitialPackageVersions.initialPackageVersion(DarResources.amulet)}.dar"
   protected val dsoGovernanceDarPath =
-    "daml/splice-dso-governance/.daml/dist/splice-dso-governance-current.dar"
+    s"daml/dars/splice-dso-governance-${InitialPackageVersions.initialPackageVersion(DarResources.dsoGovernance)}.dar"
 
   override def environmentDefinition: EnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology4Svs(this.getClass.getSimpleName)
+      .withAdditionalSetup(implicit env => {
+        // Some tests rely on those DARs being present without starting the SV/validator app which usually upload these.
+        sv2Backend.participantClient.upload_dar_unless_exists(dsoGovernanceDarPath)
+        bobValidatorBackend.participantClient.upload_dar_unless_exists(amuletDarPath)
+      })
       .withManualStart
 }


### PR DESCRIPTION
[ci]

but this time with the right version

fixes https://github.com/DACH-NY/cn-test-failures/issues/4944

The reason why this didn't fail initially is that sometimes another test runs first that uploads the DAR.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
