### PR TITLE
fix off-by-one in sv node indices

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -264,8 +264,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -274,13 +284,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -264,18 +264,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -284,8 +279,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -294,8 +289,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -304,13 +299,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -620,8 +620,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-0-0-gw",
-              "number": 26006,
+              "name": "cometbft-0-1-gw",
+              "number": 26016,
               "protocol": "TCP"
             }
           },
@@ -630,8 +630,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-1-0-gw",
-              "number": 26106,
+              "name": "cometbft-0-1-gw",
+              "number": 26016,
               "protocol": "TCP"
             }
           },
@@ -640,8 +640,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-2-0-gw",
-              "number": 26206,
+              "name": "cometbft-1-1-gw",
+              "number": 26116,
               "protocol": "TCP"
             }
           },
@@ -650,8 +650,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-3-0-gw",
-              "number": 26306,
+              "name": "cometbft-1-1-gw",
+              "number": 26116,
               "protocol": "TCP"
             }
           },
@@ -660,8 +660,58 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-4-0-gw",
-              "number": 26406,
+              "name": "cometbft-2-1-gw",
+              "number": 26216,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-2-1-gw",
+              "number": 26216,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-3-1-gw",
+              "number": 26316,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-3-1-gw",
+              "number": 26316,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-1-gw",
+              "number": 26416,
+              "protocol": "TCP"
+            }
+          },
+          {
+            "hosts": [
+              "*"
+            ],
+            "port": {
+              "name": "cometbft-4-1-gw",
+              "number": 26416,
               "protocol": "TCP"
             }
           }
@@ -1670,34 +1720,34 @@
               "targetPort": 443
             },
             {
-              "name": "cometbft-0-0-gw",
-              "port": 26006,
+              "name": "cometbft-0-1-gw",
+              "port": 26016,
               "protocol": "TCP",
-              "targetPort": 26006
+              "targetPort": 26016
             },
             {
-              "name": "cometbft-1-0-gw",
-              "port": 26106,
+              "name": "cometbft-1-1-gw",
+              "port": 26116,
               "protocol": "TCP",
-              "targetPort": 26106
+              "targetPort": 26116
             },
             {
-              "name": "cometbft-2-0-gw",
-              "port": 26206,
+              "name": "cometbft-2-1-gw",
+              "port": 26216,
               "protocol": "TCP",
-              "targetPort": 26206
+              "targetPort": 26216
             },
             {
-              "name": "cometbft-3-0-gw",
-              "port": 26306,
+              "name": "cometbft-3-1-gw",
+              "port": 26316,
               "protocol": "TCP",
-              "targetPort": 26306
+              "targetPort": 26316
             },
             {
-              "name": "cometbft-4-0-gw",
-              "port": 26406,
+              "name": "cometbft-4-1-gw",
+              "port": 26416,
               "protocol": "TCP",
-              "targetPort": 26406
+              "targetPort": 26416
             }
           ]
         },

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -197,18 +197,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -217,8 +212,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -227,8 +222,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -237,13 +232,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -197,8 +197,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -207,13 +217,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -183,8 +183,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -193,13 +203,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -183,18 +183,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -203,8 +198,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -213,8 +208,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -223,13 +218,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -276,8 +276,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -286,13 +296,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -276,18 +276,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -296,8 +291,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -306,8 +301,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -316,13 +311,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -241,18 +241,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -261,8 +256,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -271,8 +266,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -281,13 +276,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -241,8 +241,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -251,13 +261,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -181,8 +181,18 @@
             "protocol": "GRPC"
           },
           {
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -191,13 +201,28 @@
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-2-0-p2p",
             "number": 26206,
             "protocol": "TCP"
           },
           {
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
+            "protocol": "TCP"
+          },
+          {
             "name": "cometbft-3-0-p2p",
             "number": 26306,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           },
           {

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -181,18 +181,13 @@
             "protocol": "GRPC"
           },
           {
-            "name": "cometbft-0-1-p2p",
-            "number": 26016,
-            "protocol": "TCP"
-          },
-          {
             "name": "cometbft-0-0-p2p",
             "number": 26006,
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-1-1-p2p",
-            "number": 26116,
+            "name": "cometbft-0-1-p2p",
+            "number": 26016,
             "protocol": "TCP"
           },
           {
@@ -201,8 +196,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-2-1-p2p",
-            "number": 26216,
+            "name": "cometbft-1-1-p2p",
+            "number": 26116,
             "protocol": "TCP"
           },
           {
@@ -211,8 +206,8 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-3-1-p2p",
-            "number": 26316,
+            "name": "cometbft-2-1-p2p",
+            "number": 26216,
             "protocol": "TCP"
           },
           {
@@ -221,13 +216,18 @@
             "protocol": "TCP"
           },
           {
-            "name": "cometbft-4-1-p2p",
-            "number": 26416,
+            "name": "cometbft-3-1-p2p",
+            "number": 26316,
             "protocol": "TCP"
           },
           {
             "name": "cometbft-4-0-p2p",
             "number": 26406,
+            "protocol": "TCP"
+          },
+          {
+            "name": "cometbft-4-1-p2p",
+            "number": 26416,
             "protocol": "TCP"
           }
         ],

