### PR TITLE
[0.4.19][static] Enable party topology metrics by default for the sv validators in our clusters

### DIFF
--- a/cluster/deployment/config.yaml
+++ b/cluster/deployment/config.yaml
@@ -138,6 +138,12 @@ svs:
       cometbftLogLevel: debug
     participant:
       bftSequencerConnection: true
+    validatorApp:
+      additionalEnvVars:
+        # enable https://github.com/hyperledger-labs/splice/pull/2499
+        - name: ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT
+          value: |
+            canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m
 validators:
   validator-runbook:
     namespace: validator

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1801,7 +1801,12 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
-        "additionalEnvVars": [],
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT",
+            "value": "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
+          }
+        ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
         "additionalUsers": [],
         "affinity": {
@@ -2615,7 +2620,12 @@
       "namespace": "sv-da-1",
       "timeout": 600,
       "values": {
-        "additionalEnvVars": [],
+        "additionalEnvVars": [
+          {
+            "name": "ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT",
+            "value": "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
+          }
+        ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
         "additionalUsers": [],
         "affinity": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1082,6 +1082,10 @@
           {
             "name": "ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION",
             "value": "canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true"
+          },
+          {
+            "name": "ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT",
+            "value": "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
           }
         ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",


### PR DESCRIPTION
ports (#2548)

(cherry picked from commit d7818355d87e2c756710f643128581d83ac1a13b)

this ensures the new party dashboards are usable when this hits mainnet

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
