### PR TITLE
bump peak_tps in ScanTotalSupplyBigQueryIntegrationTest from observed behavior

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
@@ -80,9 +80,9 @@ class ScanTotalSupplyBigQueryIntegrationTest
   // The test currently produces 80 transactions, which is 0.000926 tps over 24 hours,
   // so we assert for a range of 70-85 transactions, or 0.0008-0.00099 tps.
   private val avgTps = (0.0008, 0.00099)
-  // The peak is 17 transactions in a (simulated) minute, or 0.28333 tps over a minute,
-  // so we assert 15-20 transactions, or 0.25-0.34 tps
-  private val peakTps = (0.25, 0.34)
+  // The peak is 22 transactions in a (simulated) minute, or 0.36667 tps over a minute,
+  // so we assert 19-25 transactions, or 0.31-0.42 tps
+  private val peakTps = (0.31, 0.42)
   private val totalRounds = 4
 
   override def beforeAll() = {


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#5954, adapting [according to bisect] to #2707.

Failure in question (the failing actual value is 100% consistent over several runs):

```
- test bigquery queries *** FAILED ***
  testing total supply queries in BigQuery forEvery failed, because: 
    at index 1, 0.36666666666666664 was not less than or equal to 0.34 peak_tps (ScanTotalSupplyBigQueryIntegrationTest.scala:685) 
  in List(("average_tps", 9.25925925925926E-4, (8.0E-4, 9.9E-4)), ("peak_tps", 0.36666666666666664, (0.25, 0.34))) (ScanTotalSupplyBigQueryIntegrationTest.scala:683)
```

*This is empirical*; @nicu-da is this what you'd expect from #2707?

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
