### PR TITLE
[ci] Add scan cache for open mining roudns (#2801)

### DIFF
--- a/apps/app/src/test/resources/include/scans/_scan.conf
+++ b/apps/app/src/test/resources/include/scans/_scan.conf
@@ -108,6 +108,10 @@
        ttl = 1s
        max-size = 1
       }
+      open-mining-rounds {
+       ttl = 1s
+       max-size = 1
+      }
   }
 
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MiningRoundsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MiningRoundsStore.scala
@@ -19,7 +19,7 @@ trait MiningRoundsStore extends AppStore {
   /** Lookup the triple of open mining rounds that should always be present
     * after bootstrapping.
     */
-  final def lookupOpenMiningRoundTriple()(implicit
+  def lookupOpenMiningRoundTriple()(implicit
       ec: ExecutionContext,
       tc: TraceContext,
   ): Future[Option[MiningRoundsStore.OpenMiningRoundTriple]] =

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -76,6 +76,10 @@ final case class ScanCacheConfig(
       ttl = NonNegativeFiniteDuration.ofMinutes(2),
       maxSize = 1000,
     ),
+    openMiningRounds: CacheConfig = CacheConfig(
+      ttl = NonNegativeFiniteDuration.ofSeconds(30),
+      maxSize = 1,
+    ),
     amuletRules: CacheConfig = CacheConfig(
       ttl = NonNegativeFiniteDuration.ofSeconds(30),
       maxSize = 1,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanStore.scala
@@ -34,6 +34,7 @@ import org.lfdecentralizedtrust.splice.scan.config.{CacheConfig, ScanCacheConfig
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbScanStoreMetrics, ScanAggregator}
 import org.lfdecentralizedtrust.splice.store.{
   Limit,
+  MiningRoundsStore,
   MultiDomainAcsStore,
   PageLimit,
   SortOrder,
@@ -365,6 +366,16 @@ class CachingScanStore(
       cacheConfig.svNodeState,
       store.lookupSvNodeState,
     ).get(svPartyId)
+
+  override def lookupOpenMiningRoundTriple()(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[Option[MiningRoundsStore.OpenMiningRoundTriple]] =
+    getCache(
+      "openMiningRounds",
+      cacheConfig.openMiningRounds,
+      (_: Unit) => store.lookupOpenMiningRoundTriple(),
+    ).get(())
 
   override def domains: SynchronizerStore = store.domains
 


### PR DESCRIPTION
This is the most expensive query that we currently run and has a performance impact on mainnet


(cherry picked from commit 43aa59a002563ebe1b859ca54adc540ecb93fc84)

port of https://github.com/hyperledger-labs/splice/pull/2801

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
