### PR TITLE
Update Canton to 3.5.9

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -7,6 +7,11 @@
 
 .. release-notes:: upcoming
 
+  - Validator
+
+    - Fix a bug introduced in 0.5.0/0.5.1 that could cause participant pruning to prune active data.
+      The bug only manifests in a rare edge case involving a manual ACS import on a participant that was already running for some time.
+
   - Scan
 
     - Removed the non-existing `command_id` field from the OpenAPI spec of all

--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.9-snapshot.20251126.17423.0.v5228cfd3",
+  "version": "3.4.9",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:1dndjajba4c0db8mv16rnn9nkgi8xx08ijbhgakck9712x5v8yg2",
-  "oss_sha256": "sha256:0s98hy9m46lb30yvkhijinlvh23nzhl7z3w6cxc3c0nzqiviqmm4"
+  "enterprise_sha256": "sha256:16v5dfsiykizq8xy374d0ks52cqv7kndlzhl84hl5k1i1jhf9217",
+  "oss_sha256": "sha256:1s6qcvmbp95ydi52y6zc27rw6ij3hzvnaxvk7611k5jyxv54dp60"
 }


### PR DESCRIPTION
[ci]

Among other things, gets us https://github.com/DACH-NY/canton/pull/29563

Needed for https://github.com/DACH-NY/canton-network-internal/issues/2842

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
