### PR TITLE
BQ: add function for stats for finance

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
@@ -70,9 +70,9 @@ class ScanTotalSupplyBigQueryIntegrationTest
   private val mintedUnclaimedsAmount = BigDecimal(0)
   private val mintedAmount =
     mintedAppRewardsAmount + mintedValidatorRewardsAmount + mintedSvRewardsAmount + mintedUnclaimedsAmount
-  private val aliceValidatorMintedAmount = BigDecimal("26046.0426105176")
+  private val aliceValidatorMintedAmount = BigDecimal("26051.7503805176")
   private val lockedAmount = BigDecimal("5000")
-  private val burnedAmount = BigDecimal("60032.83108")
+  private val burnedAmount = BigDecimal("60010")
   private val unlockedAmount = mintedAmount - lockedAmount - burnedAmount
   private val unmintedAmount = BigDecimal("570776.255709163")
   private val amuletHolders = 5
@@ -530,7 +530,7 @@ class ScanTotalSupplyBigQueryIntegrationTest
     // The TPS query assumes staleness of up to 4 hours, so we query for stats 5 hours after the current ledger time.
     val timestamp = getLedgerTime.toInstant.plus(5, ChronoUnit.HOURS).toString
     val sql =
-      s"SELECT * FROM `$project.$functionsDatasetName.all_stats`('$timestamp', 0);"
+      s"SELECT * FROM `$project.$functionsDatasetName.all_dashboard_stats`('$timestamp', 0);"
 
     logger.info(s"Querying all stats as of $timestamp")
 


### PR DESCRIPTION
Have been focusing on the dashboards for a while, but the finance folks just asked for stats again, so giving their queries some love too. Goal: support a dashboard where they can insert an arbitrary record time and get all the "finance-related" stats for it:

<img width="754" height="746" alt="Screenshot from 2025-09-18 21-52-53" src="https://github.com/user-attachments/assets/89b23db5-3af3-4116-bb76-baac1528c264" />

Side contribution: also fixes https://github.com/DACH-NY/cn-test-failures/issues/5589

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
