### PR TITLE
move some jobs to gh-hosted runners

### DIFF
--- a/.github/workflows/assign_fork_prs.yml
+++ b/.github/workflows/assign_fork_prs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   assign:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: Assign PR from fork

--- a/.github/workflows/cluster_tests.yml
+++ b/.github/workflows/cluster_tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   trigger_cluster_test:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     outputs:

--- a/.github/workflows/notify_readme_changes.yml
+++ b/.github/workflows/notify_readme_changes.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger_ciupgrade:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     name: Notify on README changes
     steps:
       - name: Checkout code

--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -20,7 +20,7 @@ jobs:
   publish_docs:
     if: github.ref == 'refs/heads/main'
     needs: ci
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
 
     permissions:
       pages: write      # to deploy to Pages

--- a/.github/workflows/pr_cluster_test.yml
+++ b/.github/workflows/pr_cluster_test.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
 
   get_head:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.get_head.outputs.sha }}
       repo: ${{ steps.get_head.outputs.repo }}
@@ -43,7 +43,7 @@ jobs:
       sha: ${{ needs.get_head.outputs.sha }}
 
   result:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     needs:
       - trigger_cluster_test_basic
       - get_head
@@ -76,7 +76,7 @@ jobs:
       sha: ${{ needs.get_head.outputs.sha }}
 
   result_hdm:
-    runs-on: self-hosted-docker-tiny
+    runs-on: ubuntu-24.04
     needs:
       - trigger_cluster_test_hdm
       - get_head


### PR DESCRIPTION
We don't seem to be gaining anything from self-hosted runners for this, and sometimes need to scale up a whole node just for this tiny job. Seems wasteful when GH runners are free and unlimited.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
