### PR TITLE
Usability changes for json diffs and SV reward weight form

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
@@ -79,6 +79,8 @@ describe('Set Amulet Config Rules Form', () => {
       },
       { timeout: 1000 }
     );
+
+    expect(screen.getByTestId('json-diffs-details')).toBeDefined();
   });
 
   test('should render errors when submit button is clicked on new form', async () => {

--- a/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
@@ -70,6 +70,8 @@ describe('Set DSO Config Rules Form', () => {
     expect(() => screen.getAllByTestId('config-current-value', { exact: false })).toThrowError(
       /Unable to find an element/
     );
+
+    expect(screen.getByTestId('json-diffs-details')).toBeDefined();
   });
 
   test('should render errors when submit button is clicked on new form', async () => {
@@ -318,37 +320,6 @@ describe('Set DSO Config Rules Form', () => {
       expect(screen.queryByText('Vote History')).toBeDefined();
       expect(screen.queryByText('Successfully submitted the proposal')).toBeDefined();
     });
-  });
-
-  test('should not render diffs if no changes to config values were made', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Wrapper>
-        <SetDsoConfigRulesForm />
-      </Wrapper>
-    );
-
-    const summaryInput = screen.getByTestId('set-dso-config-rules-summary');
-    await user.type(summaryInput, 'Summary of the proposal');
-
-    const urlInput = screen.getByTestId('set-dso-config-rules-url');
-    await user.type(urlInput, 'https://example.com');
-
-    const jsonDiffs = screen.getByText('JSON Diffs');
-    expect(jsonDiffs).toBeDefined();
-
-    await user.click(jsonDiffs);
-    expect(screen.queryByText('No changes')).toBeDefined();
-
-    const reviewButton = screen.getByTestId('submit-button');
-    await waitFor(async () => {
-      expect(reviewButton.getAttribute('disabled')).toBeNull();
-    });
-
-    expect(jsonDiffs).toBeDefined();
-    await user.click(jsonDiffs);
-    expect(screen.queryByText('No changes')).toBeDefined();
   });
 
   test('should render diffs if changes to config values were made', async () => {

--- a/apps/sv/frontend/src/__tests__/governance/forms/update-sv-reward-weight-form-test.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/update-sv-reward-weight-form-test.test.tsx
@@ -142,13 +142,13 @@ describe('Update SV Reward Weight Form', () => {
 
     await user.type(expiryDateInput, thePast);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.queryByText('Expiration must be in the future')).toBeDefined();
     });
 
     await user.type(expiryDateInput, theFuture);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.queryByText('Expiration must be in the future')).toBeNull();
     });
   });
@@ -230,6 +230,37 @@ describe('Update SV Reward Weight Form', () => {
 
     await validateCurrentWeightFor('Digital-Asset-2', '10');
     await validateCurrentWeightFor('Digital-Asset-Eng-2', '12345');
+  });
+
+  test('Weight is reset when sv changes', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateSvRewardWeightForm />
+      </Wrapper>
+    );
+
+    const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
+    expect(weightInput).toBeDefined();
+    expect(weightInput.getAttribute('value')).toBe('');
+
+    // set the weight before changing sv
+    await user.type(weightInput, '10999');
+    expect(weightInput.getAttribute('value')).toBe('10999');
+
+    const memberDropdown = screen.getByTestId('update-sv-reward-weight-member-dropdown');
+    expect(memberDropdown).toBeDefined();
+    const selectInput = screen.getByRole('combobox');
+    fireEvent.mouseDown(selectInput);
+
+    await waitFor(async () => {
+      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
+      expect(memberToSelect).toBeDefined();
+      await user.click(memberToSelect);
+    });
+
+    expect(weightInput.getAttribute('value')).toBe('');
   });
 
   test('Weight must be a valid number', async () => {
@@ -345,7 +376,7 @@ describe('Update SV Reward Weight Form', () => {
     });
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
-    expect(weightInput).toBeDefined();
+    expect(weightInput.getAttribute('value')).toBe('');
     await user.type(weightInput, '1000');
 
     await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation
@@ -355,7 +386,7 @@ describe('Update SV Reward Weight Form', () => {
     });
     await user.click(submitButton); //review proposal
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByTestId('config-change-current-value').textContent).toBe('12345');
       expect(screen.getByTestId('config-change-new-value').textContent).toBe('1000');
     });

