### PR TITLE
Ignore enqueue after time shutdown warning

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -163,4 +163,7 @@ DB_CONNECTION_LOST.*Database health check failed to establish a valid connection
 # TODO(#3069): Byproduct of mediator pruning; double-check this is expected (and unavoidable)
 Dynamic synchronizer parameters to compute earliest available pruning timestamp not found
 
+# TODO(#3193): Likely a race in the shutdown of the actor system vs us scheduling something else on it
+java.lang.IllegalStateException: cannot enqueue after timer shutdown
+
 # Make sure to have a trailing newline


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6496

Log ignore added to https://github.com/DACH-NY/canton-network-internal/issues/2589 even though it might be unrelated to Canton 3.4.