### PR TITLE
Deprecate /v0/transactions even harder

### DIFF
--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1431,7 +1431,9 @@ paths:
       x-jvm-package: scan
       operationId: "listTransactionHistory"
       description: |
-        **Deprecated**. Lists transactions, by default in ascending order, paged, from ledger begin or optionally starting after a provided event id.
+        **Deprecated with known bugs that will not be fixed, use /v2/updates instead**.
+
+        Lists transactions, by default in ascending order, paged, from ledger begin or optionally starting after a provided event id.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Apparently our current disclaimer was not clear enough for people to not build on /v0/transactions. Wording was cleared with Bernhard.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
