### PR TITLE
Fix MUI v7 Grid spacing

### DIFF
--- a/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
@@ -87,7 +87,7 @@ const ActionCard = (props: ActionCardProps) => {
           justifyContent: 'space-between',
         }}
       >
-        <Grid container spacing={1}>
+        <Grid flexGrow={1} container spacing={1}>
           <Grid size={{ xs: 3 }}>
             <Box>
               <Typography variant="subtitle2" color="text.secondary" gutterBottom>


### PR DESCRIPTION
Fixes following issue:

In the MUI v7 Grids are not taking 100% of their parents width: 
 - Current spacing:
<img width="1504" height="215" alt="Screenshot 2025-10-31 at 15 54 26" src="https://github.com/user-attachments/assets/78a4f390-d349-4bf3-8442-cf16246a088a" />

- Fixed spacing:
<img width="1540" height="183" alt="Screenshot 2025-10-31 at 15 53 39" src="https://github.com/user-attachments/assets/95ebd176-e78a-44b5-b821-7ea7cf85f502" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
