### PR TITLE
Remove todo artifacts

### DIFF
--- a/.github/workflows/build.static_tests.yml
+++ b/.github/workflows/build.static_tests.yml
@@ -65,12 +65,6 @@ jobs:
           CIRCLE_BRANCH: ${{ github.ref }}
           CIRCLE_PULL_REQUEST: ${{ github.event.pull_request.number }}
 
-      - name: Store TODOs as artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: todos
-          path: todo-out/todos
-
       - name: Lint GHA
         uses: ./.github/actions/nix/run_bash_command_in_nix
         with:


### PR DESCRIPTION
With the new static test job, CI on forks now fails as it conflicts between that job and the main job.

Rather than trying to make it conditional or rename it to avoid the conflict, this just removes the step. Noone has used this for years afaik.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
