### PR TITLE
Bump sequencer monitoring allowed cardinality

### DIFF
--- a/cluster/images/common/monitoring.conf
+++ b/cluster/images/common/monitoring.conf
@@ -17,8 +17,7 @@ canton {
         address = "0.0.0.0"
         port = 10013
       }]
-      # Raised to allow for per domain member labels (e.g. daml.sequencer.traffic-control.event-delivered-cost, see #16410)
-      cardinality = 20000
+      cardinality = 40000
       # enable all metric qualifiers
       qualifiers = ["errors", "latency", "saturation", "traffic", "debug"]
       histograms = [


### PR DESCRIPTION
Adresses https://github.com/DACH-NY/canton-network-internal/issues/2425 via a better default.

We started getting warnings due to maxing out the cardinality once we deployed a second SV at MainNet scale. Seems likely that other operators will encounter the same.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