--- a/cluster/pulumi/common/src/loopback.ts
+++ b/cluster/pulumi/common/src/loopback.ts
@@ -56,7 +56,7 @@ export function installLoopback(namespace: ExactNamespace): pulumi.Resource[] {
     );
     if (!isMainNet) {
       // For non-mainnet clusters, include "node 0" for the sv runbook
-      ret.push(port(migration, 0));
+      ret.unshift(port(migration, 0));
     }
     return ret;
   });

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -24,6 +24,7 @@ import {
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
   isDevNet,
+  isMainNet,
 } from '../../common';
 import { clusterBasename, infraConfig, loadIPRanges } from './config';
 
@@ -225,7 +226,10 @@ function configureCometBFTGatewayService(
   const cometBftIngressPorts = Array.from({ length: numMigrations }, (_, i) => i).flatMap(
     migration =>
       Array.from({ length: numSVs }, (_, node) => node).map(node =>
-        ingressPort(`cometbft-${migration}-${node}-gw`, cometBFTExternalPort(migration, node))
+        ingressPort(
+          `cometbft-${migration}-${node + 1}-gw`,
+          cometBFTExternalPort(migration, node + 1)
+        )
       )
   );
   return configureGatewayService(
@@ -574,17 +578,26 @@ function configureGateway(
   // and support easily deploying without refreshing the infra stack.
   const numSVs = dsoSize < 5 && isDevNet ? 5 : dsoSize;
 
-  const servers = Array.from({ length: numMigrations }, (_, i) => i).flatMap(migration =>
-    Array.from({ length: numSVs }, (_, node) => node).map(node => ({
-      // We cannot really distinguish TCP traffic by hostname, so configuring to "*" to be explicit about that
-      hosts: ['*'],
-      port: {
-        name: `cometbft-${migration}-${node}-gw`,
-        number: cometBFTExternalPort(migration, node),
-        protocol: 'TCP',
-      },
-    }))
-  );
+  const server = (migration: number, node: number) => ({
+    // We cannot really distinguish TCP traffic by hostname, so configuring to "*" to be explicit about that
+    hosts: ['*'],
+    port: {
+      name: `cometbft-${migration}-${node + 1}-gw`,
+      number: cometBFTExternalPort(migration, node + 1),
+      protocol: 'TCP',
+    },
+  });
+
+  const servers = Array.from({ length: numMigrations }, (_, i) => i).flatMap(migration => {
+    const ret = Array.from({ length: numSVs }, (_, node) => node).map(node =>
+      server(migration, node)
+    );
+    if (!isMainNet) {
+      // For non-mainnet clusters, include "node 0" for the sv runbook
+      ret.push(server(migration, 0));
+    }
+    return ret;
+  });
 
   const appsGw = new k8s.apiextensions.CustomResource(
     'cn-apps-gateway',

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -594,7 +594,7 @@ function configureGateway(
     );
     if (!isMainNet) {
       // For non-mainnet clusters, include "node 0" for the sv runbook
-      ret.push(server(migration, 0));
+      ret.unshift(server(migration, 0));
     }
     return ret;
   });


### PR DESCRIPTION
It's actually a combination of two mistakes:

- dso size of 4 means SVs 1-4, not 0-3
- sv runbook is not counted in the dso size, and has index 0

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
