### PR TITLE
add default ledger api audience to all m2m apps

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3385,6 +3385,20 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "audience": "https://canton.network.global",
+      "clientId": "SV1 SV Backend (Pulumi managed, test-stack)_id",
+      "scopes": [
+        "daml_ledger_api"
+      ]
+    },
+    "name": "sv1SvBackendAppLedgerGrant",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
+    "type": "auth0:index/clientGrant:ClientGrant"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "appType": "non_interactive",
       "description": " ** Managed by Pulumi, do not edit manually **\nUsed for the SV backend for SV1 on test-stack",
       "name": "SV1 SV Backend (Pulumi managed, test-stack)"
@@ -3479,6 +3493,20 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "audience": "https://canton.network.global",
+      "clientId": "SV1 Validator Backend (Pulumi managed, test-stack)_id",
+      "scopes": [
+        "daml_ledger_api"
+      ]
+    },
+    "name": "sv1ValidatorBackendAppLedgerGrant",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
+    "type": "auth0:index/clientGrant:ClientGrant"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "appType": "non_interactive",
       "description": " ** Managed by Pulumi, do not edit manually **\nUsed for the Validator backend for SV1 on test-stack",
       "name": "SV1 Validator Backend (Pulumi managed, test-stack)"
@@ -3504,6 +3532,20 @@
     "id": "",
     "inputs": {
       "audience": "https://ledger_api.sv-da-1.test-stack.canton.network",
+      "clientId": "SVDA1 SV Backend (Pulumi managed, test-stack)_id",
+      "scopes": [
+        "daml_ledger_api"
+      ]
+    },
+    "name": "svda1SvBackendAppLedgerGrant",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
+    "type": "auth0:index/clientGrant:ClientGrant"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "audience": "https://canton.network.global",
       "clientId": "SVDA1 SV Backend (Pulumi managed, test-stack)_id",
       "scopes": [
         "daml_ledger_api"
@@ -3598,6 +3640,20 @@
     "id": "",
     "inputs": {
       "audience": "https://ledger_api.sv-da-1.test-stack.canton.network",
+      "clientId": "SVDA1 Validator Backend (Pulumi managed, test-stack)_id",
+      "scopes": [
+        "daml_ledger_api"
+      ]
+    },
+    "name": "svda1ValidatorBackendAppLedgerGrant",
+    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
+    "type": "auth0:index/clientGrant:ClientGrant"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "audience": "https://canton.network.global",
       "clientId": "SVDA1 Validator Backend (Pulumi managed, test-stack)_id",
       "scopes": [
         "daml_ledger_api"

--- a/cluster/pulumi/infra/src/auth0.ts
+++ b/cluster/pulumi/infra/src/auth0.ts
@@ -137,6 +137,22 @@ function newM2MApp(
       }
     );
 
+    if (ledgerApiAudValue !== 'https://canton.network.global') {
+      // TODO(DACH-NY/canton-network-internal#2206): For now, we also grant all apps access to the old default ledger API
+      // audience, to un-break it until we clean up the audiences we use.
+      new auth0.ClientGrant(
+        `${resourceName}LedgerGrant`,
+        {
+          clientId: ret.id,
+          audience: 'https://canton.network.global',
+          scopes: ['daml_ledger_api'],
+        },
+        {
+          provider: auth0DomainProvider,
+        }
+      );
+    }
+
     if (ledgerApiAudValue !== appAudValue) {
       new auth0.ClientGrant(
         `${resourceName}AppGrant`,


### PR DESCRIPTION
So I messed up audiences, and on prod-like envs (including cimain and cilr), we configure the pulumi-created ledger API  in auth0, but then the apps still use the old default. While I work on fixing that properly, this should unbreak the current state at least.

Part of https://github.com/DACH-NY/canton-network-internal/issues/2206
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5892

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
