### PR TITLE
Bump `party-allocator-keys` PVC size to 2x

### DIFF
--- a/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
+++ b/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
@@ -63,7 +63,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10G
+      storage: 20G
   storageClassName: {{ .Values.pvc.volumeStorageClass }}
 ---
 apiVersion: v1


### PR DESCRIPTION
Based on increased usage on CILR.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
