### PR TITLE
Take full screen screenshot on frontend failures

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -442,7 +442,8 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
     */
   protected def screenshot()(implicit webDriver: WebDriverType): Unit = {
     clue("Saving screenshot") {
-      val screenshotFile = webDriver.getScreenshotAs(OutputType.FILE)
+      val fullScreen = webDriver.findElement(By.tagName("body"))
+      val screenshotFile = fullScreen.getScreenshotAs(OutputType.FILE)
       val time = Calendar.getInstance.getTime
       val timestamp = new SimpleDateFormat("yy-MM-dd-H:m:s.S").format(time)
       val filename = Paths.get("log", s"screenshot-${timestamp}.png").toString


### PR DESCRIPTION
improves screenshot readability:

<img width="1354" height="1209" alt="screenshot-25-10-31-10:36:2 275" src="https://github.com/user-attachments/assets/cb3c4ac9-8191-463d-9499-574790f0a392" />
vs 
<img width="1366" height="631" alt="screenshot-25-10-31-10:38:59 418" src="https://github.com/user-attachments/assets/acb4da8a-22c7-462d-9a8c-213ba5c5b017" />

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
