### PR TITLE
stop leaking absolute paths in pulumi preview for commands

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -5,6 +5,7 @@ import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import * as ip from 'ip';
+import * as nodePath from 'path';
 import {
   InstalledHelmChart,
   installPostgresPasswordSecret,
@@ -347,7 +348,7 @@ function createPublicationAndReplicationSlots(
   const dbName = scanAppDatabaseName(postgres);
   const schemaName = dbName;
   const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
-  const path = `${root}/cluster/pulumi/canton-network/bigquery-cloudsql.sh`;
+  const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/canton-network/bigquery-cloudsql.sh`;
   const scriptArgs = pulumi.interpolate`\
       --private-network-project="${privateNetwork.project}" \
       --compute-region="${cloudsdkComputeRegion()}" \

--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -5,13 +5,7 @@ import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import * as ip from 'ip';
-import * as nodePath from 'path';
-import {
-  InstalledHelmChart,
-  installPostgresPasswordSecret,
-  MOCK_SPLICE_ROOT,
-  SPLICE_ROOT,
-} from 'splice-pulumi-common';
+import { InstalledHelmChart, installPostgresPasswordSecret } from 'splice-pulumi-common';
 import { config } from 'splice-pulumi-common/src/config';
 import {
   Postgres,
@@ -20,7 +14,11 @@ import {
   privateNetwork,
   protectCloudSql,
 } from 'splice-pulumi-common/src/postgres';
-import { ExactNamespace, CLUSTER_BASENAME } from 'splice-pulumi-common/src/utils';
+import {
+  ExactNamespace,
+  CLUSTER_BASENAME,
+  commandScriptPath,
+} from 'splice-pulumi-common/src/utils';
 
 interface ScanBigQueryConfig {
   dataset: string;
@@ -347,8 +345,7 @@ function createPublicationAndReplicationSlots(
 ) {
   const dbName = scanAppDatabaseName(postgres);
   const schemaName = dbName;
-  const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
-  const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/canton-network/bigquery-cloudsql.sh`;
+  const path = commandScriptPath('cluster/pulumi/canton-network/bigquery-cloudsql.sh');
   const scriptArgs = pulumi.interpolate`\\
       --private-network-project="${privateNetwork.project}" \\
       --compute-region="${cloudsdkComputeRegion()}" \\

--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -349,20 +349,20 @@ function createPublicationAndReplicationSlots(
   const schemaName = dbName;
   const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
   const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/canton-network/bigquery-cloudsql.sh`;
-  const scriptArgs = pulumi.interpolate`\
-      --private-network-project="${privateNetwork.project}" \
-      --compute-region="${cloudsdkComputeRegion()}" \
-      --service-account-email="${postgres.databaseInstance.serviceAccountEmailAddress}" \
-      --tables-to-replicate-length="${tablesToReplicate.length}" \
-      --db-name="${dbName}" \
-      --schema-name="${schemaName}" \
-      --tables-to-replicate-list="${tablesToReplicate.map(n => `'${n}'`).join(', ')}" \
-      --tables-to-replicate-joined="${tablesToReplicate.join(', ')}" \
-      --postgres-user-name="${postgres.user.name}" \
-      --publication-name="${publicationName}" \
-      --replication-slot-name="${replicationSlotName}" \
-      --replicator-user-name="${replicatorUserName}" \
-      --postgres-instance-name="${postgres.databaseInstance.name}" \
+  const scriptArgs = pulumi.interpolate`\\
+      --private-network-project="${privateNetwork.project}"\\
+      --compute-region="${cloudsdkComputeRegion()}"\\
+      --service-account-email="${postgres.databaseInstance.serviceAccountEmailAddress}"\\
+      --tables-to-replicate-length="${tablesToReplicate.length}"\\
+      --db-name="${dbName}"\\
+      --schema-name="${schemaName}"\\
+      --tables-to-replicate-list="${tablesToReplicate.map(n => `'${n}'`).join(', ')}"\\
+      --tables-to-replicate-joined="${tablesToReplicate.join(', ')}"\\
+      --postgres-user-name="${postgres.user.name}"\\
+      --publication-name="${publicationName}"\\
+      --replication-slot-name="${replicationSlotName}"\\
+      --replicator-user-name="${replicatorUserName}"\\
+      --postgres-instance-name="${postgres.databaseInstance.name}"\\
       --scan-app-database-name="${scanAppDatabaseName(postgres)}"`;
   return new command.local.Command(
     `${postgres.namespace.logicalName}-${replicatorUserName}-pub-replicate-slots`,

--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -350,19 +350,19 @@ function createPublicationAndReplicationSlots(
   const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
   const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/canton-network/bigquery-cloudsql.sh`;
   const scriptArgs = pulumi.interpolate`\\
-      --private-network-project="${privateNetwork.project}"\\
-      --compute-region="${cloudsdkComputeRegion()}"\\
-      --service-account-email="${postgres.databaseInstance.serviceAccountEmailAddress}"\\
-      --tables-to-replicate-length="${tablesToReplicate.length}"\\
-      --db-name="${dbName}"\\
-      --schema-name="${schemaName}"\\
-      --tables-to-replicate-list="${tablesToReplicate.map(n => `'${n}'`).join(', ')}"\\
-      --tables-to-replicate-joined="${tablesToReplicate.join(', ')}"\\
-      --postgres-user-name="${postgres.user.name}"\\
-      --publication-name="${publicationName}"\\
-      --replication-slot-name="${replicationSlotName}"\\
-      --replicator-user-name="${replicatorUserName}"\\
-      --postgres-instance-name="${postgres.databaseInstance.name}"\\
+      --private-network-project="${privateNetwork.project}" \\
+      --compute-region="${cloudsdkComputeRegion()}" \\
+      --service-account-email="${postgres.databaseInstance.serviceAccountEmailAddress}" \\
+      --tables-to-replicate-length="${tablesToReplicate.length}" \\
+      --db-name="${dbName}" \\
+      --schema-name="${schemaName}" \\
+      --tables-to-replicate-list="${tablesToReplicate.map(n => `'${n}'`).join(', ')}" \\
+      --tables-to-replicate-joined="${tablesToReplicate.join(', ')}" \\
+      --postgres-user-name="${postgres.user.name}" \\
+      --publication-name="${publicationName}" \\
+      --replication-slot-name="${replicationSlotName}" \\
+      --replicator-user-name="${replicatorUserName}" \\
+      --postgres-instance-name="${postgres.databaseInstance.name}" \\
       --scan-app-database-name="${scanAppDatabaseName(postgres)}"`;
   return new command.local.Command(
     `${postgres.namespace.logicalName}-${replicatorUserName}-pub-replicate-slots`,

--- a/cluster/pulumi/common/src/utils.ts
+++ b/cluster/pulumi/common/src/utils.ts
@@ -3,6 +3,7 @@
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import * as fs from 'fs';
+import * as nodePath from 'path';
 import { PathLike } from 'fs';
 import { load } from 'js-yaml';
 
@@ -14,7 +15,7 @@ import { spliceEnvConfig } from './config/envConfig';
 export const HELM_CHART_TIMEOUT_SEC = Number(config.optionalEnv('HELM_CHART_TIMEOUT_SEC')) || 600;
 export const HELM_MAX_HISTORY_SIZE = Number(config.optionalEnv('HELM_MAX_HISTORY_SIZE')) || 0; // 0 => no limit
 
-export const MOCK_SPLICE_ROOT = config.optionalEnv('MOCK_SPLICE_ROOT');
+const MOCK_SPLICE_ROOT = config.optionalEnv('MOCK_SPLICE_ROOT');
 export const SPLICE_ROOT = config.requireEnv('SPLICE_ROOT', 'root directory of the repo');
 export const PULUMI_STACKS_DIR = config.requireEnv('PULUMI_STACKS_DIR');
 export const CLUSTER_BASENAME = config.requireEnv('GCP_CLUSTER_BASENAME');
@@ -223,6 +224,12 @@ function getPathToPublicConfigFile(fileName: string): string | undefined {
   }
 
   return `${path}/configs/${clusterDirectory}/${fileName}`;
+}
+
+// only for use with command.local.Command pulumi objects
+export function commandScriptPath(relativeToSplice: string): string {
+  const relativeRoot = nodePath.relative(process.cwd(), MOCK_SPLICE_ROOT || SPLICE_ROOT);
+  return nodePath.join(relativeRoot, relativeToSplice);
 }
 
 export function externalIpRangesFile(): string | undefined {

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -3,10 +3,10 @@
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
-import * as nodePath from 'path';
 import { local } from '@pulumi/command';
 import { spliceConfig } from 'splice-pulumi-common/src/config/config';
 import { PodMonitor, ServiceMonitor } from 'splice-pulumi-common/src/metrics';
+import { commandScriptPath } from 'splice-pulumi-common/src/utils';
 
 import {
   activeVersion,
@@ -20,8 +20,6 @@ import {
   infraAffinityAndTolerations,
   InstalledHelmChart,
   installSpliceHelmChart,
-  MOCK_SPLICE_ROOT,
-  SPLICE_ROOT,
 } from '../../common';
 import { clusterBasename, infraConfig, loadIPRanges } from './config';
 
@@ -38,8 +36,7 @@ function configureIstioBase(
   ns: k8s.core.v1.Namespace,
   istioDNamespace: k8s.core.v1.Namespace
 ): k8s.helm.v3.Release {
-  const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
-  const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/infra/migrate-istio.sh`;
+  const path = commandScriptPath('cluster/pulumi/infra/migrate-istio.sh');
   const migration = new local.Command(`migrate-istio-crds`, {
     create: path,
   });

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -3,6 +3,7 @@
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
+import * as nodePath from 'path';
 import { local } from '@pulumi/command';
 import { spliceConfig } from 'splice-pulumi-common/src/config/config';
 import { PodMonitor, ServiceMonitor } from 'splice-pulumi-common/src/metrics';
@@ -38,7 +39,7 @@ function configureIstioBase(
   istioDNamespace: k8s.core.v1.Namespace
 ): k8s.helm.v3.Release {
   const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
-  const path = `${root}/cluster/pulumi/infra/migrate-istio.sh`;
+  const path = `${nodePath.relative(process.cwd(), root)}/cluster/pulumi/infra/migrate-istio.sh`;
   const migration = new local.Command(`migrate-istio-crds`, {
     create: path,
   });

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -14,13 +14,13 @@ import {
   CLUSTER_NAME,
   clusterProdLike,
   COMETBFT_RETAIN_BLOCKS,
+  commandScriptPath,
   ENABLE_COMETBFT_PRUNING,
   GCP_PROJECT,
   GrafanaKeys,
   HELM_MAX_HISTORY_SIZE,
   isMainNet,
   loadTesterConfig,
-  MOCK_SPLICE_ROOT,
   ObservabilityReleaseName,
   publicPrometheusRemoteWrite,
   SPLICE_ROOT,
@@ -542,8 +542,7 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
     }
   );
 
-  const root = MOCK_SPLICE_ROOT || SPLICE_ROOT;
-  const path = `${root}/cluster/pulumi/infra/prometheus-crd-update.sh`;
+  const path = commandScriptPath('cluster/pulumi/infra/prometheus-crd-update.sh');
   new local.Command(
     `update-prometheus-crd-${prometheusStackCrdVersion}`,
     {


### PR DESCRIPTION
All 3 `Command`s show up as nonsense diffs showing a change in the path to the script. Let's try to find a more stable path instead.

Also add some newlines to the long bigquery-cloudsql command so future diffs are easier to read.

* [x] 46cf798f9007d84573394ded680524c3cdd6a1b1 deploys cleanly to scratchb with bigquery on
* [x] previews in DACH-NY/canton-network-internal#1104


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
