### PR TITLE
Enable rate limits for acs and topology export endpoints

### DIFF
--- a/apps/app/src/test/resources/include/participants.conf
+++ b/apps/app/src/test/resources/include/participants.conf
@@ -59,5 +59,12 @@ _participant_template {
     }
   }
 
+  admin-api.stream.limits {
+    "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ExportAcsOld": 1,
+    "com.digitalasset.canton.admin.participant.v30.PartyManagementService/ExportAcsOld": 1,
+    "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ImportAcsOld": 1,
+    "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ImportAcs": 1
+  }
+
   topology.broadcast-batch-size = 1
 }

--- a/apps/app/src/test/resources/include/sequencers.conf
+++ b/apps/app/src/test/resources/include/sequencers.conf
@@ -50,4 +50,10 @@ _sequencer_reference_template {
     "com.digitalasset.canton.sequencer.api.v30.SequencerService/DownloadTopologyStateForInit" : 3,
     "com.digitalasset.canton.sequencer.api.v30.SequencerService/SubscribeV2" : 1000,
   }
+  admin-api.stream.limits {
+    "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisState": 1,
+    "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisStateV2": 1,
+    "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingState": 1,
+    "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingStateV2": 1
+  }
 }

--- a/cluster/images/canton-cometbft-sequencer/app.conf
+++ b/cluster/images/canton-cometbft-sequencer/app.conf
@@ -50,6 +50,12 @@ canton {
         address = "0.0.0.0"
         port = 5009
         max-inbound-message-size = 104857600 # 100MB
+        stream.limits {
+          "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisState": 1,
+          "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisStateV2": 1,
+          "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingState": 1,
+          "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingStateV2": 1
+        }
       }
 
 

--- a/cluster/images/canton-participant/app.conf
+++ b/cluster/images/canton-participant/app.conf
@@ -55,6 +55,12 @@ canton {
       admin-api {
         address = "0.0.0.0"
         port = 5002
+        stream.limits {
+          "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ExportAcsOld": 1,
+          "com.digitalasset.canton.admin.participant.v30.PartyManagementService/ExportAcsOld": 1,
+          "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ImportAcsOld": 1,
+          "com.digitalasset.canton.admin.participant.v30.ParticipantRepairService/ImportAcs": 1
+        }
       }
 
       init {

--- a/cluster/images/canton-sequencer/app.conf
+++ b/cluster/images/canton-sequencer/app.conf
@@ -47,6 +47,12 @@ canton {
         address = "0.0.0.0"
         port = 5009
         max-inbound-message-size = 104857600 # 100MB
+        stream.limits {
+          "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisState": 1,
+          "com.digitalasset.canton.topology.admin.v30.TopologyManagerReadService/GenesisStateV2": 1,
+          "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingState": 1,
+          "com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingStateV2": 1
+        }
       }
 
 


### PR DESCRIPTION
[ci]

Tested manually on CILR and it seems to work or at least not obviously break.

Don't really see a reason to allow more than 1 for any of these at least by default.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
