### PR TITLE
cluster, helm, splice-info: Configuration tuning

### DIFF
--- a/cluster/helm/splice-info/templates/configmap-config.yaml
+++ b/cluster/helm/splice-info/templates/configmap-config.yaml
@@ -8,7 +8,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   staticfile.conf: |
+    server_tokens off;
+
     add_header Cache-Control no-cache;
+
+    gzip on;
+    gzip_types {{ .Values.contentType }};
 
     types {
         {{ .Values.contentType }} html;

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -62,7 +62,7 @@
       "properties": {
         "network": {
           "type": "string",
-          "enum": ["dev", "test", "main"]
+          "enum": ["localdev", "dev", "test", "main"]
         },
         "configDigest": {
           "type": "object",


### PR DESCRIPTION
- Hardening: Do not expose Nginx version
- Enable gzipping of responses
- Allow localdev as a value for "network" (useful for local development)