### PR TITLE
[ci] Improve logging around pausing triggers

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TriggerTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TriggerTestUtil.scala
@@ -1,6 +1,7 @@
 package org.lfdecentralizedtrust.splice.util
 
 import com.digitalasset.canton.{BaseTest, ScalaFuturesWithPatience}
+import com.typesafe.scalalogging.LazyLogging
 import org.lfdecentralizedtrust.splice.automation.Trigger
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition.sv1Backend
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.SpliceTestConsoleEnvironment
@@ -35,7 +36,7 @@ trait TriggerTestUtil { self: BaseTest =>
   }
 }
 
-object TriggerTestUtil extends ScalaFuturesWithPatience {
+object TriggerTestUtil extends ScalaFuturesWithPatience with LazyLogging {
 
   /** Enable/Disable triggers before executing a code block
     */
@@ -44,10 +45,14 @@ object TriggerTestUtil extends ScalaFuturesWithPatience {
       triggersToResumeAtStart: Seq[Trigger] = Seq.empty,
   )(codeBlock: => T): T = {
     try {
+      logger.info(s"Pausing triggers for block: $triggersToPauseAtStart")
+      logger.info(s"Resuming triggers for block: $triggersToPauseAtStart")
       triggersToPauseAtStart.foreach(_.pause().futureValue)
       triggersToResumeAtStart.foreach(_.resume())
       codeBlock
     } finally {
+      logger.info(s"Resuming triggers after block: $triggersToPauseAtStart")
+      logger.info(s"Pausing triggers after block: $triggersToPauseAtStart")
       triggersToPauseAtStart.foreach(_.resume())
       triggersToResumeAtStart.foreach(_.pause().futureValue)
     }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SourceBasedTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SourceBasedTrigger.scala
@@ -111,17 +111,27 @@ abstract class SourceBasedTrigger[T: Pretty](implicit
   private var waitForResumePromise: Promise[Unit] = Promise.successful(())
 
   override def pause(): Future[Unit] = blocking {
-    synchronized {
-      if (waitForResumePromise.isCompleted) {
-        waitForResumePromise = Promise()
+    withNewTrace(this.getClass.getSimpleName) { implicit traceContext => _ =>
+      logger.info("Pausing trigger.")
+      blocking {
+        synchronized {
+          if (waitForResumePromise.isCompleted) {
+            waitForResumePromise = Promise()
+          }
+          Future.successful(())
+        }
       }
-      Future.successful(())
     }
   }
 
   override def resume(): Unit = blocking {
-    synchronized {
-      val _ = waitForResumePromise.trySuccess(())
+    withNewTrace(this.getClass.getSimpleName) { implicit traceContext => _ =>
+      logger.info("Resuming trigger.")
+      blocking {
+        synchronized {
+          val _ = waitForResumePromise.trySuccess(())
+        }
+      }
     }
   }
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/MergeValidatorLicenseContractsTrigger.scala
@@ -68,7 +68,7 @@ class MergeValidatorLicenseContractsTrigger(
         }
       outcome <-
         if (validatorLicenses.length > 1) {
-          logger.warn(
+          logger.info(
             s"Validator $validator has ${validatorLicenses.length} Validator License contracts."
           )
           mergeValidatorLicenseContracts(


### PR DESCRIPTION
Improve logging for https://github.com/DACH-NY/cn-test-failures/issues/4938 as it makes no sense

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
