### PR TITLE
backport to a weird branch: Fix override order of approved SV identities (#2332)

### DIFF
--- a/cluster/configs/configs/configs/TestNet/approved-sv-id-values.yaml
+++ b/cluster/configs/configs/configs/TestNet/approved-sv-id-values.yaml
@@ -13,3 +13,7 @@ approvedSvIdentities:
         weight: 100000
       - beneficiary: "Broadridge-validator-1::1220c89a73e7b47f16dfb48a521eeedfe2a8620ea1b19b815ab427388d9f5427faa5"
         weight: 50000
+  - name: Digital-Asset-1
+    publicKey: THIS_IS_THE_WRONG_KEY
+    # this is the right reward weight though
+    rewardWeightBps: 150000

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1235,7 +1235,7 @@
             },
             "approvedSvIdentities": {
               "type": "md5",
-              "value": "7dc4e6604e5b8d704a0ad2994ac501ff"
+              "value": "5871224b744b45122540483fddbd550f"
             }
           },
           "network": "test",
@@ -1649,7 +1649,7 @@
           {
             "name": "Digital-Asset-1",
             "publicKey": "svda1-id-public-key",
-            "rewardWeightBps": 10000
+            "rewardWeightBps": 150000
           }
         ],
         "auth": {
@@ -2076,7 +2076,7 @@
             },
             "approvedSvIdentities": {
               "type": "md5",
-              "value": "7dc4e6604e5b8d704a0ad2994ac501ff"
+              "value": "5871224b744b45122540483fddbd550f"
             }
           },
           "network": "test",
@@ -2490,7 +2490,7 @@
           {
             "name": "Digital-Asset-1",
             "publicKey": "svda1-id-public-key",
-            "rewardWeightBps": 10000
+            "rewardWeightBps": 150000
           }
         ],
         "auth": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -777,6 +777,11 @@
             "name": "SV2",
             "publicKey": "PUBLIC_KEY_2==",
             "rewardWeightBps": 150000
+          },
+          {
+            "name": "Digital-Asset-1",
+            "publicKey": "THIS_IS_THE_WRONG_KEY",
+            "rewardWeightBps": 150000
           }
         ],
         "auth": {

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -296,6 +296,7 @@ async function installSvAndValidator(
     participantIdentitiesDumpImport: participantBootstrapDumpSecret
       ? { secretName: participantBootstrapDumpSecretName }
       : undefined,
+    // TODO(tech-debt): it's a bit confusing: we *only* approve from approved-sv-identities files here (so no "local" SV overrides)
     approvedSvIdentities: approvedSvIdentities(),
     domain: {
       ...(valuesFromYamlFile.domain || {}),


### PR DESCRIPTION
Backports https://github.com/hyperledger-labs/splice/pull/2332 to the branch we currently use as a base branch for ciperiodic upgrade and hdm tests.

Will wait for cimain confirmation that this fixes things before clicking merge.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
