### PR TITLE
Fix transfer instruction context endpoint when decoding the wrong template

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
@@ -28,7 +28,7 @@ class WalletPaymentIntegrationTest
 
       val nonExistentName = "does not exist"
       val errorString =
-        s"HTTP 404 Not Found GET at '/api/validator/v0/wallet/app-payment-requests/does%20not%20exist' on 127.0.0.1:5503. Command failed, message: contract id not found: ContractId(id = $nonExistentName"
+        s"HTTP 404 Not Found GET at '/api/validator/v0/wallet/app-payment-requests/does%20not%20exist' on 127.0.0.1:5503. Command failed, message: Contract id not found: ContractId(id = $nonExistentName"
 
       assertThrowsAndLogsCommandFailures(
         aliceWalletClient.getAppPaymentRequest(new AppPaymentRequest.ContractId(nonExistentName)),

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsIntegrationTest.scala
@@ -29,7 +29,7 @@ class WalletSubscriptionsIntegrationTest
 
       val nonExistentName = "does not exist"
       val errorString =
-        s"HTTP 404 Not Found GET at '/api/validator/v0/wallet/subscription-requests/does%20not%20exist' on 127.0.0.1:5503. Command failed, message: contract id not found: ContractId(id = $nonExistentName"
+        s"HTTP 404 Not Found GET at '/api/validator/v0/wallet/subscription-requests/does%20not%20exist' on 127.0.0.1:5503. Command failed, message: Contract id not found: ContractId(id = $nonExistentName"
 
       assertThrowsAndLogsCommandFailures(
         aliceWalletClient.getSubscriptionRequest(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
@@ -43,7 +43,6 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
 import com.google.protobuf.ByteString
 import io.circe.Json
-import io.grpc.Status
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.UpdateHistoryResponse
 
 import java.time.Instant
@@ -270,7 +269,7 @@ trait MultiDomainAcsStore extends HasIngestionSink with AutoCloseable with Named
   def destinationHistory: HistoryBackfilling.DestinationHistory[UpdateHistoryResponse]
 }
 
-object MultiDomainAcsStore {
+object MultiDomainAcsStore extends StoreErrors {
 
   sealed trait TxLogBackfillingState
   object TxLogBackfillingState {
@@ -839,11 +838,7 @@ object MultiDomainAcsStore {
   ): Future[A] =
     found.map { result =>
       result.getOrElse(
-        throw Status.NOT_FOUND
-          .withDescription(
-            show"contract id not found: ${PrettyContractId(companionClass.typeId(companion), id)}"
-          )
-          .asRuntimeException
+        throw contractIdNotFound(PrettyContractId(companionClass.typeId(companion), id))
       )
     }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/StoreErrors.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/StoreErrors.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.store
 
 import io.grpc.{Status, StatusRuntimeException}
+import org.lfdecentralizedtrust.splice.util.PrettyInstances.PrettyContractId
 
 trait StoreErrors {
   def roundNotAggregated(): StatusRuntimeException = {
@@ -12,6 +13,10 @@ trait StoreErrors {
 
   def txLogNotFound() = {
     Status.NOT_FOUND.withDescription("No matching log indices found").asRuntimeException
+  }
+
+  def contractIdNotFound(cid: PrettyContractId) = {
+    Status.NOT_FOUND.withDescription(s"Contract id not found: $cid").asRuntimeException
   }
 
   def txLogIsOfWrongType(name: String) = {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/StoreErrors.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/StoreErrors.scala
@@ -3,8 +3,9 @@
 
 package org.lfdecentralizedtrust.splice.store
 
+import cats.implicits.showInterpolator
 import io.grpc.{Status, StatusRuntimeException}
-import org.lfdecentralizedtrust.splice.util.PrettyInstances.PrettyContractId
+import org.lfdecentralizedtrust.splice.util.PrettyInstances.*
 
 trait StoreErrors {
   def roundNotAggregated(): StatusRuntimeException = {
@@ -16,7 +17,7 @@ trait StoreErrors {
   }
 
   def contractIdNotFound(cid: PrettyContractId) = {
-    Status.NOT_FOUND.withDescription(s"Contract id not found: $cid").asRuntimeException
+    Status.NOT_FOUND.withDescription(show"Contract id not found: ${cid}").asRuntimeException
   }
 
   def txLogIsOfWrongType(name: String) = {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -5,6 +5,7 @@ package org.lfdecentralizedtrust.splice.store.db
 
 import com.daml.ledger.javaapi.data.Identifier
 import com.daml.ledger.javaapi.data.codegen.ContractId
+import com.digitalasset.canton.ProtoDeserializationError.ValueConversionError
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.{ContractCompanion, ContractState}
 import org.lfdecentralizedtrust.splice.store.db.AcsQueries.{
@@ -339,7 +340,10 @@ object AcsQueries {
           createdAt.toInstant,
         )
         .fold(
-          err => throw new IllegalStateException(s"Stored a contract that cannot be decoded: $err"),
+          _ =>
+            throw io.grpc.Status.NOT_FOUND
+              .withDescription("Contract not found.")
+              .asRuntimeException(),
           identity,
         )
     }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -13,6 +13,7 @@ import com.google.protobuf.ByteString
 import io.circe.Json
 import io.grpc.Status
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.{ContractCompanion, ContractState}
+import org.lfdecentralizedtrust.splice.store.StoreErrors
 import org.lfdecentralizedtrust.splice.store.db.AcsQueries.{
   AcsStoreId,
   SelectFromAcsTableResult,
@@ -315,7 +316,7 @@ object AcsQueries {
       createdEventBlob: Array[Byte],
       createdAt: Timestamp,
       contractExpiresAt: Option[Timestamp],
-  ) {
+  ) extends StoreErrors {
     def toContract[C, TCId <: ContractId[_], T](companion: C)(implicit
         companionClass: ContractCompanion[C, TCId, T],
         decoder: TemplateJsonDecoder,
@@ -334,11 +335,9 @@ object AcsQueries {
         )
         .fold(
           _ =>
-            throw Status.NOT_FOUND
-              .withDescription(
-                s"contract id not found: ${PrettyContractId(companionClass.typeId(companion), contractId.contractId)}"
-              )
-              .asRuntimeException,
+            throw contractIdNotFound(
+              PrettyContractId(companionClass.typeId(companion), contractId.contractId)
+            ),
           identity,
         )
     }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -5,7 +5,6 @@ package org.lfdecentralizedtrust.splice.store.db
 
 import com.daml.ledger.javaapi.data.Identifier
 import com.daml.ledger.javaapi.data.codegen.ContractId
-import com.digitalasset.canton.ProtoDeserializationError.ValueConversionError
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.{ContractCompanion, ContractState}
 import org.lfdecentralizedtrust.splice.store.db.AcsQueries.{

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.javaapi.data.codegen.ContractId
 import com.digitalasset.canton.resource.DbStorage.Implicits.BuilderChain.toSQLActionBuilderChain
 import com.digitalasset.canton.resource.DbStorage.SQLActionBuilderChain
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
-import com.digitalasset.canton.util.ShowUtil.*
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.google.protobuf.ByteString
 import io.circe.Json
@@ -20,8 +19,8 @@ import org.lfdecentralizedtrust.splice.store.db.AcsQueries.{
   SelectFromAcsTableWithStateResult,
   SelectFromContractStateResult,
 }
-import org.lfdecentralizedtrust.splice.util.PrettyInstances.PrettyContractId
 import org.lfdecentralizedtrust.splice.util.*
+import org.lfdecentralizedtrust.splice.util.PrettyInstances.PrettyContractId
 import scalaz.{@@, Tag}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 import slick.jdbc.canton.SQLActionBuilder
@@ -337,7 +336,7 @@ object AcsQueries {
           _ =>
             throw Status.NOT_FOUND
               .withDescription(
-                show"contract id not found: ${PrettyContractId(companionClass.typeId(companion), contractId.contractId)}"
+                s"contract id not found: ${PrettyContractId(companionClass.typeId(companion), contractId.contractId)}"
               )
               .asRuntimeException,
           identity,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -21,7 +21,7 @@ import org.lfdecentralizedtrust.splice.store.db.AcsQueries.{
   SelectFromContractStateResult,
 }
 import org.lfdecentralizedtrust.splice.util.*
-import org.lfdecentralizedtrust.splice.util.PrettyInstances.PrettyContractId
+import org.lfdecentralizedtrust.splice.util.PrettyInstances.*
 import scalaz.{@@, Tag}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 import slick.jdbc.canton.SQLActionBuilder


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/1780

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
