### PR TITLE
Ensure token-standard-cli is npm-installed before running tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1897,6 +1897,8 @@ lazy val `apps-app`: Project =
       `canton-community-base`,
       `canton-community-integration-testing` % "test",
       `splice-util-featured-app-proxies-daml` % "test",
+      // necessary for token-standard-cli to get `npm install`ed so that TokenStandardCliSanityCheckPlugin can run
+      `apps-common-frontend`,
     )
     .settings(
       libraryDependencies += "org.scalatestplus" %% "selenium-4-12" % "3.2.17.0" % "test",


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5715 for sure totally 100% this time's the good one let's go yeah