### PR TITLE
Use sbt --client in make files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(app-bundle): $(canton-amulet-dar) $(wallet-payments-dar)
 	sbt --client --batch bundle
 
 $(canton-amulet-dar) $(wallet-payments-dar) &:
-	sbt --client --batch 'splice-amulet-daml'/damlBuild 'splice-wallet-payments-daml'/damlBuild
+	sbt --batch 'splice-amulet-daml'/damlBuild 'splice-wallet-payments-daml'/damlBuild
 
 $(load-tester):
 	cd "${SPLICE_ROOT}/load-tester" && npm ci && npm run build


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5808, by preventing different sbts from stepping on each other's work 
see also: https://daholdings.slack.com/archives/C03J6NCPSE4/p1759505448124789


https://github.com/hyperledger-labs/splice/actions/runs/18228357489/job/51905429825?pr=2538
The `npm install` order makes sense