### PR TITLE
Fix log ignore

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -120,8 +120,11 @@ Failed to connect to scan of .*SvDevNetReonboardingIntegrationTest
 # Log suppression doesn't seem to work here as the tests use a different logger
 GENERIC_CONFIG_ERROR.*SpliceConfigTest
 
+# shutdown can be slower than the timeouts
+shutdown did not complete gracefully in allotted 3 seconds
+
 # ExecutorServiceMetrics closes the gauges twice through shutdown and shutownNow in cases where shutdown times out
-.*InstrumentDescriptor.*name=daml.executor.* has called close() multiple times
+.*InstrumentDescriptor.*name=daml.executor.* has called close\(\) multiple times
 
 
 # Make sure to have a trailing newline


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5420

We added some log ignores in https://github.com/hyperledger-labs/splice/pull/1770, then fixed them in https://github.com/hyperledger-labs/splice/pull/1874, but they are still broken:
- The pattern doesn't escape `()` and doesn't match the warning
- The line `shutdown did not complete gracefully in allotted 3 seconds` wasn't ignored (it appeared at least in https://github.com/DACH-NY/cn-test-failures/issues/5420 before all the other warnings)