### PR TITLE
Override base versions for ciperiodic tests

### DIFF
--- a/build-tools/find_latest_base_version.sh
+++ b/build-tools/find_latest_base_version.sh
@@ -5,6 +5,7 @@
 
 set -euo pipefail
 
-
-latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
-echo "release-line-${latest_release}"
+# TODO(DACH-NY/canton-network-internal#1735) revert back to LATEST_RELEASE once that is 0.4.18
+# latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
+# echo "release-line-${latest_release}"
+echo "release-line-0.4.18-snapshot.20250918.919.0.v461bbb85"

--- a/build-tools/find_latest_hard_migration_base_version.sh
+++ b/build-tools/find_latest_hard_migration_base_version.sh
@@ -8,5 +8,7 @@
 
 set -euo pipefail
 
-latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
-echo "release-line-${latest_release}"
+# TODO(DACH-NY/canton-network-internal#1735) revert back to LATEST_RELEASE once that is 0.4.18
+# latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
+# echo "release-line-${latest_release}"
+echo "release-line-0.4.18-snapshot.20250918.919.0.v461bbb85"


### PR DESCRIPTION
This is a branch off of the merge commit of #2262

(Didn't want to go through backport hell, so with this we always upgrade/migrate from a network that also has DA-1.)

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