--- a/apps/sv/frontend/src/components/form-components/SelectField.tsx
+++ b/apps/sv/frontend/src/components/form-components/SelectField.tsx
@@ -17,10 +17,12 @@ export interface SelectFieldProps {
   title: string;
   options: Option[];
   id: string;
+  onChange?: () => void;
 }
 
 export const SelectField: React.FC<SelectFieldProps> = props => {
   const { title, options, id } = props;
+  const externalOnChange = props.onChange ?? (() => {});
   const field = useFieldContext<string>();
 
   return (
@@ -32,7 +34,10 @@ export const SelectField: React.FC<SelectFieldProps> = props => {
       <FormControl variant="outlined" error={!field.state.meta.isValid} fullWidth>
         <Select
           value={field.state.value}
-          onChange={(e: SelectChangeEvent) => field.handleChange(e.target.value as string)}
+          onChange={(e: SelectChangeEvent) => {
+            field.handleChange(e.target.value as string);
+            externalOnChange();
+          }}
           onBlur={field.handleBlur}
           error={!field.state.meta.isValid}
           id={`${id}-dropdown`}

--- a/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
@@ -168,8 +168,6 @@ export const SetAmuletConfigRulesForm: () => JSX.Element = () => {
     allAmuletConfigChanges,
     false
   );
-  const changedFields = changes.filter(c => c.currentValue !== c.newValue);
-  const hasChangedFields = changedFields.length > 0;
 
   const baseConfig = amuletConfig;
   const newConfig = buildAmuletRulesConfigFromChanges(changes);
@@ -291,7 +289,7 @@ export const SetAmuletConfigRulesForm: () => JSX.Element = () => {
       )}
 
       <JsonDiffAccordion>
-        {amuletConfigToCompareWith && amuletConfigToCompareWith[1] && hasChangedFields ? (
+        {amuletConfigToCompareWith && amuletConfigToCompareWith[1] ? (
           <PrettyJsonDiff
             changes={{
               newConfig: dsoAction.value.newConfig,
@@ -299,9 +297,7 @@ export const SetAmuletConfigRulesForm: () => JSX.Element = () => {
               actualConfig: amuletConfigToCompareWith[1],
             }}
           />
-        ) : (
-          <Typography>No changes</Typography>
-        )}
+        ) : null}
       </JsonDiffAccordion>
 
       <form.AppForm>

--- a/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
@@ -175,8 +175,6 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
   const changes = configFormDataToConfigChanges(form.state.values.config, dsoConfigChanges, false);
   const changedFields = changes.filter(c => c.currentValue !== c.newValue);
 
-  const hasChangedFields = changedFields.length > 0;
-
   const baseConfig = dsoConfig;
   const newConfig = buildDsoRulesConfigFromChanges(changes);
   const dsoAction: DsoRules_ActionRequiringConfirmation = {
@@ -294,7 +292,7 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
       )}
 
       <JsonDiffAccordion>
-        {dsoConfigToCompareWith[1] && hasChangedFields ? (
+        {dsoConfigToCompareWith[1] ? (
           <PrettyJsonDiff
             changes={{
               newConfig: dsoAction.value.newConfig,
@@ -302,9 +300,7 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
               actualConfig: dsoConfigToCompareWith[1],
             }}
           />
-        ) : (
-          <Typography>No changes</Typography>
-        )}
+        ) : null}
       </JsonDiffAccordion>
 
       <form.AppForm>

--- a/apps/sv/frontend/src/components/forms/UpdateSvRewardWeightForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateSvRewardWeightForm.tsx
@@ -195,7 +195,9 @@ export const UpdateSvRewardWeightForm: React.FC = _ => {
               name="sv"
               validators={{
                 onBlur: ({ value }) => validateSvSelection(value),
-                onChange: ({ value }) => validateSvSelection(value),
+                onChange: ({ value }) => {
+                  return validateSvSelection(value);
+                },
               }}
             >
               {field => (
@@ -203,6 +205,7 @@ export const UpdateSvRewardWeightForm: React.FC = _ => {
                   title="Member"
                   options={svOptions}
                   id="update-sv-reward-weight-member"
+                  onChange={() => form.resetField('weight')}
                 />
               )}
             </form.AppField>


### PR DESCRIPTION
* Always show json for config forms
* Reset weight when sv is changed in form

Fixes #2550

Config json always on:

https://github.com/user-attachments/assets/3b77a17f-de34-4e08-910b-959ba4586192



Reset weight when SV changes:

https://github.com/user-attachments/assets/1b300ec6-a81c-4404-bcf0-95c2fcf4a9c1





### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
