### PR TITLE
Prevent flakes caused by TransferPreapproval not yet ingested by Scans

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -530,7 +530,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
       val onboarding @ OnboardingResult(externalParty, _, _) =
         onboardExternalParty(validatorBackend)
       walletClient.tap(50.0)
-      createTransferPreapprovalIfNotExists(walletClient)
+      createTransferPreapprovalEnsuringItExists(walletClient, validatorBackend)
       createAndAcceptExternalPartySetupProposal(validatorBackend, onboarding)
       eventually() {
         validatorBackend.lookupTransferPreapprovalByParty(externalParty) should not be empty

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RecoverExternalPartyIntegrationTest.scala
@@ -177,7 +177,7 @@ class RecoverExternalPartyIntegrationTest
 
     // Tap so we have money for creating the preapproval
     bobValidatorWalletClient.tap(5000.0)
-    createTransferPreapprovalIfNotExists(bobValidatorWalletClient)
+    createTransferPreapprovalEnsuringItExists(bobValidatorWalletClient, bobValidatorBackend)
 
     // Grant rights to bob's validator backend the rights to prepare transactions
     // and submit signed on behalf of the party.

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
@@ -199,8 +199,8 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
       val aliceValidator = RichPartyId.local(aliceValidatorBackend.getValidatorPartyId())
 
       aliceValidatorWalletClient.tap(BigDecimal(1000))
-      createTransferPreapprovalIfNotExists(aliceWalletClient)
-      createTransferPreapprovalIfNotExists(aliceValidatorWalletClient)
+      createTransferPreapprovalEnsuringItExists(aliceWalletClient, aliceValidatorBackend)
+      createTransferPreapprovalEnsuringItExists(aliceValidatorWalletClient, aliceValidatorBackend)
 
       val charlieParty = onboardWalletUser(charlieWalletClient, aliceValidatorBackend)
 
@@ -550,7 +550,10 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
             // TransferIn (derived by tx-kind), while making sure that charlie has no leftovers
             val charlieAmount = 500.0
             charlieWalletClient.tap(walletAmuletToUsd(charlieAmount))
-            createTransferPreapprovalIfNotExists(aliceWalletClient) // it was deleted before
+            createTransferPreapprovalEnsuringItExists(
+              aliceWalletClient,
+              aliceValidatorBackend,
+            ) // it was deleted before
             charlieWalletClient.transferPreapprovalSend(
               alice.partyId,
               charlieAmount - 11,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -572,7 +572,7 @@ class WalletIntegrationTest
         sv1ScanBackend.lookupTransferPreapprovalByParty(aliceUserParty) shouldBe None
         val (_, cid) = actAndCheck(
           "Create TransferPreapproval",
-          createTransferPreapprovalIfNotExists(aliceWalletClient),
+          createTransferPreapprovalEnsuringItExists(aliceWalletClient, aliceValidatorBackend),
         )(
           "Scan lookup returns TransferPreapproval",
           c => {
@@ -719,7 +719,7 @@ class WalletIntegrationTest
         aliceValidatorWalletClient.tap(10.0)
         actAndCheck(
           "Create TransferPreapproval for end user",
-          createTransferPreapprovalIfNotExists(aliceWalletClient),
+          createTransferPreapprovalEnsuringItExists(aliceWalletClient, aliceValidatorBackend),
         )(
           "Scan lookup returns TransferPreapproval for end user",
           c => {
@@ -730,7 +730,10 @@ class WalletIntegrationTest
         )
         actAndCheck(
           "Create TransferPreapproval for validator operator",
-          createTransferPreapprovalIfNotExists(aliceValidatorWalletClient),
+          createTransferPreapprovalEnsuringItExists(
+            aliceValidatorWalletClient,
+            aliceValidatorBackend,
+          ),
         )(
           "Scan lookup returns TransferPreapproval",
           c => {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
@@ -222,7 +222,7 @@ abstract class WalletSweepIntegrationTest
           50.0
         ) // validator needs to have some funds to create preapproval
         walletClient.tap(50.0)
-        createTransferPreapprovalIfNotExists(walletClient)
+        createTransferPreapprovalEnsuringItExists(walletClient, aliceValidatorBackend)
       },
     )(
       "Transfer preapproval is visible in scan",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
@@ -421,7 +421,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
         browseToSv1Wallet(sv1ValidatorWalletUser)
         actAndCheck(
           "SV1 creates a transfer preapproval and automation renews it immediately",
-          createTransferPreapprovalIfNotExists(sv1WalletClient),
+          createTransferPreapprovalEnsuringItExists(sv1WalletClient, sv1ValidatorBackend),
         )(
           "SV1 sees the creation and renewal transactions",
           _ => {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
@@ -1629,7 +1629,7 @@ class WalletTxLogIntegrationTest
       val charlieUserParty = onboardWalletUser(charlieWalletClient, aliceValidatorBackend)
 
       aliceValidatorWalletClient.tap(100) // funds to create preapproval
-      createTransferPreapprovalIfNotExists(charlieWalletClient)
+      createTransferPreapprovalEnsuringItExists(charlieWalletClient, aliceValidatorBackend)
 
       assertCommandFailsDueToInsufficientFunds(
         aliceWalletClient.transferPreapprovalSend(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -1310,7 +1310,7 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
   }
 
   /** @param partyWalletClient the wallet in which to create the transfer preapproval
-    * @param checkValidator a validator to use to check that the preapproval was created and ingested by all Scans
+    * @param checkValidator a validator to use to check that the preapproval was created and ingested by enough Scans
     */
   def createTransferPreapprovalEnsuringItExists(
       partyWalletClient: WalletAppClientReference,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -1309,17 +1309,29 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
       .supported
   }
 
-  def createTransferPreapprovalIfNotExists(
-      partyWalletClient: WalletAppClientReference
+  /** @param partyWalletClient the wallet in which to create the transfer preapproval
+    * @param checkValidator a validator to use to check that the preapproval was created and ingested by all Scans
+    */
+  def createTransferPreapprovalEnsuringItExists(
+      partyWalletClient: WalletAppClientReference,
+      checkValidator: ValidatorAppBackendReference,
   ): TransferPreapproval.ContractId = {
     // creating the transfer preapproval can fail because there are no funds (which this won't recover),
     // but also by the validator being slow to approve the preapproval, which we can recover here
-    eventuallySucceeds() {
+    val cid = eventuallySucceeds() {
       partyWalletClient.createTransferPreapproval() match {
         case CreateTransferPreapprovalResponse.Created(contractId) => contractId
         case CreateTransferPreapprovalResponse.AlreadyExists(contractId) => contractId
       }
     }
+    // Ensure enough Scans have ingested it for it to be usable
+    eventually() {
+      checkValidator.lookupTransferPreapprovalByParty(
+        PartyId.tryFromProtoPrimitive(partyWalletClient.userStatus().party)
+      ) shouldBe defined
+    }
+
+    cid
   }
 
 }


### PR DESCRIPTION
Which then fails BFT fetch of it when calling .transferPreapprovalSend

Fixes https://github.com/DACH-NY/cn-test-failures/issues/5832