### PR TITLE
remove github_token from static tests

### DIFF
--- a/.github/workflows/build.static_tests.yml
+++ b/.github/workflows/build.static_tests.yml
@@ -6,6 +6,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+  issues: read # used by the TODO checker
 
 jobs:
   static_tests:
@@ -57,8 +60,6 @@ jobs:
           additional_nix_args: "--keep GH_USER --keep GH_TOKEN --keep CIRCLE_BRANCH --keep CIRCLE_PULL_REQUEST"
         env:
           # The script assumes CCI env vars, so we map GHA ones to CCI ones here
-          GH_USER: ${{ github.actor }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CIRCLE_BRANCH: ${{ github.ref }}
           CIRCLE_PULL_REQUEST: ${{ github.event.pull_request.number }}
 

--- a/scripts/check-todos.sh
+++ b/scripts/check-todos.sh
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-# hub CLI used in checkTodos.sc requires GITHUB_USER and GITHUB_TOKEN
-export GITHUB_TOKEN=$GH_TOKEN
-export GITHUB_USER=$GH_USER
 
 SPLICE_ROOT=$( git rev-parse --show-toplevel )
 


### PR DESCRIPTION
We'll need to revisit it as part of https://github.com/hyperledger-labs/splice/issues/1232, e.g. use the secret if it exists, and if not, support only Splice and not private repos.
But for now, I don't want this to block https://github.com/hyperledger-labs/splice/issues/1662

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
