### PR TITLE
[ci] Sync cometbft timeout with actual prod timeout

### DIFF
--- a/apps/sv/src/test/resources/cometbft/sv1/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv1/config/config.toml
@@ -379,7 +379,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)

--- a/apps/sv/src/test/resources/cometbft/sv2/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv2/config/config.toml
@@ -379,7 +379,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)

--- a/apps/sv/src/test/resources/cometbft/sv2Local/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv2Local/config/config.toml
@@ -379,7 +379,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)

--- a/apps/sv/src/test/resources/cometbft/sv3/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv3/config/config.toml
@@ -379,7 +379,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)

--- a/apps/sv/src/test/resources/cometbft/sv4/config/config.toml
+++ b/apps/sv/src/test/resources/cometbft/sv4/config/config.toml
@@ -379,7 +379,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)


### PR DESCRIPTION
helm chart already defines it as 1s

Spent too much time investigating the effect of 3s on prod networks, only to discover that it's set to 1s when trying to actually set it to 1s

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
