### PR TITLE
Reduce gcp logging components

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -336,9 +336,9 @@ function _prompt_to_confirm() {
 
 function _get_logging_components() {
     if env-bool SELF_HOSTED_FLUENT_BIT; then
-        echo "SYSTEM,API_SERVER,CONTROLLER_MANAGER,SCHEDULER"
+        echo "SYSTEM"
     else
-        echo "SYSTEM,API_SERVER,CONTROLLER_MANAGER,SCHEDULER,WORKLOAD"
+        echo "SYSTEM,WORKLOAD"
     fi
 }
 


### PR DESCRIPTION
I think I accidentally turned on too much when I tried to disable workloads in favor of our own fluentbit.

Compare here to devnet 

<img width="1053" height="58" alt="image" src="https://github.com/user-attachments/assets/bae6775f-1801-4ffe-a93b-716388a1a9ff" />


[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
