### PR TITLE
Adjust docs for splice-api-token-burn-mint-v1

### DIFF
--- a/docs/src/app_dev/daml_api/index.rst
+++ b/docs/src/app_dev/daml_api/index.rst
@@ -38,7 +38,6 @@ Canton Network Token Standard APIs (CIP-0056)
       ../api/splice-api-token-allocation-request-v1/index
       ../api/splice-api-token-allocation-instruction-v1/index
       ../api/splice-api-token-allocation-v1/index
-      ../api/splice-api-token-burn-mint-v1/index
 
 .. TODO(#1074): also add links to OpenAPI docs for the REST API parts of these APIs
 
@@ -54,3 +53,22 @@ Featured App Activity Markers API (CIP-0047)
       :maxdepth: 1
 
       ../api/splice-api-featured-app-v1/index
+
+Additional Splice Daml APIs
+---------------------------
+
+The app provider of an asset registry is not necessarily the same as the party controlling the minting and burning of tokens.
+A typical example are tokens that are bridged from another network. The
+following API targets that use-case; and thus enables to decouple the upgrade cycles of an asset registry from the ones of the bridging app.
+
+   .. toctree::
+      :maxdepth: 1
+
+      ../api/splice-api-token-burn-mint-v1/index
+
+The API is built in a similar style as the token standard APIs, but is not part
+of the token standard. In particular, implementors of the token standard are not required to implement this API.
+
+Nevertheless the API definition is guaranteed to be stable, and can be used by for the purpose explained above.
+If there were changes to the API, then they would be published as a new version of the API using a fresh package name,
+so that both the old and the new version can be used in parallel.

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -18,6 +18,10 @@ Upcoming
     so you may need to adjust some alerts to be slightly less
     aggressive.
 
+- Documentation
+
+  - Clarified that the Daml API ``splice-token-burn-mint-v1`` is not part of the token standard, see :ref:`app_dev_daml_api`.
+
 0.4.8
 -----
 


### PR DESCRIPTION
to match the fact that it is not a token standard API.

[static]

Based on a request by @bame-da to be clear that this burn-mint is not part of the CIP.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
