### PR TITLE
Remove deprecated /v0/total-amulet-balance and /v0/wallet-balance APIs

### DIFF
--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1174,60 +1174,6 @@ paths:
         "500":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
 
-  /v0/total-amulet-balance:
-    get:
-      deprecated: true
-      tags: [deprecated, scan]
-      x-jvm-package: scan
-      operationId: "getTotalAmuletBalance"
-      description: "**Deprecated**. Get the total balance of Amulet in the network"
-      parameters:
-        - in: query
-          name: asOfEndOfRound
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GetTotalAmuletBalanceResponse"
-        "404":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
-
-  /v0/wallet-balance:
-    get:
-      deprecated: true
-      tags: [deprecated]
-      x-jvm-package: scan
-      operationId: "getWalletBalance"
-      description: |
-        **Deprecated**, use /v0/holdings/summary with /v0/state/acs/snapshot-timestamp instead. Get the Amulet balance for a specific party at the end of a closed round
-      parameters:
-        - in: query
-          name: party_id
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: asOfEndOfRound
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/GetWalletBalanceResponse"
-        "404":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
-
   /v0/amulet-config-for-round:
     get:
       deprecated: true
@@ -1780,18 +1726,6 @@ components:
       properties:
         featured_app_right:
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/schemas/Contract"
-    GetWalletBalanceResponse:
-      type: object
-      required: ["wallet_balance"]
-      properties:
-        wallet_balance:
-          type: string
-    GetTotalAmuletBalanceResponse:
-      type: object
-      required: ["total_balance"]
-      properties:
-        total_balance:
-          type: string
     GetAmuletConfigForRoundResponse:
       type: object
       required:


### PR DESCRIPTION
This draft PR only removes the endpoints from the openAPI spec so that the impact is clear.

-  `/v0/total-amulet-balance`  is replaced by total supply on `/registry/metadata/v1/instruments/{instrumentId}` (`getInstrument('Amulet')`)
- `/v0/wallet-balance` is replaced by `/v0/holdings/summary`



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
