### PR TITLE
Ignore warnings for shutdown taking too long

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -86,6 +86,7 @@ unexpected exception: Task slick.*rejected from slick.util.AsyncExecutorWithMetr
 
 # TODO (#944): investigate what task is it still running and see if we can somehow fix it
 Timeout 10 seconds expired, but tasks still running. Shutting down forcibly
+ForkJoinIdlenessExecutorService.*shutdown did not complete gracefully in allotted
 
 Consensus not reached.*BftScanConnection:BftScanConnectionTest.*
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5457

I tried to find why exactly it cannot shutdown in time, but I haven't found anything interesting.
Tests pass even with this warning, and if there was anything important it should be caught by other warnings (that don't show up), so ignore it is...
