### PR TITLE
Upgrade lnav to 0.13.2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -18,12 +18,12 @@ use_flake_subdir() {
 [[ -f .envrc.private ]] && [[ -z "$IGNORE_PRIVATE_ENVRC" ]] && source_env .envrc.private || true
 
 # TODO(DACH-NY/canton-network-node#3876) work around for $TMPDIR is removed. #3876 to investigate more
-OLD_TMPDIR=$TMPDIR
+OLD_TMPDIR=${TMPDIR-unset}
 
 use flake_subdir
 
 # TODO(DACH-NY/canton-network-node#3876) work around for $TMPDIR is removed. #3876 to investigate more
-export TMPDIR=$OLD_TMPDIR
+[ $OLD_TMPDIR != "unset" ] && export TMPDIR=$OLD_TMPDIR
 
 source_env .envrc.vars
 

--- a/nix/lnav.nix
+++ b/nix/lnav.nix
@@ -3,16 +3,16 @@
 # so we use the binary distribution that ships with a compatible pcre version.
 stdenv.mkDerivation rec {
   name = "lnav";
-  version = "0.12.0";
+  version = "0.13.2";
 
   src =
     if stdenv.isDarwin then
       fetchzip {
         url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-x86_64-macos.zip";
-        sha256 = "sha256-3+mpfqSu1KigrBrnVZ1s9/9da4tce7xQUgWcmdH9//k=";
+        sha256 = "sha256-xUGgn8hIgRV2UY+tZZdpixj/8k5FygYfiWlGlfQ6iiY=";
       } else fetchzip {
         url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-linux-musl-x86_64.zip";
-        sha256 = "sha256-dr1nkOCOyzLq6eP/s2lK2UvpWNe7WIo6v4QF+riVtEo=";
+        sha256 = "sha256-OP9s1Rbc/vKcQ/Tagsb84y8vHt3R0b0/Y79bqcX9G3k=";
       };
 
   installPhase = ''


### PR DESCRIPTION
[static]

I've run it for a bit locally now and it seems to work a bit better for me than the old one (fewer crashes and lockups, maybe a bit faster).

The tmpdir fix just makes sure that if tmpdir is not set it doesn't end up being set to an empty string. Copy pasted from Canton.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
