### PR TITLE
[ci] Set topology delay to 250ms

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvHandler.scala
@@ -574,7 +574,7 @@ class HttpSvHandler(
                 case _ => None
               } match {
               case Some(activeMapping) =>
-                activeMapping.base.sequenced
+                activeMapping.base.validFrom
               case None =>
                 throw Status.NOT_FOUND
                   .withDescription(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -408,8 +408,7 @@ class SV1Initializer(
         )
         val initialValues = DynamicSynchronizerParameters.initialValues(clock, ProtocolVersion.v33)
         val values = initialValues.tryUpdate(
-          // TODO(DACH-NY/canton-network-node#6055) Consider increasing topology change delay again
-          topologyChangeDelay = NonNegativeFiniteDuration.tryOfMillis(0),
+          topologyChangeDelay = NonNegativeFiniteDuration.tryOfMillis(250),
           trafficControlParameters = Some(initialTrafficControlParameters),
           reconciliationInterval =
             PositiveSeconds.fromConfig(SvUtil.defaultAcsCommitmentReconciliationInterval),


### PR DESCRIPTION
Should improve network throughput

Relates to https://github.com/DACH-NY/canton-network-node/issues/6055

Assumption is that validFrom = sequenced + change delay (effective), lets see what the tests say 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
