### PR TITLE
[static] add dependency on the release for the mutli validator services

### DIFF
--- a/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
+++ b/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
@@ -53,7 +53,7 @@ export class MultiNodeDeployment extends pulumi.ComponentResource {
   ) {
     super('canton:network:Deployment', name, {}, opts);
 
-    const newOpts = { ...opts, parent: this, dependsOn: [args.namespace] };
+    const newOpts = { ...opts, parent: this, dependsOn: [args.namespace] as pulumi.Resource[] };
     const zeroPad = (num: number, places: number) => String(num).padStart(places, '0');
     this.deployment = new k8s.apps.v1.Deployment(
       name,
@@ -220,7 +220,7 @@ export class MultiNodeDeployment extends pulumi.ComponentResource {
           },
         },
       },
-      newOpts
+      { ...newOpts, dependsOn: newOpts.dependsOn.concat([this.deployment]) }
     );
 
     const monitor = new ServiceMonitor(


### PR DESCRIPTION
services have to wait to have pods as targets, and they need to be healthy
if you don't have the dep you can get into stupid issues like the service is created before the pod. code execution !=  pulumi execution 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
