### PR TITLE
Backport Add config for enabling access logging across the entire cluster (#2747)

### DIFF
--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -71,6 +71,7 @@ export const InfraConfigSchema = z.object({
     }),
     istio: z.object({
       enableIngressAccessLogging: z.boolean(),
+      enableClusterAccessLogging: z.boolean().default(false),
     }),
     extraCustomResources: z.object({}).catchall(z.any()).default({}),
   }),

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -100,10 +100,8 @@ function configureIstiod(
         },
         // https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/
         meshConfig: {
-          // Uncomment to turn on access logging across the entire cluster (we disabled it by default to reduce cost):
-          // accessLogFile: '/dev/stdout',
           // taken from https://github.com/istio/istio/issues/37682
-          accessLogFile: '',
+          accessLogFile: infraConfig.istio.enableClusterAccessLogging ? '/dev/stdout' : '',
           accessLogEncoding: 'JSON',
           // https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging  disable as we don't use annotations
           enablePrometheusMerge: false,


### PR DESCRIPTION
Backports #2747 to release-line-0.4.19
