### PR TITLE
Extend `cluster_enable_workload_identity` to also prep the node pool

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -892,6 +892,11 @@ function subcmd_cluster_enable_workload_identity() {
 
     _info "Enabling workload identity for the cluster."
     gcloud container clusters update "${GCP_CLUSTER_NAME}" --workload-pool="${CLOUDSDK_CORE_PROJECT}.svc.id.goog"
+
+    _info "Enabling GKE metadata on the cn-apps node pool."
+    gcloud container node-pools update cn-apps-pool \
+        --cluster "cn-${GCP_CLUSTER_BASENAME}net" \
+        --workload-metadata=GKE_METADATA
 }
 ###
 


### PR DESCRIPTION
Follow-up to https://github.com/hyperledger-labs/splice/pull/1362 that was needed to get https://github.com/DACH-NY/canton-network-internal/pull/1017 moving.

S.a.: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#option_2_node_pool_modification

Context https://github.com/DACH-NY/canton-network-internal/issues/798

(Already applied on `ci`; merging so we have a record. Yes we still need to move all of this into Pulumi, but not today...)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
