### PR TITLE
Bump vetting delay to 24h

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -336,7 +336,9 @@ case class SvAppBackendConfig(
     // distributed between 0 and the maximum delay) to ensure that not
     // all validators submit the transaction at the same time
     // overloading the network.
-    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
+    // 24h is chosen to be long enough to avoid a load spike (it's ~86k seconds so assuming it's 1 topology transaction/s on average for 86k validators)
+    // but short enough to allow for node downtime and other issues.
+    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(24),
     // `latestPackagesOnly=true` is intended for LocalNet testing only and is not supported in production
     latestPackagesOnly: Boolean = false,
     followAmuletConversionRateFeed: Option[AmuletConversionRateFeedConfig] = None,

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -206,7 +206,9 @@ case class ValidatorAppBackendConfig(
     // distributed between 0 and the maximum delay) to ensure that not
     // all validators submit the transaction at the same time
     // overloading the network.
-    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(1),
+    // 24h is chosen to be long enough to avoid a load spike (it's ~86k seconds so assuming it's 1 topology transaction/s on average for 86k validators)
+    // but short enough to allow for node downtime and other issues.
+    maxVettingDelay: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(24),
     // `latestPackagesOnly=true` is intended for LocalNet testing only and is not supported in production
     latestPackagesOnly: Boolean = false,
 ) extends SpliceBackendConfig // TODO(DACH-NY/canton-network-node#736): fork or generalize this trait.


### PR DESCRIPTION
Honestly kinda random. I do wonder if we can just set it to a week or even longer but in practice this seems long enough for this year at least given our validator scaling expectations.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
