### PR TITLE
cluster, images, fix: Make empty value for SPLICE_MALLOC_ARENA_MAX work

### DIFF
--- a/cluster/images/common/entrypoint.sh
+++ b/cluster/images/common/entrypoint.sh
@@ -66,7 +66,7 @@ fi
 #
 # Setting SPLICE_MALLOC_ARENA_MAX to 0 or '' will disable the limit and use the
 # default value.
-export MALLOC_ARENA_MAX=${SPLICE_MALLOC_ARENA_MAX:-2}
+export MALLOC_ARENA_MAX=${SPLICE_MALLOC_ARENA_MAX-2}
 
 json_log "Starting '${EXE}' with arguments: ${ARGS[*]}" "entrypoint.sh"
 


### PR DESCRIPTION
Use the default only if SPLICE_MALLOC_ARENA_MAX is not set. Previously, setting SPLICE_MALLOC_ARENA_MAX to an empty value would still result in the default (which is 2) being used.

Note: this change is no-op unless your configuration have environment variable SPLICE_MALLOC_ARENA_MAX set to `''`