### PR TITLE
[party-allocator] Stream over directory entries

### DIFF
--- a/party-allocator/src/index.ts
+++ b/party-allocator/src/index.ts
@@ -6,7 +6,7 @@ import {
   Command,
   DisclosedContract,
 } from "@lfdecentralizedtrust/canton-json-api-v2-openapi";
-import { readdir, writeFile } from "node:fs/promises";
+import { opendir, writeFile } from "node:fs/promises";
 import { config } from "./config.js";
 import fs from "fs";
 import { logger } from "./logger.js";
@@ -315,12 +315,13 @@ async function main() {
   if (!fs.existsSync(config.keyDirectory)) {
     fs.mkdirSync(config.keyDirectory);
   }
-  const contents = await readdir(config.keyDirectory);
-  const keyIndices = contents.map((f) => {
-    const match = f.match(/(?<index>.*)_priv.key/);
-    return parseInt(match?.groups?.index || "0");
-  });
-  const maxIndex = keyIndices.length > 0 ? Math.max(...keyIndices) + 1 : 0;
+  const dir = await opendir(config.keyDirectory);
+  let maxIndex = 0;
+  for await (const f of dir) {
+    const match = f.name.match(/(?<index>.*)_priv.key/);
+    const index = parseInt(match?.groups?.index || "0");
+    maxIndex = Math.max(maxIndex, index + 1);
+  }
   metrics.totalPartiesAllocated.record(maxIndex);
   // We just reinitialize the party at maxIndex + 1 from scratch instead of trying to clever
   // and incrementally handle all kinds of failures.


### PR DESCRIPTION
Should hopefully avoid the issues we are seeing on scratche. I wasn't actually able to test on scratche yet as I need to upgrade everything for that to work but I did kubectl edit the image on cilr and it at least doesn't break that.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
