### PR TITLE
WalletSurviveCantonRestartIntegrationTest: bump wait on participant init

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSurviveCantonRestartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSurviveCantonRestartIntegrationTest.scala
@@ -55,7 +55,7 @@ class WalletSurviveCantonRestartIntegrationTest
         withCanton(cantonArgs, cantonExtraConfig, "wallet-survives-canton-restarts-1") {
           clue("Wait for validator initialization") {
             // Need to wait for the participant node to startup for the user allocation to go through
-            eventuallySucceeds(timeUntilSuccess = 40.seconds) {
+            eventuallySucceeds(timeUntilSuccess = 120.seconds) {
               EnvironmentDefinition.withAllocatedValidatorUser(aliceValidatorBackend)
             }
             aliceValidatorBackend.waitForInitialization()


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5417

The participant did come up eventually and AFAICT the validator app would have continued init if we hadn't stopped that.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
