### PR TITLE
Randomize submission of vetting transactions to avoid load spikes

### DIFF
--- a/apps/app/src/test/resources/include/svs/_sv.conf
+++ b/apps/app/src/test/resources/include/svs/_sv.conf
@@ -45,4 +45,6 @@
   # Ensure we get frequent acks to handle our aggressive pruning intervals in tests
   time-tracker-min-observation-duration = 10s
   topology-change-delay-duration = 250ms
+  # Don't want to sleep in tests
+  max-vetting-delay = 0s
 }

--- a/apps/app/src/test/resources/include/validators/_validator.conf
+++ b/apps/app/src/test/resources/include/validators/_validator.conf
@@ -25,4 +25,7 @@
   }
   # Ensure we get frequent acks to handle our aggressive pruning intervals in tests
   time-tracker-min-observation-duration = 10s
+  max-vetting-delay = 0s
+  # Don't want to sleep in tests
+  max-vetting-delay = 0s
 }

--- a/apps/app/src/test/resources/include/validators/_validator.conf
+++ b/apps/app/src/test/resources/include/validators/_validator.conf
@@ -25,7 +25,6 @@
   }
   # Ensure we get frequent acks to handle our aggressive pruning intervals in tests
   time-tracker-min-observation-duration = 10s
-  max-vetting-delay = 0s
   # Don't want to sleep in tests
   max-vetting-delay = 0s
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/PackageVettingTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/PackageVettingTrigger.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.automation
 
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.SynchronizerId
 import com.digitalasset.canton.tracing.TraceContext
 import org.lfdecentralizedtrust.splice.environment.{PackageIdResolver, ParticipantAdminConnection}
@@ -11,8 +12,10 @@ import org.lfdecentralizedtrust.splice.util.{AmuletConfigSchedule, PackageVettin
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.Future
 
-abstract class PackageVettingTrigger(packages: Set[PackageIdResolver.Package])
-    extends PollingTrigger
+abstract class PackageVettingTrigger(
+    packages: Set[PackageIdResolver.Package],
+    maxVettingDelay: NonNegativeFiniteDuration,
+) extends PollingTrigger
     with PackageIdResolver.HasAmuletRules
     with PackageVetting.HasVoteRequests {
 
@@ -46,6 +49,7 @@ abstract class PackageVettingTrigger(packages: Set[PackageIdResolver.Package])
           domainId,
           amuletRules,
           AmuletConfigSchedule.getAcceptedEffectiveVoteRequests(dsoRules, voteRequests),
+          Some((context.pollingClock, maxVettingDelay)),
         )
       )
     } yield false

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
@@ -737,6 +737,7 @@ abstract class TopologyAdminConnection(
                         logger.info(
                           s"Waiting until $minSubmissionTime before submitting topology transaction"
                         )
+                        // This is a noop if minSubmissionTime is in the past.
                         clock.scheduleAt(_ => (), minSubmissionTime).onShutdown(())
                       }
                     sleep.flatMap { _ =>

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/PackageVetting.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/PackageVetting.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.util
 
 import com.digitalasset.daml.lf.data.Ref.PackageVersion
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.time.Clock
 import com.digitalasset.canton.tracing.{Spanning, TraceContext}
@@ -58,6 +59,7 @@ class PackageVetting(
       domainId,
       packagesToVet,
       None,
+      maxVettingDelay = None,
     )
   }
 
