### PR TITLE
[forward port] Batched expiry for (locked) amulet (#2893)

### DIFF
--- a/apps/app/src/test/resources/include/svs/_sv.conf
+++ b/apps/app/src/test/resources/include/svs/_sv.conf
@@ -25,10 +25,6 @@
     }
   }
   automation {
-    # amulet expiry and unclaimed reward expiry are not problematic in our tests environments as participants do not go offline.
-    # TODO(M3-63) Currently, auto-expiration of unclaimed rewards and amulet expiry is disabled by default
-    enable-expire-amulet = true
-
     enable-expire-validator-faucet = true
 
     # CometBFT reconciliation is disabled by default as it would destabilize the CometBFT network by reflecting the

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AmuletExpiryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AmuletExpiryIntegrationTest.scala
@@ -1,0 +1,123 @@
+package org.lfdecentralizedtrust.splice.integration.tests
+
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import com.digitalasset.canton.logging.SuppressionRule
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
+  ConfigurableApp,
+  updateAutomationConfig,
+}
+import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
+import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithSharedEnvironment
+import org.lfdecentralizedtrust.splice.store.db.DbMultiDomainAcsStore
+import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.{
+  AdvanceOpenMiningRoundTrigger,
+  ExpiredAmuletTrigger,
+  ExpiredLockedAmuletTrigger,
+}
+import org.lfdecentralizedtrust.splice.util.*
+import org.slf4j.event.Level
+
+import java.time.Duration
+
+@org.lfdecentralizedtrust.splice.util.scalatesttags.SpliceAmulet_0_1_9
+class AmuletExpiryIntegrationTest
+    extends IntegrationTestWithSharedEnvironment
+    with WalletTestUtil
+    with TimeTestUtil
+    with SplitwellTestUtil
+    with TriggerTestUtil {
+
+  // The direct creation of (Locked)Amulet is no appreciated by history parsers
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
+  override protected def runUpdateHistorySanityCheck: Boolean = false
+
+  override def environmentDefinition: SpliceEnvironmentDefinition =
+    EnvironmentDefinition
+      // TODO(#2885): switch to a 4 SV topology once we have contention avoidance in place
+      .simpleTopology1Sv(this.getClass.getSimpleName)
+      .addConfigTransform((_, config) =>
+        ConfigTransforms.updateInitialTickDuration(NonNegativeFiniteDuration.ofMillis(500))(config)
+      )
+      // Start rounds trigger in paused state
+      .addConfigTransforms((_, config) =>
+        updateAutomationConfig(ConfigurableApp.Sv)(sv => {
+          sv.withPausedTrigger[AdvanceOpenMiningRoundTrigger]
+        })(config)
+      )
+      // disable the reward collection to avoid accidental creation or merging of amulet
+      .addConfigTransforms((_, config) =>
+        updateAutomationConfig(ConfigurableApp.Validator)(
+          _.copy(enableAutomaticRewardsCollectionAndAmuletMerging = false)
+        )(config)
+      )
+      // Make batches for amulet expiry trigger smaller, so we see the logic working
+      .addConfigTransforms((_, config) =>
+        ConfigTransforms.updateAllSvAppConfigs_(
+          _.copy(
+            delegatelessAutomationExpiredAmuletBatchSize = 2
+          )
+        )(config)
+      )
+
+  "Amulet should expire" in { implicit env =>
+    val sv1UserId = sv1WalletClient.config.ledgerApiUser
+    val sv1UserParty = onboardWalletUser(sv1WalletClient, sv1ValidatorBackend)
+
+    val numAmulets = 10
+    val amuletAmount = BigDecimal(123.0)
+
+    loggerFactory.suppress(
+      SuppressionRule.forLogger[DbMultiDomainAcsStore[?]] && SuppressionRule.Level(Level.ERROR)
+    )(
+      actAndCheck(
+        "Create locked and unlocked dust amulet", {
+          for (i <- 1 to numAmulets) {
+            createAmulet(
+              sv1ValidatorBackend.participantClientWithAdminToken,
+              sv1UserId,
+              sv1UserParty,
+              amount = amuletAmount,
+              holdingFee = amuletAmount,
+            )
+            createLockedAmulet(
+              sv1ValidatorBackend.participantClientWithAdminToken,
+              sv1UserId,
+              sv1UserParty,
+              lockHolders = Seq(sv1UserParty),
+              amount = amuletAmount,
+              holdingFee = amuletAmount,
+              expiredDuration = Duration.ofSeconds(1),
+            )
+          }
+        },
+      )(
+        "Locked and unlocked dust amulet is created",
+        _ => {
+          sv1WalletClient.list().amulets should have length numAmulets.toLong
+          sv1WalletClient.list().lockedAmulets should have length numAmulets.toLong
+        },
+      )
+    )
+
+    actAndCheck(
+      "Advance 4 rounds and turn on triggers", {
+        advanceRoundsByOneTickViaAutomation()
+        advanceRoundsByOneTickViaAutomation()
+        advanceRoundsByOneTickViaAutomation()
+        advanceRoundsByOneTickViaAutomation()
+
+        env.svs.local.foreach(sv => {
+          sv.dsoDelegateBasedAutomation.trigger[ExpiredAmuletTrigger].resume()
+          sv.dsoDelegateBasedAutomation.trigger[ExpiredLockedAmuletTrigger].resume()
+        })
+      },
+    )(
+      "Check that dust amulet gets expired",
+      _ => {
+        sv1WalletClient.list().amulets shouldBe empty
+        sv1WalletClient.list().lockedAmulets shouldBe empty
+      },
+    )
+  }
+}

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -32,6 +32,7 @@ import org.lfdecentralizedtrust.splice.wallet.store.TxLogEntry
 import com.digitalasset.canton.console.CommandFailure
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.LockedAmulet
 import org.lfdecentralizedtrust.splice.environment.PackageVersionSupport
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
 import org.lfdecentralizedtrust.splice.wallet.admin.api.client.commands.HttpWalletAppClient.CreateTransferPreapprovalResponse
