### PR TITLE
Switch to v2 topology export/import for sequencers

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
@@ -96,14 +96,16 @@ class SequencerAdminConnection(
   def initializeFromBeginning(
       topologySnapshot: GenericStoredTopologyTransactions,
       domainParameters: StaticSynchronizerParameters,
-  )(implicit traceContext: TraceContext): Future[InitializeSequencerResponse] =
+  )(implicit traceContext: TraceContext): Future[InitializeSequencerResponse] = {
+    val builder = ByteString.newOutput()
+    topologySnapshot.result.foreach(_.writeDelimitedTo(domainParameters.protocolVersion, builder))
     runCmd(
       SequencerAdminCommands.InitializeFromGenesisStateV2(
-        // TODO(DACH-NY/canton-network-node#10953) Stop doing that.
-        topologySnapshot.toByteString(domainParameters.protocolVersion),
+        builder.toByteString,
         domainParameters,
       )
     )
+  }
 
   /** This is used for initializing the sequencer after hard domain migrations.
     */


### PR DESCRIPTION
[ci]

Tested a bit on CILR. Doesn't make a particularly meaningful difference but slightly faster (~1:55 vs ~2:05min)  although it may just be noise. Still no downside in switching imho.

Note: I deliberately only switch for sequencers here and not for validators as for those we need to worry about someone migrating from 3.3 -> 3.4 without upgrading to the latest version first which would then make the import fail.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
