### PR TITLE
Match package name on template filter

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/LedgerApiExtensions.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/LedgerApiExtensions.scala
@@ -390,7 +390,8 @@ trait LedgerApiExtensions extends AppendedClues with Matchers {
             partyId: PartyId,
             predicate: TC => Boolean = (_: TC) => true,
         ): Seq[TC] = {
-          val filterIdentifier = PackageQualifiedName(templateCompanion.getTemplateIdWithPackageId)
+          val filterIdentifier =
+            PackageQualifiedName.getFromResources(templateCompanion.getTemplateIdWithPackageId)
           val templateId = TemplateId(
             s"#${filterIdentifier.packageName}",
             filterIdentifier.qualifiedName.moduleName,
@@ -429,7 +430,8 @@ trait LedgerApiExtensions extends AppendedClues with Matchers {
         ](templateCompanion: javaapi.data.codegen.ContractCompanion[TC, TCid, T])(
             partyId: PartyId
         ): Seq[CreatedEvent] = {
-          val filterIdentifier = PackageQualifiedName(templateCompanion.getTemplateIdWithPackageId)
+          val filterIdentifier =
+            PackageQualifiedName.getFromResources(templateCompanion.getTemplateIdWithPackageId)
           val templateId = TemplateId(
             s"#${filterIdentifier.packageName}",
             filterIdentifier.qualifiedName.moduleName,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -1124,7 +1124,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                       AmuletRules.TEMPLATE_ID_WITH_PACKAGE_ID,
                       AnsRules.TEMPLATE_ID_WITH_PACKAGE_ID,
                     ).map(
-                      PackageQualifiedName(_)
+                      PackageQualifiedName.getFromResources(_)
                     )
                   ),
                 )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -510,8 +510,8 @@ class ScanTimeBasedIntegrationTest
       migrationId,
       templates = Some(
         Vector(
-          PackageQualifiedName(Amulet.TEMPLATE_ID_WITH_PACKAGE_ID),
-          PackageQualifiedName(AnsEntry.TEMPLATE_ID_WITH_PACKAGE_ID),
+          PackageQualifiedName.getFromResources(Amulet.TEMPLATE_ID_WITH_PACKAGE_ID),
+          PackageQualifiedName.getFromResources(AnsEntry.TEMPLATE_ID_WITH_PACKAGE_ID),
         )
       ),
       partyIds = Some(Vector(aliceUserParty)),

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/QualifiedName.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/QualifiedName.scala
@@ -15,7 +15,7 @@ final case class PackageQualifiedName(packageName: String, qualifiedName: Qualif
 }
 
 object PackageQualifiedName {
-  def findFromResources(identifier: Identifier): Option[PackageQualifiedName] = {
+  def lookupFromResources(identifier: Identifier): Option[PackageQualifiedName] = {
     DarResources
       .lookupPackageId(identifier.getPackageId)
       .map { resource =>
@@ -27,7 +27,7 @@ object PackageQualifiedName {
   }
 
   def getFromResources(identifier: Identifier): PackageQualifiedName = {
-    findFromResources(identifier)
+    lookupFromResources(identifier)
       .getOrElse(throw new IllegalArgumentException(s"No package found for template $identifier"))
   }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/QualifiedName.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/QualifiedName.scala
@@ -3,12 +3,9 @@
 
 package org.lfdecentralizedtrust.splice.util
 
-import com.daml.ledger.javaapi.data.Identifier
+import com.daml.ledger.javaapi.data.{Event, Identifier}
 import org.lfdecentralizedtrust.splice.environment.DarResources
 
-/** To support upgrading templates are addressed
-  * using their qualified name, ignoring the package id.
-  */
 final case class QualifiedName(moduleName: String, entityName: String) {
   override def toString = s"$moduleName:$entityName"
 }
@@ -18,13 +15,26 @@ final case class PackageQualifiedName(packageName: String, qualifiedName: Qualif
 }
 
 object PackageQualifiedName {
-  def apply(identifier: Identifier): PackageQualifiedName = {
-    val resource = DarResources
+  def findFromResources(identifier: Identifier): Option[PackageQualifiedName] = {
+    DarResources
       .lookupPackageId(identifier.getPackageId)
+      .map { resource =>
+        PackageQualifiedName(
+          resource.metadata.name,
+          QualifiedName(identifier),
+        )
+      }
+  }
+
+  def getFromResources(identifier: Identifier): PackageQualifiedName = {
+    findFromResources(identifier)
       .getOrElse(throw new IllegalArgumentException(s"No package found for template $identifier"))
+  }
+
+  def fromEvent(event: Event): PackageQualifiedName = {
     PackageQualifiedName(
-      resource.metadata.name,
-      QualifiedName(identifier),
+      event.getPackageName,
+      QualifiedName(event.getTemplateId.getModuleName, event.getTemplateId.getEntityName),
     )
   }
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
@@ -611,7 +611,8 @@ abstract class StoreTest extends AsyncWordSpec with BaseTest {
     externalpartyamuletrulesCodegen.TransferCommandCounter.ContractId,
     externalpartyamuletrulesCodegen.TransferCommandCounter,
   ] = {
-    val templateId = externalpartyamuletrulesCodegen.TransferCommandCounter.TEMPLATE_ID
+    val templateId =
+      externalpartyamuletrulesCodegen.TransferCommandCounter.TEMPLATE_ID_WITH_PACKAGE_ID
     val template = new externalpartyamuletrulesCodegen.TransferCommandCounter(
       dsoParty.toProtoPrimitive,
       sender.toProtoPrimitive,

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
@@ -428,7 +428,8 @@ abstract class StoreTest extends AsyncWordSpec with BaseTest {
 
   protected def validatorLivenessActivityRecord(validator: PartyId, round: Long = 1L) = {
     contract(
-      identifier = validatorLicenseCodegen.ValidatorLivenessActivityRecord.TEMPLATE_ID,
+      identifier =
+        validatorLicenseCodegen.ValidatorLivenessActivityRecord.TEMPLATE_ID_WITH_PACKAGE_ID,
       contractId =
         new validatorLicenseCodegen.ValidatorLivenessActivityRecord.ContractId(nextCid()),
       payload = new validatorLicenseCodegen.ValidatorLivenessActivityRecord(
@@ -588,7 +589,7 @@ abstract class StoreTest extends AsyncWordSpec with BaseTest {
     amuletrulesCodegen.TransferPreapproval.ContractId,
     amuletrulesCodegen.TransferPreapproval,
   ] = {
-    val templateId = amuletrulesCodegen.TransferPreapproval.TEMPLATE_ID
+    val templateId = amuletrulesCodegen.TransferPreapproval.TEMPLATE_ID_WITH_PACKAGE_ID
     val template = new amuletrulesCodegen.TransferPreapproval(
       dsoParty.toProtoPrimitive,
       receiver.toProtoPrimitive,

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTest.scala
@@ -94,7 +94,7 @@ abstract class StoreTest extends AsyncWordSpec with BaseTest {
 
   protected def getPackageName(identifier: Identifier) = {
     PackageQualifiedName
-      .findFromResources(identifier)
+      .lookupFromResources(identifier)
       .map(_.packageName)
       // should only be necessary for upgrade/malicious identifiers
       .orElse(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
@@ -123,7 +123,7 @@ class UpdateHistoryTest extends UpdateHistoryTestBase {
                   /*offset = */ 32,
                   /*nodeId = */ 52,
                   /*templateId*/ id1,
-                  /*packageName*/ dummyPackageName,
+                  /*packageName*/ getPackageName(id1),
                   /*interfaceId*/ Some(id1).toJava,
                   /*contractId*/ contractId,
                   /*choice*/ "someChoice",

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
@@ -14,7 +14,7 @@ import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.daml.lf.data.Bytes
 import com.google.rpc.status.Status
 import com.google.rpc.status.Status.toJavaProto
-import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.AppRewardCoupon
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.{Amulet, AppRewardCoupon}
 import org.lfdecentralizedtrust.splice.environment.ledger.api.{
   ReassignmentUpdate,
   TransactionTreeUpdate,
@@ -27,7 +27,6 @@ import java.util.Collections
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
-
 import UpdateHistory.UpdateHistoryResponse
 
 class UpdateHistoryTest extends UpdateHistoryTestBase {
@@ -83,11 +82,7 @@ class UpdateHistoryTest extends UpdateHistoryTestBase {
             val party1 = mkPartyId("someParty").toProtoPrimitive
             val party2 = mkPartyId("someParty").toProtoPrimitive
             val contractId = nextCid()
-            val id1 = new com.daml.ledger.javaapi.data.Identifier(
-              "somePackageId1",
-              "someModuleName1",
-              "someEntityName1",
-            )
+            val id1 = Amulet.TEMPLATE_ID_WITH_PACKAGE_ID
             val someValue = new DamlRecord(
               new DamlRecord.Field("a", new Int64(42))
             )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -382,7 +382,7 @@ object AcsSnapshotStore {
 
   private val holdingsTemplates =
     Vector(Amulet.TEMPLATE_ID_WITH_PACKAGE_ID, LockedAmulet.TEMPLATE_ID_WITH_PACKAGE_ID).map(
-      PackageQualifiedName(_)
+      PackageQualifiedName.getFromResources
     )
 
   private def decodeHoldingContract(createdEvent: CreatedEvent): Either[
@@ -393,14 +393,14 @@ object AcsSnapshotStore {
       .withDescription(s"Failed to decode $createdEvent")
       .asRuntimeException()
     if (
-      PackageQualifiedName(createdEvent.getTemplateId) == PackageQualifiedName(
+      PackageQualifiedName.fromEvent(createdEvent) == PackageQualifiedName.getFromResources(
         Amulet.TEMPLATE_ID_WITH_PACKAGE_ID
       )
     ) {
       Right(Contract.fromCreatedEvent(Amulet.COMPANION)(createdEvent).getOrElse(failedToDecode))
     } else {
       if (
-        PackageQualifiedName(createdEvent.getTemplateId) != PackageQualifiedName(
+        PackageQualifiedName.fromEvent(createdEvent) != PackageQualifiedName.getFromResources(
           LockedAmulet.TEMPLATE_ID_WITH_PACKAGE_ID
         )
       ) {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanStore.scala
@@ -1081,7 +1081,7 @@ class DbScanStore(
       tc: TraceContext,
   ): Future[Option[Contract[TCId, T]]] = {
     val templateId = companionClass.typeId(companion)
-    val packageName = PackageQualifiedName(templateId).packageName
+    val packageName = PackageQualifiedName.getFromResources(templateId).packageName
     for {
       row <- storage
         .querySingle(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AcsSnapshotStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AcsSnapshotStoreTest.scala
@@ -894,15 +894,6 @@ class AcsSnapshotStoreTest
         dummyDomain,
         "acs-snapshot-store-test",
         recordTime.toInstant,
-        packageName = DarResources
-          .lookupPackageId(create.identifier.getPackageId)
-          .getOrElse(
-            throw new IllegalArgumentException(
-              s"No package found for template ${create.identifier}"
-            )
-          )
-          .metadata
-          .name,
       )
     )
     updateHistory.ingestionSink

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AcsSnapshotStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AcsSnapshotStoreTest.scala
@@ -350,7 +350,7 @@ class AcsSnapshotStoreTest
             None,
             PageLimit.tryCreate(10),
             Seq.empty,
-            Seq(PackageQualifiedName(t1.identifier)),
+            Seq(PackageQualifiedName.getFromResources(t1.identifier)),
           )
           resultTemplate2 <- store.queryAcsSnapshot(
             DefaultMigrationId,
@@ -358,7 +358,7 @@ class AcsSnapshotStoreTest
             None,
             PageLimit.tryCreate(10),
             Seq.empty,
-            Seq(PackageQualifiedName(t2.identifier)),
+            Seq(PackageQualifiedName.getFromResources(t2.identifier)),
           )
         } yield {
           resultTemplate1.createdEventsInPage.map(_.event.getContractId) should be(
@@ -403,7 +403,7 @@ class AcsSnapshotStoreTest
             None,
             PageLimit.tryCreate(10),
             Seq(providerParty(1)),
-            Seq(PackageQualifiedName(ok.identifier)),
+            Seq(PackageQualifiedName.getFromResources(ok.identifier)),
           )
         } yield {
           result.createdEventsInPage.map(_.event.getContractId) should be(
@@ -500,7 +500,11 @@ class AcsSnapshotStoreTest
             None,
             Vector.empty,
             Seq(providerParty(1)),
-            Seq(PackageQualifiedName(roundCodegen.OpenMiningRound.TEMPLATE_ID_WITH_PACKAGE_ID)),
+            Seq(
+              PackageQualifiedName.getFromResources(
+                roundCodegen.OpenMiningRound.TEMPLATE_ID_WITH_PACKAGE_ID
+              )
+            ),
           )
         } yield {
           result should be(ok.map(_.contractId.contractId))

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ScanStoreTest.scala
@@ -1830,7 +1830,6 @@ abstract class ScanStoreTest
           first <- dummyDomain.create(
             firstDsoRules,
             recordTime = recordTimeFirst,
-            packageName = "splice-dso-governance",
           )(
             store.updateHistory
           )
@@ -1838,12 +1837,10 @@ abstract class ScanStoreTest
           _ <- dummyDomain.create(
             secondDsoRules,
             recordTime = recordTimeSecond,
-            packageName = "splice-dso-governance",
           )(store.updateHistory)
           _ <- dummyDomain.create(
             thirdDsoRules,
             recordTime = recordTimeThird,
-            packageName = "splice-dso-governance",
           )(store.updateHistory)
           result <- store.lookupContractByRecordTime(
             DsoRules.COMPANION,
@@ -1870,7 +1867,6 @@ abstract class ScanStoreTest
           first <- dummyDomain.create(
             firstAmuletRules,
             recordTime = recordTimeFirst,
-            packageName = "splice-amulet",
           )(
             store.updateHistory
           )
@@ -1878,14 +1874,12 @@ abstract class ScanStoreTest
           _ <- dummyDomain.create(
             secondAmuletRules,
             recordTime = recordTimeSecond,
-            packageName = "splice-amulet",
           )(
             store.updateHistory
           )
           _ <- dummyDomain.create(
             thirdAmuletRules,
             recordTime = recordTimeThird,
-            packageName = "splice-amulet",
           )(store.updateHistory)
           result <- store.lookupContractByRecordTime(
             AmuletRules.COMPANION,

--- a/apps/validator/src/test/scala/org/lfdecentralizedtrust/splice/store/ValidatorStoreTest.scala
+++ b/apps/validator/src/test/scala/org/lfdecentralizedtrust/splice/store/ValidatorStoreTest.scala
@@ -323,7 +323,7 @@ abstract class ValidatorStoreTest extends StoreTest with HasExecutionContext {
   }
 
   private def externalPartySetupProposal(user: PartyId) = {
-    val templateId = amuletrulesCodegen.ExternalPartySetupProposal.TEMPLATE_ID
+    val templateId = amuletrulesCodegen.ExternalPartySetupProposal.TEMPLATE_ID_WITH_PACKAGE_ID
     val template = new amuletrulesCodegen.ExternalPartySetupProposal(
       validator.toProtoPrimitive,
       user.toProtoPrimitive,

--- a/apps/wallet/src/test/scala/org/lfdecentralizedtrust/splice/store/db/UserWalletStoreTest.scala
+++ b/apps/wallet/src/test/scala/org/lfdecentralizedtrust/splice/store/db/UserWalletStoreTest.scala
@@ -1334,7 +1334,7 @@ abstract class UserWalletStoreTest extends TransferInputStoreTest with HasExecut
   }
 
   protected def transferPreapprovalProposal(receiver: PartyId, provider: PartyId) = {
-    val templateId = preapprovalCodegen.TransferPreapprovalProposal.TEMPLATE_ID
+    val templateId = preapprovalCodegen.TransferPreapprovalProposal.TEMPLATE_ID_WITH_PACKAGE_ID
     val template =
       new TransferPreapprovalProposal(
         receiver.toProtoPrimitive,


### PR DESCRIPTION
Part of #829

This is the easy part. If no interfaces are involved, only ingestion has to change.
Interface-related changes to come later.