### PR TITLE
Set liveness margin for new sequencer connection pools

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -4,7 +4,7 @@ import com.daml.nonempty.NonEmpty
 import com.digitalasset.canton.admin.api.client.data.PruningSchedule
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.config.{FullClientConfig, PositiveDurationSeconds}
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
 import com.digitalasset.canton.crypto.{SigningKeyUsage, SigningPublicKey}
 import com.digitalasset.canton.topology.{
   MediatorId,
@@ -182,6 +182,7 @@ class ManualStartIntegrationTest
                 .value
             sequencerConnections.connections.size shouldBe 1
             sequencerConnections.sequencerTrustThreshold shouldBe PositiveInt.tryCreate(1)
+            sequencerConnections.sequencerLivenessMargin shouldBe NonNegativeInt.zero
             sequencerConnections.submissionRequestAmplification shouldBe SvAppBackendConfig.DefaultMediatorSequencerRequestAmplification
             mediatorConnection.getPruningSchedule().futureValue.value shouldBe PruningSchedule(
               "0 /10 * * * ?",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorIntegrationTest.scala
@@ -13,7 +13,7 @@ import org.lfdecentralizedtrust.splice.util.WalletTestUtil
 import org.lfdecentralizedtrust.splice.validator.config.ValidatorAppBackendConfig
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.sequencing.SubmissionRequestAmplification
 import com.digitalasset.canton.topology.PartyId
@@ -152,6 +152,7 @@ class ValidatorIntegrationTest extends IntegrationTest with WalletTestUtil {
         .sequencerConnections
       sequencerConnections.connections.size shouldBe 4
       sequencerConnections.sequencerTrustThreshold shouldBe PositiveInt.tryCreate(2)
+      sequencerConnections.sequencerLivenessMargin shouldBe NonNegativeInt.one
       sequencerConnections.submissionRequestAmplification shouldBe SubmissionRequestAmplification(
         PositiveInt.tryCreate(2),
         ValidatorAppBackendConfig.DEFAULT_SEQUENCER_REQUEST_AMPLIFICATION_PATIENCE,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -480,6 +480,11 @@ abstract class ValidatorPreflightIntegrationTestBase
             domainConnectionConfig.sequencerConnections.connections.size
           )
           .value
+        domainConnectionConfig.sequencerConnections.sequencerLivenessMargin shouldBe Thresholds
+          .sequencerConnectionsLivenessMargin(
+            domainConnectionConfig.sequencerConnections.connections.size
+          )
+          .value
         domainConnectionConfig.sequencerConnections.submissionRequestAmplification.factor shouldBe Thresholds
           .sequencerSubmissionRequestAmplification(
             domainConnectionConfig.sequencerConnections.connections.size

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/Thresholds.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/Thresholds.scala
@@ -5,7 +5,7 @@ package org.lfdecentralizedtrust.splice.config
 
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules
 import org.lfdecentralizedtrust.splice.util.Contract
-import com.digitalasset.canton.config.RequireTypes.PositiveInt
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, PositiveInt}
 import com.digitalasset.canton.topology.transaction.{HostingParticipant, ParticipantPermission}
 
 import scala.math.{ceil, floor}
@@ -20,6 +20,9 @@ object Thresholds {
       PositiveInt.tryCreate(Math.floorDiv(n - 1, 3) + 1)
     }
   }
+
+  private def FThreshold(n: Int): NonNegativeInt =
+    FPlus1Threshold(n).decrement
 
   def mediatorDomainStateThreshold(
       currentMediatorSize: Int
@@ -39,6 +42,11 @@ object Thresholds {
     FPlus1Threshold(
       sequencersSize
     )
+
+  // Sequencer connection pools keep threshold + liveness margin connections.
+  // so with this set to f, we get 2f+1 total connections.
+  def sequencerConnectionsLivenessMargin(sequencersSize: Int): NonNegativeInt =
+    FThreshold(sequencersSize)
 
   def sequencerSubmissionRequestAmplification(sequencersSize: Int): PositiveInt =
     sequencerConnectionsSizeThreshold(sequencersSize)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/MediatorAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/MediatorAdminConnection.scala
@@ -83,7 +83,7 @@ class MediatorAdminConnection(
         SequencerConnections.tryMany(
           Seq(sequencerConnection),
           PositiveInt.tryCreate(1),
-          // TODO(#2110) Rethink this when we enable sequencer connection pools.
+          // Mediators do not have BFT connections.
           sequencerLivenessMargin = NonNegativeInt.zero,
           submissionRequestAmplification,
           // TODO(#2666) Make the delays configurable.
@@ -121,7 +121,7 @@ class MediatorAdminConnection(
         SequencerConnections.tryMany(
           Seq(sequencerConnection),
           PositiveInt.tryCreate(1),
-          // TODO(#2110) Rethink this when we enable sequencer connection pools.
+          // Mediators do not have BFT connections.
           sequencerLivenessMargin = NonNegativeInt.zero,
           submissionRequestAmplification,
           // TODO(#2666) Make the delays configurable.

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/LocalSequencerConnectionsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/LocalSequencerConnectionsTrigger.scala
@@ -108,7 +108,7 @@ class LocalSequencerConnectionsTrigger(
           val newConnections = SequencerConnections.tryMany(
             Seq(localSequencerConnection),
             PositiveInt.tryCreate(1),
-            // TODO(#2110) Rethink this when we enable sequencer connection pools.
+            // We only have a single connection here.
             sequencerLivenessMargin = NonNegativeInt.zero,
             submissionRequestAmplification = sequencerRequestAmplification,
             // TODO(#2666) Make the delays configurable.

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -142,7 +142,7 @@ class JoiningNodeInitializer(
         SequencerConnections.tryMany(
           Seq(GrpcSequencerConnection.tryCreate(url)),
           PositiveInt.one,
-          // TODO(#2110) Rethink this when we enable sequencer connection pools.
+          // We only have a single connection here.
           sequencerLivenessMargin = NonNegativeInt.zero,
           config.participantClient.sequencerRequestAmplification,
           // TODO(#2666) Make the delays configurable.

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -190,7 +190,7 @@ class SV1Initializer(
               )
             ),
             PositiveInt.one,
-            // TODO(#2110) Rethink this when we enable sequencer connection pools.
+            // We only have a single connection here.
             sequencerLivenessMargin = NonNegativeInt.zero,
             config.participantClient.sequencerRequestAmplification,
             // TODO(#2666) Make the delays configurable.

--- a/apps/validator/src/main/openapi/validator-internal.yaml
+++ b/apps/validator/src/main/openapi/validator-internal.yaml
@@ -702,12 +702,16 @@ components:
         - connections
         - sequencer_trust_threshold
         - submission_request_amplification
+        - sequencer_liveness_margin
       properties:
         connections:
           type: array
           items:
             $ref: "#/components/schemas/SequencerAliasToConnections"
         sequencer_trust_threshold:
+          type: integer
+          format: int32
+        sequencer_liveness_margin:
           type: integer
           format: int32
         submission_request_amplification:

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
@@ -221,7 +221,10 @@ class HttpValidatorAdminHandler(
                   transportSecurity,
                 )
             }.toVector,
-            connectionConfig.sequencerConnections.sequencerTrustThreshold.value,
+            sequencerTrustThreshold =
+              connectionConfig.sequencerConnections.sequencerTrustThreshold.value,
+            sequencerLivenessMargin =
+              connectionConfig.sequencerConnections.sequencerLivenessMargin.value,
             definitions.SequencerSubmissionRequestAmplification(
               connectionConfig.sequencerConnections.submissionRequestAmplification.factor.value,
               connectionConfig.sequencerConnections.submissionRequestAmplification.patience.duration.toSeconds,

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ReconcileSequencerConnectionsTrigger.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ReconcileSequencerConnectionsTrigger.scala
@@ -13,7 +13,6 @@ import org.lfdecentralizedtrust.splice.environment.{ParticipantAdminConnection, 
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.validator.domain.DomainConnector
 import com.daml.nonempty.NonEmpty
-import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig
 import com.digitalasset.canton.sequencing.{
@@ -97,8 +96,8 @@ class ReconcileSequencerConnectionsTrigger(
                     SequencerConnections.tryMany(
                       nonEmptyConnections.forgetNE,
                       Thresholds.sequencerConnectionsSizeThreshold(nonEmptyConnections.size),
-                      // TODO(#2110) Rethink this when we enable sequencer connection pools.
-                      sequencerLivenessMargin = NonNegativeInt.zero,
+                      sequencerLivenessMargin =
+                        Thresholds.sequencerConnectionsLivenessMargin(nonEmptyConnections.size),
                       submissionRequestAmplification = SubmissionRequestAmplification(
                         Thresholds.sequencerSubmissionRequestAmplification(
                           nonEmptyConnections.size

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -16,7 +16,6 @@ import org.lfdecentralizedtrust.splice.validator.config.ValidatorAppBackendConfi
 import com.daml.nonempty.NonEmpty
 import com.digitalasset.canton.{SequencerAlias, SynchronizerAlias}
 import com.digitalasset.canton.config.SynchronizerTimeTrackerConfig
-import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig
@@ -160,8 +159,8 @@ class DomainConnector(
                       Thresholds.sequencerSubmissionRequestAmplification(nonEmptyConnections.size),
                       config.sequencerRequestAmplificationPatience,
                     ),
-                    // TODO(#2110) Rethink this when we enable sequencer connection pools.
-                    sequencerLivenessMargin = NonNegativeInt.zero,
+                    sequencerLivenessMargin =
+                      Thresholds.sequencerConnectionsLivenessMargin(nonEmptyConnections.size),
                     // TODO(#2666) Make the delays configurable.
                     sequencerConnectionPoolDelays = SequencerConnectionPoolDelays.default,
                   )


### PR DESCRIPTION
This is a noop at this point given that we don't have them enabled but seems nice to have a separate PR to set them correctly.

fixes #3161

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
