### PR TITLE
Add advisory lock to SqlIndexInitializationTrigger

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
@@ -3,11 +3,62 @@
 
 package org.lfdecentralizedtrust.splice.store.db
 
+import com.digitalasset.canton.resource.DbStorage
+import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.jdbc.JdbcProfile
+import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
+
+import scala.concurrent.ExecutionContext
+
 /** Registry for advisory lock identifiers used in splice applications.
   */
 object AdvisoryLockIds {
   // 0x73706c equals ASCII encoded "spl". Modeled after Canton's HaConfig, which uses ASCII "dml".
   private val base: Long = 0x73706c00
 
-  final val acsSnapshotDataInsert: Long = base + 1
+  final case class AdvisoryLockId(value: Long) extends AnyVal
+  final case class FailedToAcquireAdvisoryLock(lockId: AdvisoryLockId)
+      extends Exception(s"Failed to acquire exclusive lock with id ${lockId.value}")
+
+  final val acsSnapshotDataInsert = AdvisoryLockId(base + 1)
+
+  final val sqlIndexInitializationTrigger = AdvisoryLockId(base + 2)
+
+  /** Executes the given action in a transaction while holding an exclusive advisory transaction lock with the given ID.
+    *
+    * An advisory lock only conflicts with other advisory locks with the same ID.
+    * It does not interfere with regular row-level or table-level locks.
+    * In contrast, regular locks (e.g. obtained via `LOCK TABLE ... IN EXCLUSIVE MODE`) would conflict with harmless
+    * background operations like autovacuum.
+    *
+    * If the lock cannot be acquired, the action fails immediately with a [[FailedToAcquireAdvisoryLock]].
+    * It does not wait for the lock to become available, nor does it retry.
+    *
+    * If the transaction is aborted for any reason, the lock is released automatically by Postgres.
+    * In case the application crashes while holding the lock, the server _should_ close the connection
+    * and abort the transaction (thus freeing the lock) as soon as it detects a disconnect.
+    * Note, however, that in some cases it may take a while for the server to detect the disconnect.
+    */
+  def withExclusiveTransactionLock[T, E <: Effect](
+      storage: DbStorage,
+      lockId: AdvisoryLockId,
+      action: DBIOAction[T, NoStream, E],
+  )(implicit
+      ec: ExecutionContext
+  ): DBIOAction[T, NoStream, Effect.Read & Effect.Transactional & E] = {
+    val profile: JdbcProfile = storage.profile.jdbc
+    import profile.api.jdbcActionExtensionMethods
+    (for {
+      lockResult <-
+        sql"SELECT pg_try_advisory_xact_lock(${lockId.value})"
+          .as[Boolean]
+          .head
+      result <-
+        if (lockResult) {
+          action
+        } else {
+          DBIOAction.failed(FailedToAcquireAdvisoryLock(lockId))
+        }
+    } yield result).transactionally
+  }
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -4,7 +4,7 @@ import com.daml.metrics.api.noop.NoOpMetricsFactory
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.store.{StoreErrors, StoreTest}
-import com.digitalasset.canton.concurrent.FutureSupervisor
+import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.resource.DbStorage
@@ -192,7 +192,7 @@ class SqlIndexInitializationTriggerStoreTest
               end;
               $$$$ language plpgsql immutable;
               """,
-            "insert test data",
+            "create slow_function",
           )
           .failOnShutdown
         _ <- storage.underlying
@@ -205,6 +205,9 @@ class SqlIndexInitializationTriggerStoreTest
                 // 'create index concurrently' internally consists of 3 transactions: one to register the index as invalid,
                 // and two table scans to build the index. Aborting the statement will leave the index in an invalid state.
                 sqlu"create index concurrently if not exists test_index on active_parties (slow_function(party))",
+                // `set statement_timeout` lasts for the whole session, and we are using connection pools,
+                // so reset it to default to avoid affecting later statements.
+                sqlu"set statement_timeout to default",
               )
               .asTry,
             "insert test data",
@@ -247,6 +250,93 @@ class SqlIndexInitializationTriggerStoreTest
         indexNamesAfter <- listIndexNames()
       } yield {
         indexNamesAfter should contain("test_index")
+      }
+    }
+
+    "avoid deleting index that is being created" in {
+      val trigger = new SqlIndexInitializationTrigger(
+        storage = storage,
+        context = triggerContext,
+        indexActions = List(
+          IndexAction.Create(
+            "test_index",
+            sqlu"create index concurrently if not exists test_index on active_parties (closed_round)",
+          )
+        ),
+      )
+      // Too annoying to get this value out of Future.sequence below, so we use a var
+      var tasksResult: Option[Seq[SqlIndexInitializationTrigger.Task]] = None
+      for {
+        _ <- Future.unit
+        _ <- storage.underlying
+          .update(
+            DBIOAction
+              .seq(
+                sqlu"""
+                  insert into active_parties (store_id, party, closed_round)
+                  values (1, 'test_party', 1)
+                """,
+                sqlu"""
+                  insert into active_parties (store_id, party, closed_round)
+                  values (2, 'test_party2', 1)
+                """,
+              ),
+            "insert test data",
+          )
+          .failOnShutdown
+        _ <- storage.underlying
+          .update(
+            sqlu"""
+              create or replace function slow_function(text) returns text as $$$$
+              begin
+                  perform pg_sleep(2); -- simulate a long-running operation
+                  return $$1;
+              end;
+              $$$$ language plpgsql immutable;
+              """,
+            "create slow_function",
+          )
+          .failOnShutdown
+
+        // This block simulates a trigger checking for tasks while an index is being created.
+        // We run the following actions in parallel to achieve this:
+        // - Create an index using slow_function(), which takes 4 seconds in total
+        //   (2 rows in the table and 2 seconds per function invocation).
+        // - Wait 2 seconds, then have the trigger check for tasks.
+        _ <- Future.sequence(
+          Seq(
+            storage.underlying
+              .update(
+                DBIOAction
+                  .seq(
+                    // This statement will take 4sec to execute, because slow_function() takes 2 seconds to execute per row,
+                    // and there are 2 rows in the table.
+                    sqlu"create index concurrently if not exists test_index on active_parties (slow_function(party))",
+                    // `set statement_timeout` lasts for the whole session, and we are using connection pools,
+                    // so reset it to default to avoid affecting later statements.
+                    sqlu"set statement_timeout to default",
+                  )
+                  .asTry,
+                "insert test data",
+              )
+              .failOnShutdown,
+            loggerFactory.assertEventuallyLogsSeq(SuppressionRule.LevelAndAbove(Level.INFO))(
+              within = {
+                Threading.sleep(2000)
+                trigger.retrieveTasks().map(tasks => tasksResult = Some(tasks))
+              },
+              assertion = { entries =>
+                forExactly(1, entries) {
+                  _.message should include(
+                    "Index test_index is being built by backend process"
+                  )
+                }
+              },
+            ),
+          )
+        )
+      } yield {
+        tasksResult.value shouldBe empty
       }
     }
   }
@@ -330,5 +420,7 @@ class SqlIndexInitializationTriggerStoreTest
     _ <- dropIndexes(
       SqlIndexInitializationTrigger.defaultIndexActions.map(_.indexName) ++ Seq("test_index")
     )
+    // Need to drop this after dropping the indexes using it.
+    _ <- storage.update(sqlu"drop function if exists slow_function", "drop slow_function")
   } yield ()
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -24,8 +24,9 @@ import com.digitalasset.canton.resource.{DbStorage, Storage}
 import com.digitalasset.canton.resource.DbStorage.Implicits.BuilderChain.toSQLActionBuilderChain
 import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
+import org.lfdecentralizedtrust.splice.store.db.AdvisoryLockIds.withExclusiveTransactionLock
 import org.lfdecentralizedtrust.splice.store.events.SpliceCreatedEvent
-import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.dbio.DBIOAction
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 import slick.jdbc.{GetResult, JdbcProfile}
 
@@ -158,40 +159,18 @@ class AcsSnapshotStore(
         join creates_to_insert on inserted_rows.create_id = creates_to_insert.row_id
         having min(inserted_rows.row_id) is not null;
              """).toActionBuilder.asUpdate
