### PR TITLE
apps, http: Enable compressed (gzip) response

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpAdminService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpAdminService.scala
@@ -70,7 +70,7 @@ object HttpAdminService {
     )
     private val routes: AtomicReference[List[Route]] = new AtomicReference(List())
     private val dynamicRoute: Route = ctx => {
-      concat((commonAdminRoute +: routes.get())*)(ctx)
+      encodeResponse(concat((commonAdminRoute +: routes.get())*))(ctx)
     }
 
     val commonAdminRoute: Route =


### PR DESCRIPTION
This allows transferring JSONs faster over the network. Note that the default behavior doesn't change. The compression is enabled only if the request contains the header `Accept-Encoding` with a supported compression method.