### PR TITLE
[static] Keep old behavior for the secret usage for the validator runbook

### DIFF
--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -290,28 +290,6 @@
     "id": "",
     "inputs": {
       "apiVersion": "v1",
-      "data": {
-        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
-        "value": {
-          "secret": "dmFsaWRhdG9yc2VjcmV0"
-        }
-      },
-      "kind": "Secret",
-      "metadata": {
-        "name": "splice-app-validator-onboarding-validator",
-        "namespace": "validator"
-      },
-      "type": "Opaque"
-    },
-    "name": "splice-app-validator-validator-onboarding-validator",
-    "provider": "",
-    "type": "kubernetes:core/v1:Secret"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "apiVersion": "v1",
       "kind": "Secret",
       "metadata": {
         "name": "splice-app-validator-ledger-api-auth",
@@ -713,13 +691,6 @@
           "id": "3"
         },
         "nodeIdentifier": "validator-runbook",
-        "onboardingSecretFrom": {
-          "secretKeyRef": {
-            "key": "secret",
-            "name": "splice-app-validator-onboarding-validator",
-            "optional": false
-          }
-        },
         "participantAddress": "participant-3",
         "participantIdentitiesDumpPeriodicBackup": {
           "backupInterval": "10m",

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -26,6 +26,7 @@ import {
   nonDevNetNonSvValidatorTopupConfig,
   nonSvValidatorTopupConfig,
   participantBootstrapDumpSecretName,
+  preApproveValidatorRunbook,
   SPLICE_ROOT,
   setupBootstrapping,
   spliceInstanceNames,
@@ -42,7 +43,7 @@ import { installParticipant } from '@lfdecentralizedtrust/splice-pulumi-common-v
 import { SplicePostgres } from '@lfdecentralizedtrust/splice-pulumi-common/src/postgres';
 
 import { installPartyAllocator } from './partyAllocator';
-import { validatorConfig } from './validatorConfig';
+import { validatorConfig, validatorName } from './validatorConfig';
 
 type BootstrapCliConfig = {
   cluster: string;
@@ -73,13 +74,18 @@ export async function installNode(auth0Client: Auth0Client): Promise<void> {
       bootstrappingConfig,
     });
 
+  const onboardingSecret =
+    preApproveValidatorRunbook || validatorName != 'validator-runbook'
+      ? validatorConfig.onboardingSecret
+      : undefined;
+
   const loopback = installLoopback(xns);
 
   const imagePullDeps = imagePullSecret(xns);
 
   const validator = await installValidator({
     xns,
-    onboardingSecret: validatorConfig.onboardingSecret,
+    onboardingSecret,
     participantBootstrapDumpSecret,
     auth0Client,
     imagePullDeps,

--- a/cluster/pulumi/validator-runbook/src/validatorConfig.ts
+++ b/cluster/pulumi/validator-runbook/src/validatorConfig.ts
@@ -15,7 +15,7 @@ function getValidatorConfig(validatorName: string) {
   return config;
 }
 
-const validatorName = config.requireEnv('SPLICE_VALIDATOR_RUNBOOK_VALIDATOR_NAME');
+export const validatorName = config.requireEnv('SPLICE_VALIDATOR_RUNBOOK_VALIDATOR_NAME');
 export const validatorConfig = getValidatorConfig(validatorName);
 
 console.error(


### PR DESCRIPTION

We assume in a lot of places that the pre approval flag controls the validator runbook



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
