### PR TITLE
0.4.9 backport: Don't retry allocateRandomSvParty if already exists (#1748)

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/SvTestUtil.scala
@@ -47,8 +47,17 @@ trait SvTestUtil extends TestCommon {
 
   def allocateRandomSvParty(name: String)(implicit env: SpliceTestConsoleEnvironment) = {
     val id = (new scala.util.Random).nextInt().toHexString
+    val partyIdHint = s"$name-$id"
     eventuallySucceeds() {
-      sv1Backend.participantClient.ledger_api.parties.allocate(s"$name-$id").party
+      try { sv1Backend.participantClient.ledger_api.parties.allocate(partyIdHint).party }
+      catch {
+        case NonFatal(e) =>
+          sv1Backend.participantClient.ledger_api.parties
+            .list()
+            .find(_.party.toProtoPrimitive.startsWith(partyIdHint))
+            .getOrElse(fail(e))
+            .party
+      }
     }
   }
 

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -114,6 +114,8 @@ Thread starvation or clock leap detected
 
 # Shutdown issues
 Previous channel ManagedChannelImpl.* was garbage collected without being shut down!
+# remove once https://github.com/DACH-NY/canton/issues/27032 is taken care of
+'Party Allocation' was aborted due to shutdown
 
 # TODO(DACH-NY/canton-network-node#2423) Figure out what causes this
 The sequencer clock timestamp .* is already past the max sequencing time


### PR DESCRIPTION
Backports https://github.com/hyperledger-labs/splice/pull/1748 because https://github.com/DACH-NY/cn-test-failures/issues/5336

Backport seems cheap enough and we'll be using this branch for a few more weeks.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
