### PR TITLE
Move to backend service-based network load balancers

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -696,6 +696,9 @@ function subcmd_create() {
         #### Enable Firewall Access
         subcmd_cluster_update_access
 
+        ### Enable Http Load Balancing
+        subcmd_cluster_enable_http_load_balancing
+
         #### Delete default firewall rules, if they exist.
         if (gcloud compute firewall-rules delete\
                          default-allow-rdp \
@@ -911,6 +914,19 @@ function subcmd_cluster_enable_workload_identity() {
         --cluster "cn-${GCP_CLUSTER_BASENAME}net" \
         --workload-metadata=GKE_METADATA
 }
+
+subcommand_whitelist[cluster_enable_http_load_balancing]='Enable http load balancing for the cluster.'
+
+function subcmd_cluster_enable_http_load_balancing() {
+    if ! gcloud container clusters describe "${GCP_CLUSTER_NAME}" --format="value(addonsConfig.httpLoadBalancing)" | grep -q "disabled=True"; then
+        _info "Http Load Balancing is already enabled for the cluster."
+        return
+    fi
+
+    _info "Enabling http load balancing for the cluster ${GCP_CLUSTER_NAME}."
+    gcloud container clusters update "${GCP_CLUSTER_NAME}" --update-addons=HttpLoadBalancing=ENABLED
+}
+
 ###
 
 subcommand_whitelist[ci_warn_lock_expiry]='Run only by CircleCI'

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1557,7 +1557,7 @@
       "chart": "gateway",
       "compat": "true",
       "maxHistory": 10,
-      "name": "istio-ingress-cometbft-test",
+      "name": "istio-ingress-cometbft",
       "namespace": "cluster-ingress",
       "repositoryOpts": {
         "repo": "https://istio-release.storage.googleapis.com/charts"
@@ -1738,7 +1738,7 @@
       "chart": "gateway",
       "compat": "true",
       "maxHistory": 10,
-      "name": "istio-ingress-test",
+      "name": "istio-ingress",
       "namespace": "cluster-ingress",
       "repositoryOpts": {
         "repo": "https://istio-release.storage.googleapis.com/charts"

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -320,7 +320,7 @@ function configureGatewayService(
   const gateway = new k8s.helm.v3.Release(
     `istio-ingress${suffix}`,
     {
-      name: `istio-ingress${suffix}-test`,
+      name: `istio-ingress${suffix}`,
       chart: 'gateway',
       version: istioVersion.istio,
       namespace: ingressNs.metadata.name,
@@ -359,6 +359,7 @@ function configureGatewayService(
           ].concat(ingressPorts),
         },
         ...infraAffinityAndTolerations,
+        // The httpLoadBalancing addon needs to be enabled to use backend service-based network load balancers.
         annotations: {
           'cloud.google.com/l4-rbs': 'enabled',
         },
@@ -366,6 +367,7 @@ function configureGatewayService(
       maxHistory: HELM_MAX_HISTORY_SIZE,
     },
     {
+      replaceOnChanges: ['values.annotations'],
       deleteBeforeReplace: true,
       dependsOn: istioPolicies
         ? istioPolicies.apply(policies => {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/2081

Switching to this backend type will allow us to 1) enable cloud armor and 2) use "modern" NLB which is [advised by gcp](https://cloud.google.com/kubernetes-engine/docs/how-to/backend-service-based-external-load-balancer#:~:text=Using%20target%20pool%2Dbased%20external%20passthrough%20Network%20Load%20Balancers%20is%20discouraged.) anyway.

[TODO] `cncluster enable_http_load_balancing` in our running cluster before merging. Expect < 60s downtime to switch to new backend type.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
