### PR TITLE
Use TokenMetadata totalSupply in Scan's total amulet

### DIFF
--- a/apps/app/src/test/resources/frontend-config.jsonnet
+++ b/apps/app/src/test/resources/frontend-config.jsonnet
@@ -72,6 +72,7 @@ local validatorNodes(clusterProtocol, clusterAddress, port) = {
   },
   scan: {
     scan: { url: 'http://localhost:5012/api/scan' },
+    tokenMetadata: { url: 'http://localhost:5012' },
   },
   sv1: {
     sv: { url: 'http://localhost:5114/api/sv' },

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -36,6 +36,20 @@
         "xunit-viewer": "^10.6.1"
       }
     },
+    "../token-standard/splice-api-token-metadata-v1/openapi-ts-client": {
+      "name": "@lfdecentralizedtrust/token-metadata-openapi",
+      "version": "1.0.0",
+      "license": "Unlicense",
+      "dependencies": {
+        "es6-promise": "^4.2.4",
+        "url-parse": "^1.4.3",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/url-parse": "1.4.4",
+        "typescript": "^4.0"
+      }
+    },
     "ans/frontend": {
       "name": "@lfdecentralizedtrust/splice-ans-frontend",
       "version": "0.1.0",
@@ -2436,6 +2450,10 @@
     },
     "node_modules/@lfdecentralizedtrust/sv-openapi": {
       "resolved": "sv/openapi-ts-client",
+      "link": true
+    },
+    "node_modules/@lfdecentralizedtrust/transfer-instruction-openapi": {
+      "resolved": "../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
       "link": true
     },
     "node_modules/@lfdecentralizedtrust/validator-openapi": {
@@ -12564,6 +12582,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@lfdecentralizedtrust/splice-common-frontend": "0.1.0",
+        "@lfdecentralizedtrust/transfer-instruction-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
         "@mui/icons-material": "5.11.9",
         "@mui/material": "^5.17.1",
         "@tanstack/react-query": "5.72.2",

--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -2452,7 +2452,7 @@
       "resolved": "sv/openapi-ts-client",
       "link": true
     },
-    "node_modules/@lfdecentralizedtrust/transfer-instruction-openapi": {
+    "node_modules/@lfdecentralizedtrust/token-metadata-openapi": {
       "resolved": "../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
       "link": true
     },
@@ -12582,7 +12582,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@lfdecentralizedtrust/splice-common-frontend": "0.1.0",
-        "@lfdecentralizedtrust/transfer-instruction-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
+        "@lfdecentralizedtrust/token-metadata-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
         "@mui/icons-material": "5.11.9",
         "@mui/material": "^5.17.1",
         "@tanstack/react-query": "5.72.2",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@lfdecentralizedtrust/transfer-instruction-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
     "@lfdecentralizedtrust/splice-common-frontend": "0.1.0",
     "@mui/icons-material": "5.11.9",
     "@mui/material": "^5.17.1",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@lfdecentralizedtrust/transfer-instruction-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
+    "@lfdecentralizedtrust/token-metadata-openapi": "file:../../../token-standard/splice-api-token-metadata-v1/openapi-ts-client",
     "@lfdecentralizedtrust/splice-common-frontend": "0.1.0",
     "@mui/icons-material": "5.11.9",
     "@mui/material": "^5.17.1",

--- a/apps/scan/frontend/public/config.js
+++ b/apps/scan/frontend/public/config.js
@@ -7,6 +7,10 @@ window.splice_config = {
       // Edit this to the cluster you're trying to connect on.
       url: 'https://scan.sv-2.TARGET_HOSTNAME/api/scan',
     },
+    tokenMetadata: {
+      // Same as scan, '/registry' is already included in the openapi definitions
+      url: 'https://scan.sv-2.TARGET_HOSTNAME',
+    },
   },
   spliceInstanceNames: {
     networkName: 'Splice',

--- a/apps/scan/frontend/src/App.tsx
+++ b/apps/scan/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import ScanValidatorLicenses from './routes/scanValidatorLicenses';
 import ValidatorFaucetsLeaderboard from './routes/validatorFaucetsLeaderboard';
 import ValidatorLeaderboard from './routes/validatorLeaderboard';
 import { useConfigPollInterval, useScanConfig } from './utils';
+import { TokenMetadataClientProvider } from './api/TokenMetadataClientContext';
 
 const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
   const config = useScanConfig();
@@ -46,10 +47,12 @@ const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   return (
     <ScanClientProvider url={config.services.scan.url}>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools initialIsOpen={false} />
-        <ScanAppVotesHooksProvider>{children}</ScanAppVotesHooksProvider>
-      </QueryClientProvider>
+      <TokenMetadataClientProvider url={config.services.tokenMetadata.url}>
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools initialIsOpen={false} />
+          <ScanAppVotesHooksProvider>{children}</ScanAppVotesHooksProvider>
+        </QueryClientProvider>
+      </TokenMetadataClientProvider>
     </ScanClientProvider>
   );
 };

