### PR TITLE
Remove version and levelValue field from logs

### DIFF
--- a/canton/community/testing/src/test/resources/logback-test.xml
+++ b/canton/community/testing/src/test/resources/logback-test.xml
@@ -19,7 +19,12 @@
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${LOG_FILE_NAME:-log/canton_network_test.clog}</file>
     <append>${LOG_APPEND:-true}</append>
-    <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder"/>
+    <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder">
+      <fieldNames>
+        <version>[ignore]</version>
+        <levelValue>[ignore]</levelValue>
+      </fieldNames>
+    </encoder>
   </appender>
 
   <!-- Appender for KMS logs -->

--- a/scripts/canton-logback.xml
+++ b/scripts/canton-logback.xml
@@ -12,7 +12,12 @@
   <if condition='isDefined("LOG_FORMAT_JSON")'>
     <then>
       <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder"/>
+        <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder">
+          <fieldNames>
+            <version>[ignore]</version>
+            <levelValue>[ignore]</levelValue>
+          </fieldNames>
+        </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
           <level>${LOG_LEVEL_STDOUT:-WARN}</level>
         </filter>
@@ -86,7 +91,12 @@
             <append>${LOG_FILE_APPEND:-true}</append>
             <!-- Allow for disabling flush on each log-line (faster, but may miss logs when crashing) -->
             <immediateFlush>${LOG_IMMEDIATE_FLUSH:-true}</immediateFlush>
-            <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder"/>
+            <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder">
+              <fieldNames>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+              </fieldNames>
+            </encoder>
             <filter class="${log_last_errors_filter}" />
           </appender>
         </then>
@@ -149,7 +159,12 @@
                   <!-- keep max 12 archived log files -->
                   <maxHistory>${LOG_FILE_HISTORY:-12}</maxHistory>
                 </rollingPolicy>
-                <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder"/>
+                <encoder class="com.digitalasset.canton.logging.CantonJsonEncoder">
+                  <fieldNames>
+                    <version>[ignore]</version>
+                    <levelValue>[ignore]</levelValue>
+                  </fieldNames>
+                </encoder>
                 <filter class="${log_last_errors_filter}" />
               </appender>
             </then>


### PR DESCRIPTION
[static]

version is just a constant 1 which is not very useful. levelValue is just a duplicate of level.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
