### PR TITLE
0.4.9 backport: Make it easy to disable SV participant BFT sequencer connections via `config.yaml` (#1829)

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -111,6 +111,9 @@ svs:
       additionalEnvVars:
         - name: CUSTOM_MOCK_ENV_VAR_NAME
           value: CUSTOM_MOCK_ENV_VAR_VALUE
+  sv:
+    participant:
+      bftSequencerConnection: false
   # TODO(tech-debt) Actually use the values below for the mock expected files (we mock deploy only sv-1 atm).
   sv-2:
     logging:

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -685,8 +685,16 @@
       "values": {
         "additionalEnvVars": [
           {
+            "name": "CUSTOM_MOCK_ENV_VAR_NAME",
+            "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
+          },
+          {
             "name": "ADDITIONAL_CONFIG_TOPOLOGY_CHANGE_DELAY",
             "value": "canton.sv-apps.sv.topology-change-delay-duration=250ms"
+          },
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.sv-apps.sv.bft-sequencer-connection = false"
           }
         ],
         "affinity": {
@@ -880,6 +888,12 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true"
+          }
+        ],
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -901,6 +915,7 @@
           "jwksUrl": "https://canton-network-sv-test.us.auth0.com/.well-known/jwks.json"
         },
         "contactPoint": "sv-support@digitalasset.com",
+        "decentralizedSynchronizerUrl": "https://sequencer-3.sv-2.mock.global.canton.network.digitalasset.com",
         "enablePostgresMetrics": true,
         "enableWallet": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
@@ -951,6 +966,7 @@
           "minTopupInterval": "1m",
           "targetThroughput": 0
         },
