### PR TITLE
fix bwd compatibility to infra stack in validator-runbook

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -755,6 +755,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "apiVersion": "v1",

--- a/cluster/expected/cluster/expected.json
+++ b/cluster/expected/cluster/expected.json
@@ -103,5 +103,15 @@
     "name": "hyperdisk-balanced-rwo",
     "provider": "",
     "type": "kubernetes:storage.k8s.io/v1:StorageClass"
+  },
+  {
+    "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
   }
 ]

--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -903,6 +903,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "apiVersion": "source.toolkit.fluxcd.io/v1",

--- a/cluster/expected/gcp/expected.json
+++ b/cluster/expected/gcp/expected.json
@@ -238,6 +238,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "disableDependentServices": true,

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3240,6 +3240,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -4745,6 +4745,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -571,6 +571,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "chart": "oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -229,6 +229,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "apiVersion": "v1",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -513,6 +513,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -287,6 +287,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {
       "apiVersion": "v1",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -279,6 +279,16 @@
   },
   {
     "custom": true,
+    "id": "organization/infra/infra.mock",
+    "inputs": {
+      "name": "organization/infra/infra.mock"
+    },
+    "name": "organization/infra/infra.mock",
+    "provider": "",
+    "type": "pulumi:pulumi:StackReference"
+  },
+  {
+    "custom": true,
     "id": "",
     "inputs": {},
     "name": "participantKmsServiceAccountKey",

--- a/cluster/pulumi/common/src/auth0/auth0.ts
+++ b/cluster/pulumi/common/src/auth0/auth0.ts
@@ -8,7 +8,8 @@ import { Output } from '@pulumi/pulumi';
 import { AuthenticationClient, ManagementClient, TokenSet } from 'auth0';
 
 import { config, isMainNet } from '../config';
-import { CLUSTER_BASENAME, fixedTokens } from '../utils';
+import { infraStack } from '../stackReferences';
+import { fixedTokens } from '../utils';
 import { DEFAULT_AUDIENCE } from './audiences';
 import type {
   Auth0Client,
@@ -300,8 +301,7 @@ export enum Auth0ClientType {
   MAINSTACK,
 }
 
-function getAuth0ClusterConfig(): Output<Auth0ClusterConfig> {
-  const infraStack = new pulumi.StackReference(`organization/infra/infra.${CLUSTER_BASENAME}`);
+export function getAuth0ClusterConfig(): Output<Auth0ClusterConfig> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const infraOutput: pulumi.Output<any> = infraStack.requireOutput('auth0');
   return infraOutput.apply(output => {

--- a/cluster/pulumi/validator-runbook/src/index.ts
+++ b/cluster/pulumi/validator-runbook/src/index.ts
@@ -1,8 +1,10 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as pulumi from '@pulumi/pulumi';
-import { Auth0ClusterConfig, Auth0Fetch, config } from '@lfdecentralizedtrust/splice-pulumi-common';
-import { infraStack } from '@lfdecentralizedtrust/splice-pulumi-common/src/stackReferences';
+import {
+  Auth0Fetch,
+  config,
+  getAuth0ClusterConfig,
+} from '@lfdecentralizedtrust/splice-pulumi-common';
 
 import { installNode } from './installNode';
 
@@ -16,7 +18,7 @@ async function auth0CacheAndInstallNode(auth0Fetch: Auth0Fetch) {
 
 // TODO(DACH-NY/canton-network-node#8008): Reduce duplication from sv-runbook stack
 async function main() {
-  const auth0ClusterCfg = infraStack.requireOutput('auth0') as pulumi.Output<Auth0ClusterConfig>;
+  const auth0ClusterCfg = getAuth0ClusterConfig();
   if (!auth0ClusterCfg.validatorRunbook) {
     throw new Error('missing validator runbook auth0 output');
   }


### PR DESCRIPTION
`getAuth0ClusterConfig` contains code for parsing the legacy infra outputs despite the auth0 changes, so that previews will work before applying infra. Unfortunately, validator-runbook was not calling that, so was [failing](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/39217/workflows/5aa63753-961a-48b1-9591-9938a0137d81/jobs/213610) previews when bumping after backporting the auth0 changes.

Here's previews on internal where I checkout splice 0.4.23 + this PR: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/39227/workflows/2d323931-61af-4dc2-92e6-e435b857a234/jobs/213659

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
