### PR TITLE
[static] Lower multi validator parallelism to 10

### DIFF
--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -792,7 +792,7 @@
         "stack": "organization/multi-validator/multi-validator.mock",
         "updateTemplate": {
           "spec": {
-            "parallel": 20
+            "parallel": 10
           }
         },
         "useLocalStackOnly": true,

--- a/cluster/pulumi/deployment/src/stacks/splice.ts
+++ b/cluster/pulumi/deployment/src/stacks/splice.ts
@@ -66,7 +66,7 @@ export function installSpliceStacks(
       [],
       // reduce parallelism to ensure rolling updates as during startup the nodes use lots of memory, leading to memory pressure on the nodes
       // and in some cases the pods get evicted
-      20
+      10
     );
   }
   if (DeployValidatorRunbook) {


### PR DESCRIPTION
should help not overload k8s



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
