### PR TITLE
[ci] Increase client http timeouts

### DIFF
--- a/apps/app/src/test/resources/include/svs/_sv.conf
+++ b/apps/app/src/test/resources/include/svs/_sv.conf
@@ -61,6 +61,10 @@
         max-failures = 20
       }
     }
+    timeouts {
+      # required if we want to also increase on the client side the timeout
+      request-timeout = 5 minutes
+    }
     custom-timeouts {
       # names should match those of the OpenAPI definition
       onboardSvPartyMigrationAuthorize = 5 minutes

--- a/cluster/images/sv-app/app.conf
+++ b/cluster/images/sv-app/app.conf
@@ -99,6 +99,10 @@ canton {
       delegateless-automation-expected-task-duration = ${?SPLICE_APP_EXPECTED_TASK_DURATION}
       delegateless-automation-expired-reward-coupon-batch-size = ${?SPLICE_APP_EXPIRED_REWARD_COUPON_BATCH_SIZE}
       parameters {
+        timeouts {
+          # required if we want to also increase on the client side the timeout
+          request-timeout = 5 minutes
+        }
         custom-timeouts {
           onboardSvPartyMigrationAuthorize = 5 minutes
         }


### PR DESCRIPTION
By default the client times out after 40 seconds so even if we bumped the server timeout we still need to increase the client one. 

This bumps the timeout for all the http clients but I don't really see a big issue there as the server side timeout should still kick in. If we do notice any type of issue we might need to add custom http clients timeouts per operation but that sounds overly complex and not useful right now. 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
