### PR TITLE
[main] Set confirmationResponseTimeout to 1 microsecond

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
@@ -158,7 +158,8 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
         .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
       parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
       parameters.mediatorReactionTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
-      parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+      parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration
+        .ofMicros(1)
     }
 
     bracket(
@@ -189,7 +190,8 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
               .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
             parameters.confirmationRequestsMaxRate shouldBe NonNegativeInt.zero
             parameters.mediatorReactionTimeout shouldBe com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
-            parameters.confirmationResponseTimeout shouldBe com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+            parameters.confirmationResponseTimeout shouldBe com.digitalasset.canton.config.NonNegativeFiniteDuration
+              .ofMicros(1)
           },
       )
 
@@ -208,7 +210,8 @@ class DistributedDomainIntegrationTest extends IntegrationTest with SvTestUtil w
               .get_dynamic_synchronizer_parameters(decentralizedSynchronizerId)
             parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
             parameters.mediatorReactionTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
-            parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration.Zero
+            parameters.confirmationResponseTimeout should be > com.digitalasset.canton.config.NonNegativeFiniteDuration
+              .ofMicros(1)
           },
       )
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
@@ -87,7 +87,8 @@ trait DomainMigrationUtil extends BaseTest with TestCommon {
     ) { params =>
       params.mapping.parameters.confirmationRequestsMaxRate should be > NonNegativeInt.zero
       params.mapping.parameters.mediatorReactionTimeout should be > NonNegativeFiniteDuration.Zero
-      params.mapping.parameters.confirmationResponseTimeout should be > NonNegativeFiniteDuration.Zero
+      params.mapping.parameters.confirmationResponseTimeout should be > NonNegativeFiniteDuration
+        .tryOfMicros(1)
     }
   }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainParametersStateTopologyConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/migration/DomainParametersStateTopologyConnection.scala
@@ -60,7 +60,7 @@ final case class MigrationSynchronizersState(
     currentState.base.validFrom
   }
   def acsExportWaitTimestamp: Instant = {
-    // At exportTimestamp we set mediatorReactionTimeout = 0 and confirmationResponseTimeout = 0. This means any confirmation request after exportTimestamp
+    // At exportTimestamp we set mediatorReactionTimeout = 0 and confirmationResponseTimeout = 1 microsecond. This means any confirmation request after exportTimestamp
     // will fail. Confirmation requests before exportTimestamp can take confirmationResponseTimeout + mediatorReactionTimeout to time out
     // so if we wait until then we know that there are no more in-flight requests.
     exportTimestamp

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SynchronizerMigrationUtil.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SynchronizerMigrationUtil.scala
@@ -15,10 +15,10 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.Topol
 import scala.concurrent.Future
 
 final object SynchronizerMigrationUtil {
-  // We only check confirmationResponseTimeout here as that is what matters for safety and it ensures that
+  // We only check mediatorReactionTimeout here as that is what matters for safety and it ensures that
   // synchronizerIsUnpaused = !synchronizerIsUnpaused instead of checking that all 3 are 0 or both are non-zero.
   def synchronizerIsPaused(params: TopologyResult[SynchronizerParametersState]): Boolean =
-    params.mapping.parameters.confirmationResponseTimeout == NonNegativeFiniteDuration.Zero
+    params.mapping.parameters.mediatorReactionTimeout == NonNegativeFiniteDuration.Zero
 
   def synchronizerIsUnpaused(params: TopologyResult[SynchronizerParametersState]): Boolean =
     !synchronizerIsPaused(params)
@@ -38,7 +38,10 @@ final object SynchronizerMigrationUtil {
         // that no transactions go through.
         confirmationRequestsMaxRate = NonNegativeInt.zero,
         mediatorReactionTimeout = NonNegativeFiniteDuration.Zero,
-        confirmationResponseTimeout = NonNegativeFiniteDuration.Zero,
+        // We want to block all transactions, ideally we would set this to zero but Canton doesn't like it when mediatorReactionTimeout + confirmationResponseTimeout = 0.
+        // So instead we set this to 1 microsecond. This still makes it impossible to get a transaction through as
+        // you need at a minimum two microseconds difference between confirmation request and verdict.
+        confirmationResponseTimeout = NonNegativeFiniteDuration.tryOfMicros(1),
       ),
       forceChanges =
         ForceFlags(ForceFlag.AllowOutOfBoundsValue), // required for mediatorReactionTimeout = 0

--- a/canton/community/base/src/main/scala/com/digitalasset/canton/config/RefinedNonNegativeDuration.scala
+++ b/canton/community/base/src/main/scala/com/digitalasset/canton/config/RefinedNonNegativeDuration.scala
@@ -148,6 +148,8 @@ trait RefinedNonNegativeDurationCompanion[D <: RefinedNonNegativeDuration[D]] {
   def tryFromJavaDuration(duration: java.time.Duration): D =
     tryFromDuration(Duration.fromNanos(duration.toNanos))
 
+  def ofMicros(millis: Long): D = apply(Duration(millis, TimeUnit.MICROSECONDS))
+
   def ofMillis(millis: Long): D = apply(Duration(millis, TimeUnit.MILLISECONDS))
 
   def ofSeconds(secs: Long): D = apply(Duration(secs, TimeUnit.SECONDS))


### PR DESCRIPTION
fwd port from #2993

fixes #2990

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
