### PR TITLE
disable KubeJobNotCompleted warnings

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2612,7 +2612,10 @@
         },
         "database": {},
         "defaultRules": {
-          "create": true
+          "create": true,
+          "disabled": {
+            "KubeJobNotCompleted": true
+          }
         },
         "fullnameOverride": "prometheus",
         "grafana": {

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -131,6 +131,12 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
         defaultRules: {
           // enable recording rules for all the k8s metrics
           create: true,
+          disabled: {
+            // The timeout is not configurable, and we have currently jobs that are expected to run for more than
+            // the 12 hr timeout, so we disable the alert. There is an alert if the job fails, so the only risk is
+            // a job that never completes.
+            KubeJobNotCompleted: true,
+          },
         },
         kubeControllerManager: {
           enabled: false,


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5733

See [here](https://github.com/prometheus-community/helm-charts/blob/1b5fec48f5063a161bdd4fb9863b02fd334402fa/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml#L441-L467), and the comment in the code.

We can of course create a rule of our own instead of this one, but I don't think we use k8s jobs enough to bother right now.

Tested on a scratchnet that this indeed removes the rule that generates this alert (in the `observability/prometheus-kubernetes-apps` PrometheusRule CR).

To prevent it from alerting in the coming 2-3 weekends, we'll need to backport this all the way to 0.4.16. 


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
