### PR TITLE
add and improve debug output of docker commands

### DIFF
--- a/build-tools/docker-push
+++ b/build-tools/docker-push
@@ -104,6 +104,6 @@ if [ -z "$pushed" ]; then
   exit 1
 fi
 
-_info "Successfully pushed Docker image ${imageReference} (with ID ${imageId}). Updating push state: ${targetPushState}"
+_info "Successfully pushed Docker image ${imageReference} (with ID ${imageId})"
 
 echo "${targetPushState}" > target/docker.push

--- a/build-tools/docker-push
+++ b/build-tools/docker-push
@@ -80,6 +80,7 @@ if docker-image-reference-exists "${imageReference}"; then
   fi
 fi
 
+_info "Tagging image ID ${imageId} with reference ${imageReference}"
 if ! _set_x docker tag "${imageId}" "${imageReference}"; then
     _error "Could not tag image '${imageId}."
     exit 1
@@ -88,6 +89,7 @@ fi
 pushed=""
 max_attempts=5
 
+_info "Pushing Docker image ${imageReference} (with ID ${imageId})"
 for ((i=1; i<=max_attempts; i++)); do
   if _set_x docker push "${imageReference}"; then
     pushed=1
@@ -101,5 +103,7 @@ if [ -z "$pushed" ]; then
   _error "Failed to push Docker image '${imageReference}' with ID '${imageId}' after ${max_attempts} attempts."
   exit 1
 fi
+
+_info "Successfully pushed Docker image ${imageReference} (with ID ${imageId}). Updating push state: ${targetPushState}"
 
 echo "${targetPushState}" > target/docker.push

--- a/build-tools/prefix-output
+++ b/build-tools/prefix-output
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "Error: No command provided." >&2
+    echo "Usage: $0 <command> [args...]" >&2
+    exit 1
+fi
+
+FULL_CMD="$*"
+
+( "$@" ) 2>&1 | awk -v prefix="[$FULL_CMD] " '{ print prefix $0 }'

--- a/cluster/images/local.mk
+++ b/cluster/images/local.mk
@@ -127,13 +127,10 @@ $(foreach image,$(images),$(eval $(call DEFINE_PHONY_RULES,$(image))))
 		--iidfile $@ $(cache_opt) $(build_arg) -t $$(cat $<) $(@D)/..
 
 %/$(docker-push):  %/$(docker-image-tag) %/$(docker-build)
-	cd $(@D)/.. && docker-push $$(cat $(abspath $<))
+	cd $(@D)/.. && prefix-output docker-push $$(cat $(abspath $<))
 
 %/$(docker-scan):  %/$(docker-image-tag)
-	cd $(@D) && docker-scan $$(cat $(abspath $<))
-
-%/$(docker-copy-release-to-ghcr):  %/$(docker-image-tag) %/$(docker-build)
-	cd $(@D)/.. && copy_release_to_ghcr $$(cat $(abspath $<))
+	cd $(@D) && prefix-output docker-scan $$(cat $(abspath $<))
 
 #########
 # Global targets
@@ -145,4 +142,4 @@ write-images:
 
 .PHONY: cluster/docker/copy_release_to_ghcr
 cluster/docker/copy_release_to_ghcr: write-images
-	./build-tools/copy_release_images_to_ghcr.sh -v '$(shell get-snapshot-version)' -f $(images_file)
+	prefix-output ./build-tools/copy_release_images_to_ghcr.sh -v '$(shell get-snapshot-version)' -f $(images_file)


### PR DESCRIPTION
- Adds some debug output
- Prefixes every output with the command that is running, as we run many make's in parallel, and it's hard to figure out what belongs where.

In an attempt to debug https://github.com/DACH-NY/cn-test-failures/issues/5854  (which I can't reproduce now, but hopefully will be helpful next time it does)


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
