### PR TITLE
Revert "[ci] Set topology delay to 250ms (#1423)"

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
@@ -178,10 +178,6 @@ case class EnvironmentDefinition(
             ),
           )
         }
-        participants(env).foreach { p =>
-          logger.info(s"Ensuring vetting topology is effective for ${p.name}")(TraceContext.empty)
-          p.topology.synchronisation.await_idle()
-        }
       }
     )
   }
@@ -414,14 +410,6 @@ case class EnvironmentDefinition(
           .updateAllSvAppFoundDsoConfigs_(
             _.focus(_.initialSynchronizerFeesConfig.baseRateBurstAmount)
               .replace(NonNegativeLong.tryCreate(2_000_000L))
-          )(conf)
-      )
-      .addConfigTransform((_, conf) =>
-        ConfigTransforms
-          .updateAllSvAppConfigs_(
-            _.focus(_.topologyChangeDelayDuration)
-              // same as canton for sim time
-              .replace(NonNegativeFiniteDuration.Zero)
           )(conf)
       )
       .withSequencerConnectionsFromScanDisabled(10_000)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
@@ -294,7 +294,7 @@ abstract class TopologyAdminConnection(
           )
       }
 
-  private def listMediatorSynchronizerState(
+  def listMediatorSynchronizerState(
       store: TopologyStoreId,
       synchronizerId: SynchronizerId,
       proposals: Boolean,
@@ -335,7 +335,7 @@ abstract class TopologyAdminConnection(
         )
     }
 
-  private def listDecentralizedNamespaceDefinition(
+  def listDecentralizedNamespaceDefinition(
       synchronizerId: SynchronizerId,
       decentralizedNamespace: Namespace,
       proposals: TopologyTransactionType = AuthorizedState,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvHandler.scala
@@ -574,7 +574,7 @@ class HttpSvHandler(
                 case _ => None
               } match {
               case Some(activeMapping) =>
-                activeMapping.base.validFrom
+                activeMapping.base.sequenced
               case None =>
                 throw Status.NOT_FOUND
                   .withDescription(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -227,7 +227,6 @@ class SvDsoAutomationService(
         participantAdminConnection,
         config.preparationTimeRecordTimeTolerance,
         config.mediatorDeduplicationTimeout,
-        config.topologyChangeDelayDuration,
       )
     )
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/ReconcileDynamicDomainParametersTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/ReconcileDynamicDomainParametersTrigger.scala
@@ -44,7 +44,6 @@ class ReconcileDynamicSynchronizerParametersTrigger(
     participantAdminConnection: ParticipantAdminConnection,
     preparationTimeRecordTimeTolerance: NonNegativeFiniteDuration,
     mediatorDeduplicationTimeout: NonNegativeFiniteDuration,
-    topologyChangeDelayDuration: NonNegativeFiniteDuration,
 )(implicit
     override val ec: ExecutionContext,
     mat: Materializer,
@@ -87,7 +86,6 @@ class ReconcileDynamicSynchronizerParametersTrigger(
         amuletConfig,
         decentralizedSynchronizerConfig,
         preparationTimeRecordTimeToleranceTarget,
-        topologyChangeDelayDuration,
       )
     } yield
       if (state.mapping.parameters != updatedConfig)
@@ -151,7 +149,6 @@ class ReconcileDynamicSynchronizerParametersTrigger(
           task.amuletConfig,
           task.synchronizerConfig,
           task.preparationTimeRecordTimeToleranceTarget,
-          topologyChangeDelayDuration,
         ),
         forceChanges =
           if (task.preparationTimeRecordTimeToleranceTarget.isDefined)
@@ -180,7 +177,6 @@ class ReconcileDynamicSynchronizerParametersTrigger(
       amuletConfig: AmuletConfig[USD],
       synchronizerConfig: Option[SynchronizerConfig],
       preparationTimeRecordTimeToleranceTarget: Option[InternalNonNegativeFiniteDuration],
-      topologyDelay: NonNegativeFiniteDuration,
   ): DynamicSynchronizerParameters = {
     val domainFeesConfig = amuletConfig.decentralizedSynchronizer.fees
     // Make sure that the bootstrap script for the upgrade domain is aligned with any changes made to the
@@ -208,7 +204,6 @@ class ReconcileDynamicSynchronizerParametersTrigger(
       ),
       mediatorDeduplicationTimeout =
         InternalNonNegativeFiniteDuration.fromConfig(mediatorDeduplicationTimeout),
-      topologyChangeDelay = topologyDelay.toInternal,
     )
   }
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -261,8 +261,6 @@ case class SvAppBackendConfig(
       NonNegativeFiniteDuration.ofHours(24),
     // Defaults to 48h as it must be at least 2x preparationTimeRecordtimeTolerance
     mediatorDeduplicationTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(48),
-    topologyChangeDelayDuration: NonNegativeFiniteDuration =
-      NonNegativeFiniteDuration.ofMillis(250),
     delegatelessAutomation: Boolean = true,
     expectedTaskDuration: Long = 5000, // milliseconds
     expiredRewardCouponBatchSize: Int = 100,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -425,7 +425,8 @@ class SV1Initializer(
         )
         val initialValues = DynamicSynchronizerParameters.initialValues(clock, ProtocolVersion.v33)
         val values = initialValues.tryUpdate(
-          topologyChangeDelay = config.topologyChangeDelayDuration.toInternal,
+          // TODO(DACH-NY/canton-network-node#6055) Consider increasing topology change delay again
+          topologyChangeDelay = NonNegativeFiniteDuration.tryOfMillis(0),
           trafficControlParameters = Some(initialTrafficControlParameters),
           reconciliationInterval =
             PositiveSeconds.fromConfig(SvUtil.defaultAcsCommitmentReconciliationInterval),

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -138,8 +138,4 @@ ACS_COMMITMENT_MISMATCH.*(bob|alice)Participant
 # TODO(#930) - investigate this on the canton side
 Instrument daml\.sequencer\.bftordering.* has exceeded the maximum allowed cardinality
 
-# TODO(#1450) - investigate this on the canton side
-FAILED_PRECONDITION/SEQUENCER_SENDER_UNKNOWN.*Senders are unknown: MED::sv
-Rejected transaction due to a participant determined timeout
-
 # Make sure to have a trailing newline


### PR DESCRIPTION
This reverts commit ca7107913798f9b7a6e5f6a5e72ccc530ff7a0a6.

Probably fixes the persistent test failure in https://github.com/DACH-NY/canton-network-internal/issues/900

The fact that the failing preflights don't become green even after multiple retries makes me uneasy; let's confirm that reverting this fixes the issue so we're safe for the next release.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