@@ -920,6 +921,51 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
         actAs = Seq(dsoParty, owner),
         readAs = Seq.empty,
         update = amulet,
+        synchronizerId = synchronizerId,
+      )
+    created.contractId
+  }
+
+  /** Directly creates a new LockedAmulet amulet. Note that the receiver and lock hodlers must be hosted on the same participant as the DSO. */
+  def createLockedAmulet(
+      participantClient: ParticipantClientReference,
+      userId: String,
+      owner: PartyId,
+      lockHolders: Seq[PartyId],
+      amount: BigDecimal = BigDecimal(10),
+      expiredDuration: Duration = Duration.ofMinutes(5),
+      round: Long = 0,
+      holdingFee: BigDecimal = BigDecimal(0.01),
+      synchronizerId: Option[SynchronizerId] = None,
+  )(implicit
+      env: SpliceTestConsoleEnvironment
+  ): amuletCodegen.LockedAmulet.ContractId = {
+    val amulet =
+      new amuletCodegen.Amulet(
+        dsoParty.toProtoPrimitive,
+        owner.toProtoPrimitive,
+        new feesCodegen.ExpiringAmount(
+          amount.bigDecimal,
+          new Round(round),
+          new feesCodegen.RatePerRound(holdingFee.bigDecimal),
+        ),
+      )
+    val expiredAt = env.environment.clock.now.add(expiredDuration)
+    val expiration = Codec.decode(Codec.Timestamp)(expiredAt.underlying.micros).value
+    val lockedAmulet = new LockedAmulet(
+      amulet,
+      new TimeLock(
+        lockHolders.map(_.toProtoPrimitive).asJava,
+        expiration.toInstant,
+        None.toJava,
+      ),
+    )
+    val created = participantClient.ledger_api_extensions.commands
+      .submitWithResult(
+        userId = userId,
+        actAs = Seq(dsoParty, owner),
+        readAs = Seq.empty,
+        update = lockedAmulet.create(),
         synchronizerId = synchronizerId,
       )
     created.contractId

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/BatchedMultiDomainExpiredContractTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/BatchedMultiDomainExpiredContractTrigger.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.automation
+
+import com.daml.ledger.javaapi.data.codegen.ContractId
+import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
+import com.digitalasset.canton.tracing.TraceContext
+import io.opentelemetry.api.trace.Tracer
+import org.apache.pekko.stream.Materializer
+import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.ContractState
+import org.lfdecentralizedtrust.splice.store.{MultiDomainAcsStore, PageLimit}
+import org.lfdecentralizedtrust.splice.util.{AssignedContract, Contract}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** A trigger for processing expired contracts whose expiry archives exactly them.
+  *
+  * Use [[ScheduledTaskTrigger]] for more complex expiry choices.
+  */
+abstract class BatchedMultiDomainExpiredContractTrigger[
+    C,
+    TCid <: ContractId[_],
+    T,
+](
+    store: MultiDomainAcsStore,
+    batchSize: Int,
+    listExpiredContracts: MultiDomainExpiredContractTrigger.ListExpiredContracts[TCid, T],
+    companion: C,
+)(implicit
+    ec: ExecutionContext,
+    mat: Materializer,
+    tracer: Tracer,
+    companionClass: MultiDomainAcsStore.ContractCompanion[C, TCid, T],
+) extends ScheduledTaskTrigger[BatchedMultiDomainExpiredContractTrigger.Batch[TCid, T]] {
+
+  import BatchedMultiDomainExpiredContractTrigger.Batch
+
+  override final protected def listReadyTasks(now: CantonTimestamp, limit: Int)(implicit
+      tc: TraceContext
+  ): Future[Seq[Batch[TCid, T]]] =
+    listExpiredContracts(now, PageLimit.tryCreate(limit * batchSize))(tc)
+      .map(_.grouped(batchSize).map(Batch(_)).toSeq)
+
+  override final protected def isStaleTask(
+      task: ScheduledTaskTrigger.ReadyTask[Batch[TCid, T]]
+  )(implicit tc: TraceContext): Future[Boolean] = {
+    Future
+      .traverse(task.work.expiredContracts)(co =>
+        store
+          .lookupContractById(companion)(co.contractId: TCid)
+          .map(
+            _.forall(_.state != ContractState.Assigned(co.domain))
+          )
+      )
+      .map(_.exists(stale => stale))
+  }
+}
+
+object BatchedMultiDomainExpiredContractTrigger {
+  final case class Batch[TCid, T](
+      expiredContracts: Seq[
+        AssignedContract[TCid, T]
+      ]
+  ) extends PrettyPrinting {
+    override def pretty: Pretty[this.type] =
+      prettyOfClass(
+        param("numExpiredContracts", _.expiredContracts.size),
+        param("expiredContractCids", _.expiredContracts.map(_.contractId.contractId.unquoted)),
+      )
+  }
+
+  type Template[TCid <: ContractId[_], T] =
+    BatchedMultiDomainExpiredContractTrigger[Contract.Companion.Template[TCid, T], TCid, T]
+  type ListExpiredContracts[TCid <: ContractId[_], T] =
+    // we use PageLimit because this is always used in the context of a trigger, where the query will be re-run repeatedly
+    (CantonTimestamp, PageLimit) => TraceContext => Future[Seq[AssignedContract[TCid, T]]]
+}

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/MultiDomainExpiredContractTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/MultiDomainExpiredContractTrigger.scala
@@ -18,7 +18,6 @@ import MultiDomainAcsStore.ContractState
   *
   * Use [[ScheduledTaskTrigger]] for more complex expiry choices.
   */
-// TODO(tech-debt): if we happen to find LOTS of instances that just expire the contract based on its expiry date, then we should consider introducing a Daml-level interface 'ExpiringContract' and handle all of them using single trigger.
 abstract class MultiDomainExpiredContractTrigger[
     C,
     TCid <: ContractId[_],

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AutomationConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AutomationConfig.scala
@@ -71,9 +71,6 @@ case class AutomationConfig(
       * TODO(DACH-NY/canton-network-node#11828) Remove this option
       */
     enableExpireValidatorFaucet: Boolean = false,
-    /** Only intended for testing. Disables the expiration of Amulet.
-      */
-    enableExpireAmulet: Boolean = false,
     /** Only intended for testing. Allows disabling governance automation.
       */
     enableDsoGovernance: Boolean = true,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/DsoDelegateBasedAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/DsoDelegateBasedAutomationService.scala
@@ -59,11 +59,8 @@ class DsoDelegateBasedAutomationService(
     }
     registerTrigger(new MergeMemberTrafficContractsTrigger(triggerContext, svTaskContext))
 
-    if (config.automation.enableExpireAmulet) {
-      registerTrigger(new ExpiredAmuletTrigger(triggerContext, svTaskContext))
-    }
-
-    registerTrigger(new ExpiredLockedAmuletTrigger(triggerContext, svTaskContext))
+    registerTrigger(new ExpiredAmuletTrigger(config, triggerContext, svTaskContext))
+    registerTrigger(new ExpiredLockedAmuletTrigger(config, triggerContext, svTaskContext))
     registerTrigger(new ExpiredSvOnboardingRequestTrigger(triggerContext, svTaskContext))
     registerTrigger(new CloseVoteRequestTrigger(triggerContext, svTaskContext))
     registerTrigger(new ExpiredSvOnboardingConfirmedTrigger(triggerContext, svTaskContext))

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletTrigger.scala
@@ -5,7 +5,6 @@ package org.lfdecentralizedtrust.splice.sv.automation.delegatebased
 
 import org.lfdecentralizedtrust.splice.automation.*
 import org.lfdecentralizedtrust.splice.codegen.java.splice
-import org.lfdecentralizedtrust.splice.util.AssignedContract
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
@@ -13,50 +12,63 @@ import org.apache.pekko.stream.Materializer
 import scala.concurrent.{ExecutionContext, Future}
 import ExpiredAmuletTrigger.*
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
+import org.lfdecentralizedtrust.splice.sv.config.SvAppBackendConfig
 
 import java.util.Optional
+import scala.jdk.CollectionConverters.*
 
 class ExpiredAmuletTrigger(
+    svConfig: SvAppBackendConfig,
     override protected val context: TriggerContext,
     override protected val svTaskContext: SvTaskBasedTrigger.Context,
 )(implicit
     override val ec: ExecutionContext,
     mat: Materializer,
     tracer: Tracer,
-) extends MultiDomainExpiredContractTrigger.Template[
+    // TODO(#2885): switch to a low-contention trigger; this one will heavily content among SVs
+) extends BatchedMultiDomainExpiredContractTrigger.Template[
       splice.amulet.Amulet.ContractId,
       splice.amulet.Amulet,
     ](
       svTaskContext.dsoStore.multiDomainAcsStore,
+      svConfig.delegatelessAutomationExpiredAmuletBatchSize,
       svTaskContext.dsoStore.listExpiredAmulets(context.config.ignoredExpiredAmuletPartyIds),
       splice.amulet.Amulet.COMPANION,
     )
     with SvTaskBasedTrigger[Task] {
   private val store = svTaskContext.dsoStore
 
-  override def completeTaskAsDsoDelegate(co: Task, controller: String)(implicit
+  override def completeTaskAsDsoDelegate(task: Task, controller: String)(implicit
       tc: TraceContext
   ): Future[TaskOutcome] =
     for {
       latestOpenMiningRound <- store.getLatestActiveOpenMiningRound()
       dsoRules <- store.getDsoRules()
-      cmd = dsoRules.exercise(
-        _.exerciseDsoRules_Amulet_Expire(
-          co.work.contractId,
-          new splice.amulet.Amulet_Expire(
-            latestOpenMiningRound.contractId
-          ),
-          Optional.of(controller),
-        )
+      cmds = task.work.expiredContracts.flatMap(co =>
+        dsoRules
+          .exercise(
+            _.exerciseDsoRules_Amulet_Expire(
+              co.contractId,
+              new splice.amulet.Amulet_Expire(
+                latestOpenMiningRound.contractId
+              ),
+              Optional.of(controller),
+            )
+          )
+          .update
+          .commands()
+          .asScala
+          .toSeq
       )
       _ <- svTaskContext
         .connection(SpliceLedgerConnectionPriority.AmuletExpiry)
         .submit(
           Seq(store.key.svParty),
           Seq(store.key.dsoParty),
-          update = cmd,
+          update = cmds,
         )
         .noDedup
+        .withSynchronizerId(dsoRules.domain)
         .yieldUnit()
     } yield TaskSuccess("archived expired amulet")
 }
@@ -64,6 +76,9 @@ class ExpiredAmuletTrigger(
 object ExpiredAmuletTrigger {
   type Task =
     ScheduledTaskTrigger.ReadyTask[
-      AssignedContract[splice.amulet.Amulet.ContractId, splice.amulet.Amulet]
+      BatchedMultiDomainExpiredContractTrigger.Batch[
+        splice.amulet.Amulet.ContractId,
+        splice.amulet.Amulet,
+      ]
     ]
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredLockedAmuletTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredLockedAmuletTrigger.scala
@@ -5,7 +5,6 @@ package org.lfdecentralizedtrust.splice.sv.automation.delegatebased
 
 import org.lfdecentralizedtrust.splice.automation.*
 import org.lfdecentralizedtrust.splice.codegen.java.splice
-import org.lfdecentralizedtrust.splice.util.AssignedContract
 import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
@@ -13,21 +12,26 @@ import org.apache.pekko.stream.Materializer
 import scala.concurrent.{ExecutionContext, Future}
 import ExpiredLockedAmuletTrigger.*
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
+import org.lfdecentralizedtrust.splice.sv.config.SvAppBackendConfig
 
 import java.util.Optional
+import scala.jdk.CollectionConverters.*
 
 class ExpiredLockedAmuletTrigger(
+    svConfig: SvAppBackendConfig,
     override protected val context: TriggerContext,
     override protected val svTaskContext: SvTaskBasedTrigger.Context,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
     tracer: Tracer,
-) extends MultiDomainExpiredContractTrigger.Template[
+    // TODO(#2885): switch to a low-contention trigger; this one will heavily content among SVs
+) extends BatchedMultiDomainExpiredContractTrigger.Template[
       splice.amulet.LockedAmulet.ContractId,
       splice.amulet.LockedAmulet,
     ](
       svTaskContext.dsoStore.multiDomainAcsStore,
+      svConfig.delegatelessAutomationExpiredAmuletBatchSize,
       svTaskContext.dsoStore.listLockedExpiredAmulets(context.config.ignoredExpiredAmuletPartyIds),
       splice.amulet.LockedAmulet.COMPANION,
     )
@@ -35,28 +39,36 @@ class ExpiredLockedAmuletTrigger(
   private val store = svTaskContext.dsoStore
 
   override protected def completeTaskAsDsoDelegate(
-      co: Task,
+      task: Task,
       controller: String,
   )(implicit tc: TraceContext): Future[TaskOutcome] = for {
     latestOpenMiningRound <- store.getLatestActiveOpenMiningRound()
     dsoRules <- store.getDsoRules()
-    cmd = dsoRules.exercise(
-      _.exerciseDsoRules_LockedAmulet_ExpireAmulet(
-        co.work.contractId,
-        new splice.amulet.LockedAmulet_ExpireAmulet(
-          latestOpenMiningRound.contractId
-        ),
-        Optional.of(controller),
-      )
+    cmds = task.work.expiredContracts.flatMap(co =>
+      dsoRules
+        .exercise(
+          _.exerciseDsoRules_LockedAmulet_ExpireAmulet(
+            co.contractId,
+            new splice.amulet.LockedAmulet_ExpireAmulet(
+              latestOpenMiningRound.contractId
+            ),
+            Optional.of(controller),
+          )
+        )
+        .update
+        .commands()
+        .asScala
+        .toSeq
     )
     _ <- svTaskContext
       .connection(SpliceLedgerConnectionPriority.AmuletExpiry)
       .submit(
         Seq(store.key.svParty),
         Seq(store.key.dsoParty),
-        update = cmd,
+        update = cmds,
       )
       .noDedup
+      .withSynchronizerId(dsoRules.domain)
       .yieldUnit()
   } yield TaskSuccess(s"archived expired locked amulet")
 }
@@ -64,6 +76,9 @@ class ExpiredLockedAmuletTrigger(
 object ExpiredLockedAmuletTrigger {
   type Task =
     ScheduledTaskTrigger.ReadyTask[
-      AssignedContract[splice.amulet.LockedAmulet.ContractId, splice.amulet.LockedAmulet]
+      BatchedMultiDomainExpiredContractTrigger.Batch[
+        splice.amulet.LockedAmulet.ContractId,
+        splice.amulet.LockedAmulet,
+      ]
     ]
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -334,6 +334,7 @@ case class SvAppBackendConfig(
     // at what number of markers should the app switch into catchup mode where
     // every SV tries to convert markers from any other SV's book of work (in a contention avoiding fashion)
     delegatelessAutomationFeaturedAppActivityMarkerCatchupThreshold: Int = 10_000,
+    delegatelessAutomationExpiredAmuletBatchSize: Int = 100,
     bftSequencerConnection: Boolean = true,
     // Skip synchronizer initialization and synchronizer config reconciliation.
     // Can be safely set to true for an SV that has completed onboarding unless you

--- a/test-full-class-names.log
+++ b/test-full-class-names.log
@@ -1,4 +1,5 @@
 org.lfdecentralizedtrust.splice.integration.tests.AmuletAllocationsIntegrationTest
+org.lfdecentralizedtrust.splice.integration.tests.AmuletExpiryIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.Ans4SvsIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.AnsIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.AutomationControlIntegrationTest


### PR DESCRIPTION
Includes removing the `automation.enable-expire-amulet` config flag, in favor of pausing triggers.

Fixes #2836

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
