### PR TITLE
Add retry in ResetDecentralizedNamespace

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/plugins/ResetTopologyStatePlugin.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/plugins/ResetTopologyStatePlugin.scala
@@ -50,6 +50,18 @@ abstract class ResetTopologyStatePlugin
 
   private def attemptToResetTopologyState(env: SpliceTests.SpliceTestConsoleEnvironment): Unit = {
     val sv1 = env.svs.local.find(_.name == "sv1").value
+    val synchronizerId = eventuallySucceeds() {
+      val connectedDomain = sv1.participantClientWithAdminToken.synchronizers
+        .list_connected()
+        .find(_.synchronizerAlias == sv1.config.domains.global.alias)
+        .getOrElse(
+          throw new IllegalStateException(
+            "Failed to reset environment as SV1 is not connected to global domain"
+          )
+        )
+      connectedDomain.synchronizerId
+    }
+
     def resetTopologyStateRetries(retries: Int): Unit = {
       if (retries > MAX_RETRIES) {
         logger.error(
@@ -58,15 +70,6 @@ abstract class ResetTopologyStatePlugin
         sys.exit(1)
       }
       try {
-        val connectedDomain = sv1.participantClientWithAdminToken.synchronizers
-          .list_connected()
-          .find(_.synchronizerAlias == sv1.config.domains.global.alias)
-          .getOrElse(
-            throw new IllegalStateException(
-              "Failed to reset environment as SV1 is not connected to global domain"
-            )
-          )
-        val synchronizerId = connectedDomain.synchronizerId
         resetTopologyState(env, synchronizerId, sv1)
       } catch {
         case _: CommandFailure =>
@@ -79,9 +82,6 @@ abstract class ResetTopologyStatePlugin
           logger.info(
             s"Restarting $topologyType reset as base serial has changed"
           )
-          resetTopologyStateRetries(retries + 1)
-        case e: IllegalStateException =>
-          logger.info(e.getMessage)
           resetTopologyStateRetries(retries + 1)
         case e: Throwable =>
           logger.error(s"Failed to reset $topologyType", e)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SpliceTests.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SpliceTests.scala
@@ -507,23 +507,6 @@ object SpliceTests extends LazyLogging {
       }
     }
 
-    /** Keeps evaluating `testCode` until it succeeds or a timeout occurs.
-      */
-    def eventuallySucceeds[T](
-        timeUntilSuccess: FiniteDuration = 20.seconds,
-        maxPollInterval: FiniteDuration = 5.seconds,
-        suppressErrors: Boolean = true,
-    )(testCode: => T): T = {
-      eventually(timeUntilSuccess, maxPollInterval) {
-        try {
-          if (suppressErrors) loggerFactory.suppressErrors(testCode) else testCode
-        } catch {
-          case e: TestFailedException => throw e
-          case NonFatal(e) => fail(e)
-        }
-      }
-    }
-
     /** Changes `name` so it is unlikely to conflict with names used somewhere else.
       * Does nothing for isolated test environments, overloaded for shared environment.
       */

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SpliceTests.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SpliceTests.scala
@@ -67,7 +67,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 import scala.math.BigDecimal.RoundingMode
 import scala.util.chaining.scalaUtilChainingOps
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /** Analogue to Canton's CommunityTests */

--- a/canton/community/testing/src/main/scala/com/digitalasset/canton/BaseTest.scala
+++ b/canton/community/testing/src/main/scala/com/digitalasset/canton/BaseTest.scala
@@ -47,6 +47,7 @@ import org.typelevel.discipline.Laws
 
 import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 trait ScalaFuturesWithPatience extends ScalaFutures {
@@ -399,6 +400,23 @@ trait BaseTest
       maxPollInterval,
       retryOnTestFailuresOnly = retryOnTestFailuresOnly,
     )(testCode)
+
+  /** Keeps evaluating `testCode` until it succeeds or a timeout occurs.
+    */
+  def eventuallySucceeds[T](
+      timeUntilSuccess: FiniteDuration = 20.seconds,
+      maxPollInterval: FiniteDuration = 5.seconds,
+      suppressErrors: Boolean = true,
+  )(testCode: => T): T = {
+    eventually(timeUntilSuccess, maxPollInterval) {
+      try {
+        if (suppressErrors) loggerFactory.suppressErrors(testCode) else testCode
+      } catch {
+        case e: TestFailedException => throw e
+        case NonFatal(e) => fail(e)
+      }
+    }
+  }
 
   /** Keeps evaluating `testCode` until it fails or a timeout occurs.
     * @return


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/4961

we are not retrying to list connected synchronizer if they're disconnect: `Failed to reset environment as SV1 is not connected to global domain, giving up`

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
