### PR TITLE
separate LoadBalancer for TCP traffic

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/cometbft-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/cometbft-values.yaml
@@ -2,7 +2,7 @@ nodeName: "YOUR_SV_NAME"
 
 sv1:
   # Replace MIGRATION_ID (part of port number!) with the current migration ID of the global synchronizer.
-  externalAddress: TARGET_HOSTNAME:26MIGRATION_ID16
+  externalAddress: cometbft.TARGET_HOSTNAME:26MIGRATION_ID16
 
   ## Uncomment these for DevNet/TestNet:
   # nodeId: "5af57aa83abcec085c949323ed8538108757be9c"

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/CometBftPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/CometBftPreflightIntegrationTest.scala
@@ -19,7 +19,7 @@ class CometBftPreflightIntegrationTest extends IntegrationTestWithSharedEnvironm
 
   "p2p port for all CometBft nodes is accessible" in { env =>
     env.svs.remote.zipWithIndex.map { case (_, index) =>
-      val cometBftP2pHost = sys.env("NETWORK_APPS_ADDRESS")
+      val cometBftP2pHost = f"cometbft.${sys.env("NETWORK_APPS_ADDRESS")}"
       val port = s"26$migrationId${index + 1}6".toInt
       clue(s"Connection to $cometBftP2pHost with port $port") {
         // All we care about is the p2p port for CometBFT being accessible by other nodes

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvCometBftPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvCometBftPreflightIntegrationTest.scala
@@ -20,7 +20,7 @@ class RunbookSvCometBftPreflightIntegrationTest extends IntegrationTestWithShare
     )
 
   "p2p port for the CometBft node is accessible" in { _ =>
-    val cometBftP2pHost = sys.env("NETWORK_APPS_ADDRESS")
+    val cometBftP2pHost = f"cometbft.${sys.env("NETWORK_APPS_ADDRESS")}"
     val cometBftPort = 26006 + migrationId.toInt * 100
     // All we care about is the p2p port for CometBFT being accessible by other nodes
     // The socket connects in the constructor, therefore if no error is thrown during the initialization then a successful TCP connection is established

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -191,6 +191,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "sv-1"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-sv-1",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -203,7 +203,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -204,7 +204,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -327,24 +327,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -617,17 +617,6 @@
         "servers": [
           {
             "hosts": [
-              "mock.network.canton.global",
-              "mock.global.canton.network.digitalasset.com"
-            ],
-            "port": {
-              "name": "grpc-swd-pub",
-              "number": 5108,
-              "protocol": "GRPC"
-            }
-          },
-          {
-            "hosts": [
               "*"
             ],
             "port": {
@@ -1229,6 +1218,25 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "grafana-service-account-token-secret",
+        "namespace": "observability"
+      },
+      "stringData": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {}
+      }
+    },
+    "name": "grafana-service-account-token-secret",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "VirtualService",
       "metadata": {
@@ -1269,6 +1277,41 @@
     "name": "grafana-virtual-service",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "grafana-sa-token",
+      "serviceAccountId": "undefined_id"
+    },
+    "name": "grafanaSAToken",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
+    "type": "grafana:index/serviceAccountToken:ServiceAccountToken"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "role": "Editor"
+    },
+    "name": "grafanaSA",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
+    "type": "grafana:index/serviceAccount:ServiceAccount"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "auth": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": "cn-admin:grafana-keys-admin-password"
+      },
+      "url": "https://public.mock.global.canton.network.digitalasset.com/grafana"
+    },
+    "name": "grafana",
+    "provider": "",
+    "type": "pulumi:providers:grafana"
   },
   {
     "custom": true,

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -182,6 +182,37 @@
       "apiVersion": "telemetry.istio.io/v1alpha1",
       "kind": "Telemetry",
       "metadata": {
+        "name": "access-logging-cometbft",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "accessLogging": [
+          {
+            "providers": [
+              {
+                "name": "envoy"
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress-cometbft"
+          }
+        }
+      }
+    },
+    "name": "access-logging-cometbft",
+    "provider": "",
+    "type": "kubernetes:telemetry.istio.io/v1alpha1:Telemetry"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "telemetry.istio.io/v1alpha1",
+      "kind": "Telemetry",
+      "metadata": {
         "name": "access-logging-public",
         "namespace": "cluster-ingress"
       },
@@ -580,8 +611,13 @@
       },
       "spec": {
         "selector": {
+<<<<<<< HEAD
           "app": "istio-ingress",
           "istio": "ingress"
+=======
+          "app": "istio-ingress-cometbft",
+          "istio": "ingress-cometbft"
+>>>>>>> 1549f31f7 ([static] works)
         },
         "servers": [
           {
@@ -610,6 +646,49 @@
               "*"
             ],
             "port": {
+<<<<<<< HEAD
+=======
+              "name": "cometbft-0-1-gw",
+              "number": 26016,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-0-2-gw",
+              "number": 26026,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-0-3-gw",
+              "number": 26036,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-0-4-gw",
+              "number": 26046,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+>>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-1-0-gw",
               "number": 26106,
               "protocol": "TCP"
@@ -620,6 +699,49 @@
               "*"
             ],
             "port": {
+<<<<<<< HEAD
+=======
+              "name": "cometbft-1-1-gw",
+              "number": 26116,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-1-2-gw",
+              "number": 26126,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-1-3-gw",
+              "number": 26136,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-1-4-gw",
+              "number": 26146,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+>>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-2-0-gw",
               "number": 26206,
               "protocol": "TCP"
@@ -630,6 +752,49 @@
               "*"
             ],
             "port": {
+<<<<<<< HEAD
+=======
+              "name": "cometbft-2-1-gw",
+              "number": 26216,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-2-2-gw",
+              "number": 26226,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-2-3-gw",
+              "number": 26236,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-2-4-gw",
+              "number": 26246,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+>>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-3-0-gw",
               "number": 26306,
               "protocol": "TCP"
@@ -640,10 +805,96 @@
               "*"
             ],
             "port": {
+<<<<<<< HEAD
+=======
+              "name": "cometbft-3-1-gw",
+              "number": 26316,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-3-2-gw",
+              "number": 26326,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-3-3-gw",
+              "number": 26336,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-3-4-gw",
+              "number": 26346,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+>>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-4-0-gw",
               "number": 26406,
               "protocol": "TCP"
             }
+<<<<<<< HEAD
+=======
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-1-gw",
+              "number": 26416,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-2-gw",
+              "number": 26426,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-3-gw",
+              "number": 26436,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-4-gw",
+              "number": 26446,
+              "protocol": "TCP"
+            }
+>>>>>>> 1549f31f7 ([static] works)
           }
         ]
       }
