### PR TITLE
[static] use a temporary base version for hdm tests

### DIFF
--- a/build-tools/find_latest_hard_migration_base_version.sh
+++ b/build-tools/find_latest_hard_migration_base_version.sh
@@ -8,5 +8,8 @@
 
 set -euo pipefail
 
-latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
-echo "release-line-${latest_release}"
+# latest_release=$(cat "$SPLICE_ROOT/LATEST_RELEASE")
+# echo "release-line-${latest_release}"
+
+# TODO(DACH-NY/canton-network-internal#2180): revert this to release-line-${latest_release} once latest_release is 0.4.21
+echo "0.4.20-with-auth0-changes"


### PR DESCRIPTION
So what I believe is happening ATM in HDM test is:

- We deploy the base version from 0.4.20 (before the auth0 m2m change)
- prepare_cluster_for_migration then de-facto runs `infra up` (indirectly via the operator, but still) from `main`, which replaces the m2m app to the one managed by pulumi, and hence the username (which is `<client_id>@clients`), but it does not touch the running apps, so the SV app is unaware of any change
- Now we try to vote on the HDM in trigger_global_domain_migration, so we ask pulumi infra for the client_id of the sv app (and get the new one), derive from that the userid, fetch the cached token for that app&userid, and try to use it with the app
- boom :boom: 

I do not want to risk backporting the auth0 stuff to the release line, so instead I created a temporary base branch for HDM tests which is the (current) release line + the auth0 changes, and this PR configures sets that as the base branch for HDM tests only.

~[hdm test](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/36412/workflows/e3a8732a-812d-4e2a-a4e7-cdf2a83bb645)~ Failed. Missing images for the base version, running publish-internal-artifacts on it now. [Take 2](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/36412/workflows/67aae883-86cf-4555-b19a-a3e8214a18de)


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
