### PR TITLE
fix exposing secret to the non-root images

### DIFF
--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -424,7 +424,7 @@ spec:
         {{- if .Values.migration.attachPvc }}
         - name: chown-domain-upgrade-dump
           image: busybox:1.37.0
-          command: ["chown", "-R", "1001:1001", "/domain-upgrade-dump"]
+          command: ["sh", "-c", "chown -R 1001:1001 /domain-upgrade-dump"]
           volumeMounts:
             - name: domain-upgrade-dump-volume
               mountPath: /domain-upgrade-dump

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -414,8 +414,10 @@ spec:
         {{- if .Values.participantIdentitiesDumpImport }}
         - name: chown-participant-bootstrapping-dump
           image: busybox:1.37.0
-          command: ["sh", "-c", "chown -R 1001:1001 /participant-bootstrapping-dump"]
+          command: ["sh", "-c", "cp -R /participant-bootstrapping-dump-secret/* /participant-bootstrapping-dump && chown -R 1001:1001 /participant-bootstrapping-dump"]
           volumeMounts:
+            - name: participant-bootstrapping-dump-secret
+              mountPath: /participant-bootstrapping-dump-secret
             - name: participant-bootstrapping-dump-volume
               mountPath: /participant-bootstrapping-dump
         {{- end }}
@@ -429,9 +431,11 @@ spec:
         {{- end }}
       volumes:
       {{- with .Values.participantIdentitiesDumpImport }}
-        - name: participant-bootstrapping-dump-volume
+        - name: participant-bootstrapping-dump-secret
           secret:
             secretName: {{ .secretName }}
+        - name: participant-bootstrapping-dump-volume
+          emptyDir: {}
       {{- end }}
       {{- if .Values.migration.attachPvc }}
         - name: domain-upgrade-dump-volume

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -414,7 +414,7 @@ spec:
         {{- if .Values.participantIdentitiesDumpImport }}
         - name: chown-participant-bootstrapping-dump
           image: busybox:1.37.0
-          command: ["sh", "-c", "cp -R /participant-bootstrapping-dump-secret/* /participant-bootstrapping-dump && chown -R 1001:1001 /participant-bootstrapping-dump"]
+          command: ["sh", "-c", "cp /participant-bootstrapping-dump-secret/content /participant-bootstrapping-dump/ && chown -R 1001:1001 /participant-bootstrapping-dump"]
           volumeMounts:
             - name: participant-bootstrapping-dump-secret
               mountPath: /participant-bootstrapping-dump-secret

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -363,7 +363,7 @@ spec:
         {{- if .Values.participantIdentitiesDumpImport }}
         - name: chown-participant-bootstrapping-dump
           image: busybox:1.37.0
-          command: ["sh", "-c", "cp -R /participant-bootstrapping-dump-secret/* /participant-bootstrapping-dump && chown -R 1001:1001 /participant-bootstrapping-dump"]
+          command: ["sh", "-c", "cp /participant-bootstrapping-dump-secret/content /participant-bootstrapping-dump/ && chown -R 1001:1001 /participant-bootstrapping-dump"]
           volumeMounts:
             - name: participant-bootstrapping-dump-secret
               mountPath: /participant-bootstrapping-dump-secret

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -365,6 +365,8 @@ spec:
           image: busybox:1.37.0
           command: ["sh", "-c", "cp -R /participant-bootstrapping-dump-secret/* /participant-bootstrapping-dump && chown -R 1001:1001 /participant-bootstrapping-dump"]
           volumeMounts:
+            - name: participant-bootstrapping-dump-secret
+              mountPath: /participant-bootstrapping-dump-secret
             - name: participant-bootstrapping-dump-volume
               mountPath: /participant-bootstrapping-dump
         {{- end }}

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -320,9 +320,11 @@ spec:
       {{- if or .Values.participantIdentitiesDumpImport $requiresMigrationPvc }}
       volumes:
       {{- with .Values.participantIdentitiesDumpImport }}
-        - name: participant-bootstrapping-dump-volume
+        - name: participant-bootstrapping-dump-secret
           secret:
             secretName: {{ .secretName }}
+        - name: participant-bootstrapping-dump-volume
+          emptyDir: {}
       {{- end }}
       {{- if $requiresMigrationPvc }}
         - name: domain-upgrade-dump-volume
@@ -361,7 +363,7 @@ spec:
         {{- if .Values.participantIdentitiesDumpImport }}
         - name: chown-participant-bootstrapping-dump
           image: busybox:1.37.0
-          command: ["sh", "-c", "chown -R 1001:1001 /participant-bootstrapping-dump"]
+          command: ["sh", "-c", "cp -R /participant-bootstrapping-dump-secret/* /participant-bootstrapping-dump && chown -R 1001:1001 /participant-bootstrapping-dump"]
           volumeMounts:
             - name: participant-bootstrapping-dump-volume
               mountPath: /participant-bootstrapping-dump


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5810

I'll rework CCI to allow testing the reonbaording workflow on a splice branch against a scratchnet, but happy for a review in the meantime so I can merge once confirmed to work.

The problem with the previous PR is that it tries to set ownership of the files in the mountpoint, but when mounting a secret, that's not a real FS, and is therefore read-only.

The approach I take here is to copy its content into an actual FS, which can then be chown'ed.

The alternative is to set fsGroup on the pod, which apparently is supposed to also set the owner of the mount point, but some internet dudes claim that's not universally supported, so I'm unsure how safe it is. Gemini suggested this approach as the second "common practice". It should work AFAICT. Do you happen to know what the common practice is here?

Successful SV reonboard test: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/34258/workflows/ea9bb3be-3741-4203-bb40-a576ad99a901

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