@@ -726,6 +977,10 @@
         "servers": [
           {
             "hosts": [
+<<<<<<< HEAD
+=======
+              "public.mock.network.canton.global",
+>>>>>>> 1549f31f7 ([static] works)
               "public.mock.global.canton.network.digitalasset.com"
             ],
             "port": {
@@ -739,6 +994,10 @@
           },
           {
             "hosts": [
+<<<<<<< HEAD
+=======
+              "public.mock.network.canton.global",
+>>>>>>> 1549f31f7 ([static] works)
               "public.mock.global.canton.network.digitalasset.com"
             ],
             "port": {
@@ -747,7 +1006,11 @@
               "protocol": "HTTPS"
             },
             "tls": {
+<<<<<<< HEAD
               "credentialName": "cn-test-stacknet-tls",
+=======
+              "credentialName": "cn-test-stacknet-public-tls",
+>>>>>>> 1549f31f7 ([static] works)
               "mode": "SIMPLE"
             }
           }
@@ -766,6 +1029,17 @@
       "networkTier": "PREMIUM"
     },
     "name": "cn-test-stack-out",
+    "provider": "",
+    "type": "gcp:compute/address:Address"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cn-test-stacknet-cometbft-ip",
+      "networkTier": "PREMIUM"
+    },
+    "name": "cn-test-stacknet-cometbft-ip",
     "provider": "",
     "type": "gcp:compute/address:Address"
   },
@@ -1373,6 +1647,42 @@
       "apiVersion": "security.istio.io/v1beta1",
       "kind": "AuthorizationPolicy",
       "metadata": {
+        "name": "istio-access-policy-allow-cometbft-0",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "action": "ALLOW",
+        "rules": [
+          {
+            "from": [
+              {
+                "source": {
+                  "remoteIpBlocks": [
+                    "0.0.0.0/0"
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress-cometbft"
+          }
+        }
+      }
+    },
+    "name": "istio-access-policy-allow-cometbft-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
         "name": "istio-access-policy-allow-public-0",
         "namespace": "cluster-ingress"
       },
@@ -1399,6 +1709,28 @@
       }
     },
     "name": "istio-access-policy-allow-public-0",
+    "provider": "",
+    "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "security.istio.io/v1beta1",
+      "kind": "AuthorizationPolicy",
+      "metadata": {
+        "name": "istio-access-policy-deny-all-cometbft",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "selector": {
+          "matchLabels": {
+            "app": "istio-ingress-cometbft"
+          }
+        }
+      }
+    },
+    "name": "istio-access-policy-deny-all-cometbft",
     "provider": "",
     "type": "kubernetes:security.istio.io/v1beta1:AuthorizationPolicy"
   },
@@ -1507,6 +1839,214 @@
     "name": "istio-gateway-monitor",
     "provider": "",
     "type": "kubernetes:monitoring.coreos.com/v1:PodMonitor"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "gateway",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "istio-ingress-cometbft",
