### PR TITLE
Don't retry allocateRandomSvParty if already exists

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
@@ -47,8 +47,17 @@ trait SvTestUtil extends TestCommon {
 
   def allocateRandomSvParty(name: String)(implicit env: SpliceTestConsoleEnvironment) = {
     val id = (new scala.util.Random).nextInt().toHexString
+    val partyIdHint = s"$name-$id"
     eventuallySucceeds() {
-      sv1Backend.participantClient.ledger_api.parties.allocate(s"$name-$id").party
+      try { sv1Backend.participantClient.ledger_api.parties.allocate(partyIdHint).party }
+      catch {
+        case NonFatal(e) =>
+          sv1Backend.participantClient.ledger_api.parties
+            .list()
+            .find(_.party.toProtoPrimitive.startsWith(partyIdHint))
+            .getOrElse(fail(e))
+            .party
+      }
     }
   }
 

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -114,6 +114,8 @@ Thread starvation or clock leap detected
 
 # Shutdown issues
 Previous channel ManagedChannelImpl.* was garbage collected without being shut down!
+# remove once https://github.com/DACH-NY/canton/issues/27032 is taken care of
+'Party Allocation' was aborted due to shutdown
 
 # TODO(DACH-NY/canton-network-node#2423) Figure out what causes this
 The sequencer clock timestamp .* is already past the max sequencing time


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5170