### PR TITLE
Add circuit breaker for ledger API command submissions

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -140,6 +140,7 @@ case class SpliceConfig(
         parameters.timeouts.processing,
         parameters.timeouts.requestTimeout,
         UpgradesConfig(),
+        validatorConfig.parameters.commandCircuitBreakerConfig,
         validatorConfig.parameters.caching,
         parameters.enableAdditionalConsistencyChecks,
         features.enablePreviewCommands,
@@ -177,6 +178,7 @@ case class SpliceConfig(
         parameters.timeouts.processing,
         parameters.timeouts.requestTimeout,
         UpgradesConfig(),
+        svConfig.parameters.commandCircuitBreakerConfig,
         svConfig.parameters.caching,
         parameters.enableAdditionalConsistencyChecks,
         features.enablePreviewCommands,
@@ -213,6 +215,7 @@ case class SpliceConfig(
         parameters.timeouts.processing,
         parameters.timeouts.requestTimeout,
         UpgradesConfig(),
+        scanConfig.parameters.commandCircuitBreakerConfig,
         scanConfig.parameters.caching,
         parameters.enableAdditionalConsistencyChecks,
         features.enablePreviewCommands,
@@ -249,6 +252,7 @@ case class SpliceConfig(
         parameters.timeouts.processing,
         parameters.timeouts.requestTimeout,
         UpgradesConfig(),
+        splitwellConfig.parameters.commandCircuitBreakerConfig,
         splitwellConfig.parameters.caching,
         parameters.enableAdditionalConsistencyChecks,
         features.enablePreviewCommands,
@@ -396,6 +400,8 @@ object SpliceConfig {
     implicit val networkAppClientConfigReader: ConfigReader[NetworkAppClientConfig] =
       deriveReader[NetworkAppClientConfig]
 
+    implicit val circuitBreakerConfig: ConfigReader[CircuitBreakerConfig] =
+      deriveReader[CircuitBreakerConfig]
     implicit val spliceParametersConfig: ConfigReader[SpliceParametersConfig] =
       deriveReader[SpliceParametersConfig]
     implicit val rateLimitersConfig: ConfigReader[RateLimitersConfig] =
@@ -786,6 +792,8 @@ object SpliceConfig {
     implicit val authConfig: ConfigWriter[AuthConfig] =
       confidentialWriter[AuthConfig](AuthConfig.hideConfidential)
 
+    implicit val circuitBreakerConfig: ConfigWriter[CircuitBreakerConfig] =
+      deriveWriter[CircuitBreakerConfig]
     implicit val spliceParametersConfig: ConfigWriter[SpliceParametersConfig] =
       deriveWriter[SpliceParametersConfig]
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -33,12 +33,13 @@ abstract class GrpcClientConfig extends NodeConfig {}
 abstract class HttpClientConfig extends NetworkAppNodeConfig {}
 
 final case class CircuitBreakerConfig(
-  maxFailures: Int = 20,
-  callTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(0), // disable timeout
-  resetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(30),
-  maxResetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofMinutes(10),
-  exponentialBackoffFactor: Double = 2.0,
-  randomFactor: Double = 0.2,
+    maxFailures: Int = 20,
+    callTimeout: NonNegativeFiniteDuration =
+      NonNegativeFiniteDuration.ofSeconds(0), // disable timeout
+    resetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(30),
+    maxResetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofMinutes(10),
+    exponentialBackoffFactor: Double = 2.0,
+    randomFactor: Double = 0.2,
 )
 
 /** This class aggregates binary-level configuration options that are shared between each Splice app instance.

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -32,6 +32,15 @@ abstract class SpliceBackendConfig extends LocalNodeConfig {
 abstract class GrpcClientConfig extends NodeConfig {}
 abstract class HttpClientConfig extends NetworkAppNodeConfig {}
 
+final case class CircuitBreakerConfig(
+  maxFailures: Int = 20,
+  callTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(0), // disable timeout
+  resetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(30),
+  maxResetTimeout: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofMinutes(10),
+  exponentialBackoffFactor: Double = 2.0,
+  randomFactor: Double = 0.2,
+)
+
 /** This class aggregates binary-level configuration options that are shared between each Splice app instance.
   * For example, the [[TracingConfig]] is configured once for all Splice apps that are started by a Splice binary as part of the
   * [[com.digitalasset.canton.config.MonitoringConfig]].
@@ -49,6 +58,7 @@ case class SharedSpliceAppParameters(
     override val processingTimeouts: ProcessingTimeout,
     requestTimeout: NonNegativeDuration,
     upgradesConfig: UpgradesConfig = UpgradesConfig(),
+    commandCircuitBreakerConfig: CircuitBreakerConfig = CircuitBreakerConfig(),
     // TODO(DACH-NY/canton-network-node#736): likely remove all of the following:
     override val cachingConfigs: CachingConfigs,
     override val enableAdditionalConsistencyChecks: Boolean,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceParametersConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceParametersConfig.scala
@@ -19,7 +19,7 @@ final case class SpliceParametersConfig(
     customTimeouts: Map[String, NonNegativeFiniteDuration] = Map.empty,
     rateLimiting: RateLimitersConfig =
       RateLimitersConfig(SpliceRateLimitConfig(enabled = true, ratePerSecond = 200), Map.empty),
-  // Configuration for the circuit breaker for ledger API command submissions.
+    // Configuration for the circuit breaker for ledger API command submissions.
     commandCircuitBreakerConfig: CircuitBreakerConfig = CircuitBreakerConfig(),
 ) extends LocalNodeParametersConfig {
   override def alphaVersionSupport: Boolean = false

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceParametersConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceParametersConfig.scala
@@ -19,6 +19,8 @@ final case class SpliceParametersConfig(
     customTimeouts: Map[String, NonNegativeFiniteDuration] = Map.empty,
     rateLimiting: RateLimitersConfig =
       RateLimitersConfig(SpliceRateLimitConfig(enabled = true, ratePerSecond = 200), Map.empty),
+  // Configuration for the circuit breaker for ledger API command submissions.
+    commandCircuitBreakerConfig: CircuitBreakerConfig = CircuitBreakerConfig(),
 ) extends LocalNodeParametersConfig {
   override def alphaVersionSupport: Boolean = false
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/NodeBase.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/NodeBase.scala
@@ -276,6 +276,7 @@ abstract class NodeBase[State <: AutoCloseable & HasHealth](
       tracerProvider,
       retryProvider,
       nodeMetrics.grpcClientMetrics,
+      parameters.commandCircuitBreakerConfig,
     )
   }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerClient.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerClient.scala
@@ -34,8 +34,8 @@ class SpliceLedgerClient(
     // client interceptors below
     val unusedTracerProvider: TracerProvider,
     override protected[this] val retryProvider: RetryProvider,
-  grpcClientMetrics: GrpcClientMetrics,
-  commandCircuitBreakerConfig: CircuitBreakerConfig,
+    grpcClientMetrics: GrpcClientMetrics,
+    commandCircuitBreakerConfig: CircuitBreakerConfig,
 )(implicit
     ec: ExecutionContextExecutor,
     as: ActorSystem,
@@ -52,9 +52,11 @@ class SpliceLedgerClient(
     exponentialBackoffFactor = commandCircuitBreakerConfig.exponentialBackoffFactor,
     randomFactor = commandCircuitBreakerConfig.randomFactor,
   ).onOpen {
-    logger.warn(s"Command circuit breaker tripped after ${commandCircuitBreakerConfig.maxFailures} failures")(TraceContext.empty)
+    logger.warn(
+      s"Command circuit breaker tripped after ${commandCircuitBreakerConfig.maxFailures} failures"
+    )(TraceContext.empty)
   }.onHalfOpen {
-    logger.info(s"Command circuit breaker moving to half-open state") (TraceContext.empty)
+    logger.info(s"Command circuit breaker moving to half-open state")(TraceContext.empty)
   }.onClose {
     logger.info(s"Command circuit breaker moving to closed state")(TraceContext.empty)
   }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/CommandCircuitBreakerTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/CommandCircuitBreakerTest.scala
@@ -5,7 +5,11 @@ import com.daml.ledger.javaapi.data.Command
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.digitalasset.canton.{BaseTest, HasActorSystem, HasExecutionContext}
 import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
-import com.digitalasset.canton.config.{NonNegativeDuration, NonNegativeFiniteDuration, ProcessingTimeout}
+import com.digitalasset.canton.config.{
+  NonNegativeDuration,
+  NonNegativeFiniteDuration,
+  ProcessingTimeout,
+}
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.{NoReportingTracerProvider, TraceContext}
@@ -20,7 +24,11 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.*
 
-class CommandCircuitBreakerTest extends AsyncWordSpec with BaseTest with HasActorSystem with HasExecutionContext {
+class CommandCircuitBreakerTest
+    extends AsyncWordSpec
+    with BaseTest
+    with HasActorSystem
+    with HasExecutionContext {
   val ledgerClient = mock[LedgerClient]
 
   val circuitBreaker = new CircuitBreaker(
@@ -41,7 +49,21 @@ class CommandCircuitBreakerTest extends AsyncWordSpec with BaseTest with HasActo
   )(NoReportingTracerProvider.tracer)
 
   def mockSubmitResult(result: => Future[Long]) = {
-    when(ledgerClient.submitAndWait[Long](any[String], any[String], any[String], any[DedupConfig], any[Seq[String]], any[Seq[String]], any[Seq[Command]], any[DisclosedContracts], any[SubmitAndWaitFor[Long]], any[Option[NonNegativeFiniteDuration]], any[Seq[String]])(any[ExecutionContext], any[TraceContext])).thenReturn(result)
+    when(
+      ledgerClient.submitAndWait[Long](
+        any[String],
+        any[String],
+        any[String],
+        any[DedupConfig],
+        any[Seq[String]],
+        any[Seq[String]],
+        any[Seq[Command]],
+        any[DisclosedContracts],
+        any[SubmitAndWaitFor[Long]],
+        any[Option[NonNegativeFiniteDuration]],
+        any[Seq[String]],
+      )(any[ExecutionContext], any[TraceContext])
+    ).thenReturn(result)
   }
 
   "SpliceLedgerConnection has a circuit breaker on command submissions" in {
@@ -59,44 +81,63 @@ class CommandCircuitBreakerTest extends AsyncWordSpec with BaseTest with HasActo
     val alice = PartyId.tryFromProtoPrimitive("alice::namespace")
     val syncId = SynchronizerId.tryFromString("sync::namespace")
     mockSubmitResult(Future.successful(42L))
-    val update =       new ValidatorRight(
-        alice.toProtoPrimitive,
-        alice.toProtoPrimitive,
-        alice.toProtoPrimitive
-      ).create
+    val update = new ValidatorRight(
+      alice.toProtoPrimitive,
+      alice.toProtoPrimitive,
+      alice.toProtoPrimitive,
+    ).create
     for {
-      _ <- connection.submit(
-      Seq(alice),
-      Seq.empty,
-      update,
-      ).withSynchronizerId(syncId).noDedup.yieldUnit()
-      _ = mockSubmitResult(Future.failed(Status.ABORTED.asRuntimeException))
-      // Trigger enough failures to open the circuit breaker
-      _ <- Future.sequence { (0 until 5).map { _ =>
-        recoverToExceptionIf[StatusRuntimeException](connection.submit(
+      _ <- connection
+        .submit(
           Seq(alice),
           Seq.empty,
           update,
-        ).withSynchronizerId(syncId).noDedup.yieldUnit()).map( ex =>
-          ex.getStatus shouldBe Status.ABORTED
         )
-      }
+        .withSynchronizerId(syncId)
+        .noDedup
+        .yieldUnit()
+      _ = mockSubmitResult(Future.failed(Status.ABORTED.asRuntimeException))
+      // Trigger enough failures to open the circuit breaker
+      _ <- Future.sequence {
+        (0 until 5).map { _ =>
+          recoverToExceptionIf[StatusRuntimeException](
+            connection
+              .submit(
+                Seq(alice),
+                Seq.empty,
+                update,
+              )
+              .withSynchronizerId(syncId)
+              .noDedup
+              .yieldUnit()
+          ).map(ex => ex.getStatus shouldBe Status.ABORTED)
+        }
       }
       // Circuit breaker now aborts even if call succeeds
       _ = mockSubmitResult(Future.successful(42L))
-      circuitBreakerEx <- recoverToExceptionIf[StatusRuntimeException](connection.submit(
-          Seq(alice),
-          Seq.empty,
-          update,
-        ).withSynchronizerId(syncId).noDedup.yieldUnit())
+      circuitBreakerEx <- recoverToExceptionIf[StatusRuntimeException](
+        connection
+          .submit(
+            Seq(alice),
+            Seq.empty,
+            update,
+          )
+          .withSynchronizerId(syncId)
+          .noDedup
+          .yieldUnit()
+      )
       _ = circuitBreakerEx.getStatus.getDescription should include("aborted by circuit breaker")
       // Wait until the circuit breaker is closed again
       _ = Threading.sleep(6000)
-      _ <- connection.submit(
-        Seq(alice),
-        Seq.empty,
-        update,
-      ).withSynchronizerId(syncId).noDedup.yieldUnit()
+      _ <- connection
+        .submit(
+          Seq(alice),
+          Seq.empty,
+          update,
+        )
+        .withSynchronizerId(syncId)
+        .noDedup
+        .yieldUnit()
     } yield succeed
   }
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/CommandCircuitBreakerTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/environment/CommandCircuitBreakerTest.scala
@@ -1,0 +1,102 @@
+package org.lfdecentralizedtrust.splice.environment
+
+import org.apache.pekko.pattern.CircuitBreaker
+import com.daml.ledger.javaapi.data.Command
+import com.daml.metrics.api.noop.NoOpMetricsFactory
+import com.digitalasset.canton.{BaseTest, HasActorSystem, HasExecutionContext}
+import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
+import com.digitalasset.canton.config.{NonNegativeDuration, NonNegativeFiniteDuration, ProcessingTimeout}
+import com.digitalasset.canton.logging.NamedLoggerFactory
+import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
+import com.digitalasset.canton.tracing.{NoReportingTracerProvider, TraceContext}
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.ValidatorRight
+import org.lfdecentralizedtrust.splice.environment.ledger.api.{DedupConfig, LedgerClient}
+import LedgerClient.SubmitAndWaitFor
+import org.lfdecentralizedtrust.splice.util.DisclosedContracts
+import org.scalatest.wordspec.AsyncWordSpec
+
+import io.grpc.{Status, StatusRuntimeException}
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.*
+
+class CommandCircuitBreakerTest extends AsyncWordSpec with BaseTest with HasActorSystem with HasExecutionContext {
+  val ledgerClient = mock[LedgerClient]
+
+  val circuitBreaker = new CircuitBreaker(
+    actorSystem.scheduler,
+    maxFailures = 5,
+    callTimeout = 0.seconds,
+    resetTimeout = 5.seconds,
+    maxResetTimeout = 5.seconds,
+    exponentialBackoffFactor = 2.0,
+    randomFactor = 0.0,
+  )
+
+  val retryProvider = new RetryProvider(
+    NamedLoggerFactory.root,
+    ProcessingTimeout(),
+    new FutureSupervisor.Impl(NonNegativeDuration.tryFromDuration(10.seconds))(scheduledExecutor()),
+    NoOpMetricsFactory,
+  )(NoReportingTracerProvider.tracer)
+
+  def mockSubmitResult(result: => Future[Long]) = {
+    when(ledgerClient.submitAndWait[Long](any[String], any[String], any[String], any[DedupConfig], any[Seq[String]], any[Seq[String]], any[Seq[Command]], any[DisclosedContracts], any[SubmitAndWaitFor[Long]], any[Option[NonNegativeFiniteDuration]], any[Seq[String]])(any[ExecutionContext], any[TraceContext])).thenReturn(result)
+  }
+
+  "SpliceLedgerConnection has a circuit breaker on command submissions" in {
+    val connection = new SpliceLedgerConnection(
+      ledgerClient,
+      "dummy-user",
+      loggerFactory,
+      retryProvider,
+      new AtomicReference(Seq.empty),
+      new AtomicReference(Seq.empty),
+      new AtomicReference(None),
+      _ => Future.unit,
+      circuitBreaker,
+    )
+    val alice = PartyId.tryFromProtoPrimitive("alice::namespace")
+    val syncId = SynchronizerId.tryFromString("sync::namespace")
+    mockSubmitResult(Future.successful(42L))
+    val update =       new ValidatorRight(
+        alice.toProtoPrimitive,
+        alice.toProtoPrimitive,
+        alice.toProtoPrimitive
+      ).create
+    for {
+      _ <- connection.submit(
+      Seq(alice),
+      Seq.empty,
+      update,
+      ).withSynchronizerId(syncId).noDedup.yieldUnit()
+      _ = mockSubmitResult(Future.failed(Status.ABORTED.asRuntimeException))
+      // Trigger enough failures to open the circuit breaker
+      _ <- Future.sequence { (0 until 5).map { _ =>
+        recoverToExceptionIf[StatusRuntimeException](connection.submit(
+          Seq(alice),
+          Seq.empty,
+          update,
+        ).withSynchronizerId(syncId).noDedup.yieldUnit()).map( ex =>
+          ex.getStatus shouldBe Status.ABORTED
+        )
+      }
+      }
+      // Circuit breaker now aborts even if call succeeds
+      _ = mockSubmitResult(Future.successful(42L))
+      circuitBreakerEx <- recoverToExceptionIf[StatusRuntimeException](connection.submit(
+          Seq(alice),
+          Seq.empty,
+          update,
+        ).withSynchronizerId(syncId).noDedup.yieldUnit())
+      _ = circuitBreakerEx.getStatus.getDescription should include("aborted by circuit breaker")
+      // Wait until the circuit breaker is closed again
+      _ = Threading.sleep(6000)
+      _ <- connection.submit(
+        Seq(alice),
+        Seq.empty,
+        update,
+      ).withSynchronizerId(syncId).noDedup.yieldUnit()
+    } yield succeed
+  }
+}

--- a/test-full-class-names-non-integration.log
+++ b/test-full-class-names-non-integration.log
@@ -3,6 +3,7 @@ org.lfdecentralizedtrust.splice.auth.SignatureVerifierTest
 org.lfdecentralizedtrust.splice.automation.SqlIndexInitializationTriggerStoreTest
 org.lfdecentralizedtrust.splice.config.SpliceConfigTest
 org.lfdecentralizedtrust.splice.config.ThresholdsTest
+org.lfdecentralizedtrust.splice.environment.CommandCircuitBreakerTest
 org.lfdecentralizedtrust.splice.environment.CommandIdDedupTest
 org.lfdecentralizedtrust.splice.environment.TopologyAwarePackageVersionSupportTest
 org.lfdecentralizedtrust.splice.http.UrlValidatorTest


### PR DESCRIPTION
[ci]

We may want to consider:

1. Removing the logic to disabling automation on synchronization time delays.
2. Add logic that disables it when the circuit breaker is enabled to avoid too much spam.

But both of that doesn't seem strictly required for now.

fixes #1815



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
