### PR TITLE
BQ: add up_to_date column to all_data view

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery_functions.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery_functions.ts
@@ -839,7 +839,9 @@ const daily_unminted = new BQLogicalView(
 const all_data = new BQLogicalView(
   'all_data',
   `
-    SELECT *
+    SELECT
+      *,
+      DATE_SUB(DATE(computed.as_of_record_time), INTERVAL 1 DAY) AS up_to_date
     FROM
         \`$$DASHBOARDS_DATASET$$.dashboards-data\` computed
         JOIN \`$$DASHBOARDS_DATASET$$.monthly_burn\` monthly_burn


### PR DESCRIPTION
Since we compute all stats as of 00:00, the as_of_record time of Sept 21 actually summarizes Sept 20. We keep getting confused on that in the dashboards, so I decided to just add another column that's one day earlier, and use that as the X axis. So now the data labeled Sept 20 actually summarizes Sept 20.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
