### PR TITLE
Improve ACS snapshot query performance

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -218,6 +218,12 @@ class AcsSnapshotStore(
                   where row_id between $begin and $end
                """ ++ partyIdsFilter ++ templatesFilter ++ sql"""
                   group by create_id
+                  order by row_id asc
+                  -- this CTE already will contain all snapshot rows (filtered by party id and template, if necessary).
+                  -- They just need to be joined with u_h_creates.
+                  -- Applying the limit later yields a worse query plan, where it requires fetching all snapshots first.
+                  -- See #1685
+                  limit ${sqlLimit(limit)}
                )
                select
                  snapshot.row_id,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -241,7 +241,7 @@ class AcsSnapshotStore(
                  contract_key
               from snapshot
               join update_history_creates creates on creates.row_id = snapshot.create_id
-              order by snapshot.row_id limit ${sqlLimit(limit)}
+              order by snapshot.row_id
             """).toActionBuilder
             .as[(Long, SelectFromCreateEvents)],
           "queryAcsSnapshot.getCreatedEvents",


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice/issues/1685

Query plan on CILR:
before:
<img width="1163" height="590" alt="image" src="https://github.com/user-attachments/assets/84901a63-b6ed-4ea7-9069-dbabcd7b0ade" />

after:
<img width="1169" height="637" alt="image" src="https://github.com/user-attachments/assets/13683022-a889-40e1-aebb-4c6aaeec705f" />

as mentioned, it no longer needs to fetch and join the entire snapshot, but only those rows that match.