### PR TITLE
Fix EventHistorySanityCheckPlugin by ignoring events before onboarding

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/plugins/EventHistorySanityCheckPlugin.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/plugins/EventHistorySanityCheckPlugin.scala
@@ -104,11 +104,6 @@ class EventHistorySanityCheckPlugin(
       val otherScanHistory = paginateEventHistory(otherScan, Some(otherStart), Chain.empty).toVector
         // the mediator takes some time after onboarding until it starts producing verdicts
         .dropWhile(_.verdict.isEmpty)
-      if (otherScanHistory.isEmpty) {
-        throw new IllegalStateException(
-          s"Scan ${otherScan.config.svUser} was empty, but that's shouldn't happen in tests."
-        )
-      }
 
       val founderHistoryToUse = founderHistorySinceOtherOnboarding.dropWhile(item =>
         item.verdict != otherScanHistory.headOption.flatMap(_.verdict)


### PR DESCRIPTION
The PR train doesn't end!

As evidenced by https://github.com/hyperledger-labs/splice/pull/2725, the test wasn't actually testing anything, since all scans were writing to the same table and thus they were all reading the exact same verdicts.
The moment you stop doing that, you find out that a bunch of updates (rightfully) do not have verdicts, or that new verdicts pop up that don't involve the DSO party.
Hopefully this fixes all that...