### PR TITLE
Fix release notes after 0.4.22 cut

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,6 +11,18 @@ Release Notes
 Upcoming
 --------
 
+  - Deployment
+
+      - Docker-compose based deployments of LocalNet, validator, and SV expose only to 127.0.0.1 by default. If you want to expose externally, use ``-E`` in validator and superValidator ``start.sh``. For LocalNet, set ``export HOST_BIND_IP=0.0.0.0`` manually.
+
+  - Validator
+
+      - ``/v0/admin/users/offboard``:
+        Offboarding a user now also deletes the ledger API user in the participant node.
+
+0.4.22
+------
+
   - SV
 
     - Improve throughput of ``FeaturedAppActivityMarkerTrigger``, which converts ``FeaturedAppActivityMarker`` contracts
@@ -68,8 +80,6 @@ Upcoming
 
     - Replace ``-Dscala.concurrent.context.minThreads=8`` with ``-Dscala.concurrent.context.numThreads=8`` and set ``-XX:ActiveProcessorCount=8``  in the ``defaultJvmOptions`` for all the helm charts that deploy scala apps. This should ensure that the internal execution contexts spawn 8 threads to handle processing and that the JVM is configured for 8 CPUs as well. The previous behavior would spawn up to number of available processors, which can be up to the number of CPUs on the actual node if no CPU limit is set. This should avoid overloading the nodes during heavy processing.
 
-    - Docker-compose based deployments of LocalNet, validator, and SV expose only to 127.0.0.1 by default. If you want to expose externally, use ``-E`` in validator and superValidator ``start.sh``. For LocalNet, set ``export HOST_BIND_IP=0.0.0.0`` manually.
-
   - SV
 
     - UI
@@ -77,11 +87,6 @@ Upcoming
       - Add the ability to specify a validator party hint when generating onboarding secrets.
 
       - The UI now provides a formatted message for easily sharing onboarding details with validator operators.
-
-  - Validator
-
-      - ``/v0/admin/users/offboard``:
-        Offboarding a user now also deletes the ledger API user in the participant node.
 
 
 0.4.19


### PR DESCRIPTION
We got a bit out of sync with the `release-line-0.4` branch.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