--- a/apps/scan/frontend/src/__tests__/setup/config.ts
+++ b/apps/scan/frontend/src/__tests__/setup/config.ts
@@ -10,6 +10,10 @@ const config = {
       // Edit this to the cluster you're trying to connect on.
       url: 'https://scan.sv-2.TARGET_HOSTNAME/api/scan',
     },
+    tokenMetadata: {
+      // Same as scan, '/registry' is already included in the openapi definitions
+      url: 'https://scan.sv-2.TARGET_HOSTNAME',
+    },
   },
   spliceInstanceNames: {
     amuletName: 'Teluma',

--- a/apps/scan/frontend/src/api/TokenMetadataClientContext.tsx
+++ b/apps/scan/frontend/src/api/TokenMetadataClientContext.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as openapi from '@lfdecentralizedtrust/token-metadata-openapi';
+import { OpenAPILoggingMiddleware } from '@lfdecentralizedtrust/splice-common-frontend-utils';
+import React, { useContext, useMemo } from 'react';
+
+const TokenMetadataClientContext = React.createContext<openapi.DefaultApi | undefined>(undefined);
+
+// Scan serves TokenMetadata
+export interface ScanConfigProps {
+  url: string;
+}
+
+export const TokenMetadataClientProvider: React.FC<React.PropsWithChildren<ScanConfigProps>> = ({
+  url,
+  children,
+}) => {
+  const client: openapi.DefaultApi | undefined = useMemo(() => {
+    const configuration = openapi.createConfiguration({
+      baseServer: new openapi.ServerConfiguration(url, {}),
+      promiseMiddleware: [new OpenAPILoggingMiddleware('TokenMetadata')],
+    });
+
+    return new openapi.DefaultApi(configuration);
+  }, [url]);
+
+  return (
+    <TokenMetadataClientContext.Provider value={client}>
+      {children}
+    </TokenMetadataClientContext.Provider>
+  );
+};
+
+export const useTokenMetadataClient: () => openapi.DefaultApi = () => {
+  const client = useContext<openapi.DefaultApi | undefined>(TokenMetadataClientContext);
+  if (!client) {
+    throw new Error('TokenMetadata client not initialized');
+  }
+  return client;
+};

--- a/apps/scan/frontend/src/components/AmountSummary.tsx
+++ b/apps/scan/frontend/src/components/AmountSummary.tsx
@@ -1,23 +1,31 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AmountDisplay } from '@lfdecentralizedtrust/splice-common-frontend';
+import { AmountDisplay, DateDisplay } from '@lfdecentralizedtrust/splice-common-frontend';
 import BigNumber from 'bignumber.js';
 
