### PR TITLE
Fix branch reference in caching definitions

### DIFF
--- a/.github/actions/cache/daml_artifacts/restore/action.yml
+++ b/.github/actions/cache/daml_artifacts/restore/action.yml
@@ -19,9 +19,9 @@ runs:
         path: |
           /tmp/daml
           apps/common/frontend/daml.js
-        key: daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }} rev:${{ github.sha }}
+        key: daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }} rev:${{ github.sha }}
         restore-keys: |
-          daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }}
+          daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }}
           daml-artifacts-${{ inputs.cache_version }} branch:main dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }}
     - name: Extract Daml artifacts
       shell: bash
@@ -31,4 +31,3 @@ runs:
         else
           echo "No cached daml artifacts files found. Skipping..."
         fi
-

--- a/.github/actions/cache/daml_artifacts/save/action.yml
+++ b/.github/actions/cache/daml_artifacts/save/action.yml
@@ -29,4 +29,4 @@ runs:
         path: |
           /tmp/daml
           apps/common/frontend/daml.js
-        key: daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }} rev:${{ github.sha }}
+        key: daml-artifacts-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'build.sbt', 'daml/dars.lock', 'nix/canton-sources.json') }} rev:${{ github.sha }}

--- a/.github/actions/cache/frontend_node_modules/restore/action.yml
+++ b/.github/actions/cache/frontend_node_modules/restore/action.yml
@@ -17,9 +17,9 @@ runs:
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/npm_install
-        key: frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }} rev:${{ github.sha }}
+        key: frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }} rev:${{ github.sha }}
         restore-keys: |
-          frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }}
+          frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }}
           frontend-npm-install-${{ inputs.cache_version }} branch:main dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }}
     - name: Extracting archive of npm dependencies
       shell: bash

--- a/.github/actions/cache/frontend_node_modules/save/action.yml
+++ b/.github/actions/cache/frontend_node_modules/save/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/npm_install
-        key: frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }} rev:${{ github.sha }}
+        key: frontend-npm-install-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('apps/package-lock.json', 'openapi-cache-key.txt', 'project/BuildCommon.scala') }} rev:${{ github.sha }}
     - name: Not archiving frontend node_modules
       if: ${{ fromJson(inputs.load_cache_hit) }}
       shell: bash

--- a/.github/actions/cache/precompiled_classes/restore/action.yml
+++ b/.github/actions/cache/precompiled_classes/restore/action.yml
@@ -17,9 +17,9 @@ runs:
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/classes
-        key: classes-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }} rev:${{ github.sha }}
+        key: classes-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }} rev:${{ github.sha }}
         restore-keys: |
-          classes-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }}
+          classes-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }}
           classes-${{ inputs.cache_version }} branch:main dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }}
     - name: Extract precompiled classes
       shell: bash

--- a/.github/actions/cache/precompiled_classes/save/action.yml
+++ b/.github/actions/cache/precompiled_classes/save/action.yml
@@ -25,4 +25,4 @@ runs:
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/classes
-        key: classes-${{ inputs.cache_version }} branch:${{ github.head_ref }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }} rev:${{ github.sha }}
+        key: classes-${{ inputs.cache_version }} branch:${{ github.head_ref || github.ref_name }} dependencies:${{ hashFiles('project/build.properties', 'project/BuildCommon.scala', 'project/DamlPlugin.scala', 'project/Dependencies.scala', 'project/CantonDependencies.scala', 'project/Houserules.scala', 'project/plugins.sbt', 'build.sbt', 'daml/dars.lock', 'openapi-cache-key.txt') }} rev:${{ github.sha }}


### PR DESCRIPTION
github head_ref is empty on main and only set for pull requests. So we write the cache for `branch:` and then try to read it as `branch:main` which is always a cache miss.

Note that main is also still not correct for PRs against the canton-3.4 branch. But that's an orthogonal issue, I'll create a separate issue for that.

fixes #1426 (hopefully, I can't easily test this until this is merged to main, pretty confident it won't break it more than it already is though)

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
