### PR TITLE
Bump Canton to 3.4.8

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.8-snapshot.20251112.17388.0.vf9e0d623",
+  "version": "3.4.8",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:04klb5z1wyrbhfqy1bisqv8pb780sf2s069c9gi02wsywa9fa43m",
-  "oss_sha256": "sha256:18w6y5b0hqcdnz37b8kaakv95jz8827vbcb69dhfa1slsxwm5xb4"
+  "enterprise_sha256": "sha256:1bg5kxig58s61davv7mfkl8zhqgndghm3xazi73xbbflpsfqzyrv",
+  "oss_sha256": "sha256:05897mxqmk4n03g4vpi17jqks9lkhh3drgy1pv9b8mcr10l9vzkh"
 }


### PR DESCRIPTION
[ci]

Among other things

- Use a non-snapshot release for the 0.5.2 release cut (assuming no further bumps).
- Consume https://github.com/DACH-NY/canton/issues/29425 to resolve https://github.com/hyperledger-labs/splice/issues/3069
- Observability improvements for sequencer circuit breakers / TPS caps

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
