### PR TITLE
Adding retry in test to avoid time mismatches

### DIFF
--- a/apps/sv/frontend/src/__tests__/sv.test.tsx
+++ b/apps/sv/frontend/src/__tests__/sv.test.tsx
@@ -122,47 +122,51 @@ Expiration
     expect(await screen.findByText('Vote Requests')).toBeDefined();
   });
 
-  test('see proper time format in popup', async () => {
-    const user = userEvent.setup();
-    render(<AppWithConfig />);
+  test(
+    'see proper time format in popup',
+    async () => {
+      const user = userEvent.setup();
+      render(<AppWithConfig />);
 
-    expect(await screen.findByText('Governance')).toBeDefined();
-    await user.click(screen.getByText('Governance'));
+      expect(await screen.findByText('Governance')).toBeDefined();
+      await user.click(screen.getByText('Governance'));
 
-    const inOneWeek = dayjs().add(1, 'week').format(dateTimeFormatISO);
-    const expirationDate = dayjs().add(23, 'minutes').format(dateTimeFormatISO);
+      const inOneWeek = dayjs().add(1, 'week').format(dateTimeFormatISO);
+      const expirationDate = dayjs().add(23, 'minutes').format(dateTimeFormatISO);
 
-    const dateInput = screen.getByTestId('datetime-picker-vote-request-expiration');
+      const dateInput = screen.getByTestId('datetime-picker-vote-request-expiration');
 
-    // We wait for the date to be set to the default value from the ledger.
-    await waitFor(() => expect(dateInput.getAttribute('value')).toBe(inOneWeek));
-    await user.type(dateInput, expirationDate);
-    expect(dateInput.getAttribute('value')).toBe(expirationDate);
+      // We wait for the date to be set to the default value from the ledger.
+      await waitFor(() => expect(dateInput.getAttribute('value')).toBe(inOneWeek));
+      await user.type(dateInput, expirationDate);
+      expect(dateInput.getAttribute('value')).toBe(expirationDate);
 
-    const formExpirationLabel = screen.getByTestId('vote-request-expiration-duration');
-    expect(formExpirationLabel).toHaveTextContent('in 23 minutes');
+      const formExpirationLabel = screen.getByTestId('vote-request-expiration-duration');
+      expect(formExpirationLabel).toHaveTextContent('in 23 minutes');
 
-    const options: HTMLOptionElement[] = await screen.findAllByTestId('display-members-option');
+      const options: HTMLOptionElement[] = await screen.findAllByTestId('display-members-option');
 
-    fireEvent.change(screen.getByTestId('display-members'), {
-      target: {
-        value: options[0].value,
-      },
-    });
+      fireEvent.change(screen.getByTestId('display-members'), {
+        target: {
+          value: options[0].value,
+        },
+      });
 
-    const summaryInput = screen.getByTestId('create-reason-summary');
-    await user.type(summaryInput, 'summaryABC');
+      const summaryInput = screen.getByTestId('create-reason-summary');
+      await user.type(summaryInput, 'summaryABC');
 
-    const urlInput = screen.getByTestId('create-reason-url');
-    await user.type(urlInput, 'https://vote-request.url');
+      const urlInput = screen.getByTestId('create-reason-url');
+      await user.type(urlInput, 'https://vote-request.url');
 
-    const submitButton = screen.getByTestId('create-voterequest-submit-button');
-    await user.click(submitButton);
+      const submitButton = screen.getByTestId('create-voterequest-submit-button');
+      await user.click(submitButton);
 
-    const submitPopup = screen.getByRole('dialog');
+      const submitPopup = screen.getByRole('dialog');
 
-    expect(submitPopup).toHaveTextContent('in 23 minutes');
-  });
+      expect(submitPopup).toHaveTextContent('in 23 minutes');
+    },
+    { retry: 2 }
+  );
 });
 
 describe('An SetConfig request', () => {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/6012

Adding a retry for this test. It will always succeed on the second attempt if there is a minute mismatch.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
