### PR TITLE
revert bigQuery migration IDs change

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
@@ -511,7 +511,7 @@ class ScanTotalSupplyBigQueryIntegrationTest
     // The TPS query assumes staleness of up to 4 hours, so we query for stats 5 hours after the current ledger time.
     val timestamp = getLedgerTime.toInstant.plus(5, ChronoUnit.HOURS).toString
     val sql =
-      s"SELECT * FROM `$project.$functionsDatasetName.all_stats`('$timestamp');"
+      s"SELECT * FROM `$project.$functionsDatasetName.all_stats`('$timestamp', 0);"
 
     logger.info(s"Querying all stats as of $timestamp")
 


### PR DESCRIPTION
On a scratchnet with a few hours of data, this blew up one call to `all_stats(CURRENT_TIMESTAMP)` from 11 sec runtime and 27 minute of slot time consumed to 1-1.5 minute of runtime (sometimes completely failing) and 24 hours of slot time consumed! :exploding_head: 

I couldn't find any workaround to the blowup, seems like this completely breaks some of Google's optimizations.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
