### PR TITLE
Run make docker-build without -j on GHA

### DIFF
--- a/.github/actions/tests/scala_test/action.yml
+++ b/.github/actions/tests/scala_test/action.yml
@@ -226,7 +226,7 @@ runs:
           export CIRCLE_SHA1="${{ github.sha }}"
           /usr/bin/sudo mkdir -p ~/.docker/buildx
           /usr/bin/sudo /usr/bin/chown $(whoami):docker ~/.docker/buildx
-          make docker-build -j
+          make docker-build
         cmd_retry_count: 5 # Retry in case of dependency download errors
         additional_nix_args: "--keep DOCKER_CERT_PATH --keep DOCKER_HOST --keep DOCKER_MACHINE_NAME --keep DOCKER_TLS_VERIFY --keep PULUMI_VERSION --keep NO_PROXY --keep CIRCLE_REPOSITORY_URL --keep CIRCLE_SHA1"
 


### PR DESCRIPTION
Testing my theory that this fixes https://github.com/DACH-NY/cn-test-failures/issues/5808
I expect the timing to not be much worsebecause it won't have to retry I assume