### PR TITLE
add a psql subcommand to cncluster script for convenient DB inspection

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -1458,7 +1458,7 @@ function subcmd_debug_shell() {
   fi
   repo="ghcr.io/digital-asset/decentralized-canton-sync-dev/docker"
 
-  local SHELL_COMMAND="${1:-/bin/bash}"
+  local SHELL_COMMAND="${*:-/bin/bash}"
 
   _info "Deploying debug pod on version $VERSION_NUMBER"
   kubectl apply --wait -f - <<EOF
@@ -2181,14 +2181,13 @@ subcommand_whitelist[psql]=""
 function subcmd_psql() {
   _cluster_must_exist
 
-  if [ $# -lt 2 ] || [ $# -gt 3 ]; then
-    _error "Usage: $SCRIPTNAME psql <namespace> <application> [search_path]"
+  if [ $# -ne 2 ]; then
+    _error "Usage: $SCRIPTNAME psql <namespace> <application>"
     exit 1
   fi
 
   local NAMESPACE="$1"
   local APPLICATION="$2"
-  local SEARCH_PATH=${3:-}
 
   _info "Retrieving DB connection info from pod description..."
   local DB_INIT_COMMAND
@@ -2297,16 +2296,29 @@ function subcmd_psql() {
     exit 1
   fi
 
-  subcmd_debug_shell " \
-    /bin/env
-      PGPASSWORD=$DB_PASSWORD \
-      ${SEARCH_PATH:+PGOPTIONS=--search_path=$SEARCH_PATH} \
-      psql \
-        --host=$DB_HOST \
-        --port=$DB_PORT \
-        --username=$DB_USERNAME \
-        --dbname=$DB_NAME \
-  "
+  case "${APPLICATION}" in
+    participant-*)
+      local SEARCH_PATH="participant"
+      ;;
+    sequencer-*)
+      local SEARCH_PATH="sequencer"
+      ;;
+    mediator-*)
+      local SEARCH_PATH="mediator"
+      ;;
+    *)
+      local SEARCH_PATH="$DB_NAME"
+      ;;
+  esac
+
+  subcmd_debug_shell /bin/env \
+    PGPASSWORD="$DB_PASSWORD" \
+    PGOPTIONS="--search_path=${SEARCH_PATH},public" \
+    psql \
+      --host="$DB_HOST" \
+      --port="$DB_PORT" \
+      --username="$DB_USERNAME" \
+      --dbname="$DB_NAME"
 }
 
 ################################


### PR DESCRIPTION
[static]

I've tested this by running the new subcommand against different databases in the cluster on a scratchnet.

> sequencer-0-pg
```
scratchnetc % cncluster psql sv-1 global-domain-0-sequencer                                                          
INFO: Retrieving DB connection info from pod description...
INFO: Retrieving DB password from secret [sequencer-0-pg-secrets]...
INFO: Deploying debug pod on version 0.4.19
pod/splice-debug created
INFO: Waiting for debug pod to become ready
pod/splice-debug condition met
INFO: Opening terminal on debug pod
psql (16.10 (Ubuntu 16.10-0ubuntu0.24.04.1), server 14.19 (Debian 14.19-1.pgdg13+1))
Type "help" for help.

cantonnet=# 
```

The optional search path parameter can be specified and it is set as shown in the following example:

> sv-app postgres
```
scratchnetc % cncluster psql sv-1 sv-app test
INFO: Retrieving DB connection info from pod description...
INFO: Retrieving DB password from secret [postgres-secrets]...
INFO: Deploying debug pod on version 0.4.19
pod/splice-debug created
INFO: Waiting for debug pod to become ready
pod/splice-debug condition met
INFO: Opening terminal on debug pod
psql (16.10 (Ubuntu 16.10-0ubuntu0.24.04.1), server 14.19 (Debian 14.19-1.pgdg13+1))
Type "help" for help.

cantonnet=# show search_path;
 search_path 
-------------
 test
(1 row)
```