### PR TITLE
[ci] Fix sim time reward time advance

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
@@ -178,7 +178,7 @@ trait TimeTestUtil extends TestCommon {
       .map(_.contract.payload.opensAt)
       .maxOption
       .foreach { opensAt =>
-        val advanceTo = opensAt.plus(defaultTickDuration.asJava.minusSeconds(1))
+        val advanceTo = opensAt.plus(defaultTickDuration.asJava.minusMillis(1))
         logger.info(
           s"Advancing time to $advanceTo from $now for reward automation to run with open time of round $opensAt for open rounds $openRounds "
         )

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/RoundBasedRewardTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/RoundBasedRewardTrigger.scala
@@ -143,7 +143,10 @@ abstract class RoundBasedRewardTrigger[T <: RoundBasedTask: Pretty]()(implicit
             }
           })
         }
-      } else Future.successful(Seq.empty)
+      } else {
+        logger.trace(s"Not running trigger yet for state ${triggerState.get()}")
+        Future.successful(Seq.empty)
+      }
     } else {
       retrieveAvailableTasksForRound()
     }


### PR DESCRIPTION
Advance up to 1ms before next round as if there is no previous open round then the trigger could run right at the end of the interval

fixes https://github.com/DACH-NY/cn-test-failures/issues/6192

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
