### PR TITLE
Rate limit validator onboardings to 1/s

### DIFF
--- a/apps/app/src/test/resources/include/svs/_sv.conf
+++ b/apps/app/src/test/resources/include/svs/_sv.conf
@@ -66,6 +66,7 @@
       }
       rate-limiters {
         prepareValidatorOnboarding.rate-per-second = 2
+        devNetOnboardValidatorPrepare.rate-per-second = 2
       }
     }
   }

--- a/cluster/images/sv-app/app.conf
+++ b/cluster/images/sv-app/app.conf
@@ -110,6 +110,7 @@ canton {
           }
           rate-limiters {
             prepareValidatorOnboarding.rate-per-second = 1
+            devNetOnboardValidatorPrepare.rate-per-second = 0.2
           }
         }
       }


### PR DESCRIPTION
Prevent abusive usage of the endpoint, as it runs actual transactions

[ci]

I was half thinking of just going to 1/10s but decided to first limit extreme usage.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
