### PR TITLE
Update nix and add functions-framework dependency

### DIFF
--- a/.github/actions/nix/setup_self_hosted_nix/action.yml
+++ b/.github/actions/nix/setup_self_hosted_nix/action.yml
@@ -102,7 +102,7 @@ runs:
               max-jobs = 16
           EOF
             fi
-            sh <(curl -fsSL --retry 8 https://releases.nixos.org/nix/nix-2.13.3/install) --no-daemon
+            sh <(curl -fsSL --retry 8 https://releases.nixos.org/nix/nix-2.28.4/install) --no-daemon
             sudo mkdir -p /etc/nix
             sudo chmod a+rw /etc/nix
             if [[ "${{ inputs.oss_only }}" == true ]]; then

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,7 +11,7 @@ When splitting-off a top-level directory into its own repo, we expect to use
 
 To update the versions used in the project follow the steps:
 - Open a terminal outside a direnv nix environment
-- Run `nix flake update path:<path-to-the-canton-network-repository>/nix`
+- Run `nix flake update --flake path:<path-to-the-canton-network-repository>/nix`
 - Commit the changes to the `flake.lock` file
 
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736166416,
-        "narHash": "sha256-U47xeACNBpkSO6IcCm0XvahsVXpJXzjPIQG7TZlOToU=",
+        "lastModified": 1755020227,
+        "narHash": "sha256-gGmm+h0t6rY88RPTaIm3su95QvQIVjAJx558YUG4Id8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b30f97d8c32d804d2d832ee837d0f1ca0695faa5",
+        "rev": "695d5db1b8b20b73292501683a524e0bd79074fb",
         "type": "github"
       },
       "original": {

--- a/nix/geckodriver.nix
+++ b/nix/geckodriver.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-rqJ6+QKfEhdHGZBT9yEWtsBlETxz4XeEZXisXf7RdIE=";
   };
 
-  cargoHash = "sha256-DvWwHhvOUN85s3315xrw46I18mSX+kFkfGPa9WGn4SI=";
+  cargoHash = "sha256-wFRZhQzFBwwNfiszwr7XK3e8tfqqFG6DIe7viWvB5vg=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv

--- a/nix/git-search-replace.nix
+++ b/nix/git-search-replace.nix
@@ -3,6 +3,8 @@
 python3Packages.buildPythonPackage rec {
   pname = "git-search-replace";
   version = "1.0.3";
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
 
   src = python3Packages.fetchPypi {
     inherit pname version;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -68,6 +68,7 @@ in pkgs.mkShell {
                                      }))
     python3Packages.dockerfile-parse
     python3Packages.flask
+    python3Packages.functions-framework
     python3Packages.GitPython
     python3Packages.gql
     python3Packages.humanize


### PR DESCRIPTION
`functions-framework` is used for [serverless](https://github.com/DACH-NY/canton-network-internal/blob/main/cluster/serverless/README.md?plain=1#L9)
