### PR TITLE
Set image pull policy for runbook charts

### DIFF
--- a/cluster/pulumi/common/src/helm.ts
+++ b/cluster/pulumi/common/src/helm.ts
@@ -174,6 +174,7 @@ export function installSpliceRunbookHelmChartByNamespaceName(
           ...values,
           imageRepo: DOCKER_REPO,
           ...appsAffinityAndTolerations,
+          ...imagePullPolicy,
         },
         timeout,
         maxHistory: HELM_MAX_HISTORY_SIZE,


### PR DESCRIPTION
[static]

I spent far too much time trying to rebuild my image to get it to pick up the right one until I realized we use a different image pull policy for the runbooks than for everything else. This only matters for local development, for everything else we use ifPresent anyway.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
