### PR TITLE
Bump max heap size for localnet canton

### DIFF
--- a/cluster/compose/localnet/resource-constraints.yaml
+++ b/cluster/compose/localnet/resource-constraints.yaml
@@ -7,9 +7,9 @@ services:
   postgres:
     mem_limit: 2g
   canton:
-    mem_limit: 6g
+    mem_limit: 7g
     environment:
-      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx3072m"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms512m -Xmx4096m"
   splice:
     mem_limit: 3g
     environment:


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5313

The amount of the increase is inspired by what we did in https://github.com/hyperledger-labs/splice/pull/1075

Also bumping the memory constraint on the container by the same amount for good measure; may I be forgiven the awkward final number there.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
