### PR TITLE
unbreak auth0, again

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3391,7 +3391,7 @@
         "daml_ledger_api"
       ]
     },
-    "name": "sv1SvBackendAppLegacyLedgerGrant",
+    "name": "sv1SvBackendAppLegacyGrant",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
     "type": "auth0:index/clientGrant:ClientGrant"
   },
@@ -3499,7 +3499,7 @@
         "daml_ledger_api"
       ]
     },
-    "name": "sv1ValidatorBackendAppLegacyLedgerGrant",
+    "name": "sv1ValidatorBackendAppLegacyGrant",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
     "type": "auth0:index/clientGrant:ClientGrant"
   },
@@ -3551,7 +3551,7 @@
         "daml_ledger_api"
       ]
     },
-    "name": "svda1SvBackendAppLegacyLedgerGrant",
+    "name": "svda1SvBackendAppLegacyGrant",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
     "type": "auth0:index/clientGrant:ClientGrant"
   },
@@ -3659,7 +3659,7 @@
         "daml_ledger_api"
       ]
     },
-    "name": "svda1ValidatorBackendAppLegacyLedgerGrant",
+    "name": "svda1ValidatorBackendAppLegacyGrant",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
     "type": "auth0:index/clientGrant:ClientGrant"
   },

--- a/cluster/pulumi/infra/src/auth0.ts
+++ b/cluster/pulumi/infra/src/auth0.ts
@@ -141,7 +141,7 @@ function newM2MApp(
       // TODO(DACH-NY/canton-network-internal#2206): For now, we also grant all apps access to the old default ledger API
       // audience, to un-break it until we clean up the audiences we use.
       new auth0.ClientGrant(
-        `${resourceName}LegacyLedgerGrant`,
+        `${resourceName}LegacyGrant`,
         {
           clientId: ret.id,
           audience: 'https://canton.network.global',


### PR DESCRIPTION
Sorry...

`error: Duplicate resource URN 'urn:pulumi:infra.cimain::infra::auth0:index/clientGrant:ClientGrant::svda1SvBackendAppLedgerGrant'; try giving it a unique name`

(This breaks only on prod-like, so just merging to main instead of trying on a scratchnet, and seeing whether this fixes cimain is the quickest path, given that cimain is just broken ATM)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
