### PR TITLE
[static] fix pulumi package name

### DIFF
--- a/cluster/pulumi/cluster/src/config.ts
+++ b/cluster/pulumi/cluster/src/config.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { clusterSubConfig } from 'splice-pulumi-common/src/config/configLoader';
+import { clusterSubConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/configLoader';
 import { z } from 'zod';
 
 const GkeNodePoolConfigSchema = z.object({

--- a/cluster/pulumi/cluster/src/fluentBit.ts
+++ b/cluster/pulumi/cluster/src/fluentBit.ts
@@ -7,7 +7,7 @@ import {
   exactNamespace,
   GCP_REGION,
   infraAffinityAndTolerations,
-} from 'splice-pulumi-common';
+} from '@lfdecentralizedtrust/splice-pulumi-common';
 
 export function installFluentBit(): void {
   // GCP does not allow configuring the fluent-bit instance it deploys. So we disable GCP's fluent-bit instance for workloads and install our own that

--- a/cluster/pulumi/cluster/src/index.ts
+++ b/cluster/pulumi/cluster/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { config } from 'splice-pulumi-common';
+import { config } from '@lfdecentralizedtrust/splice-pulumi-common';
 
 import { installFluentBit } from './fluentBit';
 import { installNodePools } from './nodePools';

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -5,7 +5,7 @@ import {
   KmsConfigSchema,
   LogLevelSchema,
 } from '@lfdecentralizedtrust/splice-pulumi-common/src/config';
-import { clusterSubConfig } from 'splice-pulumi-common/src/config/configLoader';
+import { clusterSubConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/configLoader';
 import { z } from 'zod';
 
 export const ValidatorNodeConfigSchema = z.object({

--- a/cluster/pulumi/common/package.json
+++ b/cluster/pulumi/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "splice-pulumi-common",
+  "name": "@lfdecentralizedtrust/splice-pulumi-common",
   "version": "1.0.0",
   "main": "src/index.ts",
   "dependencies": {

--- a/cluster/pulumi/common/src/config/networkWideConfig.ts
+++ b/cluster/pulumi/common/src/config/networkWideConfig.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { clusterYamlConfig } from 'splice-pulumi-common/src/config/configLoader';
+import { clusterYamlConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/configLoader';
 import { z } from 'zod';
 
 // Network wide configuration expected to be shared by all nodes.

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -78,7 +78,7 @@
             }
         },
         "common": {
-            "name": "splice-pulumi-common",
+            "name": "@lfdecentralizedtrust/splice-pulumi-common",
             "version": "1.0.0",
             "dependencies": {
                 "@google-cloud/storage": "^6.11.0",
@@ -7897,10 +7897,6 @@
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
             "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
-        },
-        "node_modules/splice-pulumi-common": {
-            "resolved": "common",
-            "link": true
         },
         "node_modules/sprintf-js": {
             "version": "1.1.3",


### PR DESCRIPTION
How does anything even work?!
We're importing it as `@lfdecentralizedtrust/splice-pulumi-common` all over the place...

cluster test: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/32144/workflows/38b20ad1-4feb-4316-9d5a-cec3ef06eb1c

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
