### PR TITLE
[static] Default validator-runbook stack to the validator-runbook name

### DIFF
--- a/build-tools/lib/pulumi-helpers
+++ b/build-tools/lib/pulumi-helpers
@@ -45,10 +45,11 @@ function _resolve_pulumi_stack() {
     elif [[ $pulumi_project == "sv-canton" ]]; then
         pulumi_stack="$pulumi_project.${SPLICE_SV}-migration-${SPLICE_MIGRATION_ID}.$GCP_CLUSTER_BASENAME"
     elif [[ $pulumi_project == "validator-runbook" ]]; then
-      if [[ $SPLICE_VALIDATOR_RUNBOOK_VALIDATOR_NAME == "validator-runbook" ]]; then
+      validator_name="${SPLICE_VALIDATOR_RUNBOOK_VALIDATOR_NAME:-validator-runbook}"
+      if [[ $validator_name == "validator-runbook" ]]; then
         pulumi_stack="validator-runbook.$GCP_CLUSTER_BASENAME"
       else
-        pulumi_stack="validators.${SPLICE_VALIDATOR_RUNBOOK_VALIDATOR_NAME}.$GCP_CLUSTER_BASENAME"
+        pulumi_stack="validators.${validator_name}.$GCP_CLUSTER_BASENAME"
       fi
     else
         pulumi_stack="$pulumi_project.$GCP_CLUSTER_BASENAME"


### PR DESCRIPTION
better ux in using cncluster commands and keeps backwards compatibility also fixing the preview commands 



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