@@ -65,6 +67,7 @@ class PackageVetting(
       domainId: SynchronizerId,
       amuletRules: Contract[AmuletRules.ContractId, AmuletRules],
       futureAmuletConfigFromVoteRequests: Seq[(Option[Instant], AmuletConfig[USD])],
+      maxVettingDelay: Option[(Clock, NonNegativeFiniteDuration)],
   )(implicit tc: TraceContext): Future[Unit] = {
     val schedule = AmuletConfigSchedule(amuletRules)
     val vettingSchedule =
@@ -79,7 +82,7 @@ class PackageVetting(
     logger.info(s"Vetting for schedule $vettingTimeSortedDars from amulet rules $schedule")
     MonadUtil
       .sequentialTraverse(vettingTimeSortedDars) { case (validFrom, packages) =>
-        vetPackages(domainId, packages.toSeq, Some(validFrom))
+        vetPackages(domainId, packages.toSeq, Some(validFrom), maxVettingDelay)
       }
       .map(_ => ())
   }
@@ -88,6 +91,7 @@ class PackageVetting(
       domainId: SynchronizerId,
       packages: Seq[(PackageIdResolver.Package, PackageVersion)],
       validFrom: Option[Instant],
+      maxVettingDelay: Option[(Clock, NonNegativeFiniteDuration)],
   )(implicit tc: TraceContext): Future[Unit] = {
     logger.debug(s"Vetting packages: ${packages.mkString(", ")} on $domainId valid from $validFrom")
     val resources = packages.flatMap { case (pkg, packageVersion) =>
@@ -113,6 +117,7 @@ class PackageVetting(
       domainId = domainId,
       validFrom = validFrom,
       resources,
+      maxVettingDelay,
     )
   }
 
@@ -120,6 +125,7 @@ class PackageVetting(
       domainId: SynchronizerId,
       validFrom: Option[Instant],
       resources: Seq[DarResource],
+      maxVettingDelay: Option[(Clock, NonNegativeFiniteDuration)],
   )(implicit tc: TraceContext) = {
     for {
       _ <- withSpan("upload_dars") { implicit tc => _ =>
@@ -135,6 +141,7 @@ class PackageVetting(
           domainId,
           resources,
           fromDate = validFrom,
+          maxVettingDelay = maxVettingDelay,
         )
       }
     } yield {}

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/PackageVetting.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/PackageVetting.scala
@@ -64,12 +64,20 @@ class PackageVetting(
   }
 
   // Adjust max vetting delay to not be longer than the validFrom date.
-  private def adjustMaxVettingDelay(validFrom: Instant, maxVettingDelay: (Clock, NonNegativeFiniteDuration)): (Clock, NonNegativeFiniteDuration) = {
+  private def adjustMaxVettingDelay(
+      validFrom: Instant,
+      maxVettingDelay: (Clock, NonNegativeFiniteDuration),
+  ): (Clock, NonNegativeFiniteDuration) = {
     val (clock, maxDelay) = maxVettingDelay
-    val validFromDelayNanos = Math.max(0, java.time.Duration.between(clock.now.toInstant, validFrom).toNanos)
-    (clock, NonNegativeFiniteDuration.tryFromJavaDuration(java.time.Duration.ofNanos(Math.min(validFromDelayNanos, maxDelay.asJava.toNanos))))
+    val validFromDelayNanos =
+      Math.max(0, java.time.Duration.between(clock.now.toInstant, validFrom).toNanos)
+    (
+      clock,
+      NonNegativeFiniteDuration.tryFromJavaDuration(
+        java.time.Duration.ofNanos(Math.min(validFromDelayNanos, maxDelay.asJava.toNanos))
+      ),
+    )
   }
-
 
   def vetPackages(
       domainId: SynchronizerId,
@@ -91,7 +99,12 @@ class PackageVetting(
 
     MonadUtil
       .sequentialTraverse(vettingTimeSortedDars) { case (validFrom, packages) =>
-        vetPackages(domainId, packages.toSeq, Some(validFrom), maxVettingDelay.map(adjustMaxVettingDelay(validFrom, _)))
+        vetPackages(
+          domainId,
+          packages.toSeq,
+          Some(validFrom),
+          maxVettingDelay.map(adjustMaxVettingDelay(validFrom, _)),
+        )
       }
       .map(_ => ())
   }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -309,6 +309,7 @@ class SvDsoAutomationService(
         participantAdminConnection,
         dsoStore,
         triggerContext,
+        config.maxVettingDelay,
       )
     )
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SvPackageVettingTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SvPackageVettingTrigger.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.sv.automation.singlesv
 
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.SynchronizerId
 import org.lfdecentralizedtrust.splice.automation.{PackageVettingTrigger, TriggerContext}
 import org.lfdecentralizedtrust.splice.environment.{PackageIdResolver, ParticipantAdminConnection}
@@ -18,10 +19,11 @@ class SvPackageVettingTrigger(
     override protected val participantAdminConnection: ParticipantAdminConnection,
     store: SvDsoStore,
     override protected val context: TriggerContext,
+    maxVettingDelay: NonNegativeFiniteDuration,
 )(implicit
     override val ec: ExecutionContext,
     override val tracer: Tracer,
-) extends PackageVettingTrigger(SvPackageVettingTrigger.packages) {
+) extends PackageVettingTrigger(SvPackageVettingTrigger.packages, maxVettingDelay) {
 
   override def getSynchronizerId()(implicit tc: TraceContext): Future[SynchronizerId] =
     store.getDsoRules().map(_.domain)

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -327,7 +327,7 @@ case class SvAppBackendConfig(
     // 1. try to reset one of your sequencers or mediators
     // 2. change sequencer URLs that need to get published externally.
     skipSynchronizerInitialization: Boolean = false,
-    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly to ensure that
+    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly (uniformly distributed between 0 and the maximum delay) to ensure that
     // not all validators submit the transaction at the same time overloading the network.
     maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
 ) extends SpliceBackendConfig {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -327,8 +327,11 @@ case class SvAppBackendConfig(
     // 1. try to reset one of your sequencers or mediators
     // 2. change sequencer URLs that need to get published externally.
     skipSynchronizerInitialization: Boolean = false,
-    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly (uniformly distributed between 0 and the maximum delay) to ensure that
-    // not all validators submit the transaction at the same time overloading the network.
+    // The maximum delay before submitting a package vetting
+    // change. The actual delay will be chosen randomly (uniformly
+    // distributed between 0 and the maximum delay) to ensure that not
+    // all validators submit the transaction at the same time
+    // overloading the network.
     maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
 ) extends SpliceBackendConfig {
   override val nodeTypeName: String = "SV"

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -327,6 +327,9 @@ case class SvAppBackendConfig(
     // 1. try to reset one of your sequencers or mediators
     // 2. change sequencer URLs that need to get published externally.
     skipSynchronizerInitialization: Boolean = false,
+    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly to ensure that
+    // not all validators submit the transaction at the same time overloading the network.
+    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
 ) extends SpliceBackendConfig {
   override val nodeTypeName: String = "SV"
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -227,6 +227,7 @@ class SV1Initializer(
                     synchronizerId,
                     packages.map(packageToVet => DarResource(packageToVet.resourcePath)),
                     None,
+                    maxVettingDelay = None,
                   )
                   .flatMap { _ =>
                     initConnection.ensureUserMetadataAnnotation(

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -837,6 +837,7 @@ class ValidatorApp(
         config.sequencerRequestAmplificationPatience,
         config.contactPoint,
         initialSynchronizerTime,
+        config.maxVettingDelay,
         loggerFactory,
       )
       _ <- MonadUtil.sequentialTraverse_(config.appInstances.toList)({ case (name, instance) =>

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
@@ -69,6 +69,7 @@ class ValidatorAutomationService(
     sequencerSubmissionAmplificationPatience: NonNegativeFiniteDuration,
     contactPoint: String,
     initialSynchronizerTime: Option[CantonTimestamp],
+    maxVettingDelay: NonNegativeFiniteDuration,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit
     ec: ExecutionContextExecutor,
@@ -199,6 +200,7 @@ class ValidatorAutomationService(
       participantAdminConnection,
       scanConnection,
       triggerContext,
+      maxVettingDelay,
     )
   )
 

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorPackageVettingTrigger.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorPackageVettingTrigger.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.validator.automation
 
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.SynchronizerId
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
@@ -18,10 +19,11 @@ class ValidatorPackageVettingTrigger(
     override protected val participantAdminConnection: ParticipantAdminConnection,
     scanConnection: BftScanConnection,
     override protected val context: TriggerContext,
+    maxVettingDelay: NonNegativeFiniteDuration,
 )(implicit
     override val ec: ExecutionContext,
     override val tracer: Tracer,
-) extends PackageVettingTrigger(ValidatorPackageVettingTrigger.packages) {
+) extends PackageVettingTrigger(ValidatorPackageVettingTrigger.packages, maxVettingDelay) {
 
   override def getSynchronizerId()(implicit tc: TraceContext): Future[SynchronizerId] =
     scanConnection.getAmuletRulesDomain()(tc)

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -197,8 +197,11 @@ case class ValidatorAppBackendConfig(
     txLogBackfillEnabled: Boolean = true,
     txLogBackfillBatchSize: Int = 100,
     disableSvValidatorBftSequencerConnection: Boolean = false,
-    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly to ensure that
-    // not all validators submit the transaction at the same time overloading the network.
+    // The maximum delay before submitting a package vetting
+    // change. The actual delay will be chosen randomly (uniformly
+    // distributed between 0 and the maximum delay) to ensure that not
+    // all validators submit the transaction at the same time
+    // overloading the network.
     maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
 ) extends SpliceBackendConfig // TODO(DACH-NY/canton-network-node#736): fork or generalize this trait.
     {

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -197,6 +197,9 @@ case class ValidatorAppBackendConfig(
     txLogBackfillEnabled: Boolean = true,
     txLogBackfillBatchSize: Int = 100,
     disableSvValidatorBftSequencerConnection: Boolean = false,
+    // The maximum delay before submitting a package vetting change. The actual delay will be chosen randomly to ensure that
+    // not all validators submit the transaction at the same time overloading the network.
+    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
 ) extends SpliceBackendConfig // TODO(DACH-NY/canton-network-node#736): fork or generalize this trait.
     {
   override val nodeTypeName: String = "validator"

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -155,3 +155,5 @@ infra:
       spec:
         key: value
         anotherKey: anotherValue
+networkWide:
+  maxVettingDelay: 1m

--- a/cluster/deployment/scratchneta/.envrc.vars
+++ b/cluster/deployment/scratchneta/.envrc.vars
@@ -39,5 +39,3 @@ export APPROVE_SV_RUNBOOK=true
 # TODO(DACH-NY/canton-network-node#14679): Remove
 export VALIDATOR_RUNBOOK_POSTGRES_PVC_SIZE="240Gi"
 export CACHE_DEV_DOCKER_REGISTRY=$DEV_DOCKER_REGISTRY
-
-export INITIAL_PACKAGE_CONFIG_JSON='{"amuletVersion": "0.1.9","amuletNameServiceVersion": "0.1.9","dsoGovernanceVersion": "0.1.13","validatorLifecycleVersion": "0.1.3","walletVersion": "0.1.9","walletPaymentsVersion": "0.1.9"}'

--- a/cluster/deployment/scratchneta/.envrc.vars
+++ b/cluster/deployment/scratchneta/.envrc.vars
@@ -39,3 +39,5 @@ export APPROVE_SV_RUNBOOK=true
 # TODO(DACH-NY/canton-network-node#14679): Remove
 export VALIDATOR_RUNBOOK_POSTGRES_PVC_SIZE="240Gi"
 export CACHE_DEV_DOCKER_REGISTRY=$DEV_DOCKER_REGISTRY
+
+export INITIAL_PACKAGE_CONFIG_JSON='{"amuletVersion": "0.1.9","amuletNameServiceVersion": "0.1.9","dsoGovernanceVersion": "0.1.13","validatorLifecycleVersion": "0.1.3","walletVersion": "0.1.9","walletPaymentsVersion": "0.1.9"}'

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1052,6 +1052,7 @@
         },
         "isDevNet": false,
         "logLevel": "DEBUG",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },
@@ -1145,6 +1146,7 @@
         "failOnAppVersionMismatch": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logLevel": "DEBUG",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -1013,6 +1013,7 @@
         "enablePostgresMetrics": true,
         "failOnAppVersionMismatch": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -778,6 +778,7 @@
           "sponsorApiUrl": "https://sv.sv-2.mock.global.canton.network.digitalasset.com"
         },
         "logLevel": "DEBUG",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },
@@ -919,6 +920,7 @@
         "enablePostgresMetrics": true,
         "enableWallet": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -706,6 +706,7 @@
         "enableWallet": true,
         "failOnAppVersionMismatch": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -1000,6 +1000,7 @@
         "enablePostgresMetrics": true,
         "failOnAppVersionMismatch": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
+        "maxVettingDelay": "1m",
         "metrics": {
           "enable": true
         },

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -350,6 +350,10 @@ spec:
             - name: ADDITIONAL_CONFIG_SYNCHRONIZER_INITIALIZATION
               value: canton.sv-apps.sv.skip-synchronizer-initialization = true
             {{- end }}
+            {{- with .Values.maxVettingDelay }}
+            - name: ADDITIONAL_CONFIG_MAX_VETTING_DELAY
+              value: canton.sv-apps.sv.max-vetting-delay = "{{ . }}"
+            {{- end }}
           ports:
             - name: sv-api
               containerPort: 5014

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -278,6 +278,10 @@ spec:
               tx-log-backfill-batch-size = "{{ .batchSize }}"
             }
         {{- end }}
+        {{- with .Values.maxVettingDelay }}
+        - name: ADDITIONAL_CONFIG_MAX_VETTING_DELAY
+          value: canton.validator-apps.validator_backend.max-vetting-delay = "{{ . }}"
+        {{- end }}
         ports:
         - containerPort: 5003
           name: val-http

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -31,6 +31,7 @@ import {
   installLoopback,
   installSpliceHelmChart,
   installValidatorOnboardingSecret,
+  networkWideConfig,
   participantBootstrapDumpSecretName,
   PersistenceConfig,
   sanitizedForPostgres,
@@ -509,6 +510,7 @@ function installSvApp(
     delegatelessAutomationExpectedTaskDuration: delegatelessAutomationExpectedTaskDuration,
     delegatelessAutomationExpiredRewardCouponBatchSize:
       delegatelessAutomationExpiredRewardCouponBatchSize,
+    maxVettingDelay: networkWideConfig?.maxVettingDelay,
     logLevel: config.logging?.appsLogLevel,
     additionalEnvVars,
   } as ChartValues;

--- a/cluster/pulumi/common-validator/src/validator.ts
+++ b/cluster/pulumi/common-validator/src/validator.ts
@@ -24,6 +24,7 @@ import {
   installSpliceHelmChart,
   installValidatorOnboardingSecret,
   LogLevel,
+  networkWideConfig,
   participantBootstrapDumpSecretName,
   ParticipantPruningConfig,
   PersistenceConfig,
@@ -232,6 +233,7 @@ export async function installValidatorApp(
       nodeIdentifier: config.nodeIdentifier,
       participantPruningSchedule: config.participantPruningConfig,
       deduplicationDuration: config.deduplicationDuration,
+      maxVettingDelay: networkWideConfig?.maxVettingDelay,
       logLevel: config.logLevel,
       resources: baseConfig.svValidator
         ? {

--- a/cluster/pulumi/common/src/config/networkWideConfig.ts
+++ b/cluster/pulumi/common/src/config/networkWideConfig.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { clusterYamlConfig } from 'splice-pulumi-common/src/config/configLoader';
+import { z } from 'zod';
+
+// Network wide configuration expected to be shared by all nodes.
+export const NetworkWideConfigSchema = z.object({
+  networkWide: z
+    .object({
+      maxVettingDelay: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type NetworkWideConfig = z.infer<typeof NetworkWideConfigSchema>;
+
+export const networkWideConfig = NetworkWideConfigSchema.parse(clusterYamlConfig).networkWide;

--- a/cluster/pulumi/common/src/index.ts
+++ b/cluster/pulumi/common/src/index.ts
@@ -26,3 +26,4 @@ export * from './participantKms';
 export * from './config/migrationSchema';
 export * from './pruning';
 export * from './config/loadTesterConfig';
+export * from './config/networkWideConfig';

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -45,6 +45,7 @@ import {
   svCometBftGovernanceKeySecret,
   svCometBftGovernanceKeyFromSecret,
   failOnAppVersionMismatch,
+  networkWideConfig,
 } from 'splice-pulumi-common';
 import { configForSv, svsConfig, updateHistoryBackfillingValues } from 'splice-pulumi-common-sv';
 import { spliceConfig } from 'splice-pulumi-common/src/config/config';
@@ -313,6 +314,7 @@ async function installSvAndValidator(
     disableOnboardingParticipantPromotionDelay,
     failOnAppVersionMismatch: failOnAppVersionMismatch,
     initialAmuletPrice: initialAmuletPrice,
+    maxVettingDelay: networkWideConfig?.maxVettingDelay,
     logLevel: svConfig.logging?.appsLogLevel,
     additionalEnvVars: svAppAdditionalEnvVars,
   };
@@ -425,6 +427,7 @@ async function installSvAndValidator(
       ids.concat([validatorWalletUserName])
     ),
     ...spliceInstanceNames,
+    maxVettingDelay: networkWideConfig?.maxVettingDelay,
   };
 
   const validatorValuesWithSpecifiedAud: ChartValues = {

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -39,6 +39,7 @@ import {
   InstalledHelmChart,
   ansDomainPrefix,
   failOnAppVersionMismatch,
+  networkWideConfig,
 } from 'splice-pulumi-common';
 import {
   installParticipant,
@@ -271,6 +272,7 @@ async function installValidator(validatorConfig: ValidatorConfig): Promise<Insta
     db: { volumeSize: clusterSmallDisk ? '240Gi' : undefined },
     enablePostgresMetrics: true,
     ...spliceInstanceNames,
+    maxVettingDelay: networkWideConfig?.maxVettingDelay,
   };
 
   const validatorValuesWithOnboardingOverride = onboardingSecret

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,15 @@
 Release Notes
 =============
 
+Upcoming
+--------
+
+- SV and Validator apps
+
+  - Add a randomized delay to broadcasting of package vetting changes used on Daml upgrades. This ensures that
+    there is no load spike when all validators try to do so at the same time. This has no impact on behavior as
+    Daml upgrades are announced ahead of time and the broadcasting still happens before the switchover.
+
 0.4.10
 ------
 


### PR DESCRIPTION
[ci]

I can't come up with a great integration test for that. I did test it on a scratchnet and it seemed to behave as expected.

Plan for ciupgrade is to set the wait to 1min so the behavior is at least observable but doesn't have any meaningful slowdown.

fixes #1863



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
