### PR TITLE
Reduce complexity in a Governance test

### DIFF
--- a/apps/sv/frontend/src/__tests__/sv.test.tsx
+++ b/apps/sv/frontend/src/__tests__/sv.test.tsx
@@ -176,7 +176,6 @@ describe('An SetConfig request', () => {
       await user.click(screen.getByText('Governance'));
 
       expect(await screen.findByText('Vote Requests')).toBeDefined();
-      expect(await screen.findByText('Governance')).toBeDefined();
 
       changeAction('CRARC_SetConfig');
 
@@ -198,8 +197,7 @@ describe('An SetConfig request', () => {
         'A Vote Request aiming to change similar fields already exists. ' +
           'You are therefore not allowed to modify the fields: transferConfig.createFee.fee'
       );
-
-      const button = screen.getByRole('button', { name: 'Send Request to Super Validators' });
+      const button = screen.getByTestId('create-voterequest-submit-button');
       expect(button.getAttribute('disabled')).toBeDefined();
     }
   );


### PR DESCRIPTION
Fixes [#5748](https://github.com/DACH-NY/cn-test-failures/issues/5748).

Changing `screen.getByRole` to `screen.getByTestId` speeds up the test by around 0.5s on my local machine and makes it faster than 
```An SetConfig request > displays a warning when an SV tries to modify a DsoRules field already changed by another request```
and 
```An SetConfig request > disables the Proceed button in the confirmation dialog if a conflict arises after request creation``` 
Which means _this particular test_ should not flake anymore

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
