### PR TITLE
Remove broken test in RunbookSvPreflightIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
@@ -17,7 +17,7 @@ import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
-import scala.util.{Random, Try}
+import scala.util.Random
 
 abstract class RunbookSvPreflightIntegrationTestBase
     extends FrontendIntegrationTestWithSharedEnvironment("sv")


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6527
See there also why this test doesn't make sense (anymore)