### PR TITLE
Bump Canton to 3.4.6

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.6-snapshot.20251107.17375.0.v0f29a2e4",
+  "version": "3.4.6",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:0f1jhk7f3ph4hacph22q9601n8jkn06i5zwz6skmwd4fphsvjfhk",
-  "oss_sha256": "sha256:0ddywd49yrky4qhgjspnzp3l1gn3ri5vbb14ghrcf89j1lmvyxxm"
+  "enterprise_sha256": "sha256:0ni5icn4vazsnhy0w7y9g6gnw8lgpdhrxax8ip6sz6dp4diwg6sa",
+  "oss_sha256": "sha256:15zphyzg23282r6pzf67blx7rpb7djj3jz6i12rn2fxhrk09hscz"
 }


### PR DESCRIPTION
Should be functionality a NOP, but the version number is nicer.

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
