### PR TITLE
README improvements for faster test execution

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -220,6 +220,8 @@ The logs from test executions are output to `/log/canton_network_test.clog`.
 Use `lnav` to view these logs for debugging failing test cases.
 No installation of `lnav` is required, as it is provided by default by our `direnv`.
 
+If you run integration tests using sbt, we recommend running them within `apps-app`, as this speeds up test execution. For example: `apps-app/testOnly org.lfdecentralizedtrust.splice.integration.tests.AnsIntegrationTest`.
+
 Documentation about common pitfalls when writing new integration tests and debugging existing ones can be found [here](/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/README.md).
 If you wish to extend our testing topology please also consult [this README](/apps/app/src/test/resources/README.md) about name and port allocation.
 


### PR DESCRIPTION
## Summary of changes
- Recommend use of `-w` or `-s` in `canton/start.sh` for wallclock tests and simtime tests.
- `start-backends-for-local-frontend-testing.sh` is not needed for running frontend integration tests. The corresponding line has been removed.
- Replace `testOnly` with `apps-app/testOnly`, which speeds up test execution


[static]

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
