### PR TITLE
Make cncluster psql query deployment instead of pod

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -2208,7 +2208,7 @@ function subcmd_psql() {
   _info "Retrieving DB connection info from pod description..."
   local DB_INIT_COMMAND
   DB_INIT_COMMAND=$(
-    kubectl describe pod \
+    kubectl describe deployment \
       --namespace "${NAMESPACE}" \
       --selector "app=${APPLICATION}" \
     | grep -i psql \
@@ -2219,7 +2219,7 @@ function subcmd_psql() {
     _error "Application ${APPLICATION} in namespace ${NAMESPACE} does not have an associated database."
     exit 1
   fi
-  
+
   eval "set -- $DB_INIT_COMMAND"
   while [ $# -gt 0 ]; do
     case "$1" in


### PR DESCRIPTION
It has the same query and it works even if the pod is down. Tested manually and seems to work.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
