### PR TITLE
Retry accept/reject transfer offer in wallet UI

### DIFF
--- a/apps/wallet/frontend/src/components/TransferOffers.tsx
+++ b/apps/wallet/frontend/src/components/TransferOffers.tsx
@@ -140,6 +140,12 @@ interface TransferOfferProps {
   transferOffer: WalletTransferOffer;
 }
 
+// An accept or a reject can fail if for example the transfer offer is visible to the validator,
+// but not to f+1 Scans (which are required to get the accept/reject context from).
+// Or overall other transient errors.
+// Ultimately, it should go through so as long as it's visible to the validator.
+const TRANSFER_OFFER_ACTION_RETRIES_COUNT = 5;
+
 export const TransferOfferDisplay: React.FC<TransferOfferProps> = props => {
   const config = useWalletConfig();
   const offer = props.transferOffer;
@@ -157,8 +163,9 @@ export const TransferOfferDisplay: React.FC<TransferOfferProps> = props => {
         : acceptTransferOffer(offer.contractId));
     },
     onError: error => {
-      console.error(`Failed to accept transfer offer ${offer.contractId}:`, error);
+      console.info(`Failed to accept transfer offer ${offer.contractId}:`, error);
     },
+    retry: TRANSFER_OFFER_ACTION_RETRIES_COUNT,
   });
   const rejectMutation = useMutation({
     mutationFn: async () => {
@@ -167,8 +174,9 @@ export const TransferOfferDisplay: React.FC<TransferOfferProps> = props => {
         : rejectTransferOffer(offer.contractId));
     },
     onError: error => {
-      console.error(`Failed to reject transfer offer ${offer.contractId}:`, error);
+      console.info(`Failed to reject transfer offer ${offer.contractId}:`, error);
     },
+    retry: TRANSFER_OFFER_ACTION_RETRIES_COUNT,
   });
 
   return (

--- a/apps/wallet/frontend/src/components/TransferOffers.tsx
+++ b/apps/wallet/frontend/src/components/TransferOffers.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {
   AmountDisplay,
   DateDisplay,
+  DisableConditionally,
   ErrorDisplay,
   Loading,
 } from '@lfdecentralizedtrust/splice-common-frontend';
@@ -27,6 +28,7 @@ import { WalletTransferOffer } from '../models/models';
 import { useWalletConfig } from '../utils/config';
 import { convertCurrency } from '../utils/currencyConversion';
 import BftAnsEntry from './BftAnsEntry';
+import { useMutation } from '@tanstack/react-query';
 
 type PartialWalletTransferOffer = {
   contractId: ContractId<TransferOffer> | ContractId<AmuletTransferInstruction>;
@@ -147,8 +149,27 @@ export const TransferOfferDisplay: React.FC<TransferOfferProps> = props => {
     acceptTokenStandardTransfer,
     rejectTokenStandardTransfer,
   } = useWalletClient();
-  const accept = offer.isTokenStandard ? acceptTokenStandardTransfer : acceptTransferOffer;
-  const reject = offer.isTokenStandard ? rejectTokenStandardTransfer : rejectTransferOffer;
+
+  const acceptMutation = useMutation({
+    mutationFn: async () => {
+      await (offer.isTokenStandard
+        ? acceptTokenStandardTransfer(offer.contractId)
+        : acceptTransferOffer(offer.contractId));
+    },
+    onError: error => {
+      console.error(`Failed to accept transfer offer ${offer.contractId}:`, error);
+    },
+  });
+  const rejectMutation = useMutation({
+    mutationFn: async () => {
+      await (offer.isTokenStandard
+        ? rejectTokenStandardTransfer(offer.contractId)
+        : rejectTransferOffer(offer.contractId));
+    },
+    onError: error => {
+      console.error(`Failed to reject transfer offer ${offer.contractId}:`, error);
+    },
+  });
 
   return (
     <Card className="transfer-offer" variant="outlined">
@@ -186,23 +207,41 @@ export const TransferOfferDisplay: React.FC<TransferOfferProps> = props => {
           </Typography>
         </Stack>
         <Stack direction="row" alignItems="center" spacing={2}>
-          <Button
-            variant="pill"
-            size="small"
-            onClick={() => accept(offer.contractId)}
-            className="transfer-offer-accept"
+          <DisableConditionally
+            conditions={[
+              {
+                disabled: acceptMutation.isPending,
+                reason: 'Accepting...',
+              },
+            ]}
           >
-            Accept
-          </Button>
-          <Button
-            variant="pill"
-            color="warning"
-            size="small"
-            onClick={() => reject(offer.contractId)}
-            className="transfer-offer-reject"
+            <Button
+              variant="pill"
+              size="small"
+              onClick={() => acceptMutation.mutate()}
+              className="transfer-offer-accept"
+            >
+              Accept
+            </Button>
+          </DisableConditionally>
+          <DisableConditionally
+            conditions={[
+              {
+                disabled: rejectMutation.isPending,
+                reason: 'Rejecting...',
+              },
+            ]}
           >
-            Reject
-          </Button>
+            <Button
+              variant="pill"
+              color="warning"
+              size="small"
+              onClick={() => rejectMutation.mutate()}
+              className="transfer-offer-reject"
+            >
+              Reject
+            </Button>
+          </DisableConditionally>
         </Stack>
         <Typography variant="caption" className="transfer-offer-expiry">
           Expires <DateDisplay datetime={offer.expiry} />


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5375

I chose 

> If that's too expensive, then in the test we should either retry the accept button

because it doesn't seem worth the effort to setup everything required for something that just manifests on (sometimes too fast) tests...
But shout if you disagree.

Also used the opportunity to use useMutation.