### PR TITLE
[ci] Some debug for protoc issue and set java.io.tmpdir

### DIFF
--- a/.github/actions/sbt/execute_sbt_command/action.yml
+++ b/.github/actions/sbt/execute_sbt_command/action.yml
@@ -50,36 +50,9 @@ runs:
       with:
         additional_nix_args: "--keep ARTIFACTORY_USER --keep ARTIFACTORY_PASSWORD ${{ inputs.additional_nix_args }}"
         cmd: |
-            # To understand issues with protoc failure to execute, remove this when https://github.com/DACH-NY/cn-test-failures/issues/5129 is resolved.
-            # Remove this see https://github.com/DACH-NY/canton-network-internal/issues/1109
-            echo -e "#!/usr/bin/env bash\necho TMP EXEC WORKS" > /tmp/test.sh
-            chmod +x /tmp/test.sh
-            echo "Copied test.sh and changed permissions:"
-            ls -l /tmp/test.sh
-            if [ -x /tmp/test.sh ]; then
-              echo "test.sh is executable"
-            else
-              echo "test.sh is NOT executable"
-            fi
-            
-            echo "Attempting to execute /tmp/test.sh..."
-            /tmp/test.sh
-            EXEC_RESULT=$?
-            if [ $EXEC_RESULT -ne 0 ]; then
-              echo "Execution failed with exit code $EXEC_RESULT"
-              if grep ' /tmp ' /proc/mounts | grep noexec; then
-                echo "/tmp is mounted with noexec; cannot execute scripts from /tmp."
-              else
-                echo "/tmp is NOT mounted with noexec, reason for failure may be different."
-              fi
-            else
-              echo "Successfully executed /tmp/test.sh"
-            fi
-            # Cleanup
-            rm -f /tmp/test.sh
-            
+            # This might help resolve https://github.com/DACH-NY/canton-network-node/issues/8146
+            export PROTOCBRIDGE_NO_CLEANUP="1"
             # just set tmpdir to a place where we can write and execute, to fix protoc execution issue: https://github.com/DACH-NY/cn-test-failures/issues/5129
-            # if above debug fails, but protoc succeeds, then we can remove the debugging code above
             mkdir -p "${HOME}/tmp"
             ABS_TMP_DIR="${HOME}/tmp"
             export SBT_OPTS="${SBT_OPTS} -Djava.io.tmpdir=${ABS_TMP_DIR}"

--- a/.github/actions/sbt/execute_sbt_command/action.yml
+++ b/.github/actions/sbt/execute_sbt_command/action.yml
@@ -50,8 +50,39 @@ runs:
       with:
         additional_nix_args: "--keep ARTIFACTORY_USER --keep ARTIFACTORY_PASSWORD ${{ inputs.additional_nix_args }}"
         cmd: |
-            # This might help resolve https://github.com/DACH-NY/canton-network-node/issues/8146
-            export PROTOCBRIDGE_NO_CLEANUP="1"
+            # To understand issues with protoc failure to execute, remove this when https://github.com/DACH-NY/cn-test-failures/issues/5129 is resolved.
+            # Remove this see https://github.com/DACH-NY/canton-network-internal/issues/1109
+            echo -e "#!/usr/bin/env bash\necho TMP EXEC WORKS" > /tmp/test.sh
+            chmod +x /tmp/test.sh
+            echo "Copied test.sh and changed permissions:"
+            ls -l /tmp/test.sh
+            if [ -x /tmp/test.sh ]; then
+              echo "test.sh is executable"
+            else
+              echo "test.sh is NOT executable"
+            fi
+            
+            echo "Attempting to execute /tmp/test.sh..."
+            /tmp/test.sh
+            EXEC_RESULT=$?
+            if [ $EXEC_RESULT -ne 0 ]; then
+              echo "Execution failed with exit code $EXEC_RESULT"
+              if grep ' /tmp ' /proc/mounts | grep noexec; then
+                echo "/tmp is mounted with noexec; cannot execute scripts from /tmp."
+              else
+                echo "/tmp is NOT mounted with noexec, reason for failure may be different."
+              fi
+            else
+              echo "Successfully executed /tmp/test.sh"
+            fi
+            # Cleanup
+            rm -f /tmp/test.sh
+            
+            # just set tmpdir to a place where we can write and execute, to fix protoc execution issue: https://github.com/DACH-NY/cn-test-failures/issues/5129
+            # if above debug fails, but protoc succeeds, then we can remove the debugging code above
+            mkdir -p "${HOME}/tmp"
+            ABS_TMP_DIR="${HOME}/tmp"
+            export SBT_OPTS="${SBT_OPTS} -Djava.io.tmpdir=${ABS_TMP_DIR}"
 
             run_sbt() {
               export ${{ inputs.extra_env_vars }}


### PR DESCRIPTION
Possibly improves protoc issue where the generated protocbridge `/tmp/protocbridge<followed_by_number>` can't get executed.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
