### PR TITLE
Fix pulumi policy npm package version

### DIFF
--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -1842,20 +1842,20 @@
             }
         },
         "node_modules/@pulumi/policy": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/@pulumi/policy/-/policy-1.18.1.tgz",
-            "integrity": "sha512-4tOOKCNGcSoFTLctM7JL1/KXGu/uLtPOq+64QHyMdfiC+SLSrR4C2VdARDCZc2EBrBIJwRLgrvbkzxRoaCVdqg==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/policy/-/policy-1.20.0.tgz",
+            "integrity": "sha512-XglLDdJg1CfxuZ0Lvxzm9mo5YInwwwkVWE6z6tjWCCj1c96eNzaQRoVF4+P9ToQ3fSTk+G00iZdgXY9hpg9Qgw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
-                "@pulumi/pulumi": "^3.196.0",
+                "@pulumi/pulumi": "^3.204.0",
                 "google-protobuf": "^3.21.4"
             }
         },
         "node_modules/@pulumi/policy/node_modules/@pulumi/pulumi": {
-            "version": "3.202.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.202.0.tgz",
-            "integrity": "sha512-Vxpo6K4dpHb4ldxxp1IvG3lzIIthmd5dWguLySqbz7MmEksHPvbgSzk2I2v8SJKGjluozQASYpgW+1myUIZjGA==",
+            "version": "3.205.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.205.0.tgz",
+            "integrity": "sha512-AcYCPNAPYpRX9D2D6vwnEfNP+1hg1R45eQYrBTJlbGY3rcR22sHP8fYheY5nJQy1g9KPY21kkkvfBDu6Ch6UIw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
@@ -9237,12 +9237,11 @@
         },
         "policies": {
             "name": "@lfdecentralizedtrust/splice-pulumi-policy",
-            "version": "1.0.0",
             "dependencies": {
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@pulumi/gcp": "8.32.1",
                 "@pulumi/kubernetes-cert-manager": "0.2.0",
-                "@pulumi/policy": "^1.18.1",
+                "@pulumi/policy": "1.20.0",
                 "@pulumiverse/grafana": "0.16.3"
             }
         },

--- a/cluster/pulumi/policies/package.json
+++ b/cluster/pulumi/policies/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@lfdecentralizedtrust/splice-pulumi-policy",
   "main": "src/index.ts",
-  "version": "1.0.0",
   "dependencies": {
     "@pulumi/kubernetes-cert-manager": "0.2.0",
     "@pulumiverse/grafana": "0.16.3",
     "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
     "@pulumi/gcp": "8.32.1",
-    "@pulumi/policy": "^1.18.1"
+    "@pulumi/policy": "1.20.0"
   },
   "overrides": {
     "@pulumi/kubernetes-cert-manager": {


### PR DESCRIPTION
should fix:

```
2025-11-04 18:23:58 UTC INFO  [main] ---                Components with Policy Violations:
2025-11-04 18:23:58 UTC INFO  [main] ---                        Protobuf 3.21.4 (npmjs:google-protobuf/3.21.4)
2025-11-04 18:23:58 UTC INFO  [main] ---                        policies 1.0.0 (npmjs:policies/1.0.0)
2025-11-04 18:23:58 UTC INFO  [main] --- 
2025-11-04 18:23:58 UTC INFO  [main] ---                Components with Policy Violation Warnings:
2025-11-04 18:23:58 UTC INFO  [main] --- 
2025-11-04 18:23:58 UTC INFO  [main] --- ===== Transitive Guidance =====
2025-11-04 18:23:58 UTC INFO  [main] --- 
2025-11-04 18:23:58 UTC INFO  [main] ---                Transitive upgrade guidance:
2025-11-04 18:23:58 UTC INFO  [main] ---                        Upgrade component @pulumi/policy/1.18.1 to version 1.20.0 in order to upgrade transitive component google-protobuf/3.21.4
```


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
