### PR TITLE
0.4 backport: Fix `get-snapshot-version` on `release-line-x.y` branches (#3167)

### DIFF
--- a/build-tools/get-release-if-on-release-branch.sh
+++ b/build-tools/get-release-if-on-release-branch.sh
@@ -20,7 +20,7 @@ fi
 sha=$(git rev-parse HEAD)
 if ! (git branch -r --contains "$sha" | grep -q "\borigin/main\b"); then
     if [[ $(git branch -r --contains "$sha") =~ origin/release-line-[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-        branch=$(git branch -r --contains "$sha" | grep -o 'origin/release-line-.*' | head -n 1)
+        branch=$(git branch -r --contains "$sha" | grep -o 'origin/release-line-[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1)
         echo "${branch#origin/release-line-}"
         exit 0
     fi


### PR DESCRIPTION
Backports https://github.com/hyperledger-labs/splice/pull/3167 to where we will hopefully never need it again...

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
