### PR TITLE
Wait longer for Canton to start in ManualStartIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -267,7 +267,7 @@ class ManualStartIntegrationTest
           def initializeWithKeyReuse(connection: ParticipantAdminConnection, name: String): Unit = {
             // Eventually, because the query to the server will fail while the server is still starting up
             // Long timeout because Canton is slow to start up
-            eventually(timeUntilSuccess = 60.seconds) {
+            eventually(timeUntilSuccess = 120.seconds) {
 
               val signingKey =
                 connection.generateKeyPair("signing", SigningKeyUsage.All).futureValue


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/5945 (see analysis there)

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
