### PR TITLE
Fix `get-snapshot-version` on `release-line-x.y` branches

### DIFF
--- a/build-tools/get-release-if-on-release-branch.sh
+++ b/build-tools/get-release-if-on-release-branch.sh
@@ -20,7 +20,7 @@ fi
 sha=$(git rev-parse HEAD)
 if ! (git branch -r --contains "$sha" | grep -q "\borigin/main\b"); then
     if [[ $(git branch -r --contains "$sha") =~ origin/release-line-[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-        branch=$(git branch -r --contains "$sha" | grep -o 'origin/release-line-.*' | head -n 1)
+        branch=$(git branch -r --contains "$sha" | grep -o 'origin/release-line-[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1)
         echo "${branch#origin/release-line-}"
         exit 0
     fi


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6477

Tested manually:

```
git checkout c2d1848bf3346b88ec39605cb15049ab2bbce543
get-snapshot-version
0.4.25
```

(Without this fix it was 0.4, which caused the problems.)

Will backport to 0.4 just in case...

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