+      "namespace": "cluster-ingress",
+      "repositoryOpts": {
+        "repo": "https://istio-release.storage.googleapis.com/charts"
+      },
+      "values": {
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "cn_infra",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "autoscaling": {
+          "maxReplicas": 15
+        },
+        "podDisruptionBudget": {
+          "maxUnavailable": 1
+        },
+        "resources": {
+          "limits": {
+            "cpu": "4",
+            "memory": "2024Mi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "512Mi"
+          }
+        },
+        "service": {
+          "externalTrafficPolicy": "Local",
+          "loadBalancerSourceRanges": [
+            "<internal IPs>",
+            "1.2.3.4/32",
+            "5.6.7.8/32",
+            "11.12.13.14/32"
+          ],
+          "ports": [
+            {
+              "name": "status-port",
+              "port": 15021,
+              "protocol": "TCP",
+              "targetPort": 15021
+            },
+            {
+              "name": "http2",
+              "port": 80,
+              "protocol": "TCP",
+              "targetPort": 80
+            },
+            {
+              "name": "https",
+              "port": 443,
+              "protocol": "TCP",
+              "targetPort": 443
+            },
+            {
+              "name": "cometbft-3-0-gw",
+              "port": 26306,
+              "protocol": "TCP",
+              "targetPort": 26306
+            },
+            {
+              "name": "cometbft-3-1-gw",
+              "port": 26316,
+              "protocol": "TCP",
+              "targetPort": 26316
+            },
+            {
+              "name": "cometbft-3-2-gw",
+              "port": 26326,
+              "protocol": "TCP",
+              "targetPort": 26326
+            },
+            {
+              "name": "cometbft-3-3-gw",
+              "port": 26336,
+              "protocol": "TCP",
+              "targetPort": 26336
+            },
+            {
+              "name": "cometbft-3-4-gw",
+              "port": 26346,
+              "protocol": "TCP",
+              "targetPort": 26346
+            },
+            {
+              "name": "cometbft-3-5-gw",
+              "port": 26356,
+              "protocol": "TCP",
+              "targetPort": 26356
+            },
+            {
+              "name": "cometbft-3-6-gw",
+              "port": 26366,
+              "protocol": "TCP",
+              "targetPort": 26366
+            },
+            {
+              "name": "cometbft-3-7-gw",
+              "port": 26376,
+              "protocol": "TCP",
+              "targetPort": 26376
+            },
+            {
+              "name": "cometbft-3-8-gw",
+              "port": 26386,
+              "protocol": "TCP",
+              "targetPort": 26386
+            },
+            {
+              "name": "cometbft-3-9-gw",
+              "port": 26396,
+              "protocol": "TCP",
+              "targetPort": 26396
+            },
+            {
+              "name": "cometbft-4-0-gw",
+              "port": 26406,
+              "protocol": "TCP",
+              "targetPort": 26406
+            },
+            {
+              "name": "cometbft-4-1-gw",
+              "port": 26416,
+              "protocol": "TCP",
+              "targetPort": 26416
+            },
+            {
+              "name": "cometbft-4-2-gw",
+              "port": 26426,
+              "protocol": "TCP",
+              "targetPort": 26426
+            },
+            {
+              "name": "cometbft-4-3-gw",
+              "port": 26436,
+              "protocol": "TCP",
+              "targetPort": 26436
+            },
+            {
+              "name": "cometbft-4-4-gw",
+              "port": 26446,
+              "protocol": "TCP",
+              "targetPort": 26446
+            },
+            {
+              "name": "cometbft-4-5-gw",
+              "port": 26456,
+              "protocol": "TCP",
+              "targetPort": 26456
+            },
+            {
+              "name": "cometbft-4-6-gw",
+              "port": 26466,
+              "protocol": "TCP",
+              "targetPort": 26466
+            },
+            {
+              "name": "cometbft-4-7-gw",
+              "port": 26476,
+              "protocol": "TCP",
+              "targetPort": 26476
+            },
+            {
+              "name": "cometbft-4-8-gw",
+              "port": 26486,
+              "protocol": "TCP",
+              "targetPort": 26486
+            },
+            {
+              "name": "cometbft-4-9-gw",
+              "port": 26496,
+              "protocol": "TCP",
+              "targetPort": 26496
+            }
+          ]
+        },
+        "tolerations": [
+          {
+            "effect": "NoSchedule",
+            "key": "cn_infra",
+            "operator": "Exists"
+          }
+        ]
+      },
+      "version": "1.26.1"
+    },
+    "name": "istio-ingress-cometbft",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
   },
   {
     "custom": true,
@@ -1757,126 +2297,6 @@
               "port": 6201,
               "protocol": "TCP",
               "targetPort": 6201
-            },
-            {
-              "name": "cometbft-3-0-gw",
-              "port": 26306,
-              "protocol": "TCP",
-              "targetPort": 26306
-            },
-            {
-              "name": "cometbft-3-1-gw",
-              "port": 26316,
-              "protocol": "TCP",
-              "targetPort": 26316
-            },
-            {
-              "name": "cometbft-3-2-gw",
-              "port": 26326,
-              "protocol": "TCP",
-              "targetPort": 26326
-            },
-            {
-              "name": "cometbft-3-3-gw",
-              "port": 26336,
-              "protocol": "TCP",
-              "targetPort": 26336
-            },
-            {
-              "name": "cometbft-3-4-gw",
-              "port": 26346,
-              "protocol": "TCP",
-              "targetPort": 26346
-            },
-            {
-              "name": "cometbft-3-5-gw",
-              "port": 26356,
-              "protocol": "TCP",
-              "targetPort": 26356
-            },
-            {
-              "name": "cometbft-3-6-gw",
-              "port": 26366,
-              "protocol": "TCP",
-              "targetPort": 26366
-            },
-            {
-              "name": "cometbft-3-7-gw",
-              "port": 26376,
-              "protocol": "TCP",
-              "targetPort": 26376
-            },
-            {
-              "name": "cometbft-3-8-gw",
-              "port": 26386,
-              "protocol": "TCP",
-              "targetPort": 26386
-            },
-            {
-              "name": "cometbft-3-9-gw",
-              "port": 26396,
-              "protocol": "TCP",
-              "targetPort": 26396
-            },
-            {
-              "name": "cometbft-4-0-gw",
-              "port": 26406,
-              "protocol": "TCP",
-              "targetPort": 26406
-            },
-            {
-              "name": "cometbft-4-1-gw",
-              "port": 26416,
-              "protocol": "TCP",
-              "targetPort": 26416
-            },
-            {
-              "name": "cometbft-4-2-gw",
-              "port": 26426,
-              "protocol": "TCP",
-              "targetPort": 26426
-            },
-            {
-              "name": "cometbft-4-3-gw",
-              "port": 26436,
-              "protocol": "TCP",
-              "targetPort": 26436
-            },
-            {
-              "name": "cometbft-4-4-gw",
-              "port": 26446,
-              "protocol": "TCP",
-              "targetPort": 26446
-            },
-            {
-              "name": "cometbft-4-5-gw",
-              "port": 26456,
-              "protocol": "TCP",
-              "targetPort": 26456
-            },
-            {
-              "name": "cometbft-4-6-gw",
-              "port": 26466,
-              "protocol": "TCP",
-              "targetPort": 26466
-            },
-            {
-              "name": "cometbft-4-7-gw",
-              "port": 26476,
-              "protocol": "TCP",
-              "targetPort": 26476
-            },
-            {
-              "name": "cometbft-4-8-gw",
-              "port": 26486,
-              "protocol": "TCP",
-              "targetPort": 26486
-            },
-            {
-              "name": "cometbft-4-9-gw",
-              "port": 26496,
-              "protocol": "TCP",
-              "targetPort": 26496
             }
           ]
         },
