### PR TITLE
Keep party allocator running and tweak log format

### DIFF
--- a/party-allocator/src/index.ts
+++ b/party-allocator/src/index.ts
@@ -241,8 +241,8 @@ async function main() {
     const match = f.match(/(?<index>.*)_priv.key/);
     return parseInt(match?.groups?.index || "0");
   });
-  const maxIndex = keyIndices.length > 0 ? Math.max(...keyIndices) : 0;
-  // We just reinitialize the party at maxIndex from scratch and accept that we allocate slightly more than maxParties in case of restarts instead of trying to clever
+  const maxIndex = keyIndices.length > 0 ? Math.max(...keyIndices) + 1 : 0;
+  // We just reinitialize the party at maxIndex + 1 from scratch instead of trying to clever
   // and incrementally handle all kinds of failures.
   logger.info(`Starting at ${maxIndex}`);
 
@@ -265,6 +265,15 @@ async function main() {
     logger.info(`Completed batch`);
     index += batchSize;
   }
+  logger.info(`Party allocator, completed. Sleeping`);
+  // sleep forever so k8s doesn't restart it over and over.
+  // For some reason, nodejs is too smart and await new Promise(() => {}) does not actually work.
+  await sleepForever();
+}
+
+async function sleepForever() {
+  await new Promise((resolve) => setInterval(() => resolve(1000 * 60 * 60)));
+  sleepForever;
 }
 
 await main();

--- a/party-allocator/src/logger.ts
+++ b/party-allocator/src/logger.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import pino from "pino";
 
+const isoTime = () => `,"@timestamp":"${new Date(Date.now()).toISOString()}"`;
+
+// Log format tweaked to parse well by fluentbit/gcp.
 export const logger = pino({
   level: "debug",
   base: null,
   formatters: {
     level: (label) => ({ level: label }),
   },
-  timestamp: pino.stdTimeFunctions.isoTime,
+  timestamp: isoTime,
+  messageKey: "message",
 });


### PR DESCRIPTION
Probably will replace the sleep forever by a metrics server but better than crashing for now.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
