### PR TITLE
Fix flake with too many party-id classnames

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -546,12 +546,12 @@ abstract class ValidatorPreflightIntegrationTestBase
       )(
         "Party ID is displayed after onboarding finishes",
         _ => {
-          findAll(className("party-id")) should have size 1
+          find(className("party-id")) should not be None
         },
       )
     } else {
       logger.debug("User is already onboarded")
-      findAll(className("party-id")) should have size 1
+      find(className("party-id")) should not be None
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6145

The `party-id` class name appears every time the `<PartyId/>` component is used.
In the screenshot of the issue you can see 2 of them (3 and 4 being outside the screenshot):
 
<img width="1366" height="682" alt="504886236-6c711780-b26e-404e-b797-bcd67e155362" src="https://github.com/user-attachments/assets/55c2058e-d78f-4576-94ec-c6164b1b3511" />


Since the only thing we're checking is that we're onboarded, we just need _one_ to exist at all.