### PR TITLE
deal with generated KMS SA account_id over size limit 30

### DIFF
--- a/cluster/pulumi/common/src/participantKms.ts
+++ b/cluster/pulumi/common/src/participantKms.ts
@@ -33,7 +33,8 @@ const createKmsServiceAccount = (
   };
   const serviceAccountName = migrationIdSuffixed(
     `${CLUSTER_BASENAME}-${xns.logicalName}-kms`,
-    migrationId
+    migrationId,
+    true
   );
   const kmsServiceAccount = new GcpServiceAccount(serviceAccountName, {
     accountId: serviceAccountName,
@@ -109,5 +110,16 @@ export const getParticipantKmsHelmResources = (
   };
 };
 
-const migrationIdSuffixed = (name: string, migrationId?: DomainMigrationIndex) =>
-  migrationId != undefined ? `${name}-migration-${migrationId}` : name;
+function migrationIdSuffixed(
+  name: string,
+  migrationId?: DomainMigrationIndex,
+  limit30?: boolean
+): string {
+  if (migrationId === undefined) {
+    return name;
+  }
+  const longName = `${name}-migration-${migrationId}`;
+  // error: gcp:serviceaccount/account:Account
+  // resource..."account_id"...must be between 6 and 30 characters long
+  return limit30 && longName.length > 30 ? `${name}-mg-${migrationId}` : longName;
+}


### PR DESCRIPTION
If the account_id is, say, 32 characters, you get a Pulumi error. We carefully avoid that specific error without changing any of the other name generation (i.e. the ones that are just fine).

Part of DACH-NY/canton-network-internal#1736.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
