### PR TITLE
Do not use rust-parallel on macos

### DIFF
--- a/build-tools/npm-run-parallel
+++ b/build-tools/npm-run-parallel
@@ -5,4 +5,11 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 SCRIPT=$1
-npm query .workspace --json | jq -r '.[].location' | xargs -I {} sh -c "if jq -e .scripts.$SCRIPT {}/package.json > /dev/null; then echo {}; fi" | rust-parallel npm run "$SCRIPT" --workspace
+
+if [[ "$(uname)" == "Darwin"* ]]
+then
+    # rust-parallel doesn't seem to be available for darwin in nix so we fallback to the sequential version
+    npm run --workspace --if-present "$SCRIPT"
+else
+    npm query .workspace --json | jq -r '.[].location' | xargs -I {} sh -c "if jq -e .scripts.$SCRIPT {}/package.json > /dev/null; then echo {}; fi" | rust-parallel npm run "$SCRIPT" --workspace
+fi

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,7 +6,7 @@ let
   damlCompilerSources = builtins.fromJSON (builtins.readFile ./daml-compiler-sources.json);
 
   # No macOS support for firefox
-  linuxOnly = if stdenv.isDarwin then [ ] else with pkgs; [ firefox iproute2 util-linux ];
+  linuxOnly = if stdenv.isDarwin then [ ] else with pkgs; [ firefox iproute2 rust-parallel util-linux ];
 
 in pkgs.mkShell {
   PULUMI_SKIP_UPDATE_CHECK = 1;
@@ -93,7 +93,6 @@ in pkgs.mkShell {
     redocly
     ripgrep
     rsync
-    rust-parallel
     sbt
     scala_2_13
     selenium-server-standalone


### PR DESCRIPTION
[static]

It looks like in newer nix versions it may work on macos https://github.com/NixOS/nixpkgs/commit/02e74dfd6dade15eba110f0969b3f7c1896b7ca3. But I don't have access to a macos machine to test this so I'll leave it to the macos users to debug this if they care about parallelism. I primarily care about CI speedups here which luckily runs on Linux.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
