### PR TITLE
Fully remove implicit waits in selenium frontend testing

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsAuth0FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsAuth0FrontendIntegrationTest.scala
@@ -4,7 +4,7 @@ import org.lfdecentralizedtrust.splice.LocalAuth0Test
 import org.lfdecentralizedtrust.splice.auth.AuthConfig.Rs256
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms.updateAllValidatorConfigs_
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
-import org.lfdecentralizedtrust.splice.util.{FrontendLoginUtil, AnsFrontendTestUtil, WalletTestUtil}
+import org.lfdecentralizedtrust.splice.util.{AnsFrontendTestUtil, FrontendLoginUtil, WalletTestUtil}
 import monocle.macros.syntax.lens.*
 
 import java.net.URI

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -675,7 +675,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
     }
   }
 
-  protected def eventuallyClickOn(query: Query)(implicit driver: WebDriverType) = {
+  protected def eventuallyClickOn(query: Query)(implicit driver: WebDriver) = {
     clue(s"Waiting for $query to be clickable") {
       waitForCondition(query) {
         ExpectedConditions.elementToBeClickable(_)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -177,7 +177,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
   val options: FirefoxOptions =
     new FirefoxOptions()
       .setLogLevel(FirefoxDriverLogLevel.DEBUG)
-      .addArguments("-headless")
+  // .addArguments("-headless")
   options.setCapability("webSocketUrl", true: Any);
 
   protected val webDrivers: mutable.Map[String, WebDriverType] = mutable.Map.empty

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -177,7 +177,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
   val options: FirefoxOptions =
     new FirefoxOptions()
       .setLogLevel(FirefoxDriverLogLevel.DEBUG)
-  // .addArguments("-headless")
+      .addArguments("-headless")
   options.setCapability("webSocketUrl", true: Any);
 
   protected val webDrivers: mutable.Map[String, WebDriverType] = mutable.Map.empty

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -33,12 +33,11 @@ import org.scalatestplus.selenium.WebBrowser
 import java.io.{File, StringReader}
 import java.nio.file.Paths
 import java.text.SimpleDateFormat
-import java.time.{Duration, Instant, ZoneOffset}
+import java.time.Duration
 import java.util.Calendar
 import java.util.concurrent.atomic.AtomicLong
 import org.openqa.selenium.firefox.GeckoDriverService
 
-import java.time.format.DateTimeFormatter
 import scala.collection.mutable
 import scala.concurrent.blocking
 import scala.concurrent.duration.*
@@ -178,7 +177,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
   val options: FirefoxOptions =
     new FirefoxOptions()
       .setLogLevel(FirefoxDriverLogLevel.DEBUG)
-      .addArguments("-headless")
+  // .addArguments("-headless")
   options.setCapability("webSocketUrl", true: Any);
 
   protected val webDrivers: mutable.Map[String, WebDriverType] = mutable.Map.empty
@@ -693,16 +692,6 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
       logger.info("Setting selenium implicit waits to 0 seconds")
       webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(0))
     }
-  }
-
-  private val DefaultDateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-  def setDateTime(
-      party: String,
-      pickerId: String,
-      instant: Instant,
-      dateTimeFormat: DateTimeFormatter = DefaultDateTimeFormat,
-  )(implicit webDriver: WebDriverType): Assertion = {
-    setDateTime(party, pickerId, dateTimeFormat.format(instant.atOffset(ZoneOffset.UTC)))
   }
 
   def setDateTime(party: String, pickerId: String, dateTime: String)(implicit

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -177,7 +177,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
   val options: FirefoxOptions =
     new FirefoxOptions()
       .setLogLevel(FirefoxDriverLogLevel.DEBUG)
-  // .addArguments("-headless")
+      .addArguments("-headless")
   options.setCapability("webSocketUrl", true: Any);
 
   protected val webDrivers: mutable.Map[String, WebDriverType] = mutable.Map.empty
@@ -681,17 +681,6 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
       }
     }
     clickOn(query)
