### PR TITLE
read runners token from secret mgr

### DIFF
--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
+import { getSecretVersionOutput } from '@pulumi/gcp/secretmanager/getSecretVersion';
 import { ConfigMap, Namespace, PersistentVolumeClaim, Secret } from '@pulumi/kubernetes/core/v1';
 import { Release } from '@pulumi/kubernetes/helm/v3';
 import { Role } from '@pulumi/kubernetes/rbac/v1';
@@ -13,7 +14,6 @@ import {
   imagePullSecretByNamespaceNameForServiceAccount,
   infraAffinityAndTolerations,
 } from 'splice-pulumi-common';
-import { spliceEnvConfig } from 'splice-pulumi-common/src/config/envConfig';
 import { DockerConfig } from 'splice-pulumi-common/src/dockerConfig';
 
 import { createCachePvc } from './cache';
@@ -765,7 +765,9 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release): void {
         // for registration, and this endpoint seems to require admin rights.
         // TODO(DACH-NY/canton-network-node#17842): The recommended thing to do is use a GitHub App. See here for a guide
         // on setting it up: https://medium.com/@timburkhardt8/registering-github-self-hosted-runners-using-github-app-9cc952ea6ca
-        github_token: spliceEnvConfig.requireEnv('GITHUB_RUNNERS_ACCESS_TOKEN'),
+        github_token: getSecretVersionOutput({ secret: 'gh-runners-access-token' }).apply(
+          k => k.secretData
+        ),
       },
     },
     {


### PR DESCRIPTION
- moves the token to secret manager instead of keeping it in our local envrc's
- replaces the token with a fine-grained one with minimal permissions required to register the runners (by saving that one in secret mgr)

Fixes (last part of) DACH-NY/canton-network-internal#467

Already applied on splice cluster, seems to work well

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
