### PR TITLE
Fix broken token-standard sanity plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1141,6 +1141,9 @@ lazy val `apps-common-frontend` = {
       `apps-wallet`,
       `apps-splitwell`,
       `apps-validator`,
+      // token-standard-cli are not "real" dependencies,
+      // but rather they prevent npm install from being executed concurrently and breaking everything
+      `token-standard-cli`,
     )
     .settings(
       // daml typescript code generation settings:
@@ -1156,7 +1159,7 @@ lazy val `apps-common-frontend` = {
           (`splice-api-token-allocation-request-v1-daml` / Compile / damlBuild).value,
       damlTsCodegenDir := baseDirectory.value / "daml.js",
       damlTsCodegen := BuildCommon.damlTsCodegenTask.value,
-      npmInstallDeps := (baseDirectory.value / "package.json" +: damlTsCodegen.value) ++ (`splice-api-token-metadata-v1-daml` / Compile / npmInstall).value,
+      npmInstallDeps := (baseDirectory.value / "package.json" +: damlTsCodegen.value) ++ (`splice-api-token-metadata-v1-daml` / Compile / npmInstall).value ++ (`token-standard-cli` / Compile / npmInstall).value,
       npmInstallOpenApiDeps :=
         Seq(
           (

--- a/project/BuildCommon.scala
+++ b/project/BuildCommon.scala
@@ -21,6 +21,8 @@ import xsbti.compile.CompileAnalysis
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{headerResources, headerSources}
 import CantonDependencies.daml_ledger_api_value_proto
 
+import java.util.concurrent.atomic.AtomicInteger
+
 object BuildCommon {
 
   object defs {
@@ -1588,6 +1590,8 @@ object BuildCommon {
     cache(dars.toSet).toSeq
   }
 
+  val id = new AtomicInteger(0)
+
   /** Runs npm-install.sh script, which in turn runs 'npm install' in a dev environment, or
     * 'npm ci' in ci. The source package.json file should be specified in pkg. Rerunning this
     * task will re-execute 'npm install' only if the package file has been modified.
@@ -1601,12 +1605,15 @@ object BuildCommon {
     val cacheDir = streams.value.cacheDirectory / "npmInstall"
     val cache =
       FileFunction.cached(cacheDir, FileInfo.hash) { _ =>
+        val i = id.getAndIncrement()
+        println(s"NPM INSTALL FOR ${npmRootDir.value} CALLED. ID $i")
         BuildUtil.runCommandWithRetries(
           Seq(npmInstallScript.getAbsolutePath),
           log,
           None,
           Some(npmRootDir.value),
         )
+        println(s"NPM INSTALL FOR ${npmRootDir.value} FINISHED. ID $i")
         Set(npmRootDir.value / "node_modules")
       }
     val openApiPackageJsons = openApiPkgs.flatMap { case (_, baseDir, hasExternalSpec) =>


### PR DESCRIPTION
...by losing my sanity

I have seen it run concurrently between both and I don't trust npm does a sensible thing anymore.
It could also just be that token-standard's npm install just never ran, so the logs will help me debug it on CI.