@@ -2301,6 +2721,23 @@
     "id": "",
     "inputs": {
       "managedZone": "prod-networks",
+      "name": "cometbft.mock.global.canton.network.digitalasset.com.",
+      "project": "da-gcp-canton-domain",
+      "rrdatas": [
+        null
+      ],
+      "ttl": 60,
+      "type": "A"
+    },
+    "name": "mock.global.canton.network.digitalasset.com-cometbft",
+    "provider": "",
+    "type": "gcp:dns/recordSet:RecordSet"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "managedZone": "prod-networks",
       "name": "public.mock.global.canton.network.digitalasset.com.",
       "project": "da-gcp-canton-domain",
       "rrdatas": [
@@ -2344,6 +2781,23 @@
       "type": "A"
     },
     "name": "mock.global.canton.network.digitalasset.com",
+    "provider": "",
+    "type": "gcp:dns/recordSet:RecordSet"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "managedZone": "canton-global",
+      "name": "cometbft.mock.network.canton.global.",
+      "project": "da-gcp-canton-domain",
+      "rrdatas": [
+        null
+      ],
+      "ttl": 60,
+      "type": "A"
+    },
+    "name": "mock.network.canton.global-cometbft",
     "provider": "",
     "type": "gcp:dns/recordSet:RecordSet"
   },

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -611,13 +611,8 @@
       },
       "spec": {
         "selector": {
-<<<<<<< HEAD
-          "app": "istio-ingress",
-          "istio": "ingress"
-=======
           "app": "istio-ingress-cometbft",
           "istio": "ingress-cometbft"
->>>>>>> 1549f31f7 ([static] works)
         },
         "servers": [
           {
@@ -646,49 +641,6 @@
               "*"
             ],
             "port": {
-<<<<<<< HEAD
-=======
-              "name": "cometbft-0-1-gw",
-              "number": 26016,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-0-2-gw",
-              "number": 26026,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-0-3-gw",
-              "number": 26036,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-0-4-gw",
-              "number": 26046,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
->>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-1-0-gw",
               "number": 26106,
               "protocol": "TCP"
@@ -699,49 +651,6 @@
               "*"
             ],
             "port": {
-<<<<<<< HEAD
-=======
-              "name": "cometbft-1-1-gw",
-              "number": 26116,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-1-2-gw",
-              "number": 26126,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-1-3-gw",
-              "number": 26136,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-1-4-gw",
-              "number": 26146,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
->>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-2-0-gw",
               "number": 26206,
               "protocol": "TCP"
@@ -752,49 +661,6 @@
               "*"
             ],
             "port": {
-<<<<<<< HEAD
-=======
-              "name": "cometbft-2-1-gw",
-              "number": 26216,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-2-2-gw",
-              "number": 26226,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-2-3-gw",
-              "number": 26236,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-2-4-gw",
-              "number": 26246,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
->>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-3-0-gw",
               "number": 26306,
               "protocol": "TCP"
@@ -805,96 +671,10 @@
               "*"
             ],
             "port": {
-<<<<<<< HEAD
-=======
-              "name": "cometbft-3-1-gw",
-              "number": 26316,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-3-2-gw",
-              "number": 26326,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-3-3-gw",
-              "number": 26336,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-3-4-gw",
-              "number": 26346,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
->>>>>>> 1549f31f7 ([static] works)
               "name": "cometbft-4-0-gw",
               "number": 26406,
               "protocol": "TCP"
             }
-<<<<<<< HEAD
-=======
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-4-1-gw",
-              "number": 26416,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-4-2-gw",
-              "number": 26426,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-4-3-gw",
-              "number": 26436,
-              "protocol": "TCP"
-            }
-          },
-          {
-            "hosts": [
-              "*"
-            ],
-            "port": {
-              "name": "cometbft-4-4-gw",
-              "number": 26446,
-              "protocol": "TCP"
-            }
->>>>>>> 1549f31f7 ([static] works)
           }
         ]
       }
