### PR TITLE
Check for staleness before waiting in delegateless automation

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/SvTaskBasedTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/SvTaskBasedTrigger.scala
@@ -172,28 +172,39 @@ trait SvTaskBasedTrigger[T <: PrettyPrinting] {
         pollingTriggerInterval,
       )
     val delay = Random.nextLong(upperBound)
-    DelayUtil
-      .delayIfNotClosing(
-        "dso-delegate-task-delay",
-        FiniteDuration.apply(delay, TimeUnit.MILLISECONDS),
-        this,
-      )
-      .onShutdown(logger.debug(s"Closing after waiting $delay ms"))
-      .flatMap(_ =>
-        isStaleTask(task).flatMap {
-          case true =>
-            Future.successful(
-              TaskSuccess(
-                s"Skipping because task ${task.toString} is already completed after waiting a delay of $delay ms"
-              )
-            )
-          case false =>
-            logger.info(
-              s"Completing dso delegate task ${task.toString} after waiting a delay of $delay ms"
-            )
-            completeTaskAsDsoDelegate(task, svParty)
-        }
-      )
+    isStaleTask(task).flatMap {
+      if (_) {
+        Future.successful(
+          TaskSuccess(
+            s"Skipping because task ${task.toString} is already completed"
+          )
+        )
+      } else {
+        DelayUtil
+          .delayIfNotClosing(
+            "dso-delegate-task-delay",
+            FiniteDuration.apply(delay, TimeUnit.MILLISECONDS),
+            this,
+          )
+          .onShutdown(logger.debug(s"Closing after waiting $delay ms"))
+          .flatMap(_ =>
+            isStaleTask(task).flatMap {
+              if (_) {
+                Future.successful(
+                  TaskSuccess(
+                    s"Skipping because task ${task.toString} is already completed after waiting a delay of $delay ms"
+                  )
+                )
+              } else {
+                logger.info(
+                  s"Completing dso delegate task ${task.toString} after waiting a delay of $delay ms"
+                )
+                completeTaskAsDsoDelegate(task, svParty)
+              }
+            }
+          )
+      }
+    }
   }
 
   protected def completeTaskAsDsoDelegate(


### PR DESCRIPTION
fixes #1516

Without this you can end up falling behind and processing things extremely slowly as the contracts you are processing are already archived but you still wait a second or so before even checking. If contracts get created faster than your wait time you will never catch up.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
