### PR TITLE
Daml: Enhance DsoRules to allow weight change and withdrawal of ValidatorLicense

### DIFF
--- a/apps/common/frontend-test-handlers/src/mocks/helpers/dso-config-helper.ts
+++ b/apps/common/frontend-test-handlers/src/mocks/helpers/dso-config-helper.ts
@@ -233,6 +233,11 @@ export function getExpectedDsoRulesConfigDiffsHTML(
       class="jsondiffpatch-property-name">voteCooldownTime</div><div
       class="jsondiffpatch-value"><pre>{
   "microseconds": "60000000"
+}</pre></div></li><li data-key="voteExecutionInstructionTimeout"
+    class="jsondiffpatch-unchanged"><div
+      class="jsondiffpatch-property-name">voteExecutionInstructionTimeout</div><div
+      class="jsondiffpatch-value"><pre>{
+  "microseconds": "86400000000"
 }</pre></div></li><li data-key="voteRequestTimeout"
     class="jsondiffpatch-unchanged"><div
       class="jsondiffpatch-property-name">voteRequestTimeout</div><div
@@ -329,6 +334,11 @@ export function getExpectedDsoRulesConfigDiffsHTML(
       class="jsondiffpatch-property-name">voteCooldownTime</div><div
       class="jsondiffpatch-value"><pre>{
   "microseconds": "60000000"
+}</pre></div></li><li data-key="voteExecutionInstructionTimeout"
+    class="jsondiffpatch-unchanged"><div
+      class="jsondiffpatch-property-name">voteExecutionInstructionTimeout</div><div
+      class="jsondiffpatch-value"><pre>{
+  "microseconds": "86400000000"
 }</pre></div></li><li data-key="voteRequestTimeout"
     class="jsondiffpatch-unchanged"><div
       class="jsondiffpatch-property-name">voteRequestTimeout</div><div


### PR DESCRIPTION
Fixes #3005

Daml changes for doing `ValidatorLicense` weight change and withdrawal via voting.

And ensure that `ValidatorLicense_RecordValidatorLivenessActivity` works only for non-zero weight.


