### PR TITLE
Remove spurious matches in illegal_daml_references hook

### DIFF
--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -1174,7 +1174,7 @@ function subcmd_no_illegal_daml_references() {
       )
     for word in "${illegal_words[@]}"; do
         echo "Checking for occurences of '$word' (case-insensitive)"
-        if rg -i "$word" daml/ -g '!daml/token-standard' -g '!daml/dars.lock'; then
+        if rg -i "$word" daml/ -g '!daml/token-standard' -g '!daml/dars.lock' -g '!**/target/'; then
             echo "$word occurs in Daml code, remove all references"
             exit 1
         fi
@@ -1200,7 +1200,7 @@ function subcmd_no_illegal_daml_references() {
       )
     for pattern in "${illegal_patterns[@]}"; do
         echo "Checking for occurences of '$pattern' (case sensitive, in code other than splitwell)"
-        if rg -P "$pattern" daml/ token-standard/ -g '!*/splitwell/*' -g '!*/splitwell-test/*' -g '!daml/dars.lock' -g '!token-standard/README.md' -g '!token-standard/CHANGELOG.md' -g '!*.json' -g '!token-standard/dependencies/*'; then
+        if rg -P "$pattern" daml/ token-standard/ -g '!*/splitwell/*' -g '!*/splitwell-test/*' -g '!daml/dars.lock' -g '!token-standard/README.md' -g '!token-standard/CHANGELOG.md' -g '!*.json' -g '!token-standard/dependencies/*' -g '!**/target/'; then
             echo "$pattern occurs in Daml code (other than splitwell), remove all references"
             exit 1
         fi
@@ -1221,11 +1221,11 @@ subcommand_whitelist[no_amulet_in_ui]='Check for Amulet and ANS in user UI'
 function subcmd_no_amulet_in_ui() {
     local illegal_patterns=(
       '(?<!TR)ANS(?!_LEDGER_NAME)'
-      "(?<!Splice[./])\bAmulet\b(?!( Rules))"
+      "(?<!(Splice[./]|Config \())\bAmulet\b(?!( Rules| Config| to Issue|\)|'))"
       )
     for pattern in "${illegal_patterns[@]}"; do
         echo "Checking for occurences of '$pattern' in frontend code"
-        if rg -P "$pattern" -g '*.tsx' -g '*.ts' -g '**test/**/*.scala' -g '!cluster/**' -g '!token-standard/**'; then
+        if rg -P "$pattern" -g '*.tsx' -g '*.ts' -g '**test/**/*.scala' -g '!__tests__' -g '!cluster/**' -g '!token-standard/**'; then
             echo "$pattern occurs in frontend, ensure it is not user-visible"
             exit 1
         fi


### PR DESCRIPTION
[static]

Before that `pre-commit run illegal_daml_references --all` reported spurious errors.

Note: on the frontend code side, I just excluded the matches that existed in a somewhat sensible way. I expect that the UI is OK these days, as we haven't heard complaints.

Problems reported by @dfordivam . Thanks!


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
