### PR TITLE
long auth0 tokens on fixed token clusters

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -38,7 +38,7 @@
       "allowOfflineAccess": true,
       "identifier": "https://ledger_api.sv-1.test-stack.canton.network",
       "name": "Ledger API for SV sv-1 on test-stack (Pulumi managed)",
-      "tokenLifetime": 2592000
+      "tokenLifetime": 86400
     },
     "name": "LedgerApisv1",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
@@ -51,7 +51,7 @@
       "allowOfflineAccess": true,
       "identifier": "https://ledger_api.sv-da-1.test-stack.canton.network",
       "name": "Ledger API for SV sv-da-1 on test-stack (Pulumi managed)",
-      "tokenLifetime": 2592000
+      "tokenLifetime": 86400
     },
     "name": "LedgerApisvda1",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
@@ -120,7 +120,7 @@
       "allowOfflineAccess": true,
       "identifier": "https://sv.sv-1.test-stack.canton.network/api",
       "name": "SV App API for SV sv-1 on test-stack (Pulumi managed)",
-      "tokenLifetime": 2592000
+      "tokenLifetime": 86400
     },
     "name": "SvAppApisv1",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",
@@ -133,7 +133,7 @@
       "allowOfflineAccess": true,
       "identifier": "https://sv.sv-da-1.test-stack.canton.network/api",
       "name": "SV App API for SV sv-da-1 on test-stack (Pulumi managed)",
-      "tokenLifetime": 2592000
+      "tokenLifetime": 86400
     },
     "name": "SvAppApisvda1",
     "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:auth0::dev::undefined_id",

--- a/cluster/pulumi/infra/src/auth0.ts
+++ b/cluster/pulumi/infra/src/auth0.ts
@@ -20,6 +20,10 @@ import {
   dsoSize,
 } from '@lfdecentralizedtrust/splice-pulumi-common-sv';
 
+function tokenLifetime(): number {
+  return fixedTokens() ? 2592000 : 86400; // TODO(DACH-NY/canton-network-internal#2114): Move this to the cluster config? We want it to be long for fixed token clusters
+}
+
 function ledgerApiAudience(
   svNamespace: string,
   clusterBasename: string,
@@ -37,7 +41,7 @@ function ledgerApiAudience(
         name: `Ledger API for SV ${svNamespace} on ${clusterBasename} (Pulumi managed)`,
         identifier: `https://ledger_api.${svNamespace}.${clusterBasename}.canton.network`,
         allowOfflineAccess: true, // TODO(DACH-NY/canton-network-internal#2114): is this still needed?
-        tokenLifetime: 2592000, // 30 days // TODO(DACH-NY/canton-network-internal#2114): make this configurable? We want it to be long for fixed token clusters
+        tokenLifetime: tokenLifetime(),
       },
       { provider: auth0DomainProvider }
     );
@@ -80,7 +84,7 @@ function svAppAudience(
         name: `SV App API for SV ${svNamespace} on ${clusterBasename} (Pulumi managed)`,
         identifier: `https://sv.${svNamespace}.${clusterBasename}.canton.network/api`,
         allowOfflineAccess: true, // TODO(DACH-NY/canton-network-internal#2114): is this still needed?
-        tokenLifetime: 2592000, // 30 days // TODO(DACH-NY/canton-network-internal#2114): make this configurable? We want it to be long for fixed token clusters
+        tokenLifetime: tokenLifetime(),
       },
       { provider: auth0DomainProvider }
     );
@@ -109,7 +113,7 @@ function validatorAppAudience(
         name: `Validator App API for SV ${svNamespace} on ${clusterBasename} (Pulumi managed)`,
         identifier: `https://validator.${svNamespace}.${clusterBasename}.canton.network/api`,
         allowOfflineAccess: true, // TODO(DACH-NY/canton-network-internal#2114): is this still needed?
-        tokenLifetime: fixedTokens() ? 2592000 : 86400, // TODO(DACH-NY/canton-network-internal#2114): Move this to the cluster config? We want it to be long for fixed token clusters
+        tokenLifetime: tokenLifetime(),
       },
       { provider: auth0DomainProvider }
     );


### PR DESCRIPTION
I nuked the fixed tokens cache on cimain, which then failed to renew because the generated tokens are too short-lived (which we assert on)

deployed on cimain: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/39025/workflows/255f453d-3ecd-4495-a527-98e05c51db7c

fixes https://github.com/DACH-NY/cn-test-failures/issues/6336


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
