### PR TITLE
Operator deployments: allow tracking a single commit

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -25,7 +25,7 @@ synchronizerMigration:
     - id: 1
       version: 0.3.18
       releaseReference:
-        gitReference: "refs/heads/release-line-0.3.18"
+        gitReference: "981227e62011e386cca3cdb5f00b472cf05a12c4"
         repoUrl: https://github.com/hyperledger-labs/splice
         pulumiStacksDir: "cluster/stacks/prod"
         pulumiBaseDir: "splice/cluster/pulumi"

--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -1037,7 +1037,7 @@
         "interval": "5m",
         "recurseSubmodules": true,
         "ref": {
-          "name": "refs/heads/release-line-0.3.18"
+          "commit": "981227e62011e386cca3cdb5f00b472cf05a12c4"
         },
         "secretRef": {
           "name": "github"
@@ -1090,7 +1090,7 @@
         "interval": "5m",
         "recurseSubmodules": true,
         "ref": {
-          "name": "refs/heads/release-line-0.3.18"
+          "commit": "981227e62011e386cca3cdb5f00b472cf05a12c4"
         },
         "secretRef": {
           "name": "github"

--- a/cluster/pulumi/common/src/operator/flux-source.ts
+++ b/cluster/pulumi/common/src/operator/flux-source.ts
@@ -22,6 +22,14 @@ export type StackFromRef = { project: string; stack: string };
 // Trim non-splitwell DARs to avoid blowing the hardcoded operator size limit of 50mb
 const repoIgnore = '**/daml/dars\n!**/daml/dars/splitwell*';
 
+function expandGitReference(gitReference: string): { name: string } | { commit: string } {
+  if (gitReference.startsWith('refs/')) {
+    return { name: gitReference };
+  } else {
+    return { commit: gitReference };
+  }
+}
+
 // https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1/gitrepositories.md
 export function gitRepoForRef(
   nameSuffix: string,
@@ -46,9 +54,7 @@ export function gitRepoForRef(
         spec: {
           interval: '5m',
           url: ref.repoUrl,
-          ref: {
-            name: ref.gitReference,
-          },
+          ref: expandGitReference(ref.gitReference),
           secretRef: { name: 'github' },
           recurseSubmodules: true,
           ignore: repoIgnore,
@@ -74,9 +80,7 @@ export function gitRepoForRef(
       spec: {
         interval: '5m',
         url: ref.repoUrl,
-        ref: {
-          name: ref.gitReference,
-        },
+        ref: expandGitReference(ref.gitReference),
         include: stacksToCopy.map(stack => ({
           fromPath: `${ref.pulumiStacksDir}/${stack.project}/Pulumi.${stack.stack}.yaml`,
           toPath: `${ref.pulumiBaseDir}/${stack.project}/Pulumi.${stack.stack}.yaml`,


### PR DESCRIPTION
Main change for https://github.com/DACH-NY/canton-network-internal/issues/2366

Tested on a scratch. Will also test on TestNet before using on MainNet.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
