### PR TITLE
Fix createTransferPreapproval timing out in tests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -528,7 +528,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
       val onboarding @ OnboardingResult(externalParty, _, _) =
         onboardExternalParty(validatorBackend)
       walletClient.tap(50.0)
-      walletClient.createTransferPreapproval()
+      createTransferPreapprovalIfNotExists(walletClient)
       createAndAcceptExternalPartySetupProposal(validatorBackend, onboarding)
       eventually() {
         validatorBackend.lookupTransferPreapprovalByParty(externalParty) should not be empty

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
@@ -177,7 +177,7 @@ class RecoverExternalPartyIntegrationTest
 
     // Tap so we have money for creating the preapproval
     bobValidatorWalletClient.tap(5000.0)
-    createTransferPreapprovalIfNotExists(bobWalletClient)
+    createTransferPreapprovalIfNotExists(bobValidatorWalletClient)
 
     // Grant rights to bob's validator backend the rights to prepare transactions
     // and submit signed on behalf of the party.

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.lfdecentralizedtrust.splice.console.LedgerApiExtensions.RichPartyId
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithSharedEnvironment
 import org.lfdecentralizedtrust.tokenstandard.transferinstruction
-
 import com.daml.nonempty.NonEmpty
 import com.digitalasset.canton.admin.api.client.commands.TopologyAdminCommands.Write.GenerateTransactions
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
@@ -16,6 +15,7 @@ import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.transaction.*
 import com.digitalasset.canton.util.HexString
 import com.digitalasset.canton.version.ProtocolVersion
+import org.lfdecentralizedtrust.splice.util.WalletTestUtil
 
 import java.nio.file.Files
 import java.time.Duration
@@ -25,7 +25,8 @@ import scala.concurrent.duration.*
 class RecoverExternalPartyIntegrationTest
     extends IntegrationTestWithSharedEnvironment
     with ExternallySignedPartyTestUtil
-    with TokenStandardTest {
+    with TokenStandardTest
+    with WalletTestUtil {
 
   override def environmentDefinition: EnvironmentDefinition =
     EnvironmentDefinition.simpleTopology1Sv(this.getClass.getSimpleName)
@@ -176,7 +177,7 @@ class RecoverExternalPartyIntegrationTest
 
     // Tap so we have money for creating the preapproval
     bobValidatorWalletClient.tap(5000.0)
-    bobValidatorWalletClient.createTransferPreapproval()
+    createTransferPreapprovalIfNotExists(bobWalletClient)
 
     // Grant rights to bob's validator backend the rights to prepare transactions
     // and submit signed on behalf of the party.

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
@@ -199,8 +199,8 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
       val aliceValidator = RichPartyId.local(aliceValidatorBackend.getValidatorPartyId())
 
       aliceValidatorWalletClient.tap(BigDecimal(1000))
-      aliceWalletClient.createTransferPreapproval()
-      aliceValidatorWalletClient.createTransferPreapproval()
+      createTransferPreapprovalIfNotExists(aliceWalletClient)
+      createTransferPreapprovalIfNotExists(aliceValidatorWalletClient)
 
       val charlieParty = onboardWalletUser(charlieWalletClient, aliceValidatorBackend)
 
@@ -550,7 +550,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
             // TransferIn (derived by tx-kind), while making sure that charlie has no leftovers
             val charlieAmount = 500.0
             charlieWalletClient.tap(walletAmuletToUsd(charlieAmount))
-            aliceWalletClient.createTransferPreapproval() // it was deleted before
+            createTransferPreapprovalIfNotExists(aliceWalletClient) // it was deleted before
             charlieWalletClient.transferPreapprovalSend(
               alice.partyId,
               charlieAmount - 11,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -571,20 +571,18 @@ class WalletIntegrationTest
         sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty) shouldBe None
         val (_, cid) = actAndCheck(
           "Create TransferPreapproval",
-          aliceWalletClient.createTransferPreapproval(),
+          createTransferPreapprovalIfNotExists(aliceWalletClient),
         )(
           "Scan lookup returns TransferPreapproval",
-          inside(_) {
-            case CreateTransferPreapprovalResponse.Created(c) => {
-              val contractFromScan =
-                sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
-              contractFromScan.contractId shouldBe c
+          c => {
+            val contractFromScan =
+              sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
+            contractFromScan.contractId shouldBe c
 
-              val contractFromValidatorBackend =
-                aliceValidatorBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
-              contractFromValidatorBackend.contractId shouldBe c
-              contractFromValidatorBackend.contractId
-            }
+            val contractFromValidatorBackend =
+              aliceValidatorBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
+            contractFromValidatorBackend.contractId shouldBe c
+            contractFromValidatorBackend.contractId
           },
         )
         aliceWalletClient.createTransferPreapproval() shouldBe CreateTransferPreapprovalResponse
@@ -720,28 +718,24 @@ class WalletIntegrationTest
         aliceValidatorWalletClient.tap(10.0)
         actAndCheck(
           "Create TransferPreapproval for end user",
-          aliceWalletClient.createTransferPreapproval(),
+          createTransferPreapprovalIfNotExists(aliceWalletClient),
         )(
           "Scan lookup returns TransferPreapproval for end user",
-          inside(_) {
-            case CreateTransferPreapprovalResponse.Created(c) => {
-              val contractFromScan =
-                sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
-              contractFromScan.contractId shouldBe c
-            }
+          c => {
+            val contractFromScan =
+              sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty).value
+            contractFromScan.contractId shouldBe c
           },
         )
         actAndCheck(
           "Create TransferPreapproval for validator operator",
-          aliceValidatorWalletClient.createTransferPreapproval(),
+          createTransferPreapprovalIfNotExists(aliceValidatorWalletClient),
         )(
           "Scan lookup returns TransferPreapproval",
-          inside(_) {
-            case CreateTransferPreapprovalResponse.Created(c) => {
-              val contractFromScan =
-                sv1ScanBackend.lookupTransferPreapprovalByParty(validatorOperatorParty).value
-              contractFromScan.contractId shouldBe c
-            }
+          c => {
+            val contractFromScan =
+              sv1ScanBackend.lookupTransferPreapprovalByParty(validatorOperatorParty).value
+            contractFromScan.contractId shouldBe c
           },
         )
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
@@ -222,7 +222,7 @@ abstract class WalletSweepIntegrationTest
           50.0
         ) // validator needs to have some funds to create preapproval
         walletClient.tap(50.0)
-        walletClient.createTransferPreapproval()
+        createTransferPreapprovalIfNotExists(walletClient)
       },
     )(
       "Transfer preapproval is visible in scan",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
@@ -419,7 +419,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
         browseToSv1Wallet(sv1ValidatorWalletUser)
         actAndCheck(
           "SV1 creates a transfer preapproval and automation renews it immediately",
-          sv1WalletClient.createTransferPreapproval(),
+          createTransferPreapprovalIfNotExists(sv1WalletClient),
         )(
           "SV1 sees the creation and renewal transactions",
           _ => {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
@@ -1628,7 +1628,7 @@ class WalletTxLogIntegrationTest
       val charlieUserParty = onboardWalletUser(charlieWalletClient, aliceValidatorBackend)
 
       aliceValidatorWalletClient.tap(100) // funds to create preapproval
-      charlieWalletClient.createTransferPreapproval()
+      createTransferPreapprovalIfNotExists(charlieWalletClient)
 
       assertCommandFailsDueToInsufficientFunds(
         aliceWalletClient.transferPreapprovalSend(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5437

This wasn't because it didn't have funds, but because the validator took too long to accept the preapproval and the walletclient timed out.