### PR TITLE
Fix `Failed clue` log checker failure...

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
@@ -46,9 +46,9 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
     }
 
     clue("SV participants are connected to all sequencers") {
-      eventually(60.seconds) {
-        forAll(Seq(sv1Backend, sv2Backend, sv3Backend, sv4Backend)) { sv =>
-          clue(s"sv ${sv.name} is connected to all sequencers") {
+      forAll(Seq(sv1Backend, sv2Backend, sv3Backend, sv4Backend)) { sv =>
+        clue(s"sv ${sv.name} is connected to all sequencers") {
+          eventually(60.seconds) {
             val synchronizerConfig = sv.participantClient.synchronizers
               .config(decentralizedSynchronizer)
               .value


### PR DESCRIPTION
TIL that if you put a `clue` in an `eventually` the log checker might get unhappy.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/5060

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
