### PR TITLE
Make npm build on party allocator also compile

### DIFF
--- a/party-allocator/package.json
+++ b/party-allocator/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "build/index.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=build/bundle.js --sourcemap=inline --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\"",
-    "compile": "tsc",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=build/bundle.js --sourcemap=inline --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\"",
+    "compile": "tsc --noEmit",
     "start": "node ./build/index.js",
     "check": "npm run format:check && npm run lint:check",
     "fix": "npm run format:fix && npm run lint:fix",

--- a/party-allocator/package.json
+++ b/party-allocator/package.json
@@ -6,7 +6,7 @@
     "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=build/bundle.js --sourcemap=inline --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\"",
     "compile": "tsc --noEmit",
     "start": "node ./build/index.js",
-    "check": "npm run format:check && npm run lint:check",
+    "check": "tsc --noEmit && npm run format:check && npm run lint:check",
     "fix": "npm run format:fix && npm run lint:fix",
     "format:check": "prettier --check -- src",
     "format:fix": "prettier --write -- src",

--- a/project/BuildCommon.scala
+++ b/project/BuildCommon.scala
@@ -200,7 +200,7 @@ object BuildCommon {
         ) ++
         addCommandAlias(
           "lint",
-          "; damlDarsLockFileCheck ; scalafmtCheck ; Test / scalafmtCheck ; scalafmtSbtCheck ; scalafixAll ; apps-frontends/npmLint ; pulumi/npmLint ; load-tester/npmLint ; runShellcheck ; syncpackCheck ; illegalDamlReferencesCheck ; headerCheck",
+          "; damlDarsLockFileCheck ; scalafmtCheck ; Test / scalafmtCheck ; scalafmtSbtCheck ; scalafixAll ; apps-frontends/npmLint ; pulumi/npmLint ; load-tester/npmLint ; party-allocator/npmLint ; runShellcheck ; syncpackCheck ; illegalDamlReferencesCheck ; headerCheck",
         ) ++
         // it might happen that some DARs remain dangling on build config changes,
         // so we explicitly remove all Splice DARs here, just in case


### PR DESCRIPTION
Apparently esbuild takes typescript as input and produces javascript but does not typecheck …

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
