### PR TITLE
[static] Add ignore for db connections lost to canton as well

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -155,4 +155,7 @@ Waiting for allocation of.*on synchronizer splitwell.*timed out
 # error code will change in the future to MAX_SEQUENCING_TIME_EXCEEDED
 SEQUENCER_SUBMISSION_REQUEST_REFUSED.* The estimated sequencing time .* is already past the max sequencing time
 
+# Sometimes the CI executor seems to take a break, which leads to spurious failed DB activeness checks, see #9388
+DB_CONNECTION_LOST.*Database health check failed to establish a valid connection.*Connection is not available, request timed out
+
 # Make sure to have a trailing newline

--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -68,7 +68,7 @@ Noticed an DsoRules epoch change.*DecentralizedSynchronizerMigrationIntegrationT
 # Nevertheless, it is still useful to have the warning in production environments, where this should never happen.
 Skipped.*faucet coupons from last claimed round.*to current round
 
-# Sometimes the CircleCI executor seems to take a break, which leads to spurious failed DB activeness checks, see #9388
+# Sometimes CI the executor seems to take a break, which leads to spurious failed DB activeness checks, see #9388
 DB_CONNECTION_LOST.*Database health check failed to establish a valid connection.*Connection is not available, request timed out
 
 # The prometheus export server does not wait for any ongoing requests when shutting down https://github.com/prometheus/client_java/issues/938


### PR DESCRIPTION
happened here https://github.com/hyperledger-labs/splice/actions/runs/18974865359/job/54191663555
just yolo it as we already have it for the canton network logs 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
