### PR TITLE
wait longer after intentional canton disconnect in integration test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSurviveCantonRestartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSurviveCantonRestartIntegrationTest.scala
@@ -75,7 +75,8 @@ class WalletSurviveCantonRestartIntegrationTest
       clue("Second run of Canton participant") {
         withCanton(cantonArgs, cantonExtraConfig, "wallet-survives-canton-restarts-2") {
           clue("We can tap and list after Canton restart and domain reconnection") {
-            eventuallySucceeds() {
+            // Due to the circuit breaker kicking in, this might take a bit longer to succeed after some failures due to the disconnect
+            eventuallySucceeds(2.minutes) {
               aliceWalletClient.tap(2)
             }
             aliceWalletClient.list()


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5366

At first I thought I'd change the circuit breaker config for this test, as failures are expected, but I then decided that we'd rather test with it, and just make sure to wait long enough for things to succeed.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