@@ -977,10 +757,6 @@
         "servers": [
           {
             "hosts": [
-<<<<<<< HEAD
-=======
-              "public.mock.network.canton.global",
->>>>>>> 1549f31f7 ([static] works)
               "public.mock.global.canton.network.digitalasset.com"
             ],
             "port": {
@@ -994,10 +770,6 @@
           },
           {
             "hosts": [
-<<<<<<< HEAD
-=======
-              "public.mock.network.canton.global",
->>>>>>> 1549f31f7 ([static] works)
               "public.mock.global.canton.network.digitalasset.com"
             ],
             "port": {
@@ -1006,11 +778,7 @@
               "protocol": "HTTPS"
             },
             "tls": {
-<<<<<<< HEAD
               "credentialName": "cn-test-stacknet-tls",
-=======
-              "credentialName": "cn-test-stacknet-public-tls",
->>>>>>> 1549f31f7 ([static] works)
               "mode": "SIMPLE"
             }
           }
@@ -1461,25 +1229,6 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "apiVersion": "v1",
-      "kind": "Secret",
-      "metadata": {
-        "name": "grafana-service-account-token-secret",
-        "namespace": "observability"
-      },
-      "stringData": {
-        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
-        "value": {}
-      }
-    },
-    "name": "grafana-service-account-token-secret",
-    "provider": "",
-    "type": "kubernetes:core/v1:Secret"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "VirtualService",
       "metadata": {
@@ -1520,41 +1269,6 @@
     "name": "grafana-virtual-service",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "name": "grafana-sa-token",
-      "serviceAccountId": "undefined_id"
-    },
-    "name": "grafanaSAToken",
-    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
-    "type": "grafana:index/serviceAccountToken:ServiceAccountToken"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "role": "Editor"
-    },
-    "name": "grafanaSA",
-    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
-    "type": "grafana:index/serviceAccount:ServiceAccount"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "auth": {
-        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
-        "value": "cn-admin:grafana-keys-admin-password"
-      },
-      "url": "https://public.mock.global.canton.network.digitalasset.com/grafana"
-    },
-    "name": "grafana",
-    "provider": "",
-    "type": "pulumi:providers:grafana"
   },
   {
     "custom": true,
@@ -1913,124 +1627,34 @@
               "targetPort": 443
             },
             {
+              "name": "cometbft-0-0-gw",
+              "port": 26006,
+              "protocol": "TCP",
+              "targetPort": 26006
+            },
+            {
+              "name": "cometbft-1-0-gw",
+              "port": 26106,
+              "protocol": "TCP",
+              "targetPort": 26106
+            },
+            {
+              "name": "cometbft-2-0-gw",
+              "port": 26206,
+              "protocol": "TCP",
+              "targetPort": 26206
+            },
+            {
               "name": "cometbft-3-0-gw",
               "port": 26306,
               "protocol": "TCP",
               "targetPort": 26306
             },
             {
-              "name": "cometbft-3-1-gw",
-              "port": 26316,
-              "protocol": "TCP",
-              "targetPort": 26316
-            },
-            {
-              "name": "cometbft-3-2-gw",
-              "port": 26326,
-              "protocol": "TCP",
-              "targetPort": 26326
-            },
-            {
-              "name": "cometbft-3-3-gw",
-              "port": 26336,
-              "protocol": "TCP",
-              "targetPort": 26336
-            },
-            {
-              "name": "cometbft-3-4-gw",
-              "port": 26346,
-              "protocol": "TCP",
-              "targetPort": 26346
-            },
-            {
-              "name": "cometbft-3-5-gw",
-              "port": 26356,
-              "protocol": "TCP",
-              "targetPort": 26356
-            },
-            {
-              "name": "cometbft-3-6-gw",
-              "port": 26366,
-              "protocol": "TCP",
-              "targetPort": 26366
-            },
-            {
-              "name": "cometbft-3-7-gw",
-              "port": 26376,
-              "protocol": "TCP",
-              "targetPort": 26376
-            },
-            {
-              "name": "cometbft-3-8-gw",
-              "port": 26386,
-              "protocol": "TCP",
-              "targetPort": 26386
-            },
-            {
-              "name": "cometbft-3-9-gw",
-              "port": 26396,
-              "protocol": "TCP",
-              "targetPort": 26396
-            },
-            {
               "name": "cometbft-4-0-gw",
               "port": 26406,
               "protocol": "TCP",
               "targetPort": 26406
-            },
-            {
-              "name": "cometbft-4-1-gw",
-              "port": 26416,
-              "protocol": "TCP",
-              "targetPort": 26416
-            },
-            {
-              "name": "cometbft-4-2-gw",
-              "port": 26426,
-              "protocol": "TCP",
-              "targetPort": 26426
-            },
-            {
-              "name": "cometbft-4-3-gw",
-              "port": 26436,
-              "protocol": "TCP",
-              "targetPort": 26436
-            },
-            {
-              "name": "cometbft-4-4-gw",
-              "port": 26446,
-              "protocol": "TCP",
-              "targetPort": 26446
-            },
-            {
-              "name": "cometbft-4-5-gw",
-              "port": 26456,
-              "protocol": "TCP",
-              "targetPort": 26456
-            },
-            {
-              "name": "cometbft-4-6-gw",
-              "port": 26466,
-              "protocol": "TCP",
-              "targetPort": 26466
-            },
-            {
-              "name": "cometbft-4-7-gw",
-              "port": 26476,
-              "protocol": "TCP",
-              "targetPort": 26476
-            },
-            {
-              "name": "cometbft-4-8-gw",
-              "port": 26486,
-              "protocol": "TCP",
-              "targetPort": 26486
-            },
-            {
-              "name": "cometbft-4-9-gw",
-              "port": 26496,
-              "protocol": "TCP",
-              "targetPort": 26496
             }
           ]
         },

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -137,7 +137,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -260,24 +260,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -136,7 +136,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -124,6 +124,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "multi-validator"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-multi-validator",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -123,7 +123,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -246,24 +246,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -110,6 +110,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "splitwell"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-splitwell",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -122,7 +122,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -903,7 +903,6 @@
           }
         },
         "nodeName": "Digital-Asset-2",
-        "peers": [],
         "serviceAccountName": "sv-canton-migration-3",
         "stateSync": {
           "enable": false,
@@ -1003,7 +1002,6 @@
           }
         },
         "nodeName": "Digital-Asset-2",
-        "peers": [],
         "serviceAccountName": "sv-canton-migration-4",
         "stateSync": {
           "enable": false,
@@ -2724,7 +2722,6 @@
           }
         },
         "nodeName": "DA-Helm-Test-Node",
-        "peers": [],
         "serviceAccountName": "sv-canton-migration-3",
         "stateSync": {
           "enable": false,
@@ -2821,7 +2818,6 @@
           }
         },
         "nodeName": "DA-Helm-Test-Node",
