### PR TITLE
gcp-project: role fixes for new CCI SA to be able to run cluster tests

### DIFF
--- a/cluster/expected/gcp-project/expected.json
+++ b/cluster/expected/gcp-project/expected.json
@@ -87,6 +87,23 @@
     "inputs": {
       "condition": {
         "description": "(managed by Pulumi)",
+        "expression": "\n          resource.name.endsWith(\"dns01-sa-key-secret/versions/latest\")\n          ",
+        "title": "DNS SA key secret"
+      },
+      "member": "serviceAccount:mock-sa@somewhere.mockoogle.com",
+      "project": "project-id",
+      "role": "roles/secretmanager.secretAccessor"
+    },
+    "name": "authorized-sa-roles/secretmanager.secretAccessor-dns-sa-key-secret-iam",
+    "provider": "",
+    "type": "gcp:projects/iAMMember:IAMMember"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "condition": {
+        "description": "(managed by Pulumi)",
         "expression": "\n          resource.name.endsWith(\"grafana-keys/versions/latest\")\n          ",
         "title": "Grafana keys"
       },
@@ -104,7 +121,7 @@
     "inputs": {
       "condition": {
         "description": "(managed by Pulumi)",
-        "expression": "resource.name.endsWith(\"secrets/gcp-bucket-sa-key-secret/versions/1\")",
+        "expression": "resource.name.endsWith(\"secrets/gcp-bucket-sa-key-secret/versions/latest\")",
         "title": "SA key secret"
       },
       "member": "serviceAccount:mock-sa@somewhere.mockoogle.com",

--- a/cluster/pulumi/gcp-project/src/authorizeServiceAccount.ts
+++ b/cluster/pulumi/gcp-project/src/authorizeServiceAccount.ts
@@ -7,6 +7,7 @@ export type ServiceAccountAuthorizationConfig = {
   serviceAccountEmail: string;
   pulumiKeyringProjectId: string;
   pulumiKeyringRegion: string;
+  dnsSaKeySecretName: string;
 };
 
 export function authorizeServiceAccount(
@@ -23,6 +24,16 @@ export function authorizeServiceAccount(
     'roles/logging.privateLogViewer',
     'roles/storage.objectAdmin',
     'roles/viewer',
+    {
+      id: 'roles/secretmanager.secretAccessor',
+      condition: {
+        title: 'DNS SA key secret',
+        description: '(managed by Pulumi)',
+        expression: `
+          resource.name.endsWith("${config.dnsSaKeySecretName}/versions/latest")
+          `,
+      },
+    },
     {
       id: 'roles/secretmanager.secretAccessor',
       condition: {
@@ -58,7 +69,7 @@ export function authorizeServiceAccount(
       condition: {
         title: 'SA key secret',
         description: '(managed by Pulumi)',
-        expression: `resource.name.endsWith("secrets/gcp-bucket-sa-key-secret/versions/1")`,
+        expression: `resource.name.endsWith("secrets/gcp-bucket-sa-key-secret/versions/latest")`,
       },
     },
     {

--- a/cluster/pulumi/gcp-project/src/gcp-project.ts
+++ b/cluster/pulumi/gcp-project/src/gcp-project.ts
@@ -79,6 +79,7 @@ export class GcpProject extends pulumi.ComponentResource {
       serviceAccountEmail: gcpProjectConfig.authorizedServiceAccount.email,
       pulumiKeyringProjectId: config.requireEnv('PULUMI_BACKEND_GCPKMS_PROJECT'),
       pulumiKeyringRegion: config.requireEnv('CLOUDSDK_COMPUTE_REGION'),
+      dnsSaKeySecretName: config.requireEnv('DNS01_SA_KEY_SECRET'),
     };
     return authorizeServiceAccount(this.gcpProjectId, authorizedServiceAccountConfig);
   }


### PR DESCRIPTION
Changes that were needed for `deploy-basic` and `deploy-hdm-operator` to make progress on https://github.com/DACH-NY/canton-network-internal/pull/1017

(I applied these on the scratchnet project already, for testing...)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
