### PR TITLE
remove file self reference

### DIFF
--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1899,7 +1899,7 @@ components:
             collected first
           type: array
           items:
-            $ref: "./scan.yaml#/components/schemas/ValidatorReceivedFaucets"
+            $ref: "#/components/schemas/ValidatorReceivedFaucets"
     GetTopValidatorsByPurchasedTrafficResponse:
       type: object
       required: ["validatorsByPurchasedTraffic"]


### PR DESCRIPTION
the scan.yaml have a self-reference to a file one layer above. Unless a copy of the file is placed there perfectly then some code-generators might break.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
