### PR TITLE
Remove config transform to bump canton domain ports

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
@@ -400,10 +400,7 @@ case class EnvironmentDefinition(
           )
         )
     )
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(10_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(10_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(10_000)(conf))
       // we bump remote app ports separately in order to not confuse
       // the PreflightIntegrationTest which also uses bumpCantonPortsBy
       .addConfigTransformsToFront((_, conf) =>

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BootstrapPackageConfigDarUploadIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BootstrapPackageConfigDarUploadIntegrationTest.scala
@@ -39,10 +39,7 @@ class BootstrapPackageConfigDarUploadIntegrationTest
       // Technically a single SV test but withCanton doesn't handle that atm.
       .simpleTopology4Svs(this.getClass.getSimpleName)
       .withPreSetup(_ => ())
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       .addConfigTransforms((_, config) =>
         ConfigTransforms.updateAllSvAppFoundDsoConfigs_(
           _.copy(initialPackageConfig = initialPackageConfig)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -313,10 +313,6 @@ class DecentralizedSynchronizerMigrationIntegrationTest
             22_000,
             Seq("sv1Local", "sv1LocalOnboarded", "sv2Local", "sv3Local", "sv4Local"),
           ) compose
-          ConfigTransforms.bumpSomeSvAppCantonDomainPortsBy(
-            22_000,
-            Seq("sv1Local", "sv1LocalOnboarded", "sv2Local", "sv3Local", "sv4Local"),
-          ) compose
           ConfigTransforms
             .bumpSomeScanAppCantonPortsBy(22_000, Seq("sv1ScanLocal")) compose
           ConfigTransforms

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisasterRecoveryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisasterRecoveryIntegrationTest.scala
@@ -92,10 +92,7 @@ class DisasterRecoveryIntegrationTest
       // Disable user allocation
       .withPreSetup(_ => ())
       .unsafeWithSequencerAvailabilityDelay(NonNegativeFiniteDuration.ofSeconds(5))
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       .addConfigTransforms(
         (_, conf) =>
           updateAutomationConfig(ConfigurableApp.Sv)(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -51,10 +51,7 @@ class ManualStartIntegrationTest
       // This test makes sure apps can automatically initialize Canton instances.
       // The Splice apps in this test should therefore completely ignore the shared canton instances
       // (which are auto-initialized), and only use the manually started fresh Canton instances.
-      .addConfigTransforms(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransforms((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       // By default, alice validator connects to the splitwell domain. This test doesn't start the splitwell node.
       .addConfigTransform((_, conf) =>
         conf.copy(validatorApps =

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ParticipantKmsIdentitiesEnterpriseIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ParticipantKmsIdentitiesEnterpriseIntegrationTest.scala
@@ -32,7 +32,6 @@ class ParticipantKmsIdentitiesEnterpriseIntegrationTest
       .clearConfigTransforms() // mainly to get static daml names
       .addConfigTransforms(
         (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
         (_, conf) =>
           updateAllValidatorConfigs { case (name, c) =>
             if (name == "aliceValidator") {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOffboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOffboardingIntegrationTest.scala
@@ -64,10 +64,7 @@ class SvOffboardingIntegrationTest
     EnvironmentDefinition
       .simpleTopology4Svs(this.getClass.getSimpleName)
       .withPreSetup(_ => ())
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       .addConfigTransformsToFront((_, conf) =>
         ConfigTransforms.bumpRemoteSplitwellPortsBy(22_000)(conf)
       )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
@@ -38,10 +38,7 @@ class SvOnboardingViaNonFoundingSvIntegrationTest
       .simpleTopology4Svs(this.getClass.getSimpleName)
       .withPreSetup(_ => ())
       .withOnboardingParticipantPromotionDelayEnabled() // Test onboarding with participant promotion delay
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       .addConfigTransforms((_, configuration) => {
         val sv1ToSv2Bump = 100
         val sv2OnboardingSvClientUrl =

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
@@ -88,10 +88,7 @@ class SvReonboardingIntegrationTest
       .simpleTopology4Svs(this.getClass.getSimpleName)
       // Disable user allocation
       .withPreSetup(_ => ())
-      .addConfigTransformsToFront(
-        (_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf),
-        (_, conf) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(conf),
-      )
+      .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
       .addConfigTransforms(
         (_, config) =>
           config.copy(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/offlinekey/SvOfflineRootNamespaceKeyIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/offlinekey/SvOfflineRootNamespaceKeyIntegrationTest.scala
@@ -31,11 +31,9 @@ class SvOfflineRootNamespaceKeyIntegrationTest
       .simpleTopology4Svs(cantonNameSuffix)
       // we start the participants during the test so we cannot pre-allocate
       .withPreSetup(_ => ())
-      .addConfigTransforms(
-        (_, config) => ConfigTransforms.bumpCantonDomainPortsBy(22_000)(config),
-        (_, config) =>
-          // use a fresh participant to ensure a fresh deployment so we can validate the topology state
-          ConfigTransforms.bumpCantonPortsBy(22_000)(config),
+      .addConfigTransforms((_, config) =>
+        // use a fresh participant to ensure a fresh deployment so we can validate the topology state
+        ConfigTransforms.bumpCantonPortsBy(22_000)(config)
       )
       // Add a suffix to the canton identifiers to avoid metric conflicts with the shared canton nodes
       .withCantonNodeNameSuffix(cantonNameSuffix)


### PR DESCRIPTION
[ci]

The split here doesn't really make sense. The one without "domain" in the name bumps the internal sequencer API URL. The one with domain in the name bumps the external API URL. Clearly both are domain related. And we always set both because otherwise you get a mismatch since internal and external are the same in integration tests.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
