### PR TITLE
0.4.6 backport: Pulumi: support loading an additional common config override (#1554)

### DIFF
--- a/cluster/pulumi/common/src/config/configLoader.ts
+++ b/cluster/pulumi/common/src/config/configLoader.ts
@@ -7,13 +7,19 @@ import { merge } from 'lodash';
 import { spliceEnvConfig } from './envConfig';
 
 function loadClusterYamlConfig(): unknown {
-  const clusterBaseConfig = readAndParseYaml(
+  const baseConfig = readAndParseYaml(
     `${spliceEnvConfig.context.splicePath}/cluster/deployment/config.yaml`
   );
+  // Load an additional common overrides config if it exists;
+  // if the file is identical to the base config for some reason, loading it will not change anything.
+  const commonOverridesConfigPath = `${spliceEnvConfig.context.clusterPath()}/../config.yaml`;
+  const commonOverridesConfig = fs.existsSync(commonOverridesConfigPath)
+    ? readAndParseYaml(commonOverridesConfigPath)
+    : {};
   const clusterOverridesConfig = readAndParseYaml(
     `${spliceEnvConfig.context.clusterPath()}/config.yaml`
   );
-  return merge({}, clusterBaseConfig, clusterOverridesConfig);
+  return merge({}, baseConfig, commonOverridesConfig, clusterOverridesConfig);
 }
 
 function readAndParseYaml(filePath: string): unknown {


### PR DESCRIPTION
Fixes #1490

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>