### PR TITLE
Reduce frontend test parallelism

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-frontend.log'
       start_canton_options: -w
-      parallelism: 5
+      parallelism: 2
       test_name: frontend-wall-clock-time
       is_frontend_test: true
       commit_sha: ${{ inputs.commit_sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-resource-intensive.log'
       start_canton_options: -w
-      parallelism: 2
+      parallelism: 3
       test_name: resource-intensive
       commit_sha: ${{ inputs.commit_sha }}
       daml_base_version: ${{ inputs.daml_base_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-resource-intensive.log'
       start_canton_options: -w
-      parallelism: 3
+      parallelism: 2
       test_name: resource-intensive
       commit_sha: ${{ inputs.commit_sha }}
       daml_base_version: ${{ inputs.daml_base_version }}
@@ -178,7 +178,7 @@ jobs:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-frontend.log'
       start_canton_options: -w
-      parallelism: 2
+      parallelism: 3
       test_name: frontend-wall-clock-time
       is_frontend_test: true
       commit_sha: ${{ inputs.commit_sha }}


### PR DESCRIPTION
Quite experimental, but looks like:
```
parallelism set to 2: 18 / 22 mins (total=40 mins)
parallelism set to 3:  12 /  12 / 19 (total=45 mins)
parallelism set to 5: 8 / 12 / 13 / 11 / 11 (total=55 mins)
```
parallelism 3 is probably the best compromise between total running time and max time

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
