### PR TITLE
Disable warning if Xmx is more than 50% of available memory

### DIFF
--- a/cluster/images/common/parameters.conf
+++ b/cluster/images/common/parameters.conf
@@ -2,5 +2,12 @@ canton {
   parameters {
     # Set to 10x confirmation timeout as suggested by Canton.
     timeouts.processing.sequenced-event-processing-bound = 10m
+
+    # Canton has warns if -Xmx exceeds half of the container's total memory,
+    # which is too conservative: we set it to 75% of the container's total memory.
+    # This prevents it from logging the warning.
+    startup-memory-check-config {
+      reporting-level = "ignore"
+    }
   }
 }


### PR DESCRIPTION
[scratch run](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/23813/workflows/ce3346a4-ffe9-47b3-a132-df4100f4a560). It failed on getting a gcloud logs link due to 502 on their side - everything else looks fine.
[logs where you can see it was downgraded to DEBUG](https://console.cloud.google.com/logs/query;query=resource.labels.cluster_name%3D%22cn-scratchcnet%22%0A%22-Xmx%22;summaryFields=resource%252Flabels%252Fnamespace_name:false:32:beginning;cursorTimestamp=2025-07-30T14:23:59.678952272Z;duration=PT1H?project=da-cn-scratchnet&inv=1&invt=Ab4JVQ)

<img width="927" height="870" alt="image" src="https://github.com/user-attachments/assets/3a23bdbc-4650-46a9-b2e4-2f0c8f157bc5" />
