### PR TITLE
[ci] Remove cpu limit in istio proxy

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2269,6 +2269,17 @@
         },
         "autoscaleMax": 30,
         "autoscaleMin": 2,
+        "defaults": {
+          "global": {
+            "proxy": {
+              "resources": {
+                "limits": {
+                  "cpu": null
+                }
+              }
+            }
+          }
+        },
         "global": {
           "istioNamespace": "cluster-ingress",
           "logAsJson": true,
@@ -2277,7 +2288,6 @@
             "excludeOutboundPorts": "5432,26657",
             "resources": {
               "limits": {
-                "cpu": null,
                 "memory": "4096Mi"
               }
             }

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -84,6 +84,17 @@ function configureIstiod(
         autoscaleMin: 2,
         autoscaleMax: 30,
         ...infraAffinityAndTolerations,
+        defaults: {
+          global: {
+            proxy: {
+              resources: {
+                limits: {
+                  cpu: null,
+                },
+              },
+            },
+          },
+        },
         global: {
           istioNamespace: ingressNs.metadata.name,
           logAsJson: true,
@@ -93,7 +104,6 @@ function configureIstiod(
             excludeOutboundPorts: '5432,26657',
             resources: {
               limits: {
-                cpu: null,
                 memory: '4096Mi',
               },
             },


### PR DESCRIPTION
linux and k8s already enforce fair CPU sharing through requests and scheduling, preventing any container from monopolizing or destabilizing the node. CPU's are not a rigid resource (best effort, throttling / scheduling), unlike memory which is rigid.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
