### PR TITLE
Handle InputUnclaimedActivityRecord in scan_txlog.py

### DIFF
--- a/scripts/scan-txlog/scan_txlog.py
+++ b/scripts/scan-txlog/scan_txlog.py
@@ -2259,6 +2259,9 @@ class State:
                         round_number, []
                     ).append(validator_liveness_activity_record)
                     del self.active_contracts[cid]
+                case "InputUnclaimedActivityRecord":
+                    cid = value.get_contract_id()
+                    del self.active_contracts[cid]
                 case _:
                     self._fail(transaction, f"Unexpected transfer input: {tag}")
         return TransferInputs(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6349

It looks like the only thing we do with UnclaimedActivityRecord is [add them to the active_contracts list](https://github.com/hyperledger-labs/splice/blob/033b851a3fea71b11a787dce8e200c2004289b80/scripts/scan-txlog/scan_txlog.py#L3338). Since it's being used as input, it should be deleted.
This only flakes occasionally because only occasionally is a transfer containing the just-created UnclaimedActivityRecord made.