### PR TITLE
Transfer fee fixes for new sv ui [ci]

### DIFF
--- a/apps/sv/frontend/src/utils/buildAmuletConfigChanges.ts
+++ b/apps/sv/frontend/src/utils/buildAmuletConfigChanges.ts
@@ -156,6 +156,9 @@ function buildTransferFeeStepsChanges(
       ?.map((b, i) => {
         const idx = i + 1;
         const a = after?.[idx];
+
+        if (b._2 === '0.0') return [];
+
         return [
           {
             fieldName: `transferFeeSteps${idx}_1`,

--- a/apps/sv/frontend/src/utils/buildAmuletRulesConfigFromChanges.ts
+++ b/apps/sv/frontend/src/utils/buildAmuletRulesConfigFromChanges.ts
@@ -74,9 +74,10 @@ export function buildAmuletRulesConfigFromChanges(
     futureValues.push({ _1: time, _2: config });
   }
 
+  const transferPreapprovalFee = getValue('transferPreapprovalFee');
   const amuletConfig: AmuletConfig<'USD'> = {
     tickDuration: { microseconds: getValue('tickDuration') },
-    transferPreapprovalFee: getValue('transferPreapprovalFee'),
+    transferPreapprovalFee: transferPreapprovalFee === '' ? null : transferPreapprovalFee,
     featuredAppActivityMarkerAmount: getValue('featuredAppActivityMarkerAmount'),
 
     transferConfig: {


### PR DESCRIPTION
This makes viewing amulet config changes cleaner(no extra fields for transfer fees on each proposal) until the fees have been removed in the cluster/network.

- omit transfer fee block if the fee is 0.0
- transferPreapproval should be `null`, not `''` when unset

Fixes #2794


Before
<img width="1199" height="929" alt="Screenshot 2025-11-19 at 13 09 22" src="https://github.com/user-attachments/assets/cdcb3aca-d62d-40c4-9ee6-899e67e49173" />


After
<img width="1199" height="890" alt="Screenshot 2025-11-19 at 13 09 33" src="https://github.com/user-attachments/assets/36b36c46-3e55-421c-aef1-b858cc9f163c" />




### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
