### PR TITLE
query to aggregate traffic purchases over a time period

### DIFF
--- a/apps/app/src/test/resources/traffic-cost-burn-time-period.sql
+++ b/apps/app/src/test/resources/traffic-cost-burn-time-period.sql
@@ -62,6 +62,7 @@ CREATE TEMP FUNCTION in_time_window(
   (migration_id < migration_id_arg
     OR (migration_id = migration_id_arg
       AND record_time <= UNIX_MICROS(as_of_record_time)))
+  AND record_time != -62135596800000000
   AND (migration_id > start_migration_id
        OR (migration_id = start_migration_id
            AND record_time >= UNIX_MICROS(start_record_time)))


### PR DESCRIPTION
Splits the "burned" query in total-supply between `amuletPaid` for traffic purchases and everything else, and also includes a start time limit. [Review this](https://github.com/hyperledger-labs/splice/pull/1926/files/23bea8f5460c7bd5779f8d010cb0f22db1312a9f..85ce9e1fd5c9ecf107a132a95e83a15cd0e57947) for the non-copy-pasted portion (i.e. not covered by prior testing).

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
