### PR TITLE
Prevent infinite loop in XXXAnsField

### DIFF
--- a/apps/common/frontend/src/components/AnsField.tsx
+++ b/apps/common/frontend/src/components/AnsField.tsx
@@ -60,8 +60,11 @@ export const BaseAnsField: React.FC<BaseAnsFieldProps> = ({
       setResolvedPartyId(party);
     };
     const ansEntryParty = ansEntry.data?.user || userInput.value;
-    setPartyAndNotify(ansEntryParty);
-  }, [userInput, ansEntry, onPartyChanged]);
+    if (resolvedPartyId !== ansEntryParty) {
+      // prevent infinite loop
+      setPartyAndNotify(ansEntryParty);
+    }
+  }, [userInput, ansEntry, resolvedPartyId, onPartyChanged]);
 
   const onInputChange = async (_: React.SyntheticEvent, newValue: string, reason: string) => {
     if (reason === 'reset') {


### PR DESCRIPTION
Theory:
This causes some vitests to get stuck in an infinite loop of useEffect => updateParent => render => useEffect => updateParent if the callback changes (which it often does unless you use `useCallback`, but that's easy to miss).
This is not noticeable in selenium nor the browser, so either they don't get stuck in a loop or unlike vitest they don't wait for the DOM to be stable.