### PR TITLE
Use toProtoPrimitive for domainId in Events endpoint

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
@@ -489,7 +489,7 @@ object ScanHttpEncodings {
     httpApi.EventHistoryVerdict(
       updateId = verdict.updateId,
       migrationId = verdict.migrationId,
-      domainId = verdict.domainId.toString(),
+      domainId = verdict.domainId.toProtoPrimitive,
       recordTime = formatRecordTime(verdict.recordTime.toInstant),
       finalizationTime = formatRecordTime(verdict.finalizationTime.toInstant),
       submittingParties = verdict.submittingParties.toVector,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodingsTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodingsTest.scala
@@ -388,10 +388,14 @@ class ScanHttpEncodingsTest extends StoreTest with TestEssentials with Matchers 
     val partyB = mkPartyId("Bob").toProtoPrimitive
     val partyC = mkPartyId("Charlie").toProtoPrimitive
 
+    val dummyDomainLongString =
+      "global-domain::122015405b2293753a19749682fce0c2a6bb6bf03bcd7d9bde2cd0dce9e426c9a2df"
+    val dummyDomainLong = SynchronizerId.tryFromString(dummyDomainLongString)
+
     val verdictBase = DbScanVerdictStore.VerdictT(
       rowId = 0L,
       migrationId = 3L,
-      domainId = dummyDomain,
+      domainId = dummyDomainLong,
       recordTime = recordTs,
       finalizationTime = recordTs,
       submittingParticipantUid = mkParticipantId("participant").toProtoPrimitive,
@@ -505,7 +509,7 @@ class ScanHttpEncodingsTest extends StoreTest with TestEssentials with Matchers 
 
     encodedVerdict.updateId shouldBe verdictBase.updateId
     encodedVerdict.migrationId shouldBe verdictBase.migrationId
-    encodedVerdict.domainId shouldBe dummyDomain.toString
+    encodedVerdict.domainId shouldBe dummyDomainLongString
     encodedVerdict.recordTime should haveMicrosecondPrecision
     encodedVerdict.finalizationTime should haveMicrosecondPrecision
     encodedVerdict.submittingParties shouldBe verdictBase.submittingParties.toVector


### PR DESCRIPTION
This fixes the issue of domainId getting truncated like `"domain_id":"global-domain::122015405b22..."`

Fixes #2764 

Also use a full domainId in testing to verify the fix.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
