### PR TITLE
Wait for total unlocked coin to appear

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternallySignedTxTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternallySignedTxTest.scala
@@ -105,10 +105,11 @@ trait ExternallySignedTxTest
         4000000.0,
         UUID.randomUUID.toString,
       )
-      aliceValidatorBackend
-        .getExternalPartyBalance(partyId)
-        .totalUnlockedCoin shouldBe "4000000.0000000000"
-
+      eventually() {
+        aliceValidatorBackend
+          .getExternalPartyBalance(partyId)
+          .totalUnlockedCoin shouldBe "4000000.0000000000"
+      }
       val partyHint2 = UUID.randomUUID().toString
       val keyName2 = "party-key-2"
       runProcess(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6207.

The above `transferPreapprovalSend` immediately creates the new amulet on ledger, but we have to wait until it's ingested in the app ACS store.