### PR TITLE
Fix user rights decoding in Java bindings

### DIFF
--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/admin/api/client/data/UserManagement.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/admin/api/client/data/UserManagement.scala
@@ -69,9 +69,14 @@ object UserRights {
         acc.copy(actAs = acc.actAs + PartyId.tryFromProtoPrimitive(value.party))
       case (acc, Kind.CanReadAs(value)) =>
         acc.copy(readAs = acc.readAs + PartyId.tryFromProtoPrimitive(value.party))
+      // irrelevant for splice
+      case (acc, Kind.CanExecuteAs(_)) =>
+        ???
       case (acc, Kind.IdentityProviderAdmin(_)) =>
         acc.copy(identityProviderAdmin = true)
       case (acc, Kind.CanReadAsAnyParty(_)) => acc.copy(readAsAnyParty = true)
+      // irrelevant for splice
+      case (acc, Kind.CanExecuteAsAnyParty(_)) => ???
     })
 }
 

--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/User.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/User.java
@@ -90,6 +90,9 @@ public final class User {
         case CAN_READ_AS:
           right = new CanReadAs(proto.getCanReadAs().getParty());
           break;
+        case CAN_EXECUTE_AS:
+          right = new CanExecuteAs(proto.getCanExecuteAs().getParty());
+          break;
         case PARTICIPANT_ADMIN:
           // since this is a singleton so far we simply ignore the actual object
           right = ParticipantAdmin.INSTANCE;
@@ -101,6 +104,10 @@ public final class User {
         case CAN_READ_AS_ANY_PARTY:
           // since this is a singleton so far we simply ignore the actual object
           right = CanReadAsAnyParty.INSTANCE;
+          break;
+        case CAN_EXECUTE_AS_ANY_PARTY:
+          // since this is a singleton so far we simply ignore the actual object
+          right = CanExecuteAsAnyParty.INSTANCE;
           break;
         default:
           throw new IllegalArgumentException("Unrecognized user right case: " + kindCase.name());
@@ -170,6 +177,22 @@ public final class User {
       }
     }
 
+    public static final class CanExecuteAs extends Right {
+      public final String party;
+
+      public CanExecuteAs(String party) {
+        this.party = party;
+      }
+
+      @Override
+      UserManagementServiceOuterClass.Right toProto() {
+        return UserManagementServiceOuterClass.Right.newBuilder()
+            .setCanExecuteAs(
+                UserManagementServiceOuterClass.Right.CanExecuteAs.newBuilder().setParty(this.party))
+            .build();
+      }
+    }
+
     public static final class CanReadAsAnyParty extends Right {
       // empty private constructor, singleton object
       private CanReadAsAnyParty() {}
@@ -181,6 +204,21 @@ public final class User {
         return UserManagementServiceOuterClass.Right.newBuilder()
             .setCanReadAsAnyParty(
                 UserManagementServiceOuterClass.Right.CanReadAsAnyParty.getDefaultInstance())
+            .build();
+      }
+    }
+
+    public static final class CanExecuteAsAnyParty extends Right {
+      // empty private constructor, singleton object
+      private CanExecuteAsAnyParty() {}
+      // not built lazily on purpose, close to no overhead here
+      public static final CanExecuteAsAnyParty INSTANCE = new CanExecuteAsAnyParty();
+
+      @Override
+      UserManagementServiceOuterClass.Right toProto() {
+        return UserManagementServiceOuterClass.Right.newBuilder()
+            .setCanExecuteAsAnyParty(
+                UserManagementServiceOuterClass.Right.CanExecuteAsAnyParty.getDefaultInstance())
             .build();
       }
     }

--- a/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto
+++ b/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto
@@ -124,6 +124,14 @@ message Right {
     string party = 1;
   }
 
+  message CanExecuteAs {
+    // The right to prepare and execute submissions as this party.
+    // This right does not entitle the user to perform any reads.
+    // If reading is required, a separate ReadAs right must be added.
+    // Right to execute as a party is also implicitly contained in the CanActAs right.
+    string party = 1;
+  }
+
   // The right to administer the identity provider that the user is assigned to.
   // It means, being able to manage users and parties that are also assigned
   // to the same identity provider.
@@ -133,6 +141,11 @@ message Right {
   // feeding external tools, such as PQS, continually without the need to change subscriptions
   // as new parties pop in and out of existence.
   message CanReadAsAnyParty {}
+
+  // The rights of a user to prepare and execute transactions as any party.
+  // Its utility is predominantly for users that perform interactive submissions
+  // on behalf of many parties.
+  message CanExecuteAsAnyParty {}
 
   // Required
   oneof kind {
@@ -146,6 +159,10 @@ message Right {
     IdentityProviderAdmin identity_provider_admin = 4;
     // The user can read as any party on a participant
     CanReadAsAnyParty can_read_as_any_party = 5;
+    // The user can prepare and execute submissions as a specific party.
+    CanExecuteAs can_execute_as = 6;
+    // The user can prepare and execute submissions as any party on a participant.
+    CanExecuteAsAnyParty can_execute_as_any_party = 7;
   }
 }
 

--- a/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/ApiUserManagementService.scala
+++ b/canton/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/platform/apiserver/services/admin/ApiUserManagementService.scala
@@ -566,6 +566,14 @@ private[apiserver] final class ApiUserManagementService(
       case proto.Right(_: proto.Right.Kind.CanReadAsAnyParty) =>
         Right(UserRight.CanReadAsAnyParty)
 
+      // irrelevant for splice
+      case proto.Right(_: proto.Right.Kind.CanExecuteAsAnyParty) =>
+        ???
+
+      // irrelevant for splice
+      case proto.Right(proto.Right.Kind.CanExecuteAs(_)) =>
+        ???
+
       case proto.Right(proto.Right.Kind.Empty) =>
         Left(
           RequestValidationErrors.InvalidArgument

--- a/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/client/services/admin/UserManagementClient.scala
+++ b/canton/community/ledger/ledger-common/src/main/scala/com/digitalasset/canton/ledger/client/services/admin/UserManagementClient.scala
@@ -207,6 +207,10 @@ object UserManagementClient {
       Some(UserRight.CanReadAs(Ref.Party.assertFromString(x.party)))
     case proto.Right(proto.Right.Kind.CanReadAsAnyParty(_)) =>
       Some(UserRight.CanReadAsAnyParty)
+    // irrelevant for splice
+    case proto.Right(proto.Right.Kind.CanExecuteAsAnyParty(_)) => ???
+    // irrelevant for splice
+    case proto.Right(proto.Right.Kind.CanExecuteAs(_)) => ???
     case proto.Right(proto.Right.Kind.Empty) =>
       None // The server sent a right of a kind that this client doesn't know about.
   }

--- a/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/JsUserManagementService.scala
+++ b/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/JsUserManagementService.scala
@@ -303,12 +303,15 @@ object JsUserManagementCodecs {
     deriveRelaxedCodec
   implicit val canActAs: Codec[user_management_service.Right.CanActAs] = deriveRelaxedCodec
   implicit val canReadAs: Codec[user_management_service.Right.CanReadAs] = deriveRelaxedCodec
+  implicit val canExecuteAs: Codec[user_management_service.Right.CanExecuteAs] = deriveRelaxedCodec
   implicit val rightKindidentityProviderAdminRW
       : Codec[user_management_service.Right.Kind.IdentityProviderAdmin] =
     deriveRelaxedCodec
   implicit val identityProviderAdmin: Codec[user_management_service.Right.IdentityProviderAdmin] =
     deriveRelaxedCodec
   implicit val canReadAsAnyPartyRW: Codec[user_management_service.Right.CanReadAsAnyParty] =
+    deriveRelaxedCodec
+  implicit val canExecuteAsAnyPartyRW: Codec[user_management_service.Right.CanExecuteAsAnyParty] =
     deriveRelaxedCodec
   implicit val kindCanActAsRW: Codec[user_management_service.Right.Kind.CanActAs] =
     deriveRelaxedCodec


### PR DESCRIPTION
[ci]

So what happens is:

1. Canton added support for CanExecuteAs.
2. Our validator app (and sv) call ListUserRights.
3. We grant CanExecuteAs rights in the party allocator to the validator operator.
4. The validator now crashes as the java bindings just fail on unknown user rights.

Will ofc port to Canton. The Canton tests for this don't seem to be in our fork so not adding tests for this in this PR.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
