### PR TITLE
shorter output/timeout/portability in validator onboarding test scriptlets

### DIFF
--- a/docs/src/validator_operator/validator_onboarding.rst
+++ b/docs/src/validator_operator/validator_onboarding.rst
@@ -126,7 +126,7 @@ Note that the following snippet requires installing `jq <https://jqlang.org/>`_ 
      grpcurl --max-time 10 "$url":443 grpc.health.v1.Health/Check
    done)
 
-Sequencers that are functional and have whitelisted your IP correctly will return ``status: SERVING`` in the ``grpcurl`` output.
+Sequencers that are functional and have whitelisted your IP correctly will return ``"status": "SERVING"`` in the ``grpcurl`` output.
 
 .. code-block:: bash
 

--- a/docs/src/validator_operator/validator_onboarding.rst
+++ b/docs/src/validator_operator/validator_onboarding.rst
@@ -89,10 +89,12 @@ Note that the following snippet requires installing `jq <https://jqlang.org/>`_.
 
 .. parsed-literal::
 
-   for url in $(curl -sSL |gsf_scan_url|/api/scan/v0/scans | jq -r '.scans | .[].scans | .[] | .publicUrl' ); do
-     echo -n "$url: ";
-     curl -sSL --connect-timeout 5 --fail-with-body $url/api/scan/version | jq -r '.version';
-   done
+   (set -o pipefail
+   CURL='curl -fsS -m 5 --connect-timeout 5'
+   for url in $($CURL |gsf_scan_url|/api/scan/v0/scans | jq -r '.scans[].scans[].publicUrl'); do
+     echo -n "$url: "
+     $CURL "$url"/api/scan/version | jq -r '.version'
+   done)
 
 You should see output in the form shown below, where each line indicates one SV and the version it is on. If you see timeouts that SV has not yet added you to their allowlist,
 if you do not get any errors, then all SVs have added you. Note that the URLs and versions will vary over time so don't try to compare exactly.
@@ -118,10 +120,11 @@ Note that the following snippet requires installing `jq <https://jqlang.org/>`_ 
 
 .. parsed-literal::
 
-   for url in $(curl -sSL |gsf_scan_url|/api/scan/v0/dso-sequencers | jq -r '.domainSequencers | .[] | .sequencers.[].url | sub("https://"; "")' ); do
-     echo -n "$url: ";
-     grpcurl --max-time 10 $url:443 grpc.health.v1.Health/Check;
-   done
+   (set -o pipefail
+   for url in $(curl -fsS -m 5 --connect-timeout 5 |gsf_scan_url|/api/scan/v0/dso-sequencers | jq -r '.domainSequencers[].sequencers[].url | sub("https://"; "")'); do
+     echo -n "$url: "
+     grpcurl --max-time 10 "$url":443 grpc.health.v1.Health/Check
+   done)
 
 Sequencers that are functional and have whitelisted your IP correctly will return ``status: SERVING`` in the ``grpcurl`` output.
 


### PR DESCRIPTION
* overall max-time for curl calls
* don't try to jq 4xx responses, just fail
* jq portability

Adapted from https://github.com/global-synchronizer-foundation/docs/discussions/8#discussioncomment-12943148 from @stas-sbi; thanks.
 
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
