### PR TITLE
[static] fix minting from unminted in BigQuery stats

### DIFF
--- a/cluster/pulumi/canton-network/src/bigQuery_functions.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery_functions.ts
@@ -291,8 +291,8 @@ const TransferSummary_minted = new BQScalarFunction(
       \`$$FUNCTIONS_DATASET$$.daml_record_numeric\`(tr_json, [1]) AS validatorRewardAmount,
       \`$$FUNCTIONS_DATASET$$.daml_record_numeric\`(tr_json, [2]) AS svRewardAmount,
       IFNULL(
-        \`PARSE_BIGNUMERIC(JSON_VALUE(tr_json,
-          \`$$FUNCTIONS_DATASET$$.daml_record_path\`(path, 'optional_numeric')))\`, 0) AS unclaimedActivityRecordAmount -- (was added only in Splice 0.4.4)
+        PARSE_BIGNUMERIC(JSON_VALUE(tr_json,
+          \`$$FUNCTIONS_DATASET$$.daml_record_path\`([11], 'optional_numeric'))), 0) AS unclaimedActivityRecordAmount -- (was added only in Splice 0.4.4)
     )
   `
 );


### PR DESCRIPTION
Ran the integration test locally, which tests at least syntactical correctness of the SQL (this code path is not exercised in the test, so it doesn't test much beyond syntax unfortunately, and I don't think we want to make the test much more complex in terms of types of data that it produces, but I might be tempted to do that eventually too).

Will require backporting to 0.4.22, 0.4.23, 0.4 + splice bumps in internal to actually land in BigQuery...

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
