### PR TITLE
[static] Add ability to configure the number of sql backups to retina

### DIFF
--- a/cluster/pulumi/common/src/config/configSchema.ts
+++ b/cluster/pulumi/common/src/config/configSchema.ts
@@ -23,6 +23,7 @@ const PulumiProjectConfigSchema = z.object({
     protected: z.boolean(),
     tier: z.string(),
     enterprisePlus: z.boolean(),
+    backupsToRetain: z.number().optional(),
   }),
 });
 export type PulumiProjectConfig = z.infer<typeof PulumiProjectConfigSchema>;

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -98,6 +98,13 @@ export class CloudPostgres extends pulumi.ComponentResource implements Postgres 
           backupConfiguration: {
             enabled: true,
             pointInTimeRecoveryEnabled: true,
+            ...(spliceConfig.pulumiProjectConfig.cloudSql.backupsToRetain
+              ? {
+                  backupRetentionSettings: {
+                    retainedBackups: spliceConfig.pulumiProjectConfig.cloudSql.backupsToRetain,
+                  },
+                }
+              : {}),
           },
           insightsConfig: {
             queryInsightsEnabled: true,


### PR DESCRIPTION
Enables https://github.com/DACH-NY/canton-network-internal/issues/928

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
