### PR TITLE
save also the non-oss nix cache

### DIFF
--- a/.github/actions/tests/scala_test/action.yml
+++ b/.github/actions/tests/scala_test/action.yml
@@ -104,6 +104,9 @@ runs:
         artifactory_user: ${{ inputs.artifactory_user }}
         artifactory_password: ${{ inputs.artifactory_password }}
         oss_only: ${{ inputs.oss_only }}
+        # The docs job saves the oss nix cache, here we save the non-oss one, but only in one runner to reduce contention
+        # TODO(#1296): When this runner stops using non-oss, move this to one that does
+        save_nix_cache: ${{ inputs.runner-index == 0 && inputs.test_suite_name == 'wall-clock-time' && !inputs.oss_only }}
 
     - name: Wait for postgres
       uses: ./.github/actions/nix/run_bash_command_in_nix


### PR DESCRIPTION
Followup to #1512 , I realized that we now have two versions of a nix env, so we need to save each of them to cache (at least) once in every run
(note that setting a different key for the cache based on the oss flag is already supported [here](https://github.com/hyperledger-labs/splice/blob/4de18208b4a930e848e63cf1e9f0008172bb4de2/.github/actions/nix/setup_self_hosted_nix/action.yml#L35-L36)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
