### PR TITLE
[ci] bump canton to 3.3.0-snapshot.20251029.16139.0.ved0544c9

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.3.0-snapshot.20251029.16138.0.vc07cf058",
+  "version": "3.3.0-snapshot.20251029.16139.0.ved0544c9",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:1d8xngxn9qcl49vh4hxvzvqk4s7q1q398la1c7q31vb201jfdwzd",
-  "oss_sha256": "sha256:0i4n4kzd3wb1n4dlhlyy8fr694xhn98zvh05hzh304r5sw7pcynr"
+  "enterprise_sha256": "sha256:1c3ja4v8lg96z116wyqi4948f36bnp6w9f5j272mdjy3mbxh39sr",
+  "oss_sha256": "sha256:0b0rr9wilcs81vr2m9dlqfxvjg64nh6f5f75r11m9vwm27j940cb"
 }


### PR DESCRIPTION
includes fix for amplification on sequencer overloaded


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
