### PR TITLE
0.4.7 backport-in-spirit: Make it easy to disable SV participant BFT sequencer connections via `config.yaml` (#1829)

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -110,6 +110,9 @@ loadTester:
   iterationsPerMinute: 30
   minRate: 0.123
 svs:
+  default:
+    participant:
+      bftSequencerConnection: false
   sv-2:
     logging:
       appsLogLevel: INFO

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -922,6 +922,10 @@
           {
             "name": "ADDITIONAL_CONFIG_TOPOLOGY_CHANGE_DELAY",
             "value": "canton.sv-apps.sv.topology-change-delay-duration=250ms"
+          },
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.sv-apps.sv.bft-sequencer-connection = false"
           }
         ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
@@ -1101,6 +1105,12 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true"
+          }
+        ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
         "additionalUsers": [],
         "affinity": {
@@ -1131,6 +1141,7 @@
           "name": "cn-mocknet"
         },
         "contactPoint": "sv-support@digitalasset.com",
+        "decentralizedSynchronizerUrl": "https://sequencer-3.sv-2.mock.global.canton.network.digitalasset.com",
         "disableAllocateLedgerApiUserParty": true,
         "enablePostgresMetrics": true,
         "failOnAppVersionMismatch": true,
@@ -1194,7 +1205,7 @@
           "minTopupInterval": "1m",
           "targetThroughput": 0
         },
-        "useSequencerConnectionsFromScan": true,
+        "useSequencerConnectionsFromScan": false,
         "validatorWalletUsers": [
           "google-oauth2|1234567890",
           "auth0|64529b128448ded6aa68048f"

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -678,6 +678,12 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.sv-apps.sv.bft-sequencer-connection = false"
+          }
+        ],
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -868,6 +874,12 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
+            "value": "canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true"
+          }
+        ],
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -889,6 +901,7 @@
           "jwksUrl": "https://canton-network-sv-test.us.auth0.com/.well-known/jwks.json"
         },
         "contactPoint": "sv-support@digitalasset.com",
+        "decentralizedSynchronizerUrl": "https://sequencer-3.sv-2.mock.global.canton.network.digitalasset.com",
         "enablePostgresMetrics": true,
         "enableWallet": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
@@ -939,6 +952,7 @@
           "minTopupInterval": "1m",
           "targetThroughput": 0
         },
+        "useSequencerConnectionsFromScan": false,
         "validatorWalletUsers": [
           "google-oauth2|1234567890",
           "auth0|64553aa683015a9687d9cc2e"

--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -11,6 +11,7 @@ const SvCometbftConfigSchema = z.object({
 });
 const SvParticipantConfigSchema = z.object({
   kms: KmsConfigSchema.optional(),
+  bftSequencerConnection: z.boolean().default(true),
 });
 // https://docs.cometbft.com/main/explanation/core/running-in-production
 const CometbftLogLevelSchema = z.enum(['info', 'error', 'debug', 'none']);

--- a/cluster/pulumi/common-validator/src/validator.ts
+++ b/cluster/pulumi/common-validator/src/validator.ts
@@ -68,6 +68,7 @@ type BasicValidatorConfig = {
   extraDomains?: ExtraDomain[];
   additionalConfig?: string;
   additionalUsers?: k8s.types.input.core.v1.EnvVar[];
+  additionalEnvVars?: k8s.types.input.core.v1.EnvVar[];
   participantAddress: Output<string> | string;
   secrets: ValidatorSecrets | ValidatorSecretsConfig;
   sweep?: SweepConfig;
@@ -104,7 +105,7 @@ export function autoAcceptTransfersConfigFromEnv(
 
 type SvValidatorConfig = BasicValidatorConfig & {
   svValidator: true;
-  decentralizedSynchronizerUrl: string;
+  decentralizedSynchronizerUrl?: string;
   migration: {
     id: DomainMigrationIndex;
   };
@@ -181,9 +182,12 @@ export async function installValidatorApp(
     {
       migration: config.migration,
       additionalUsers: config.additionalUsers || [],
+      additionalEnvVars: config.additionalEnvVars || undefined,
       validatorPartyHint: config.validatorPartyHint,
       appDars: config.appDars || [],
-      decentralizedSynchronizerUrl: undefined,
+      decentralizedSynchronizerUrl: config.svValidator
+        ? config.decentralizedSynchronizerUrl
+        : undefined,
       scanAddress: config.scanAddress,
       extraDomains: config.extraDomains,
       validatorWalletUsers: config.validatorWalletUsers,
@@ -208,7 +212,8 @@ export async function installValidatorApp(
           ? { secretName: participantBootstrapDumpSecretName }
           : undefined,
       svValidator: config.svValidator,
-      useSequencerConnectionsFromScan: true,
+      useSequencerConnectionsFromScan:
+        !config.svValidator || config.decentralizedSynchronizerUrl === undefined,
       metrics: {
         enable: true,
       },


### PR DESCRIPTION
backports #1829

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
