### PR TITLE
[main] Set confirmationResponseTimeout = 0 for migrations

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
@@ -298,7 +298,7 @@ case class EnvironmentDefinition(
   def withAmuletPrice(price: BigDecimal): EnvironmentDefinition =
     addConfigTransforms((_, conf) => ConfigTransforms.setAmuletPrice(price)(conf))
 
-  /** For an SV’s sequencer to be safely usable, we need to wait for participantResponseTimeout + mediatorResponseTimeout.
+  /** For an SV’s sequencer to be safely usable, we need to wait for confirmationResponseTimeout + mediatorResponseTimeout.
     * However, in some tests, we do care that an SV can connect to their own sequencer reasonably quickly.
     * To make that work, we lower the delay to a number that is not fully safe but empirically
     * long enough that all in-flight transactions succeed or fail before.

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
@@ -162,6 +162,7 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
         .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
       parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
       parameters.mediatorReactionTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+      parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
     }
 
     bracket(
@@ -192,6 +193,7 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
               .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
             parameters.confirmationRequestsMaxRate shouldBe NonNegativeInt.zero
             parameters.mediatorReactionTimeout shouldBe com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+            parameters.confirmationResponseTimeout shouldBe com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
           },
       )
 
@@ -210,6 +212,7 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
               .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
             parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
             parameters.mediatorReactionTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+            parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
           },
       )
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
@@ -87,6 +87,7 @@ trait DomainMigrationUtil extends BaseTest with TestCommon {
     ) { params =>
       params.mapping.parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
       params.mapping.parameters.mediatorReactionTimeout should be > NonNegativeFiniteDuration.Zero
+      params.mapping.parameters.confirmationResponseTimeout should be > NonNegativeFiniteDuration.Zero
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
@@ -42,7 +42,7 @@ trait TimeTestUtil extends TestCommon {
         // get dropped by the sequencer due to exceeding max-sequencing-time.
         // While we do recover from such an issue, we recover from it once the participant
         // times out with LOCAL_VERDICT_TIMEOUT. That timeout is measured in wall clock
-        // so we will wait the full participantResponseTimeout (30s by default) which
+        // so we will wait the full confirmationResponseTimeout (30s by default) which
         // then results in `eventually`'s in tests never completing.
         //
         // The waiting implement below should ensure that existing background automation (e.g. amulet merging)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainParametersStateTopologyConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainParametersStateTopologyConnection.scala
@@ -60,7 +60,7 @@ final case class MigrationSynchronizersState(
     currentState.base.validFrom
   }
   def acsExportWaitTimestamp: Instant = {
-    // At exportTimestamp we set mediatorReactionTimeout = 0. This means any confirmation request after exportTimestamp
+    // At exportTimestamp we set mediatorReactionTimeout = 0 and confirmationResponseTimeout = 0. This means any confirmation request after exportTimestamp
     // will fail. Confirmation requests before exportTimestamp can take confirmationResponseTimeout + mediatorReactionTimeout to time out
     // so if we wait until then we know that there are no more in-flight requests.
     exportTimestamp

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/DomainParamsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/DomainParamsStore.scala
@@ -109,6 +109,9 @@ final class DomainParamsStore(
     metrics.mediatorReactionTimeout.updateValue(
       params.mapping.parameters.mediatorReactionTimeout.toScala.toMillis
     )
+    metrics.confirmationResponseTimeout.updateValue(
+      params.mapping.parameters.confirmationResponseTimeout.toScala.toMillis
+    )
     blocking {
       synchronized {
         val newState = state.copy(lastParams = Some(params))
@@ -169,9 +172,22 @@ object DomainParamsStore {
         -1L,
       )(MetricsContext.Empty)
 
+    val confirmationResponseTimeout: Gauge[Long] =
+      metricsFactory.gauge(
+        MetricInfo(
+          name = prefix :+ "confirmation-response-timeout-ms",
+          summary = "DynamicSynchronizerParameters.confirmationResponseTimeout",
+          description =
+            "Last known value of DynamicSynchronizerParameters.confirmationResponseTimeout in ms on the configured global domain.",
+          qualification = Traffic,
+        ),
+        -1L,
+      )(MetricsContext.Empty)
+
     override def close(): Unit = {
       confirmationRequestsMaxRate.close()
       mediatorReactionTimeout.close()
+      confirmationResponseTimeout.close()
     }
   }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SynchronizerMigrationUtil.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SynchronizerMigrationUtil.scala
@@ -15,10 +15,10 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.Topol
 import scala.concurrent.Future
 
 final object SynchronizerMigrationUtil {
-  // We only check mediatorReactionTimeout here as that is what matters for safety and it ensures that
-  // synchronizerIsUnpaused = !synchronizerIsUnpaused instead of checking that both are 0 or both are non-zero.
+  // We only check confirmationResponseTimeout here as that is what matters for safety and it ensures that
+  // synchronizerIsUnpaused = !synchronizerIsUnpaused instead of checking that all 3 are 0 or both are non-zero.
   def synchronizerIsPaused(params: TopologyResult[SynchronizerParametersState]): Boolean =
-    params.mapping.parameters.mediatorReactionTimeout == NonNegativeFiniteDuration.Zero
+    params.mapping.parameters.confirmationResponseTimeout == NonNegativeFiniteDuration.Zero
 
   def synchronizerIsUnpaused(params: TopologyResult[SynchronizerParametersState]): Boolean =
     !synchronizerIsPaused(params)
@@ -34,10 +34,11 @@ final object SynchronizerMigrationUtil {
         // instaed of timing out. It is only enforced on the
         // write path so there can still be transaction going through after we set it to zero
         // if the sequencer has not yet observed the topology change.
-        // mediator reaction timeout is enforced as part of the transaction protocol so there we really get a guarantee
+        // mediator reaction timeout and participant response timeout is enforced as part of the transaction protocol so there we really get a guarantee
         // that no transactions go through.
         confirmationRequestsMaxRate = NonNegativeInt.zero,
         mediatorReactionTimeout = NonNegativeFiniteDuration.Zero,
+        confirmationResponseTimeout = NonNegativeFiniteDuration.Zero,
       ),
       forceChanges =
         ForceFlags(ForceFlag.AllowOutOfBoundsValue), // required for mediatorReactionTimeout = 0
@@ -54,6 +55,8 @@ final object SynchronizerMigrationUtil {
         confirmationRequestsMaxRate =
           DynamicSynchronizerParameters.defaultConfirmationRequestsMaxRate,
         mediatorReactionTimeout = DynamicSynchronizerParameters.defaultMediatorReactionTimeout,
+        confirmationResponseTimeout =
+          DynamicSynchronizerParameters.defaultConfirmationResponseTimeout,
       ),
     )
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -414,7 +414,7 @@ final case class SvSequencerConfig(
     adminApi: FullClientConfig,
     internalApi: FullClientConfig,
     externalPublicApiUrl: String,
-    // This needs to be participantResponseTimeout + mediatorResponseTimeout to make sure that the sequencer
+    // This needs to be confirmationResponseTimeout + mediatorResponseTimeout to make sure that the sequencer
     // does not have to serve requests that have been in flight before the sequencer's signing keys became valid.
     // See also https://github.com/DACH-NY/canton-network-node/issues/5938#issuecomment-1677165109
     // The default value of 60 seconds is based on Canton defaulting to 30s for each of those.

--- a/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/SynchronizerParameters.scala
+++ b/canton/community/base/src/main/scala/com/digitalasset/canton/protocol/SynchronizerParameters.scala
@@ -534,7 +534,7 @@ object DynamicSynchronizerParameters extends VersioningCompanion[DynamicSynchron
     NonNegativeInt.tryCreate(10 * 1024 * 1024)
   )
 
-  private val defaultConfirmationResponseTimeout: NonNegativeFiniteDuration =
+  val defaultConfirmationResponseTimeout: NonNegativeFiniteDuration =
     NonNegativeFiniteDuration.tryOfSeconds(30)
   val defaultMediatorReactionTimeout: NonNegativeFiniteDuration =
     NonNegativeFiniteDuration.tryOfSeconds(30)

--- a/network-health/NETWORK_HEALTH.md
+++ b/network-health/NETWORK_HEALTH.md
@@ -286,7 +286,7 @@ Particularly useful are the lag and the catchup speed which let you estimate how
 
 If you need more detailed information, you can also look at the sequencer logs.
 For example, in the logs below you can see SBI acknowledging timestamp `2024-04-29T05:06:06.692783Z` at `2024-04-29 05:35:41.170` so it is roughly lagging 30min behind but the participant is active. A delay of a few seconds is expected, anything larger than a minute will mean that this participant is unable to confirm
-transactions because it sees the confirmation only after the configured `participantResponseTimeout`.
+transactions because it sees the confirmation only after the configured `confirmationResponseTimeout`.
 
 ![SBI lagging](pics/acknowledgement_lag.png)
 
@@ -328,7 +328,7 @@ Network wide issues can come from any of the layers involved in the daml transac
 4. Participants are unable to read the confirmation request.
 5. Participants are unable to submit confirmation requests.
 6. Mediators are unable to read the confirmation request.
-7. Mediators don't get enough confirmations before `participantResponseTimeout`
+7. Mediators don't get enough confirmations before `confirmationResponseTimeout`
 8. Sequencers do not receive enough mediator responses before `mediatorResponseTimeout`
 9. SV apps are not submitting status reports
 


### PR DESCRIPTION
mediatorReactionTimeout = 0 is not sufficient since the mediator reaction timeout only starts counting after
confirmationResponseTimeout is reached. By setting both to zero we really guarantee that no transactions go through. Confirmed by Andreas L.

fixes #2929

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
