### PR TITLE
bump flux version

### DIFF
--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -418,7 +418,7 @@
           ]
         }
       },
-      "version": "2.16.2"
+      "version": "2.14.1"
     },
     "name": "flux",
     "provider": "",

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -418,7 +418,7 @@
           ]
         }
       },
-      "version": "2.12.4"
+      "version": "2.16.2"
     },
     "name": "flux",
     "provider": "",

--- a/cluster/pulumi/operator/src/flux/flux.ts
+++ b/cluster/pulumi/operator/src/flux/flux.ts
@@ -8,7 +8,7 @@ import { namespace } from '../namespace';
 export const flux = new k8s.helm.v3.Release('flux', {
   name: 'flux',
   chart: 'flux2',
-  version: '2.16.2',
+  version: '2.14.1',
   namespace: namespace.ns.metadata.name,
   repositoryOpts: {
     repo: 'https://fluxcd-community.github.io/helm-charts',

--- a/cluster/pulumi/operator/src/flux/flux.ts
+++ b/cluster/pulumi/operator/src/flux/flux.ts
@@ -8,6 +8,9 @@ import { namespace } from '../namespace';
 export const flux = new k8s.helm.v3.Release('flux', {
   name: 'flux',
   chart: 'flux2',
+  // When trying to upgrade to 2.15.0 and 2.16.2, source-controller failed to pull the code, with an error of git not being found in PATH
+  // (source-controller does not use git from PATH, but a built-in git implementation, so this seems to be a symptom of some other failure,
+  //  perhaps authentication to the private repo), so for now we do not upgrade past 2.14.1.
   version: '2.14.1',
   namespace: namespace.ns.metadata.name,
   repositoryOpts: {

--- a/cluster/pulumi/operator/src/flux/flux.ts
+++ b/cluster/pulumi/operator/src/flux/flux.ts
@@ -8,7 +8,7 @@ import { namespace } from '../namespace';
 export const flux = new k8s.helm.v3.Release('flux', {
   name: 'flux',
   chart: 'flux2',
-  version: '2.12.4',
+  version: '2.16.2',
   namespace: namespace.ns.metadata.name,
   repositoryOpts: {
     repo: 'https://fluxcd-community.github.io/helm-charts',


### PR DESCRIPTION
This is not the latest (2.14.1, which uses flux 14.1 vs 2.16.2 which uses flux 16.2), but the following release (2.15.0) broke something in the git checkout for us which didn't seem worth spending much more time investigating. It materializes in "command git not found in PATH", but I suspect it's something around the ssh authentication or something like that because flux does not even use git from PATH, it has a builtin git library.

Tested locally with `cncluster apply_operator`. Thought of also testing through hdm_test, but that uses the operator from cn-internal main, so I'll leave that to the periodic test.

Fixes #1091

(I believe that applying this would require running deploy-operator workflow manually on all clusters, as it updates the operator stack itself. Created https://github.com/DACH-NY/canton-network-internal/issues/843 to track that)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
