### PR TITLE
Disable event history sanity check in test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvDevNetReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvDevNetReonboardingIntegrationTest.scala
@@ -32,6 +32,8 @@ class SvDevNetReonboardingIntegrationTest extends SvIntegrationTestBase {
         )(conf)
       )
 
+  override protected def runEventHistorySanityCheck: Boolean = false
+
   "Reonboarding an SV with the same name removes the old SV from PartyToParticipant and the Decentralized Namespace" in {
     implicit env =>
       clue("SV3 and SV4 use different participants") {


### PR DESCRIPTION
As the validator backend is being stopped in this test, the event history sync is expected to not be in sync with other SVs

Fixes #2513 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