-        "peers": [],
         "serviceAccountName": "sv-canton-migration-4",
         "stateSync": {
           "enable": false,

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -889,7 +889,7 @@
         },
         "node": {
           "enableTimeoutCommit": false,
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26316",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26316",
           "id": "5af57aa83abcec085c949323ed8538108757be9c",
           "identifier": "global-domain-3-cometbft",
           "istioPort": 26316,
@@ -910,7 +910,7 @@
           "rpcServers": "https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc,https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc"
         },
         "sv1": {
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26316",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26316",
           "keyAddress": "8A931AB5F957B8331BDEF3A0A081BD9F017A777F",
           "nodeId": "5af57aa83abcec085c949323ed8538108757be9c",
           "publicKey": "gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw="
@@ -989,7 +989,7 @@
         },
         "node": {
           "enableTimeoutCommit": false,
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26416",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26416",
           "id": "5af57aa83abcec085c949323ed8538108757be9c",
           "identifier": "global-domain-4-cometbft",
           "istioPort": 26416,
@@ -1010,7 +1010,7 @@
           "rpcServers": "https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc,https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc"
         },
         "sv1": {
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26416",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26416",
           "keyAddress": "8A931AB5F957B8331BDEF3A0A081BD9F017A777F",
           "nodeId": "5af57aa83abcec085c949323ed8538108757be9c",
           "publicKey": "gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw="
@@ -2713,7 +2713,7 @@
         },
         "node": {
           "enableTimeoutCommit": false,
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26306",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26306",
           "id": "9116f5faed79dcf98fa79a2a40865ad9b493f463",
           "identifier": "global-domain-3-cometbft",
           "istioPort": 26306,
@@ -2731,7 +2731,7 @@
           "rpcServers": "https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc,https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc"
         },
         "sv1": {
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26316",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26316",
           "keyAddress": "8A931AB5F957B8331BDEF3A0A081BD9F017A777F",
           "nodeId": "5af57aa83abcec085c949323ed8538108757be9c",
           "publicKey": "gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw="
@@ -2810,7 +2810,7 @@
         },
         "node": {
           "enableTimeoutCommit": false,
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26406",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26406",
           "id": "9116f5faed79dcf98fa79a2a40865ad9b493f463",
           "identifier": "global-domain-4-cometbft",
           "istioPort": 26406,
@@ -2828,7 +2828,7 @@
           "rpcServers": "https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc,https://sv.sv-2.mock.global.canton.network.digitalasset.com:443/api/sv/v0/admin/domain/cometbft/json-rpc"
         },
         "sv1": {
-          "externalAddress": "mock.global.canton.network.digitalasset.com:26416",
+          "externalAddress": "cometbft.mock.global.canton.network.digitalasset.com:26416",
           "keyAddress": "8A931AB5F957B8331BDEF3A0A081BD9F017A777F",
           "nodeId": "5af57aa83abcec085c949323ed8538108757be9c",
           "publicKey": "gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw="

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -203,6 +203,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "sv"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-sv",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -215,7 +215,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -216,7 +216,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -339,24 +339,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -180,7 +180,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -181,7 +181,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -304,24 +304,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -168,6 +168,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "validator"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-validator",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -108,6 +108,48 @@
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "VirtualService",
+      "metadata": {
+        "name": "cometbft-loopback",
+        "namespace": "validator1"
+      },
+      "spec": {
+        "exportTo": [
+          "."
+        ],
+        "gateways": [
+          "mesh"
+        ],
+        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "tcp": [
+          {
+            "match": [
+              {
+                "gateways": [
+                  "mesh"
+                ]
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "istio-ingress-cometbft.cluster-ingress.svc.cluster.local"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "name": "loopback-cometbft-validator1",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "ServiceEntry",
       "metadata": {
         "name": "loopback",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -120,7 +120,9 @@
         "gateways": [
           "mesh"
         ],
-        "hosts": "cometbft.mock.global.canton.network.digitalasset.com",
+        "hosts": [
+          "cometbft.mock.global.canton.network.digitalasset.com"
+        ],
         "tcp": [
           {
             "match": [

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -121,7 +121,7 @@
           "mesh"
         ],
         "hosts": [
-          "cometbft.mock.global.canton.network.digitalasset.com"
+          "mock.global.canton.network.digitalasset.com"
         ],
         "tcp": [
           {
@@ -244,24 +244,6 @@
           "*.sv-2.mock.global.canton.network.digitalasset.com"
         ],
         "http": [
-          {
-            "match": [
-              {
-                "gateways": [
-                  "mesh"
-                ]
-              }
-            ],
-            "route": [
-              {
-                "destination": {
-                  "host": "istio-ingress.cluster-ingress.svc.cluster.local"
-                }
-              }
-            ]
-          }
-        ],
-        "tcp": [
           {
             "match": [
               {

--- a/cluster/helm/splice-istio-gateway/templates/gateway.yaml
+++ b/cluster/helm/splice-istio-gateway/templates/gateway.yaml
@@ -47,16 +47,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: istio-ingress
-    istio: ingress
+    app: istio-ingress-cometbft
+    istio: ingress-cometbft
   servers:
-  - port:
-      number: 5108
-      name: grpc-swd-pub
-      protocol: GRPC
-    hosts:
-    - "{{ (.Values.cluster).cantonHostname }}"
-    - "{{ (.Values.cluster).daHostname }}"
   {{- $domains := untilStep 0 (int .Values.cometbftPorts.domains) 1 -}}
   {{- $synchronizerNodes := untilStep 0 (int .Values.cometbftPorts.nodes) 1 -}}
   {{- range $index, $domain := $domains }}

--- a/cluster/pulumi/common-sv/src/synchronizer/cometBftNodeConfigs.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometBftNodeConfigs.ts
@@ -86,6 +86,6 @@ export class CometBftNodeConfigs {
   }
 
   private p2pExternalAddress(nodeIndex: number): string {
-    return `${CLUSTER_HOSTNAME}:${cometBFTExternalPort(this._domainMigrationId, nodeIndex)}`;
+    return `cometbft.${CLUSTER_HOSTNAME}:${cometBFTExternalPort(this._domainMigrationId, nodeIndex)}`;
   }
 }

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -116,20 +116,20 @@ export function installCometBftNode(
       enableTimeoutCommit,
     },
     logLevel: svConfiguration.logging?.cometbftLogLevel,
-    peers: nodeConfigs.peers
-      .filter(peer => peer.id !== nodeConfigs.self.id && peer.id !== nodeConfigs.sv1.nodeId)
-      .map(peer => {
-        /*
-         * We configure the peers explicitly here so that every cometbft node knows about the other nodes.
-         * This is required to bypass the use of externalAddress when communicating between cometbft nodes for sv1-sv4
-         * We bypass the external address and use the internal kubernetes services address so that there is no requirement for
-         * sending the traffic through the loopback to satisfy the firewall rules
-         * */
-        return {
-          nodeId: peer.id,
-          externalAddress: nodeConfigs.p2pServiceAddress(peer.id),
-        };
-      }),
+    // peers: nodeConfigs.peers
+    //   .filter(peer => peer.id !== nodeConfigs.self.id && peer.id !== nodeConfigs.sv1.nodeId)
+    //   .map(peer => {
+    //     /*
+    //      * We configure the peers explicitly here so that every cometbft node knows about the other nodes.
+    //      * This is required to bypass the use of externalAddress when communicating between cometbft nodes for sv1-sv4
+    //      * We bypass the external address and use the internal kubernetes services address so that there is no requirement for
+    //      * sending the traffic through the loopback to satisfy the firewall rules
+    //      * */
+    //     return {
+    //       nodeId: peer.id,
+    //       externalAddress: nodeConfigs.p2pServiceAddress(peer.id),
+    //     };
+    //   }),
     stateSync: {
       ...cometBftValues.stateSync,
       enable: stateSyncEnabled,

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -116,20 +116,6 @@ export function installCometBftNode(
       enableTimeoutCommit,
     },
     logLevel: svConfiguration.logging?.cometbftLogLevel,
-    // peers: nodeConfigs.peers
-    //   .filter(peer => peer.id !== nodeConfigs.self.id && peer.id !== nodeConfigs.sv1.nodeId)
-    //   .map(peer => {
-    //     /*
-    //      * We configure the peers explicitly here so that every cometbft node knows about the other nodes.
-    //      * This is required to bypass the use of externalAddress when communicating between cometbft nodes for sv1-sv4
-    //      * We bypass the external address and use the internal kubernetes services address so that there is no requirement for
-    //      * sending the traffic through the loopback to satisfy the firewall rules
-    //      * */
-    //     return {
-    //       nodeId: peer.id,
-    //       externalAddress: nodeConfigs.p2pServiceAddress(peer.id),
-    //     };
-    //   }),
     stateSync: {
       ...cometBftValues.stateSync,
       enable: stateSyncEnabled,

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -76,15 +76,24 @@ export const monitoringConfig = fullConfig.monitoring;
 
 type IpRangesDict = { [key: string]: IpRangesDict } | string[];
 
-function extractIpRanges(x: IpRangesDict): string[] {
-  return Array.isArray(x)
-    ? x
-    : Object.keys(x).reduce((acc: string[], k: string) => acc.concat(extractIpRanges(x[k])), []);
+function extractIpRanges(x: IpRangesDict, svsOnly: boolean = false): string[] {
+  if (svsOnly) {
+    if (Array.isArray(x)) {
+      throw new Error("Cannot distinguish SV IP ranges from non-SV IP ranges in an array");
+    }
+    return extractIpRanges(x['svs'], false);
+  } else {
+    return Array.isArray(x)
+      ? x
+      : Object.keys(x).reduce((acc: string[], k: string) => acc.concat(extractIpRanges(x[k])), []);
+  }
 }
 
-export function loadIPRanges(): pulumi.Output<string[]> {
+export function loadIPRanges(
+  svsOnly: boolean = false
+): pulumi.Output<string[]> {
   const file = externalIpRangesFile();
-  const externalIpRanges = file ? extractIpRanges(loadJsonFromFile(file)) : [];
+  const externalIpRanges = file ? extractIpRanges(loadJsonFromFile(file), svsOnly) : [];
 
   const internalWhitelistedIps = getSecretVersionOutput({
     secret: 'pulumi-internal-whitelists',

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -79,7 +79,7 @@ type IpRangesDict = { [key: string]: IpRangesDict } | string[];
 function extractIpRanges(x: IpRangesDict, svsOnly: boolean = false): string[] {
   if (svsOnly) {
     if (Array.isArray(x)) {
-      throw new Error("Cannot distinguish SV IP ranges from non-SV IP ranges in an array");
+      throw new Error('Cannot distinguish SV IP ranges from non-SV IP ranges in an array');
     }
     return extractIpRanges(x['svs'], false);
   } else {
@@ -89,9 +89,7 @@ function extractIpRanges(x: IpRangesDict, svsOnly: boolean = false): string[] {
   }
 }
 
-export function loadIPRanges(
-  svsOnly: boolean = false
-): pulumi.Output<string[]> {
+export function loadIPRanges(svsOnly: boolean = false): pulumi.Output<string[]> {
   const file = externalIpRangesFile();
   const externalIpRanges = file ? extractIpRanges(loadJsonFromFile(file), svsOnly) : [];
 

--- a/cluster/pulumi/infra/src/index.ts
+++ b/cluster/pulumi/infra/src/index.ts
@@ -24,7 +24,12 @@ export const ingressIp = network.ingressIp.address;
 export const ingressNs = network.ingressNs.ns.metadata.name;
 export const egressIp = network.egressIp.address;
 
-const istio = configureIstio(network.ingressNs, ingressIp, network.cometbftIngressIp.address, network.publicIngressIp.address);
+const istio = configureIstio(
+  network.ingressNs,
+  ingressIp,
+  network.cometbftIngressIp.address,
+  network.publicIngressIp.address
+);
 
 // Ensures that images required from Quay for observability can be pulled
 const observabilityDependsOn = istio.concat([network]);

--- a/cluster/pulumi/infra/src/index.ts
+++ b/cluster/pulumi/infra/src/index.ts
@@ -24,7 +24,7 @@ export const ingressIp = network.ingressIp.address;
 export const ingressNs = network.ingressNs.ns.metadata.name;
 export const egressIp = network.egressIp.address;
 
-const istio = configureIstio(network.ingressNs, ingressIp, network.publicIngressIp.address);
+const istio = configureIstio(network.ingressNs, ingressIp, network.cometbftIngressIp.address, network.publicIngressIp.address);
 
 // Ensures that images required from Quay for observability can be pulled
 const observabilityDependsOn = istio.concat([network]);

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -309,18 +309,18 @@ function configurePublicGatewayService(
       ).concat(
         spliceConfig.pulumiProjectConfig.hasPublicDocs
           ? [
-            {
-              to: [
-                {
-                  operation: {
-                    hosts: [
-                      ...new Set([getDnsNames().cantonDnsName, getDnsNames().daDnsName]),
-                    ].map(host => `docs.${host}`),
+              {
+                to: [
+                  {
+                    operation: {
+                      hosts: [
+                        ...new Set([getDnsNames().cantonDnsName, getDnsNames().daDnsName]),
+                      ].map(host => `docs.${host}`),
+                    },
                   },
-                },
-              ],
-            },
-          ]
+                ],
+              },
+            ]
           : []
       ),
     },
@@ -456,9 +456,9 @@ function configureGatewayService(
     {
       dependsOn: istioPolicies
         ? istioPolicies.apply(policies => {
-          const base: pulumi.Resource[] = [ingressNs, istiod];
-          return base.concat(policies);
-        })
+            const base: pulumi.Resource[] = [ingressNs, istiod];
+            return base.concat(policies);
+          })
         : [ingressNs, istiod],
     }
   );
@@ -600,16 +600,7 @@ function configureGateway(
           app: 'istio-ingress-cometbft',
           istio: 'ingress-cometbft',
         },
-        servers: [
-          {
-            hosts: [getDnsNames().cantonDnsName, getDnsNames().daDnsName],
-            port: {
-              name: 'grpc-swd-pub',
-              number: 5108,
-              protocol: 'GRPC',
-            },
-          },
-        ].concat(servers),
+        servers,
       },
     },
     {
@@ -679,7 +670,7 @@ function configureDocsAndReleases(
     match: { port: number; uri?: { prefix: string } }[];
     route: { destination: { port: { number: number }; host: string } }[];
   }[] = enableGcsProxy
-      ? [
+    ? [
         {
           match: [
             {
@@ -701,7 +692,7 @@ function configureDocsAndReleases(
           ],
         },
       ]
-      : [];
+    : [];
   const nonPublic = new k8s.apiextensions.CustomResource(
     'cluster-docs-releases',
     {

--- a/cluster/pulumi/infra/src/network.ts
+++ b/cluster/pulumi/infra/src/network.ts
@@ -61,17 +61,14 @@ function clusterDnsEntries(
       },
       opts
     ),
-    new gcp.dns.RecordSet(
-      dnsName + '-cometbft',
-      {
-        name: `cometbft.${dnsName}.`,
-        ttl: 60,
-        type: 'A',
-        project: gcpDnsProject,
-        managedZone: managedZone,
-        rrdatas: [cometbftIngressIp.address],
-      },
-    ),
+    new gcp.dns.RecordSet(dnsName + '-cometbft', {
+      name: `cometbft.${dnsName}.`,
+      ttl: 60,
+      type: 'A',
+      project: gcpDnsProject,
+      managedZone: managedZone,
+      rrdatas: [cometbftIngressIp.address],
+    }),
     new gcp.dns.RecordSet(
       dnsName + '-public',
       {

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -588,14 +588,13 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
     supportTeamEmailAddress
   );
   createGrafanaAlerting(namespaceName);
-  // FIXME: uncomment (or get rid of this)
-  // if (grafanaPublicVirtualService) {
-  //   createGrafanaServiceAccount(
-  //     namespaceName,
-  //     adminPassword,
-  //     dependsOn.concat([prometheusStack, grafanaPublicVirtualService])
-  //   );
-  // }
+  if (grafanaPublicVirtualService) {
+    createGrafanaServiceAccount(
+      namespaceName,
+      adminPassword,
+      dependsOn.concat([prometheusStack, grafanaPublicVirtualService])
+    );
+  }
   createGrafanaEnvoyFilter(namespaceName, [prometheusStack]);
 
   return prometheusStack;

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -588,13 +588,14 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
     supportTeamEmailAddress
   );
   createGrafanaAlerting(namespaceName);
-  if (grafanaPublicVirtualService) {
-    createGrafanaServiceAccount(
-      namespaceName,
-      adminPassword,
-      dependsOn.concat([prometheusStack, grafanaPublicVirtualService])
-    );
-  }
+  // FIXME: uncomment (or get rid of this)
+  // if (grafanaPublicVirtualService) {
+  //   createGrafanaServiceAccount(
+  //     namespaceName,
+  //     adminPassword,
+  //     dependsOn.concat([prometheusStack, grafanaPublicVirtualService])
+  //   );
+  // }
   createGrafanaEnvoyFilter(namespaceName, [prometheusStack]);
 
   return prometheusStack;


### PR DESCRIPTION
- Adds another IP address, DNS entry (cometbft.<cluster), and load balancer with only SVs (+internal addresses) whitelisted
- Modifies cometbft to advertise its address as cometbft.<cluster>
- Also modifies our cometbft config to not explicitly list peers via their internal addresses, but rather use their advertised URLs and loopback

Tests:
- Does cometBFT survive a URL change? I deployed this on a cluster, edited the helm value of sv-1's cometbft to set its externalAddress to a dummy value (foo.scratcha...:26016), cometbft on all SVs continued happily churning blocks
- Standard cluster test: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/24396/workflows/dc62075a-87f4-43a8-829b-9d63afd5045e
- A modified cluster test workflow, which first deploys the cluster from the base branch, before deploying from this branch and running the standard tests on it (to test applying this change on top of a running cluster): https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/24388/workflows/dacd9721-b174-42cf-82e8-c8cf81d449e9

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
