### PR TITLE
Bump timeout until success in participant pruning test 

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualStartIntegrationTest.scala
@@ -190,7 +190,7 @@ class ManualStartIntegrationTest
         }
 
         clue("Check sv1 participant is actively pruning") {
-          eventually(40.seconds) {
+          eventually(70.seconds) {
             sv1Backend.svAutomation
               .connection(Low)
               // returns 0 when participant pruning is disabled


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/6568

so the 20 seconds timeout is definitely reached:
```
2025-12-02T18:44:06.841 [⋮] DEBUG - o.l.s.i.t.ManualStartIntegrationTest:ManualStartIntegrationTest (---) - Running clue: Check sv1 participant is actively pruning 
2025-12-02T18:44:26.846 [⋮] ERROR - o.l.s.i.t.ManualStartIntegrationTest:ManualStartIntegrationTest (---) - Failed clue: Using external Canton process manual-start org.scalatest.exceptions.TestFailedException: 0 was not greater than 0
```

Not sure it will definitely fix it, but let's try bumping this value before further investigation.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
