### PR TITLE
[ci] Disable new reward scheduling and bump reward interval to 300s

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AutomationConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AutomationConfig.scala
@@ -27,12 +27,12 @@ case class AutomationConfig(
     pollingJitter: Double = 0.2,
     /** Enabled schedling reward operations unfiromly across the first tick of a round opening.
       */
-    enableNewRewardTriggerScheduling: Boolean = true,
+    enableNewRewardTriggerScheduling: Boolean = false,
     /** Reward operations can result in spikes overloading sequencers on each round switch so we
       * use a lower polling interval of 1/3 tick with tick = 600s
       */
     rewardOperationPollingInterval: NonNegativeFiniteDuration =
-      NonNegativeFiniteDuration.ofSeconds(200),
+      NonNegativeFiniteDuration.ofSeconds(300),
     /** Reward operations can result in spikes overloading sequencers on each round switch so we
       * use higher jitter.
       */


### PR DESCRIPTION
Ideally I would've wanted this in 0.4.21 but to have confidence in that we would need https://github.com/hyperledger-labs/splice/pull/2690 in, and adapting the tests proved more painful than expected because we have lots of tests  that make the assumption that the triggers always just run on wall clock every second.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
