### PR TITLE
Switch load-tester to token-standard transfers

### DIFF
--- a/load-tester/config.sample.json
+++ b/load-tester/config.sample.json
@@ -6,6 +6,7 @@
       "walletBaseUrl": "$K6_WALLET_BASE_URL",
       "auth": {
         "kind": "oauth",
+        "audience": "$OIDC_AUTHORITY_VALIDATOR_AUDIENCE",
         "oauthDomain": "$K6_OAUTH_DOMAIN",
         "oauthClientId": "$K6_OAUTH_CLIENT_ID",
         "usersPassword": "$K6_USERS_PASSWORD",

--- a/load-tester/src/client/validator/helpers.ts
+++ b/load-tester/src/client/validator/helpers.ts
@@ -3,13 +3,12 @@
 import BigNumber from 'bignumber.js';
 import { Counter, Trend } from 'k6/metrics';
 
-import { syncRetryUndefined, syncRetryUntil } from '../../utils';
+import { syncRetryUndefined } from '../../utils';
 import { GetBalanceResponse } from './models';
 import { ValidatorClient } from './validator';
 
 const createOfferLatency = new Trend('create_offer_latency', true);
 const acceptOfferLatency = new Trend('accept_offer_latency', true);
-const completeTransferLatency = new Trend('complete_transfer_latency', true);
 
 const transfersCompleted = new Counter('transfers_completed');
 const transfersFailed = new Counter('transfers_failed');
@@ -31,46 +30,36 @@ export function sendAndWaitForTransferOffer(
   const startTime = Date.now();
 
   const receiverParty = receiver.partyId()!; // assumes doIfOnboarded has been called for receiver
-  const transferOffer = sender.v0.wallet.createTransferOffer(amount, receiverParty);
+  try {
+    const transferOffer = sender.v0.wallet.createTransferOffer(amount, receiverParty);
 
-  if (transferOffer) {
-    // Record transferOffer created time
-    const createdOfferTime = Date.now();
-    createOfferLatency.add(createdOfferTime - startTime);
+    if (transferOffer) {
+      // Record transferOffer created time
+      const createdOfferTime = Date.now();
+      createOfferLatency.add(createdOfferTime - startTime);
 
-    const receivingOffer = syncRetryUndefined(
-      () =>
-        receiver.v0.wallet
-          .listTransferOffers()
-          ?.offers.find(o => o.contract_id === transferOffer.offer_contract_id),
-    );
-
-    if (receivingOffer) {
-      receiver.v0.wallet.acceptTransferOffer(
-        receivingOffer.contract_id,
-        receivingOffer.payload.trackingId,
+      const receivingOffer = syncRetryUndefined(
+        () =>
+          receiver.v0.wallet
+            .listTransferOffers()
+            ?.transfers.find(o => o.contract_id === transferOffer.output.transfer_instruction_cid),
       );
 
-      // Record transferOffer accept time
-      const acceptOfferTime = Date.now();
-      acceptOfferLatency.add(acceptOfferTime - createdOfferTime);
+      if (receivingOffer) {
+        receiver.v0.wallet.acceptTransferOffer(receivingOffer.contract_id);
 
-      // Wait for transfer to either complete or fail
-      const trackingId = receivingOffer.payload.trackingId;
-      const result = syncRetryUntil(
-        () => receiver.v0.wallet.getTransferOfferStatus(trackingId),
-        res => res?.status === 'completed' || res?.status === 'failed',
-      );
+        // Record transferOffer accept time
+        const acceptOfferTime = Date.now();
+        acceptOfferLatency.add(acceptOfferTime - createdOfferTime);
 
-      if (result?.status === 'completed') {
         transfersCompleted.add(1);
-        completeTransferLatency.add(Date.now() - acceptOfferTime);
-      } else {
-        transfersFailed.add(1);
       }
+    } else {
+      console.error('We expected a transfer offer from the sending side');
+      transfersFailed.add(1);
     }
-  } else {
-    console.error('We expected a transfer offer from the sending side');
+  } catch (e) {
+    console.error(`Transfer failed with ${e}`);
     transfersFailed.add(1);
   }
 }

--- a/load-tester/src/client/validator/models.ts
+++ b/load-tester/src/client/validator/models.ts
@@ -10,53 +10,17 @@ const contract = z.object({
   created_at: z.string(),
 });
 
-const transferOfferPayload = z.object({
-  trackingId: z.string(),
-  description: z.string(),
-  expiresAt: z.string(),
-  receiver: z.string(),
-  amount: z.object({
-    amount: z.string(),
-    unit: z.enum(['AmuletUnit', 'USDUnit']),
-  }),
-  sender: z.string(),
-  dso: z.string(),
-});
-
-export const acceptTransferOfferResponse = z.object({
-  accepted_offer_contract_id: z.string(),
-});
+export const acceptTransferOfferResponse = z.object({});
 
 export type AcceptTransferOfferResponse = z.infer<typeof acceptTransferOfferResponse>;
 
 export const createTransferOfferResponse = z.object({
-  offer_contract_id: z.string(),
+  output: z.object({
+    transfer_instruction_cid: z.string(),
+  }),
 });
 
 export type CreateTransferOfferResponse = z.infer<typeof createTransferOfferResponse>;
-
-const partyAndAmount = z.any();
-
-const listTransactionsItem = z.object({
-  transaction_type: z.string(),
-  transaction_subtype: z.object({
-    template_id: z.string(),
-    choice: z.string(),
-    amulet_operation: z.optional(z.string()),
-  }),
-  event_id: z.string(),
-  offset: z.optional(z.string()),
-  domain_id: z.string(),
-  date: z.string().datetime(),
-  provider: z.optional(z.string()),
-  sender: z.optional(partyAndAmount),
-  receivers: z.optional(z.array(partyAndAmount)),
-  holding_fees: z.optional(z.string()),
-  amulet_price: z.optional(z.string()),
-  app_rewards_used: z.optional(z.string()),
-  validator_rewards_used: z.optional(z.string()),
-  details: z.optional(z.string()),
-});
 
 export const getBalanceResponse = z.object({
   round: z.number(),
@@ -67,26 +31,10 @@ export const getBalanceResponse = z.object({
 
 export type GetBalanceResponse = z.infer<typeof getBalanceResponse>;
 
-export const getTransferOfferStatusResponse = z.object({
-  status: z.enum(['created', 'accepted', 'completed', 'failed']),
-  transaction_id: z.optional(z.string()).nullable(),
-  contract_id: z.optional(z.string()),
-  failure_kind: z.optional(z.string()).nullable(),
-  withdrawn_reason: z.optional(z.string()).nullable(),
-});
-
-export type GetTransferOfferStatusResponse = z.infer<typeof getTransferOfferStatusResponse>;
-
-export const listTransactionsResponse = z.object({
-  items: z.array(listTransactionsItem),
-});
-
-export type ListTransactionsResponse = z.infer<typeof listTransactionsResponse>;
-
-const transferOfferContract = contract.and(z.object({ payload: transferOfferPayload }));
+const transferOfferContract = contract;
 
 export const listTransferOffersResponse = z.object({
-  offers: z.array(transferOfferContract),
+  transfers: z.array(transferOfferContract),
 });
 
 export type ListTransferOffersResponse = z.infer<typeof listTransferOffersResponse>;


### PR DESCRIPTION
There are two main differences:

1. There is no status endpoint. This makes retries a bit harder. We could in theory make some of this work directly through the JSON API. But it seems like if we need this something is already a bit sketchy and treating that as a failed transaction doesn't seem too bad.
2. There is no complete stage. If accept goes through it's done, if it fails it fails.

This likely needs some adjustment on the target rate to keep the same number of confirmation requests as before.

My plan is to merge this and the reduction in SV status reports and then callibrate CILR to have the same as before.

[ci]

fixes #1449



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
