### PR TITLE
Fix npm-run-parallel and make tests sequential

### DIFF
--- a/build-tools/npm-run-parallel
+++ b/build-tools/npm-run-parallel
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # This is essentially npm run --workspace --if-present SCRIPT but in parallel
+set -eou pipefail
 if [ $# -ne 1 ]; then
     echo "Usage: npm-run-parallel NPM_SCRIPT_NAME"
     exit 1
@@ -11,5 +12,5 @@ then
     # rust-parallel doesn't seem to be available for darwin in nix so we fallback to the sequential version
     npm run --workspace --if-present "$SCRIPT"
 else
-    npm query .workspace --json | jq -r '.[].location' | xargs -I {} sh -c "if jq -e .scripts.$SCRIPT {}/package.json > /dev/null; then echo {}; fi" | rust-parallel npm run "$SCRIPT" --workspace
+    npm query .workspace --json | jq -r '.[].location' | xargs -I {} sh -c "if jq -e .scripts.[\\\"$SCRIPT\\\"] {}/package.json > /dev/null; then echo {}; fi" | rust-parallel npm run "$SCRIPT" --workspace
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -1187,7 +1187,7 @@ lazy val `apps-common-frontend` = {
         )
           BuildCommon.TS.runWorkspaceCommand(npmRootDir.value, "build", workspace, log)
         runCommand(
-          Seq("npm-run-parallel", "test:sbt"),
+          Seq("npm", "run", "test:sbt", "--workspaces", "--if-present"),
           log,
           None,
           Some(npmRootDir.value),


### PR DESCRIPTION
[ci]

The parallel run just times out in a bunch of tests so reverting that back to sequential now. I did check that the parallel script runs properly and fails on failures now.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