-      storage.queryAndUpdate(withExclusiveSnapshotDataLock(statement), "insertNewSnapshot")
+      storage.queryAndUpdate(
+        // Note: The acs_snapshot_data table must not have interleaved rows from two different acs snapshots.
+        // In rare cases, it can happen that the application crashes while writing a snapshot, then
+        // restarts and starts writing a _different_ snapshot while the previous statement is still running.
+        // We use an advisory lock to prevent this.
+        withExclusiveTransactionLock(storage, AdvisoryLockIds.acsSnapshotDataInsert, statement),
+        "insertNewSnapshot",
+      )
     }.andThen { _ =>
       AcsSnapshotStore.PreventConcurrentSnapshotsSemaphore.release()
     }
   }
-
-  /** Wraps the given action in a transaction that holds an exclusive lock on the acs_snapshot_data table.
-    *
-    *  Note: The acs_snapshot_data table must not have interleaved rows from two different acs snapshots.
-    *  In rare cases, it can happen that the application crashes while writing a snapshot, then
-    *  restarts and starts writing a different snapshot while the previous statement is still running.
-    *
-    *  The exclusive lock prevents this.
-    *  We use a transaction-scoped advisory lock, which is released when the transaction ends.
-    *  Regular locks (e.g. obtained via `LOCK TABLE ... IN EXCLUSIVE MODE`) would conflict with harmless
-    *  background operations like autovacuum or create index concurrently.
-    *
-    *  In case the application crashes while holding the lock, the server _should_ close the connection
-    *  and abort the transaction as soon as it detects a disconnect.
-    *  TODO(#2488): Verify that the server indeed closes connections in a reasonable time.
-    */
-  private def withExclusiveSnapshotDataLock[T, E <: Effect](
-      action: DBIOAction[T, NoStream, E]
-  ): DBIOAction[T, NoStream, Effect.Read & Effect.Transactional & E] =
-    (for {
-      lockResult <- sql"SELECT pg_try_advisory_xact_lock(${AdvisoryLockIds.acsSnapshotDataInsert})"
-        .as[Boolean]
-        .head
-      result <- lockResult match {
-        case true => action
-        // Lock conflicts should almost never happen. If they do, we fail immediately and rely on the trigger infrastructure to retry and log errors.
-        case false => DBIOAction.failed(new Exception("Failed to acquire exclusive lock"))
-      }
-    } yield result).transactionally
 
   def deleteSnapshot(
       snapshot: AcsSnapshot


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6328

The new test proves that `SqlIndexInitializationTrigger` would detect if an index is being built and not do anything. This PR still adds an advisory lock to SqlIndexInitializationTrigger, as in test code we are running multiple instances of `SqlIndexInitializationTrigger` against the same database.