### PR TITLE
remove double counting due to imports

### DIFF
--- a/apps/app/src/test/resources/total-supply-bigquery.sql
+++ b/apps/app/src/test/resources/total-supply-bigquery.sql
@@ -93,7 +93,8 @@ CREATE TEMP FUNCTION sum_bignumeric_acs(
     AND c.template_id_entity_name = entity_name
     AND (c.migration_id < migration_id
       OR (c.migration_id = migration_id
-        AND c.record_time <= UNIX_MICROS(as_of_record_time)))));
+        AND c.record_time <= UNIX_MICROS(as_of_record_time)))))
+    AND c.record_time != -62135596800000000;
 
 
 -- Total unspent but locked Amulet amount.
@@ -254,7 +255,8 @@ CREATE TEMP FUNCTION burned(
               AND c.template_id_entity_name = 'Amulet'
               AND (e.migration_id < migration_id_arg
                 OR (e.migration_id = migration_id_arg
-                    AND e.record_time <= UNIX_MICROS(as_of_record_time)))))));
+                    AND e.record_time <= UNIX_MICROS(as_of_record_time)))))))
+              AND c.record_time != -62135596800000000;
 
 
 -- using the functions


### PR DESCRIPTION
Filter out imports that caused double-counting

Results now are:
```
[{
  "locked": "44963025.7374569222",
  "unlocked": "27494184017.0319782195",
  "current_supply_total": "27539147042.7694351417",
  "unminted": "1641284616.1695462368",
  "minted": "27794061233.7845494983",
  "allowed_mint": "29435345849.9540957351",
  "burned": "389815326.9210125444"
}]
```

Which is at least more sensible than before, but still inaccurate. Specifically, `(minted - burned) != current_supply`

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
