### PR TITLE
[ci] Specify encoding for the dump write

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/BackupDump.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/BackupDump.scala
@@ -4,12 +4,13 @@
 package org.lfdecentralizedtrust.splice.util
 
 import better.files.File
-import org.lfdecentralizedtrust.splice.config.BackupDumpConfig
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.tracing.TraceContext
 import io.circe.Decoder
+import org.lfdecentralizedtrust.splice.config.BackupDumpConfig
 
 import java.io.FileNotFoundException
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Path, Paths}
 import scala.util.Try
 
@@ -40,7 +41,7 @@ object BackupDump {
     import better.files.File
     val file = File(path)
     file.parent.createDirectories()
-    file.write(content)
+    file.write(content)(File.OpenOptions.default, StandardCharsets.UTF_8)
     file
   }
 
@@ -54,7 +55,7 @@ object BackupDump {
     if (!dumpFile.exists) {
       throw new FileNotFoundException(s"Failed to find dump file at $path")
     } else {
-      val jsonString: String = dumpFile.contentAsString
+      val jsonString: String = dumpFile.contentAsString(StandardCharsets.UTF_8)
       io.circe.parser.decode[T](jsonString) match {
         case Left(error) =>
           throw new IllegalArgumentException(


### PR DESCRIPTION
fixes https://github.com/hyperledger-labs/splice/issues/2864

reproduced locally with stacktrace

```


An exception or error caused a run to abort: Requested array size exceeds VM limit 
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
	at java.base/java.lang.String.encodeWithEncoder(String.java:902)
	at java.base/java.lang.String.encode(String.java:875)
	at java.base/java.lang.String.getBytes(String.java:1818)
	at better.files.File.write(File.scala:373)
```

the stacktrace goes though `encodeWithEncoder` which was surprising because the utf-8 encoding should go through `encodeUTF8`. the file write api uses the `Charset.defaultCharset()` which in theory should be utf-8 for java 17+ but it does not seem to work. 

so the root issue is here https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/String.java#L871 the `Charset.defaultCharset()` result is UTF_8 but it fails the check `==  UTF_8.INSTANCE` (equals does return true)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
