### PR TITLE
Updated cluster-lock-users, added pasindutennage-da

### DIFF
--- a/build-tools/cluster-lock-users.json
+++ b/build-tools/cluster-lock-users.json
@@ -16,5 +16,6 @@
     "OriolMunoz-da": ["oriolmunoz"],
     "ray-roestenburg-da": ["raymondroestenburg"],
     "nicu-da": ["nicu"],
-    "stephencompall-DA": ["stephencompall"]
+    "stephencompall-DA": ["stephencompall"],
+    "pasindutennage-da": ["pasindu"]
 }


### PR DESCRIPTION
Added pasindutennage-da to cluster-lock-users

Signed-off-by: Pasindu Tennage <pasindu.tennage@digitalasset.com>

[static]