### PR TITLE
Save Nix EE cache on Canton enterprise job

### DIFF
--- a/.github/actions/tests/scala_test/action.yml
+++ b/.github/actions/tests/scala_test/action.yml
@@ -106,7 +106,7 @@ runs:
         oss_only: ${{ inputs.oss_only }}
         # The docs job saves the oss nix cache, here we save the non-oss one, but only in one runner to reduce contention
         # TODO(#1296): When this runner stops using non-oss, move this to one that does
-        save_nix_cache: ${{ inputs.runner_index == 0 && inputs.test_suite_name == 'wall-clock-time' && inputs.oss_only == 'false' }}
+        save_nix_cache: ${{ inputs.runner_index == 0 && inputs.test_suite_name == 'canton-enterprise' }}
 
     - name: Wait for postgres
       uses: ./.github/actions/nix/run_bash_command_in_nix


### PR DESCRIPTION
[ci]

That one finishes faster so this should give slightly faster CI times.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
