### PR TITLE
set deployment BigQuery data staleness to 4 hours

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -159,6 +159,9 @@ function installDatastream(
           singleTargetDataset: {
             datasetId: pulumi.interpolate`projects/${bigQueryDataset.project}/datasets/${bigQueryDataset.datasetId}`,
           },
+          // editing dataFreshness does not alter existing BQ tables, see its
+          // docstring or https://github.com/hyperledger-labs/splice/issues/2011
+          dataFreshness: '14400s',
         },
         destinationConnectionProfile: destination.name,
       },


### PR DESCRIPTION
Fixes #2011. Confirmed on scratch by running

```sql
SELECT
  table_name,
  option_name,
  option_value
FROM
  devnet_da2_scan.INFORMATION_SCHEMA.TABLE_OPTIONS
WHERE
  option_name = 'max_staleness'
  AND table_name in ('scan_sv_1_update_history_creates', 'scan_sv_1_update_history_exercises');
```

which yielded

```json
[{
  "table_name": "scan_sv_1_update_history_exercises",
  "option_name": "max_staleness",
  "option_value": "0-0 0 4:0:0"
}, {
  "table_name": "scan_sv_1_update_history_creates",
  "option_name": "max_staleness",
  "option_value": "0-0 0 4:0:0"
}]
```


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
