### PR TITLE
0.4.9 backport: [ci] Do not use the dso party for the acs preflight (#1743)

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RateLimitPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RateLimitPreflightIntegrationTest.scala
@@ -1,6 +1,7 @@
 package org.lfdecentralizedtrust.splice.integration.tests.runbook
 
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.util.FutureInstances.parallelFuture
 import com.digitalasset.canton.util.MonadUtil
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
@@ -30,7 +31,11 @@ class RateLimitPreflightIntegrationTest extends IntegrationTestWithSharedEnviron
       rateLimitIsEnforced(
         10, {
           scanCli.getAcsSnapshot(
-            dsoParty,
+            // Dummy party that doesn't exist to avoid creating load
+            PartyId.tryCreate(
+              "rate-limit-party",
+              dsoParty.namespace,
+            ),
             None,
           )
         },


### PR DESCRIPTION
~Plausibly~ fixes https://github.com/DACH-NY/cn-test-failures/issues/5299

And even if not it sounds like a good idea :)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
