### PR TITLE
ValidatorApp: retry an early `listOwnerToKeyMapping` request

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/setup/NodeInitializer.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/setup/NodeInitializer.scala
@@ -125,6 +125,7 @@ class NodeInitializer(
               s"Node has identity $id, matching expected identifier $idenfitierName."
             )
             // fixes previously initialized nodes with messed up keys
+            // TODO(#3115): we probably don't need this anymore; consider removing
             rotateSigningKeyIfSameAsNamespaceKey(id, nodeIdentity)
           } else {
             logger.error(
@@ -150,7 +151,15 @@ class NodeInitializer(
       nodeIdentity: UniqueIdentifier => Member & NodeIdentity,
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[Option[OwnerToKeyMapping]] = {
     for {
-      ownerToKeyMappings <- connection.listOwnerToKeyMapping(nodeIdentity(id))
+      // Canton nodes enable their endpoints one at a time, and return NOT_IMPLEMENTED while an endpoint is not yet enabled.
+      // (Hence the retry here.)
+      ownerToKeyMappings <- retryProvider.retry(
+        RetryFor.WaitingOnInitDependency,
+        "list_owner_to_key_mapping",
+        s"${connection.serviceName} answers the listOwnerToKeyMapping request",
+        connection.listOwnerToKeyMapping(nodeIdentity(id)),
+        logger,
+      )
     } yield ownerToKeyMappings.map(_.mapping).find { mapping =>
       mapping.keys.exists {
         case key: SigningPublicKey =>


### PR DESCRIPTION
May fail app init if the participant is still warming up.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/6379

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
