### PR TITLE
[static] Fix postgres pulumi protection flag

### DIFF
--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -193,9 +193,9 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
     instanceName: string,
     alias: string,
     secretName: string,
+    disableProtection: boolean,
     values?: ChartValues,
     overrideDbSizeFromValues?: boolean,
-    disableProtection?: boolean,
     version?: CnChartVersion
   ) {
     const logicalName = xns.logicalName + '-' + instanceName;
@@ -279,7 +279,7 @@ export function installPostgres(
       instanceName,
       alias,
       secretName,
-      undefined,
+      o.disableProtection || true,
       undefined,
       undefined,
       version

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -864,6 +864,7 @@ function installPostgres(namespace: ExactNamespace): SplicePostgres {
     'grafana-pg',
     'grafana-pg',
     'grafana-pg-secret',
+    true,
     { db: { volumeSize: '20Gi' } }, // A tiny pvc should be enough for grafana
     true // overrideDbSizeFromValues
   );

--- a/cluster/pulumi/sv-runbook/src/postgres.ts
+++ b/cluster/pulumi/sv-runbook/src/postgres.ts
@@ -39,7 +39,7 @@ export function installPostgres(
     );
     const volumeSizeOverride = determineVolumeSizeOverride(valuesFromFile.db?.volumeSize);
     const values = _.merge(valuesFromFile || {}, { db: { volumeSize: volumeSizeOverride } });
-    return new SplicePostgres(xns, name, name, secretName, values);
+    return new SplicePostgres(xns, name, name, secretName, true, values);
   }
 }
 

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -155,9 +155,9 @@ async function installValidator(
     // can be removed once base version > 0.2.1
     `postgres`,
     'postgres-secrets',
+    supportsValidatorRunbookReset,
     postgresValues,
-    true,
-    supportsValidatorRunbookReset
+    true
   );
   const participantAddress = installParticipant(
     validatorConfig,


### PR DESCRIPTION
it seems the protection flag is not included in the expected files (only for cloud sql is it actually set)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
