### PR TITLE
Add retry in allocateRandomSvParty

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
@@ -47,7 +47,9 @@ trait SvTestUtil extends TestCommon {
 
   def allocateRandomSvParty(name: String)(implicit env: SpliceTestConsoleEnvironment) = {
     val id = (new scala.util.Random).nextInt().toHexString
-    sv1Backend.participantClient.ledger_api.parties.allocate(s"$name-$id").party
+    eventuallySucceeds() {
+      sv1Backend.participantClient.ledger_api.parties.allocate(s"$name-$id").party
+    }
   }
 
   def median(values: Seq[BigDecimal]): Option[BigDecimal] = {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/5144

the participant was disconnected from the synchronizer by the **CantonSyncService** when calling `allocateRandomSvParty("validatorX")`:
```
2025-07-24T11:24:40.347 [⋮] DEBUG - o.l.s.i.t.SvFrontendIntegrationTest:SvFrontendIntegrationTest (---) - Finished clue: (check) a new secret row is added 
2025-07-24T11:24:40.614 [⋮] INFO - c.d.c.p.s.CantonSyncService:participant=sv1Participant (a66278d1f0f90560ce6d750c84e6610a---) - Disconnecting from Synchronizer 'global' 
2025-07-24T11:24:40.615 [⋮] ERROR - c.d.c.n.g.ApiRequestLogger:participant=sv1Participant (2067dab1cabeaa9a2d5f09b844e40bb3---) - Request com.daml.ledger.api.v2.admin.PartyManagementService/AllocateParty by /127.0.0.1:50702: failed with INTERNAL/'Party Allocation' was aborted due to shutdown. com.digitalasset.canton.lifecycle.UnlessShutdown$AbortedDueToShutdownException: 'Party Allocation' was aborted due to shutdown.
2025-07-24T11:24:40.615 [⋮] INFO - c.d.c.s.c.ResilientSequencerSubscription:participant=sv1Participant/synchronizerId=global-domain::12205bb12ca2/sequencerAlias=Digital-Asset-Eng-2 (---) - 'sequencer-client' is now in state Failed(Disconnected from synchronizer). Previous state was Ok(). 
2025-07-24T11:24:40.626 [⋮] ERROR - o.l.s.i.EnvironmentDefinition$$anon$36:SvFrontendIntegrationTest/config=c3c423e3 (---) - Request failed for remote participant for `sv1``.
  GrpcServerError: INTERNAL/An error occurred. Please contact the operator and inquire about the request <no-correlation-id> with tid <no-tid>
  Request: AllocateParty(validatorX-a9e76d74,Map(),)
  DecodedCantonError(code = 'NA', category = GenericErrorCategory(Some(INTERNAL),ERROR,None,true,-1,1), cause = "A security-sensitive error has been received")
  Command ConsoleEnvironment.run$ invoked from SpliceConsoleEnvironment.scala:26 
2025-07-24T11:24:40.830 [⋮] WARN - c.d.c.LogReporter:reporter=scala-test (---) - Test failed: 'SvFrontendIntegrationTest/SV UIs should can prepare an onboarding secret for new validator', message: Command execution failed., location: SeeStackDepthException com.digitalasset.canton.console.CommandFailure: Command execution failed.
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
