### PR TITLE
remove clue inside an eventually()

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogTestUtil.scala
@@ -73,20 +73,20 @@ trait WalletTxLogTestUtil extends TestCommon with WalletTestUtil with TimeTestUt
 
       // ingestion can happen in-between the call `actual=listTransactions()` and the paginated ones,
       // so both need to be inside the same `eventually` block
-      clue("Paginated result should be equal to non-paginated result") {
-        val paginatedResult = Iterator
-          .unfold[Seq[TxLogEntry], Option[String]](None)(beginAfterId => {
-            val page = wallet.listTransactions(beginAfterId, pageSize = 2)
-            if (page.isEmpty)
-              None
-            else
-              Some(page -> Some(page.last.eventId))
-          })
-          .toSeq
-          .flatten
 
-        paginatedResult should contain theSameElementsInOrderAs actual
-      }
+      // Confirm that the paginated result is equal to the non-paginated result
+      val paginatedResult = Iterator
+        .unfold[Seq[TxLogEntry], Option[String]](None)(beginAfterId => {
+          val page = wallet.listTransactions(beginAfterId, pageSize = 2)
+          if (page.isEmpty)
+            None
+          else
+            Some(page -> Some(page.last.eventId))
+        })
+        .toSeq
+        .flatten
+
+      paginatedResult should contain theSameElementsInOrderAs actual
     }
   }
 


### PR DESCRIPTION
Causes logs that fails the log check if it fails.
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5528


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
