### PR TITLE
fix the fix to cometbft ports

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -620,8 +620,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-0-1-gw",
-              "number": 26016,
+              "name": "cometbft-0-0-gw",
+              "number": 26006,
               "protocol": "TCP"
             }
           },
@@ -640,8 +640,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-1-1-gw",
-              "number": 26116,
+              "name": "cometbft-1-0-gw",
+              "number": 26106,
               "protocol": "TCP"
             }
           },
@@ -660,8 +660,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-2-1-gw",
-              "number": 26216,
+              "name": "cometbft-2-0-gw",
+              "number": 26206,
               "protocol": "TCP"
             }
           },
@@ -680,8 +680,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-3-1-gw",
-              "number": 26316,
+              "name": "cometbft-3-0-gw",
+              "number": 26306,
               "protocol": "TCP"
             }
           },
@@ -700,8 +700,8 @@
               "*"
             ],
             "port": {
-              "name": "cometbft-4-1-gw",
-              "number": 26416,
+              "name": "cometbft-4-0-gw",
+              "number": 26406,
               "protocol": "TCP"
             }
           },

--- a/cluster/pulumi/common/src/loopback.ts
+++ b/cluster/pulumi/common/src/loopback.ts
@@ -41,9 +41,9 @@ export function installLoopback(namespace: ExactNamespace): pulumi.Resource[] {
   );
 
   const numMigrations = DecentralizedSynchronizerUpgradeConfig.highestMigrationId + 1;
-  // For DevNet-like clusters, we always assume at least 5 SVs to reduce churn on the gateway definition,
+  // For DevNet-like clusters, we always assume at least 4 SVs (not including sv-runbook) to reduce churn on the gateway definition,
   // and support easily deploying without refreshing the infra stack.
-  const numSVs = dsoSize < 5 && isDevNet ? 5 : dsoSize;
+  const numSVs = dsoSize < 4 && isDevNet ? 4 : dsoSize;
 
   const port = (migration: number, node: number) => ({
     number: cometBFTExternalPort(migration, node),

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -574,9 +574,9 @@ function configureGateway(
   );
 
   const numMigrations = DecentralizedSynchronizerUpgradeConfig.highestMigrationId + 1;
-  // For DevNet-like clusters, we always assume at least 5 SVs to reduce churn on the gateway definition,
+  // For DevNet-like clusters, we always assume at least 4 SVs (not including sv-runbook) to reduce churn on the gateway definition,
   // and support easily deploying without refreshing the infra stack.
-  const numSVs = dsoSize < 5 && isDevNet ? 5 : dsoSize;
+  const numSVs = dsoSize < 4 && isDevNet ? 4 : dsoSize;
 
   const server = (migration: number, node: number) => ({
     // We cannot really distinguish TCP traffic by hostname, so configuring to "*" to be explicit about that

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -582,15 +582,15 @@ function configureGateway(
     // We cannot really distinguish TCP traffic by hostname, so configuring to "*" to be explicit about that
     hosts: ['*'],
     port: {
-      name: `cometbft-${migration}-${node + 1}-gw`,
-      number: cometBFTExternalPort(migration, node + 1),
+      name: `cometbft-${migration}-${node}-gw`,
+      number: cometBFTExternalPort(migration, node),
       protocol: 'TCP',
     },
   });
 
   const servers = Array.from({ length: numMigrations }, (_, i) => i).flatMap(migration => {
     const ret = Array.from({ length: numSVs }, (_, node) => node).map(node =>
-      server(migration, node)
+      server(migration, node + 1)
     );
     if (!isMainNet) {
       // For non-mainnet clusters, include "node 0" for the sv runbook


### PR DESCRIPTION
Argh!!!!
Confirmed with a `cncluster pulumi infra preview` on a scratchnet that it does the expected thing (as opposed to before this fix, where the preview failed due to a name conflict)

Fixes https://github.com/DACH-NY/cn-test-failures/issues/5319

[cluster test, as I should have run on the previous PR to learn that it's broken.....](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/24774/workflows/90408e85-1789-486d-9c94-0aa7177d1fd8)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
