### PR TITLE
Bump cometbft mempool and cache size

### DIFF
--- a/apps/sv/src/test/resources/cometbft/sv1/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv1/config/config.toml
@@ -282,7 +282,7 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 1000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
@@ -290,7 +290,7 @@ size = 1000
 max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 100000
+cache_size = 200000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/apps/sv/src/test/resources/cometbft/sv2/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv2/config/config.toml
@@ -282,7 +282,7 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 1000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
@@ -290,7 +290,7 @@ size = 1000
 max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 100000
+cache_size = 200000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/apps/sv/src/test/resources/cometbft/sv2Local/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv2Local/config/config.toml
@@ -282,7 +282,7 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 1000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
@@ -290,7 +290,7 @@ size = 1000
 max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 100000
+cache_size = 200000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/apps/sv/src/test/resources/cometbft/sv3/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv3/config/config.toml
@@ -282,7 +282,7 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 1000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
@@ -290,7 +290,7 @@ size = 1000
 max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 100000
+cache_size = 200000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/apps/sv/src/test/resources/cometbft/sv4/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv4/config/config.toml
@@ -282,7 +282,7 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 1000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
@@ -290,7 +290,7 @@ size = 1000
 max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 100000
+cache_size = 200000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -97,8 +97,8 @@ enableAntiAffinity: true
 logLevel: debug
 mempool:
   # max number of transactions kept in the mempool
-  size: 1000
+  size: 2000
   # number of transactions to keep to deduplicate new transactions
-  deduplicationCacheSize: 100000
+  deduplicationCacheSize: 200000
   # max number of seconds that a transaction will be kept in the mempool without being included in a block before being discarded
   ttlSeconds: 300

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -25,6 +25,10 @@ Upcoming
   - Clarifications around the :ref:`validator disaster recovery <validator_dr>` process.
   - Add how-to docs for :ref:`Token Standard usage <token_standard>`.
 
+- Cometbft
+
+  - Doubled the default mempool size and deduplication cache size as they get exceeded on prod networks occasionally.
+
 0.4.11
 ------
 


### PR DESCRIPTION
fixes #1934

[ci]

I honestly don't have a great reason for choosing these specific values. Doubling seems as good as anything else :shrug:

See https://github.com/DACH-NY/canton-network-node/pull/17821/files for an earlier change we made in the same direction.

Note that I didn't bump the TTL because I don't see a compelling reason why that helps with anything.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
