### PR TITLE
Automatically assign issues from external contributors to triage team

### DIFF
--- a/.github/workflows/assign_issues_external.yml
+++ b/.github/workflows/assign_issues_external.yml
@@ -1,0 +1,26 @@
+name: Auto-assign issues from external contributors
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assign issue from external contributors
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const author = issue.user.login.toLowerCase();
+            const isInternalContributor = author.endsWith('-da') || author === 'cocreature';
+            if (issue.assignees.length === 0 && !isInternalContributor) {
+              console.log('Assigning issue to the triage team...');
+              await github.rest.issues.addAssignees({
+                issue_number: issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignees: ['isegall-da', 'martinflorian-da', 'ray-roestenburg-da'],
+              });
+            } 


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/1306

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
