### PR TITLE
Remove concurrency annotations from post_merge jobs

### DIFF
--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -5,10 +5,6 @@ on:
       - 'main'
       - 'release-line-**'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 permissions:
   id-token: write # Required for GCP Workload Identity for failure notifications
   contents: read


### PR DESCRIPTION
Noone seems to know why we have them. In general being able to test things merged to main faster seems desirable.

If it doesn't work, we'll learn soon enough I guess and can add it back with a comment on why we need it.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
