### PR TITLE
Canton default change: `max-token-lifetime=Inf`

### DIFF
--- a/apps/app/src/test/resources/include/participants.conf
+++ b/apps/app/src/test/resources/include/participants.conf
@@ -75,7 +75,8 @@ _participant_template {
       enable-verbose-hashing = true
     }
     # Default expiration used in tests
-    max-token-lifetime = 30 days
+    # TODO(DACH-NY/canton-network-internal#2347) Revisit this; we want to avoid users to have to set an exp field in their tokens
+    max-token-lifetime = Inf
     # Required for pruning
     admin-token-config.admin-claim=true
   }

--- a/cluster/compose/localnet/conf/canton/app.conf
+++ b/cluster/compose/localnet/conf/canton/app.conf
@@ -58,8 +58,8 @@ _participant {
   init.ledger-api.max-deduplication-duration = 30s
 
   ledger-api {
-    # TODO(DACH-NY/canton-network-internal#2347) Revisit this, we need 30 days in fixed token mode.
-    max-token-lifetime = 30 days
+    # TODO(DACH-NY/canton-network-internal#2347) Revisit this; we want to avoid users to have to set an exp field in their tokens
+    max-token-lifetime = Inf
     # Required for pruning
     admin-token-config.admin-claim=true
     address = "0.0.0.0"

--- a/cluster/images/canton-participant/app.conf
+++ b/cluster/images/canton-participant/app.conf
@@ -71,8 +71,8 @@ canton {
       }
 
       ledger-api {
-        # TODO(DACH-NY/canton-network-internal#2347) Revisit this, we need 30 days in fixed token mode.
-        max-token-lifetime = 30 days
+        # TODO(DACH-NY/canton-network-internal#2347) Revisit this; we want to avoid users to have to set an exp field in their tokens
+        max-token-lifetime = Inf
         # Required for pruning
         admin-token-config.admin-claim=true
         address = "0.0.0.0"


### PR DESCRIPTION
According to upstream, setting this to `Inf` should remove the requirement of adding an `exp` field to tokens (which might be a breaking change for some validators).

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
