### PR TITLE
Bump timeout in FeaturedActivityMarkerIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FeaturedAppActivityMarkerIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FeaturedAppActivityMarkerIntegrationTest.scala
@@ -72,7 +72,7 @@ class FeaturedAppActivityMarkerIntegrationTest
 
     val markerMultiplier = 10
 
-    actAndCheck(timeUntilSuccess = 40.seconds)(
+    actAndCheck(timeUntilSuccess = 60.seconds)(
       "Create activity markers", {
         for (i <- 1 to markerMultiplier) {
           aliceValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.commands


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6240

Timeout bump from https://github.com/hyperledger-labs/splice/pull/2815 was too small.