+        "useSequencerConnectionsFromScan": false,
         "validatorWalletUsers": [
           "google-oauth2|1234567890",
           "auth0|64553aa683015a9687d9cc2e"

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -342,6 +342,9 @@ async function installValidator(
   const validatorDbName = `validator_${sanitizedForPostgres(svConfig.nodeName)}`;
   const decentralizedSynchronizerUrl = `https://sequencer-${decentralizedSynchronizerMigrationConfig.active.id}.sv-2.${CLUSTER_HOSTNAME}`;
 
+  const bftSequencerConnection =
+    !svConfig.participant || svConfig.participant.bftSequencerConnection;
+
   const validator = await installValidatorApp({
     xns,
     migration: {
@@ -366,12 +369,21 @@ async function installValidator(
       : [postgres],
     svValidator: true,
     participantAddress: sv.participant.internalClusterAddress,
-    decentralizedSynchronizerUrl: decentralizedSynchronizerUrl,
+    decentralizedSynchronizerUrl: bftSequencerConnection ? undefined : decentralizedSynchronizerUrl,
     scanAddress: internalScanUrl(svConfig),
     secrets: validatorSecrets,
     sweep: svConfig.sweep,
     nodeIdentifier: svConfig.onboardingName,
     logLevel: svConfig.logging?.appsLogLevel,
+    additionalEnvVars: bftSequencerConnection
+      ? undefined
+      : [
+          {
+            name: 'ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION',
+            value:
+              'canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true',
+          },
+        ],
   });
 
   return validator;
@@ -401,9 +413,18 @@ function installSvApp(
         },
       ]
     : [];
-  const additionalEnvVars = (config.svApp?.additionalEnvVars || []).concat(
-    topologyChangeDelayEnvVars
-  );
+  const bftSequencerConnectionEnvVars =
+    !config.participant || config.participant.bftSequencerConnection
+      ? []
+      : [
+          {
+            name: 'ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION',
+            value: 'canton.sv-apps.sv.bft-sequencer-connection = false',
+          },
+        ];
+  const additionalEnvVars = (config.svApp?.additionalEnvVars || [])
+    .concat(topologyChangeDelayEnvVars)
+    .concat(bftSequencerConnectionEnvVars);
   const svValues = {
     ...decentralizedSynchronizerMigrationConfig.migratingNodeConfig(),
     ...spliceInstanceNames,

--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -9,12 +9,13 @@ import { z } from 'zod';
 const SvCometbftConfigSchema = z.object({
   snapshotName: z.string(),
 });
-const SvParticipantConfigSchema = z.object({
-  kms: KmsConfigSchema.optional(),
-});
 const EnvVarConfigSchema = z.object({
   name: z.string(),
   value: z.string(),
+});
+const SvParticipantConfigSchema = z.object({
+  kms: KmsConfigSchema.optional(),
+  bftSequencerConnection: z.boolean().default(true),
 });
 const SvAppConfigSchema = z.object({
   additionalEnvVars: z.array(EnvVarConfigSchema).default([]),

--- a/cluster/pulumi/common-validator/src/validator.ts
+++ b/cluster/pulumi/common-validator/src/validator.ts
@@ -68,6 +68,7 @@ type BasicValidatorConfig = {
   extraDomains?: ExtraDomain[];
   additionalConfig?: string;
   additionalUsers?: k8s.types.input.core.v1.EnvVar[];
+  additionalEnvVars?: k8s.types.input.core.v1.EnvVar[];
   participantAddress: Output<string> | string;
   secrets: ValidatorSecrets | ValidatorSecretsConfig;
   sweep?: SweepConfig;
@@ -104,7 +105,7 @@ export function autoAcceptTransfersConfigFromEnv(
 
 type SvValidatorConfig = BasicValidatorConfig & {
   svValidator: true;
-  decentralizedSynchronizerUrl: string;
+  decentralizedSynchronizerUrl?: string;
   migration: {
     id: DomainMigrationIndex;
   };
@@ -181,9 +182,12 @@ export async function installValidatorApp(
     {
       migration: config.migration,
       additionalUsers: config.additionalUsers || [],
+      additionalEnvVars: config.additionalEnvVars || undefined,
       validatorPartyHint: config.validatorPartyHint,
       appDars: config.appDars || [],
-      decentralizedSynchronizerUrl: undefined,
+      decentralizedSynchronizerUrl: config.svValidator
+        ? config.decentralizedSynchronizerUrl
+        : undefined,
       scanAddress: config.scanAddress,
       extraDomains: config.extraDomains,
       validatorWalletUsers: config.validatorWalletUsers,
@@ -208,7 +212,8 @@ export async function installValidatorApp(
           ? { secretName: participantBootstrapDumpSecretName }
           : undefined,
       svValidator: config.svValidator,
-      useSequencerConnectionsFromScan: true,
+      useSequencerConnectionsFromScan:
+        !config.svValidator || config.decentralizedSynchronizerUrl === undefined,
       metrics: {
         enable: true,
       },

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -237,6 +237,28 @@ async function installSvAndValidator(
 
   const appsPg = installPostgres(xns, 'apps-pg', 'apps-pg-secret', 'postgres-values-apps.yaml');
 
+  const bftSequencerConnection =
+    !svConfig.participant || svConfig.participant.bftSequencerConnection;
+  const topologyChangeDelayEnvVars = svsConfig?.synchronizer?.topologyChangeDelay
+    ? [
+        {
+          name: 'ADDITIONAL_CONFIG_TOPOLOGY_CHANGE_DELAY',
+          value: `canton.sv-apps.sv.topology-change-delay-duration=${svsConfig.synchronizer.topologyChangeDelay}`,
+        },
+      ]
+    : [];
+  const disableBftSequencerConnectionEnvVars = bftSequencerConnection
+    ? []
+    : [
+        {
+          name: 'ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION',
+          value: 'canton.sv-apps.sv.bft-sequencer-connection = false',
+        },
+      ];
+  const svAppAdditionalEnvVars = (svConfig.svApp?.additionalEnvVars || [])
+    .concat(topologyChangeDelayEnvVars)
+    .concat(disableBftSequencerConnectionEnvVars);
+
   const valuesFromYamlFile = loadYamlFromFile(
     `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/sv-values.yaml`,
     {
@@ -292,14 +314,7 @@ async function installSvAndValidator(
     failOnAppVersionMismatch: failOnAppVersionMismatch,
     initialAmuletPrice: initialAmuletPrice,
     logLevel: svConfig.logging?.appsLogLevel,
-    additionalEnvVars: svsConfig?.synchronizer?.topologyChangeDelay
-      ? [
-          {
-            name: 'ADDITIONAL_CONFIG_TOPOLOGY_CHANGE_DELAY',
-            value: `canton.sv-apps.sv.topology-change-delay-duration=${svsConfig.synchronizer.topologyChangeDelay}`,
-          },
-        ]
-      : undefined,
+    additionalEnvVars: svAppAdditionalEnvVars,
   };
 
   const svValuesWithSpecifiedAud: ChartValues = {
@@ -431,6 +446,28 @@ async function installSvAndValidator(
     topup: topupConfig ? { enabled: true, ...topupConfig } : { enabled: false },
   };
 
+  const validatorValuesWithMaybeNoBftSequencerConnection: ChartValues = {
+    ...validatorValuesWithMaybeTopups,
+    ...(bftSequencerConnection
+      ? {}
+      : {
+          decentralizedSynchronizerUrl: svValues.decentralizedSynchronizerUrl,
+          useSequencerConnectionsFromScan: false,
+        }),
+    additionalEnvVars: [
+      ...(validatorValuesWithMaybeTopups.additionalEnvVars || []),
+      ...(bftSequencerConnection
+        ? []
+        : [
+            {
+              name: 'ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION',
+              value:
+                'canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true',
+            },
+          ]),
+    ],
+  };
+
   const cnsUiClientId = svNameSpaceAuth0Clients['cns'];
   if (!cnsUiClientId) {
     throw new Error('No CNS ui client id in auth0 config');
@@ -440,7 +477,7 @@ async function installSvAndValidator(
     xns,
     'validator',
     'splice-validator',
-    validatorValuesWithMaybeTopups,
+    validatorValuesWithMaybeNoBftSequencerConnection,
     activeVersion,
     {
       dependsOn: imagePullDeps


### PR DESCRIPTION
backports #1829

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