-  }
-
-  protected def enableSeleniumImplicitWait[T](codeBlock: => T)(implicit webDriver: WebDriver): T = {
-    try {
-      logger.info("Setting selenium implicit waits to 5 seconds")
-      webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5))
-      codeBlock
-    } finally {
-      logger.info("Setting selenium implicit waits to 0 seconds")
-      webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(0))
-    }
   }
 
   def setDateTime(party: String, pickerId: String, dateTime: String)(implicit

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -249,7 +249,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
       )
       (driver, bidi)
     }
-    webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5))
+    webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(0))
     registerWebDriver(name, webDriver)
 
     biDi.addListener[LogEntry](

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanFrontendTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanFrontendTimeBasedIntegrationTest.scala
@@ -27,7 +27,6 @@ import scala.jdk.CollectionConverters.*
 
 class ScanFrontendTimeBasedIntegrationTest
     extends FrontendIntegrationTestWithSharedEnvironment("scan-ui")
-    with FrontendLoginUtil
     with AmuletConfigUtil
     with WalletTestUtil
     with WalletFrontendTestUtil

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -25,7 +25,6 @@ import org.openqa.selenium.support.ui.Select
 import org.slf4j.event.Level
 
 import java.util.Optional
-import scala.concurrent.duration.DurationInt
 
 class SvFrontendIntegrationTest
     extends SvFrontendCommonIntegrationTest
@@ -836,7 +835,7 @@ class SvFrontendIntegrationTest
               requestReasonUrl,
               requestReasonBody,
               if (expiresSoon) {
-                new RelTime(java.time.Duration.ofMinutes(1).toMillis * 1000L)
+                new RelTime(java.time.Duration.ofSeconds(10).toMillis * 1000L)
               } else {
                 sv1Backend.getDsoInfo().dsoRules.payload.config.voteRequestTimeout
               },
@@ -917,7 +916,7 @@ class SvFrontendIntegrationTest
 
           clue("the vote requests get rejected (one by vote, one by expiry)") {
             // Generous buffer for expiry
-            eventually(120.seconds) {
+            eventually() {
               val rows = getAllVoteRows("sv-voting-in-progress-table-body")
               rows.size shouldBe previousVoteRequestsInProgress
             }
@@ -972,7 +971,7 @@ class SvFrontendIntegrationTest
               requestReasonUrl,
               requestReasonBody,
               if (expiresSoon) {
-                new RelTime(java.time.Duration.ofMinutes(1).toMillis * 1000L)
+                new RelTime(java.time.Duration.ofSeconds(10).toMillis * 1000L)
               } else {
                 sv1Backend.getDsoInfo().dsoRules.payload.config.voteRequestTimeout
               },
@@ -1057,7 +1056,7 @@ class SvFrontendIntegrationTest
 
           clue("the vote requests get rejected (one by vote, one by expiry)") {
             // Generous buffer for expiry
-            eventually(120.seconds) {
+            eventually() {
               val rows = getAllVoteRows("sv-voting-in-progress-table-body")
               rows.size shouldBe previousVoteRequestsInProgress
             }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -1156,7 +1156,7 @@ class SvFrontendIntegrationTest
   }
 
   def changeAction(actionName: String)(implicit webDriver: WebDriverType) = {
-    find(id("display-actions")) should not be empty
+    eventually() { find(id("display-actions")) should not be empty }
     val dropDownAction = new Select(webDriver.findElement(By.id("display-actions")))
     dropDownAction.selectByValue(actionName)
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsFrontendIntegrationTest.scala
@@ -184,7 +184,7 @@ class WalletSubscriptionsFrontendIntegrationTest
         actAndCheck(
           "Alice sees the subscription in the list", {
             go to s"http://localhost:3000" // already logged in
-            click on "navlink-subscriptions"
+            eventuallyClickOn(id("navlink-subscriptions"))
           },
         )(
           "Alice sees the new subscription in the list",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
@@ -6,6 +6,7 @@ import org.lfdecentralizedtrust.splice.util.Auth0Util.WithAuth0Support
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions
 
+import scala.concurrent.duration.DurationInt
 import scala.util.Using
 
 trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
@@ -34,21 +35,16 @@ trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
       }
       currentUrl should startWith(url)
     }
-    // Check if the user is already logged in by looking for the logout button
-    if (find(id("logout-button")).isDefined) {
-      // If so, click it. Use a helper that waits for clickability for extra safety.
-      eventuallyClickOn(id("logout-button"))
-    }
-
-    // NOW, explicitly wait for the login page to be ready by waiting for the user ID field
-    // to be clickable. This is the most important step.
-    clue("Waiting for login page to be ready") {
-      waitForCondition(id("user-id-field")) {
-        ExpectedConditions.elementToBeClickable(_)
+    eventuallySucceeds(timeUntilSuccess = 5.seconds) {
+      if (find(id("logout-button")).isDefined) {
+        eventuallyClickOn(id("logout-button"))
+      }
+      clue("Waiting for login page to be ready") {
+        waitForCondition(id("user-id-field"), timeUntilSuccess = Some(1.seconds)) {
+          ExpectedConditions.elementToBeClickable(_)
+        }
       }
     }
-
-    // Once the wait is successful, you can safely interact with the login form
     textField("user-id-field").value = ledgerApiUser
     eventuallyClickOn(id("login-button"))
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
@@ -34,7 +34,7 @@ trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
       }
       currentUrl should startWith(url)
     }
-    eventuallySucceeds(timeUntilSuccess = 5.seconds) {
+    eventually(timeUntilSuccess = 5.seconds) {
       if (find(id("logout-button")).isDefined) {
         eventuallyClickOn(id("logout-button"))
       }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
@@ -26,7 +26,6 @@ trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
   )(implicit
       webDriver: WebDriver
   ) = {
-    // logins need implicit waits to work
     eventually() {
       val url = if (port == 80) {
         s"http://$hostname"

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
@@ -38,7 +38,7 @@ trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
       if (find(id("logout-button")).isDefined) {
         eventuallyClickOn(id("logout-button"))
       }
-      clue("Waiting for login page to be ready") {
+      silentClue("Waiting for login page to be ready") {
         waitForCondition(id("user-id-field"), timeUntilSuccess = Some(1.seconds)) {
           ExpectedConditions.elementToBeClickable(_)
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletFrontendTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletFrontendTestUtil.scala
@@ -15,7 +15,7 @@ trait WalletFrontendTestUtil extends WalletTestUtil { self: FrontendTestCommon =
   )(implicit webDriver: WebDriverType, env: SpliceTestConsoleEnvironment): Unit = {
 
     def tap(): Unit = {
-      click on "tap-amount-field"
+      eventuallyClickOn(id("tap-amount-field"))
       numberField("tap-amount-field").underlying.clear()
       numberField("tap-amount-field").underlying.sendKeys(tapQuantity.toString())
       click on "tap-button"

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletFrontendTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletFrontendTestUtil.scala
@@ -102,7 +102,7 @@ trait WalletFrontendTestUtil extends WalletTestUtil { self: FrontendTestCommon =
       )
     } catch {
       case e: Throwable =>
-        throw new RuntimeException(s"Could not parse the string '$str' as a amulet amount", e)
+        fail(s"Could not parse the string '$str' as a amulet amount", e)
     }
   }
 


### PR DESCRIPTION
part of #1826 

Both HDM and cluster tests passed.

cluster: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/26051/workflows/83a8d3c9-0cfc-4e83-8001-461fae2f00e5

HDM: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/26064/workflows/596e0656-8d38-448b-8278-876dd69ad7b4

Estimation of frontend test time reduction of around 60%.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