-import { Card, CardContent, Typography } from '@mui/material';
+import { Card, CardContent, Stack, Typography } from '@mui/material';
 
 const NetworkTotal: React.FC<{
   title: string;
   amount: BigNumber;
+  asOf?: Date;
   idCC: string;
   idUSD: string;
   amuletPrice: BigNumber;
-}> = ({ title, amount, idCC, idUSD, amuletPrice }) => {
+}> = ({ title, amount, asOf, idCC, idUSD, amuletPrice }) => {
   return (
     <Card>
       <CardContent>
-        <Typography variant="h5" textTransform="uppercase" fontWeight="700" mb={2}>
-          {title}
-        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Typography variant="h5" textTransform="uppercase" fontWeight="700" mb={2}>
+            {title}
+          </Typography>
+          {asOf ? (
+            <Typography>
+              as of <DateDisplay datetime={asOf} />
+            </Typography>
+          ) : null}
+        </Stack>
         <Typography variant="h1" mb={1} id={idCC} data-testid="amulet-circulating-supply">
           <AmountDisplay amount={amount} currency="AmuletUnit" />
         </Typography>

--- a/apps/scan/frontend/src/components/TotalAmuletBalance.tsx
+++ b/apps/scan/frontend/src/components/TotalAmuletBalance.tsx
@@ -1,40 +1,45 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ErrorDisplay, Loading } from '@lfdecentralizedtrust/splice-common-frontend';
-import {
-  useAmuletPrice,
-  useTotalAmuletBalance,
-} from '@lfdecentralizedtrust/splice-common-frontend/scan-api';
+import { useAmuletPrice } from '@lfdecentralizedtrust/splice-common-frontend/scan-api';
 import BigNumber from 'bignumber.js';
 
 import { useScanConfig } from '../utils/config';
 import AmountSummary from './AmountSummary';
+import { useAmuletMetadata } from '../hooks/useAmuletMetadata';
 
 export const TotalAmuletBalance: React.FC = () => {
   const config = useScanConfig();
-  const totalAmuletBalanceQuery = useTotalAmuletBalance();
+  const amuletMetadataQuery = useAmuletMetadata();
   const amuletPriceQuery = useAmuletPrice();
 
-  const isLoading = totalAmuletBalanceQuery.isLoading || amuletPriceQuery.isLoading;
-  const isError = totalAmuletBalanceQuery.isError || amuletPriceQuery.isError;
+  const isLoading = amuletMetadataQuery.isLoading || amuletPriceQuery.isLoading;
+  const isError = amuletMetadataQuery.isError || amuletPriceQuery.isError;
   const isDataUndefined =
-    totalAmuletBalanceQuery.data === undefined || amuletPriceQuery.data === undefined;
+    amuletMetadataQuery.data === undefined ||
+    !amuletMetadataQuery.data.totalSupply ||
+    amuletPriceQuery.data === undefined;
   const title = `Total Circulating ${config.spliceInstanceNames.amuletName}`;
 
-  return isLoading ? (
-    <Loading />
-  ) : isError || isDataUndefined ? (
-    <ErrorDisplay message={'Could not retrieve total amulet balance or amulet price'} />
-  ) : (
-    <AmountSummary
-      title={title}
-      amount={new BigNumber(totalAmuletBalanceQuery.data.total_balance)}
-      idCC="total-amulet-balance-amulet"
-      idUSD="total-amulet-balance-usd"
-      amuletPrice={amuletPriceQuery.data}
-      data-testid="amount-summary"
-    />
-  );
+  if (isLoading) {
+    return <Loading />;
+  } else if (isError || isDataUndefined) {
+    return <ErrorDisplay message={'Could not retrieve total amulet balance or amulet price'} />;
+  } else {
+    const totalSupply = new BigNumber(amuletMetadataQuery.data.totalSupply || '0');
+    const asOf = amuletMetadataQuery.data?.totalSupplyAsOf;
+    return (
+      <AmountSummary
+        title={title}
+        amount={totalSupply}
+        asOf={asOf}
+        idCC="total-amulet-balance-amulet"
+        idUSD="total-amulet-balance-usd"
+        amuletPrice={amuletPriceQuery.data}
+        data-testid="amount-summary"
+      />
+    );
+  }
 };
 
 export default TotalAmuletBalance;

--- a/apps/scan/frontend/src/hooks/useAmuletMetadata.tsx
+++ b/apps/scan/frontend/src/hooks/useAmuletMetadata.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTokenMetadataClient } from '../api/TokenMetadataClientContext';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { Instrument } from '@lfdecentralizedtrust/token-metadata-openapi';
+
+export const useAmuletMetadata = (): UseQueryResult<Instrument> => {
+  const metadataClient = useTokenMetadataClient();
+  return useQuery({
+    queryKey: ['useAmuletMetadata'],
+    queryFn: async () => {
+      return await metadataClient.getInstrument('Amulet');
+    },
+  });
+};

--- a/apps/scan/frontend/src/utils/config.tsx
+++ b/apps/scan/frontend/src/utils/config.tsx
@@ -13,6 +13,7 @@ import { z } from 'zod';
 
 type ScanServicesConfig = {
   scan: z.infer<typeof serviceSchema>;
+  tokenMetadata: z.infer<typeof serviceSchema>;
 };
 
 type ScanConfig = {
@@ -24,6 +25,7 @@ type ScanConfig = {
 const configScheme = z.object({
   services: z.object({
     scan: serviceSchema,
+    tokenMetadata: serviceSchema,
   }),
   spliceInstanceNames: spliceInstanceNamesSchema,
   pollInterval: pollIntervalSchema,

--- a/cluster/images/scan-web-ui/config.js
+++ b/cluster/images/scan-web-ui/config.js
@@ -4,6 +4,10 @@ window.splice_config = {
       // URL of scan backend.
       url: "https://" + window.location.host + "/api/scan",
     },
+    tokenMetadata: {
+      // Same as scan, '/registry' is already included in the openapi definitions
+      url: "https://" + window.location.host,
+    },
   },
   pollInterval: "${SPLICE_APP_UI_POLL_INTERVAL}",
   spliceInstanceNames: {

--- a/party-allocator/package-lock.json
+++ b/party-allocator/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "../token-standard/splice-api-token-transfer-instruction-v1/openapi-ts-client": {
-      "name": "transfer-instruction-openapi",
+      "name": "@lfdecentralizedtrust/transfer-instruction-openapi",
       "version": "1.0.0",
       "dev": true,
       "license": "Unlicense",


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice/issues/2254

<img width="1861" height="240" alt="image" src="https://github.com/user-attachments/assets/f4bf6f3e-ce89-4aef-9afd-ca054f74452b" />

This excludes holding fees _when using the ACS snapshot version_, as per the BE implmenetation: https://github.com/hyperledger-labs/splice/blob/42d13e343f7584603c7b41b6621e0f94e9f2d7c2/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpTokenStandardMetadataHandler.scala#L100

Therefore, there is no need to use the feature support endpoint for this change, as the response already contains the right data.