### PR TITLE
Tweak fluent bit configuration

### DIFF
--- a/cluster/pulumi/cluster/src/fluentBit.ts
+++ b/cluster/pulumi/cluster/src/fluentBit.ts
@@ -45,6 +45,7 @@ export function installFluentBit(): void {
         // Mandatory parameters, doesn't look like we have a way to exclude the location sadly even though it isn't very useful for us.
         `    k8s_cluster_name ${CLUSTER_NAME}`,
         `    k8s_cluster_location  ${GCP_REGION}`,
+        `    severity_key level`,
       ].join('\n'),
       filters: [
         // First parse just in containerd format to extra time stamps and friends
@@ -54,6 +55,12 @@ export function installFluentBit(): void {
         '    Key_Name     log',
         '    Reserve_Data True',
         '    Parser       containerd',
+        // First parse just in containerd format to extra time stamps and friends
+        '[FILTER]',
+        '    Name         lua',
+        '    Match        kube.*',
+        '    script  /fluent-bit/scripts/k8s_filters.lua',
+        '    call    truncate',
         // Rename log to message as this is what stack driver expects
         '[FILTER]',
         '    Name        modify',
@@ -65,11 +72,13 @@ export function installFluentBit(): void {
         '    Match        kube.*',
         '    Key_Name     message',
         '    Reserve_Data True',
+        '    Parser       fluentbit',
         '    Parser       glog',
         '    Parser       json_iso8601',
         // Enrich with k8s metadata
         '[FILTER]',
         '    Name             kubernetes',
+        '    Buffer_Size      1Mb',
         '    Match            kube.*',
         '    Kube_URL         https://kubernetes.default.svc:443',
         '    Kube_CA_File     /var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
@@ -82,7 +91,7 @@ export function installFluentBit(): void {
         '[FILTER]',
         '    Name    lua',
         '    Match   kube.*',
-        '    script  /fluent-bit/scripts/k8s_labels.lua',
+        '    script  /fluent-bit/scripts/k8s_filters.lua',
         '    call    tweak_k8s_labels',
       ].join('\n'),
       customParsers: [
@@ -99,21 +108,40 @@ export function installFluentBit(): void {
         '    Format      regex',
         "    # We skip the glog timestamp as it doesn't have year (in most cases) and time zone information.",
         '    # Instead, we rely on the containerd timestamp, which is available for every log line.',
-        '    Regex       ^(?<severity>\\w)\\d{4}?\\d{4} [^\\s]*\\s+(?<pid>\\d+)\\s+(?<source_file>[^ \\]]+)\\:(?<source_line>\\d+)\\]\\s(?<message>.*)$',
+        '    Regex       ^(?<level>\\w)\\d{4}?\\d{4} [^\\s]*\\s+(?<pid>\\d+)\\s+(?<source_file>[^ \\]]+)\\:(?<source_line>\\d+)\\]\\s(?<message>.*)$',
+        // yes fluentbit really does not have a parser for its log format
+        '[PARSER]',
+        '    Name        fluentbit',
+        '    Format      regex',
+        '    Regex  ^\\[(?<time>[^\\]]+)\\][ ]*\\[[ ]*(?<level>[^\\]]+)\\][ ]*\\[(?<plugin>[^\\]]+)\\] (?<message>.*)',
+        '    Time_Key time',
+        '    Time_Format %Y/%m/%d %H:%M:%S',
         '[PARSER]',
         '    Name        json_iso8601',
         '    Format json',
+        '    Time_Key @timestamp',
         '    Time_Format %Y-%m-%dT%H:%M:%S.%L%z',
+        // Allow missing second fraction,
+        '    Time_Strict off',
       ].join('\n'),
     },
     luaScripts: {
-      'k8s_labels.lua': [
+      'k8s_filters.lua': [
         'function tweak_k8s_labels(tag, timestamp, record)',
         '  if record.kubernetes and record.kubernetes.labels then',
         '    record.k8s_labels = { ["app.kubernetes.io/name"] = record.kubernetes.labels["app.kubernetes.io/name"], ["app.kubernetes.io/version"] = record.kubernetes.labels["app.kubernetes.io/version"], ["migration_id"] = record.kubernetes.labels["migration_id"] }',
         '    record.kubernetes = nil',
         '  end',
         // 2 means we tweaked the record but not the timestamp
+        '  return 2, timestamp, record',
+        'end',
+        // GCP does not like log messages more than 250k so we truncate to 200k here which seems to match what the builtin
+        // parser does. Note that just like the upstream parser this does also break json parsing.
+        'function truncate(tag, timestamp, record)',
+        '  local max_length = 200000',
+        '  if record.msg and string.len(record.msg) > max_length then',
+        '    record.message = string.sub(record.message, 1, max_length)',
+        '  end',
         '  return 2, timestamp, record',
         'end',
       ].join('\n'),


### PR DESCRIPTION
Based on CILR experience

- fix severity parsing
- truncate long log messages because otherise stack driver gets angry
- make time parsing more lenient
- make fluent bit parse its own logs better



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
