### PR TITLE
Pulumi: support loading an additional common config override

### DIFF
--- a/cluster/pulumi/common/src/config/configLoader.ts
+++ b/cluster/pulumi/common/src/config/configLoader.ts
@@ -7,13 +7,19 @@ import { merge } from 'lodash';
 import { spliceEnvConfig } from './envConfig';
 
 function loadClusterYamlConfig(): unknown {
-  const clusterBaseConfig = readAndParseYaml(
+  const baseConfig = readAndParseYaml(
     `${spliceEnvConfig.context.splicePath}/cluster/deployment/config.yaml`
   );
+  // Load an additional common overrides config if it exists;
+  // if the file is identical to the base config for some reason, loading it will not change anything.
+  const commonOverridesConfigPath = `${spliceEnvConfig.context.clusterPath()}/../config.yaml`;
+  const commonOverridesConfig = fs.existsSync(commonOverridesConfigPath)
+    ? readAndParseYaml(commonOverridesConfigPath)
+    : {};
   const clusterOverridesConfig = readAndParseYaml(
     `${spliceEnvConfig.context.clusterPath()}/config.yaml`
   );
-  return merge({}, clusterBaseConfig, clusterOverridesConfig);
+  return merge({}, baseConfig, commonOverridesConfig, clusterOverridesConfig);
 }
 
 function readAndParseYaml(filePath: string): unknown {


### PR DESCRIPTION
Fixes #1490

Proof that it works: https://github.com/DACH-NY/canton-network-internal/pull/943

Will move common log alerts configs out of this repo next... (once https://github.com/DACH-NY/canton-network-internal/pull/943 gets merged, which will be after this PR here)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
