### PR TITLE
Support for granting ValidatorLicense via SV UI

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -5,6 +5,19 @@
 
 .. _release_notes:
 
+Integration branch
+--------
+
+- Daml
+
+  - `ValidatorLicense` now has `weight`, and `kind` fields
+
+- SV
+
+  - `dso_acs_store` requires migration to add a column for storing `ValidatorLivenessActivityRecord` weight
+
+  - SVs can grant `ValidatorLicense` to any arbitrary party. See `CIP <https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0073/cip-0073.md>` for the motivation.
+
 Upcoming
 --------
 


### PR DESCRIPTION
Fixes #2904 

- Adds support for granting `ValidatorLicense` via SV UI and console.
- Show weight + License kind in ValidatorLicense UI
  - Weight will only be shown if it is non-null
  - A check-mark will be shown if it is a validator node operator
- Scan API fixes: ValidatorReceivedFaucets
- And includes scala code fixes for the daml changes introduced in #2903 
- Adds a column in `dso_acs_store` for storing `ValidatorLivenessActivityRecord` weight

- Removes `SvMergeDuplicatedValidatorLicenseIntegrationTest` and adds its functionality in new test `SvValidatorLicenseIntegrationTest`
