### PR TITLE
Prevent content-runtime-updater from logging errors for every transient failure

### DIFF
--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
 
             fail_count=0
             # prevent spamming alerts by logging only after the issues are persistent
-            LOG_TO_STDERR_AFTER_FAILURES=100
+            log_to_stderr_after_failures=${LOG_TO_STDERR_AFTER_FAILURES:-100}
             while true; do
               start_time=$(date +%s);
 
@@ -77,7 +77,7 @@ spec:
               else
                 fail_count=$((fail_count + 1))
                 echo "Failed to fetch DSO from $SCAN_URL (failure #$fail_count): $result"
-                if [ $((fail_count % LOG_TO_STDERR_AFTER_FAILURES)) -eq 0 ]; then
+                if [ $((fail_count % log_to_stderr_after_failures)) -eq 0 ]; then
                   echo "ERROR: $fail_count consecutive failures fetching DSO from $SCAN_URL" 1>&2
                 fi
               fi;
@@ -89,6 +89,10 @@ spec:
         env:
           - name: SCAN_URL
             value: {{ .Values.runtimeDetails.scanUrl | quote }}
+          {{ - if .Values.runtimeDetails.logToStderrAfterFailures }}
+          - name: LOG_TO_STDERR_AFTER_FAILURES
+            value: {{ .Values.runtimeDetails.logToStderrAfterFailures | quote }}
+          {{- end }}
         volumeMounts:
         - name: content-runtime
           mountPath: /usr/share/nginx/html/runtime

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            set -eu;
+            set -u;
 
             period=60;
 
@@ -60,20 +60,32 @@ spec:
 
             echo "{\"dso\": \"/$dso_json_path\"}" > "$runtime_index_file";
 
+            fail_count=0
+            # prevent spamming alerts by logging only after the issues are persistent
+            LOG_TO_STDERR_AFTER_FAILURES=100
             while true; do
               start_time=$(date +%s);
-              exit_code=0;
 
-              if curl -m 10 -fs "$SCAN_URL/api/scan/v0/dso" > "$dso_json_file.new"; then
+              # prevent curl from writing to stderr while still logging them ourselves
+              result=$(curl -m 10 -sS --fail-with-body "$SCAN_URL/api/scan/v0/dso" 2>&1)
+              exit_code=$?
+              if [ $exit_code -eq 0 ]; then
+                # ensure it's valid JSON by using jq
+                echo "$result" | jq . > "$dso_json_file.new"
                 mv "$dso_json_file.new" "$dso_json_file";
+                fail_count=0
               else
-                exit_code=$?;
-                echo "ERROR: Failed to fetch DSO from $SCAN_URL";
+                fail_count=$((fail_count + 1))
+                echo "Failed to fetch DSO from $SCAN_URL (failure #$fail_count): $result"
+                if [ $((fail_count % LOG_TO_STDERR_AFTER_FAILURES)) -eq 0 ]; then
+                  echo "ERROR: $fail_count consecutive failures fetching DSO from $SCAN_URL" 1>&2
+                fi
               fi;
 
               end_time=$(date +%s);
               sleep "$((period - (end_time - start_time)))";
             done;
+
         env:
           - name: SCAN_URL
             value: {{ .Values.runtimeDetails.scanUrl | quote }}

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -67,13 +67,13 @@ spec:
               start_time=$(date +%s);
 
               # prevent curl from writing to stderr while still logging them ourselves
-              result=$(curl -m 10 -sS --fail-with-body "$SCAN_URL/api/scan/v0/dso" 2>&1)
-              exit_code=$?
-              if [ $exit_code -eq 0 ]; then
-                # ensure it's valid JSON by using jq
-                echo "$result" | jq . > "$dso_json_file.new"
-                mv "$dso_json_file.new" "$dso_json_file";
-                fail_count=0
+              if result=$(curl -m 10 -sS --fail-with-body "$SCAN_URL/api/scan/v0/dso" 2>&1); then
+                if echo "$result" | jq . > "$dso_json_file.new"; then
+                  mv "$dso_json_file.new" "$dso_json_file";
+                  fail_count=0
+                else
+                  echo "Failed to parse DSO JSON from $SCAN_URL (failure #$fail_count): $result" 1>&2
+                fi
               else
                 fail_count=$((fail_count + 1))
                 echo "Failed to fetch DSO from $SCAN_URL (failure #$fail_count): $result"

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -62,7 +62,6 @@ spec:
 
             fail_count=0
             # prevent spamming alerts by logging only after the issues are persistent
-            log_to_stderr_after_failures=${LOG_TO_STDERR_AFTER_FAILURES:-100}
             while true; do
               start_time=$(date +%s);
 
@@ -77,7 +76,7 @@ spec:
               else
                 fail_count=$((fail_count + 1))
                 echo "Failed to fetch DSO from $SCAN_URL (failure #$fail_count): $result"
-                if [ $((fail_count % log_to_stderr_after_failures)) -eq 0 ]; then
+                if [ $((fail_count % LOG_TO_STDERR_AFTER_FAILURES)) -eq 0 ]; then
                   echo "ERROR: $fail_count consecutive failures fetching DSO from $SCAN_URL" 1>&2
                 fi
               fi;
