### PR TITLE
Add log ignore for dropping invalid indexes

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -128,5 +128,8 @@ GENERIC_CONFIG_ERROR.*SpliceConfigTest
 
 Circuit breaker .* tripped after .* failures.*(Command|Splice)CircuitBreakerTest
 
+# See DACH-NY/cn-test-failures#6328: In rare cases, creating an index asynchronously can fail.
+# This is more likely in test code where we run multiple apps against the same database, all trying to create the same index.
+Index .* should be created and is invalid, dropping it
 
 # Make sure to have a trailing newline


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6328

I don't want to demote the warning, as otherwise we get no feedback that the trigger is not progressing, and we really don't expect the trigger to fail in production where each app gets its own database.
