### PR TITLE
move grafana pg instance to infra nodes

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2601,7 +2601,7 @@
                 {
                   "matchExpressions": [
                     {
-                      "key": "cn_apps",
+                      "key": "cn_infra",
                       "operator": "Exists"
                     }
                   ]
@@ -2626,7 +2626,7 @@
         "tolerations": [
           {
             "effect": "NoSchedule",
-            "key": "cn_apps",
+            "key": "cn_infra",
             "operator": "Exists"
           }
         ]

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -9,7 +9,11 @@ import { Resource } from '@pulumi/pulumi';
 import { CnChartVersion } from './artifacts';
 import { clusterSmallDisk, CloudSqlConfig, config } from './config';
 import { spliceConfig } from './config/config';
-import { installSpliceHelmChart } from './helm';
+import {
+  appsAffinityAndTolerations,
+  infraAffinityAndTolerations,
+  installSpliceHelmChart,
+} from './helm';
 import { installPostgresPasswordSecret } from './secrets';
 import { ChartValues, CLUSTER_BASENAME, ExactNamespace, GCP_ZONE } from './utils';
 
@@ -196,7 +200,8 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
     values?: ChartValues,
     overrideDbSizeFromValues?: boolean,
     disableProtection?: boolean,
-    version?: CnChartVersion
+    version?: CnChartVersion,
+    useInfraAffinityAndTolerations: boolean = false
   ) {
     const logicalName = xns.logicalName + '-' + instanceName;
     const logicalNameAlias = xns.logicalName + '-' + alias; // pulumi name before #12391
@@ -237,7 +242,9 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
       {
         aliases: [{ name: logicalNameAlias, type: 'kubernetes:helm.sh/v3:Release' }],
         dependsOn: [passwordSecret],
-      }
+      },
+      true,
+      useInfraAffinityAndTolerations ? infraAffinityAndTolerations : appsAffinityAndTolerations
     );
     this.pg = pg;
 

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -865,6 +865,9 @@ function installPostgres(namespace: ExactNamespace): SplicePostgres {
     'grafana-pg',
     'grafana-pg-secret',
     { db: { volumeSize: '20Gi' } }, // A tiny pvc should be enough for grafana
-    true // overrideDbSizeFromValues
+    true, // overrideDbSizeFromValues
+    false, // disableProtection
+    undefined, // chart version
+    true // useInfraAffinityAndTolerations
   );
 }


### PR DESCRIPTION
Because:
1. It makes more sense
2. On e.g. ci cluster, the node types for infra and app are different, and the storage type that we use (standard-rwo) is not supported on the c4 nodes that we use for apps.

When applied, this will probably kill the data but I believe that's fine for the grafana DB itself.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