@@ -89,10 +88,8 @@ spec:
         env:
           - name: SCAN_URL
             value: {{ .Values.runtimeDetails.scanUrl | quote }}
-          {{- if .Values.runtimeDetails.logToStderrAfterFailures }}
           - name: LOG_TO_STDERR_AFTER_FAILURES
-            value: {{ .Values.runtimeDetails.logToStderrAfterFailures | quote }}
-          {{- end }}
+            value: {{ .Values.runtimeDetails.logToStderrAfterFailures | default 100 | quote }}
         volumeMounts:
         - name: content-runtime
           mountPath: /usr/share/nginx/html/runtime

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            set -u;
+            set -eu;
 
             period=60;
 

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               start_time=$(date +%s);
               exit_code=0;
 
-              if curl -m 10 -fsS "$SCAN_URL/api/scan/v0/dso" > "$dso_json_file.new"; then
+              if curl -m 10 -fs "$SCAN_URL/api/scan/v0/dso" > "$dso_json_file.new"; then
                 mv "$dso_json_file.new" "$dso_json_file";
               else
                 exit_code=$?;

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -73,10 +73,6 @@ spec:
 
               end_time=$(date +%s);
               sleep "$((period - (end_time - start_time)))";
-
-              if [ "$exit_code" -ne 0 ]; then
-                exit $exit_code;
-              fi;
             done;
         env:
           - name: SCAN_URL

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
         env:
           - name: SCAN_URL
             value: {{ .Values.runtimeDetails.scanUrl | quote }}
-          {{ - if .Values.runtimeDetails.logToStderrAfterFailures }}
+          {{- if .Values.runtimeDetails.logToStderrAfterFailures }}
           - name: LOG_TO_STDERR_AFTER_FAILURES
             value: {{ .Values.runtimeDetails.logToStderrAfterFailures | quote }}
           {{- end }}

--- a/cluster/helm/splice-info/tests/deployment_test.yaml
+++ b/cluster/helm/splice-info/tests/deployment_test.yaml
@@ -28,11 +28,11 @@ tests:
     asserts:
       # Sanity check
       - equal:
-        path: spec.template.spec.containers[0].name
-        value: "nginx"
+          path: spec.template.spec.containers[0].name
+          value: "nginx"
       - equal:
-        path: spec
-        value: "https://scan.url"
+          path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='SCAN_URL')].value
+          value: "https://scan.url"
       - equal:
-        path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='LOG_TO_STDERR_AFTER_FAILURES')].value
-        value: "123"
+          path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='LOG_TO_STDERR_AFTER_FAILURES')].value
+          value: "123"

--- a/cluster/helm/splice-info/tests/deployment_test.yaml
+++ b/cluster/helm/splice-info/tests/deployment_test.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: "Splice-info values"
+templates:
+  - deployment.yaml
+
+release:
+  # Set for testing labels
+  name: mock
+  namespace: mons
+chart:
+  # Override for testing labels
+  version: 0.1.1
+  appVersion: 0.1.0
+imagePullPolicy: IfNotPresent
+nginxImage: "some-nginx-image"
+
+tests:
+  - it: "should include runtime details env vars"
+    set:
+      runtimeDetails:
+        scanUrl: "https://scan.url"
+        logToStderrAfterFailures: 123
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      # Sanity check
+      - equal:
+        path: spec.template.spec.containers[0].name
+        value: "nginx"
+      - equal:
+        path: spec
+        value: "https://scan.url"
+      - equal:
+        path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='LOG_TO_STDERR_AFTER_FAILURES')].value
+        value: "123"

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -56,7 +56,8 @@
       "required": [ "scanUrl" ],
       "additionalProperties": false,
       "properties": {
-        "scanUrl": { "type": "string", "minLength": 1 }
+        "scanUrl": { "type": "string", "minLength": 1 },
+        "logToStderrAfterFailures": { "type": "integer", "minimum": 1 }
       }
     },
     "deploymentDetails": {


### PR DESCRIPTION
Part of https://github.com/hyperledger-labs/splice/issues/2091

With `LOG_TO_STDERR_AFTER_FAILURES=3`:
Sample output to stdout:
```
curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Failed to fetch DSO from https://scan.sv-26.dev.global.canton.network.digitalasset.com (failure #9): curl: (60) SSL: no alternative certificate subject name matches target hostname 'scan.sv-26.dev.global.canton.network.digitalasset.com'
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Failed to fetch DSO from https://scan.sv-26.dev.global.canton.network.digitalasset.com (failure #10): curl: (60) SSL: no alternative certificate subject name matches target hostname 'scan.sv-26.dev.global.canton.network.digitalasset.com'
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
```

Sample output to stderr:
```
ERROR: 3 consecutive failures fetching DSO from https://scan.sv-26.dev.global.canton.network.digitalasset.com
ERROR: 6 consecutive failures fetching DSO from https://scan.sv-26.dev.global.canton.network.digitalasset.com
ERROR: 9 consecutive failures fetching DSO from https://scan.sv-26.dev.global.canton.network.digitalasset.com
```