### PR TITLE
nix: remove gsutil pyopenssl workaround

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -17,46 +17,6 @@
   python3 = super.python3.override {
     packageOverrides = pySelf : pySuper : rec {
       sphinx-reredirects = pySelf.callPackage ./sphinx-reredirects.nix { };
-      # gsutil requires an older version of pyopenssl dependency
-      pyopenssl = pySuper.pyopenssl.overridePythonAttrs (old: rec {
-        version = "24.2.1";
-        src = super.fetchFromGitHub {
-          owner = "pyca";
-          repo = "pyopenssl";
-          tag = version;
-          hash = "sha256-/TQnDWdycN4hQ7ZGvBhMJEZVafmL+0wy9eJ8hC6rfio=";
-        };
-        # we remove the docs output because it fails to build and we don't need it
-        outputs = [
-          "out"
-          "dev"
-        ];
-        # tweaked to remove the sphinx hook to build docs
-        nativeBuildInputs = [
-          super.openssl
-        ];
-      });
-      # downgraded to work with pyopenssl
-      cryptography = (pySuper.cryptography.override {}).overridePythonAttrs (old: rec {
-        pname = "cryptography";
-        version = "43.0.1";
-        src = pySuper.fetchPypi {
-          inherit pname version;
-          hash = "sha256-ID6Sp1cW2M+0kdxHx54X0NkgfM/8vLNfWY++RjrjRE0=";
-        };
-
-        cargoRoot = "src/rust";
-
-        cargoDeps = super.rustPlatform.fetchCargoTarball {
-          inherit src;
-          sourceRoot = "${pname}-${version}/${cargoRoot}";
-          name = "${pname}-${version}";
-          hash = "sha256-wiAHM0ucR1X7GunZX8V0Jk2Hsi+dVdGgDKqcYjSdD7Q=";
-        };
-      });
-      # downgraded together with cryptography. We can't just override it
-      # as it's not exposed in pythonpackages so we need to copy vectors.nix
-      cryptography-vectors = super.callPackage ./vectors.nix { buildPythonPackage = pySuper.buildPythonPackage; cryptography = pySelf.cryptography; flit-core = pySuper.flit-core; };
     };
   };
   pre-commit = super.pre-commit.overrideAttrs (old: {


### PR DESCRIPTION
The version we bumped to in https://github.com/hyperledger-labs/splice/pull/1412 seems to (finally!) fix this for good.

...and now it seems that the workaround is actually causing things to not work.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/4957

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
