### PR TITLE
[ci] Remove cpu limits, requests are set.

### DIFF
--- a/cluster/helm/cn-docs/templates/docs.yaml
+++ b/cluster/helm/cn-docs/templates/docs.yaml
@@ -36,8 +36,9 @@ spec:
               containerPort: 443
               protocol: TCP
           resources:
+            requests:
+              cpu: 100m
             limits:
-              cpu: 1
               memory: "1536Mi"
           env:
             - name: SPLICE_CLUSTER

--- a/cluster/helm/cn-docs/templates/gcs-proxy.yaml
+++ b/cluster/helm/cn-docs/templates/gcs-proxy.yaml
@@ -34,8 +34,9 @@ spec:
               containerPort: 8080
               protocol: TCP
           resources:
+            requests:
+              cpu: 100m
             limits:
-              cpu: 1
               memory: "512Mi"
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-domain/values-template.yaml
+++ b/cluster/helm/splice-domain/values-template.yaml
@@ -11,7 +11,6 @@ pod:
 defaultJvmOptions: -XX:+UseG1GC -XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=75 -Dscala.concurrent.context.numThreads=8 -XX:ActiveProcessorCount=8 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/persistent-data
 resources:
   limits:
-    cpu: "2"
     memory: 8Gi
   requests:
     cpu: "1"

--- a/cluster/helm/splice-info/values-template.yaml
+++ b/cluster/helm/splice-info/values-template.yaml
@@ -35,7 +35,6 @@ contentType: "application/json"
 
 resources:
   limits:
-    cpu: 500m
     memory: 512Mi
   requests:
     cpu: "0"

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -115,7 +115,7 @@
       "properties": {
         "limits": {
           "type": "object",
-          "required": [ "cpu", "memory" ],
+          "required": [ "memory" ],
           "properties": {
             "cpu": {
               "type": "string",

--- a/cluster/helm/splice-postgres/values-template.yaml
+++ b/cluster/helm/splice-postgres/values-template.yaml
@@ -4,7 +4,6 @@
 imageRepo: "ghcr.io/digital-asset/decentralized-canton-sync/docker"
 resources:
   limits:
-    cpu: "4"
     memory: 12Gi
   requests:
     cpu: "0.5"

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -257,7 +257,6 @@ spec:
             cpu: 0.1
             memory: 240Mi
           limits:
-            cpu: 1
             memory: 1536Mi
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-splitwell-app/values-template.yaml
+++ b/cluster/helm/splice-splitwell-app/values-template.yaml
@@ -6,7 +6,6 @@ defaultJvmOptions: -XX:+UseG1GC -XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage
 fixedTokens: false
 resources:
   limits:
-    cpu: "2"
     memory: 1536Mi
   requests:
     cpu: "0.2"

--- a/cluster/helm/splice-splitwell-web-ui/values-template.yaml
+++ b/cluster/helm/splice-splitwell-web-ui/values-template.yaml
@@ -3,8 +3,9 @@
 
 imageRepo: "ghcr.io/digital-asset/decentralized-canton-sync/docker"
 resources:
+  requests:
+    cpu: 100m
   limits:
-    cpu: "1"
     memory: 1536Mi
 
 spliceInstanceNames:

--- a/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
@@ -70,7 +70,6 @@ spec:
               cpu: 0.1
               memory: 240Mi
             limits:
-              cpu: 1
               memory: 1536Mi
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/ans-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/ans-web-ui.yaml
@@ -80,7 +80,6 @@ spec:
             cpu: 0.1
             memory: 240Mi
           limits:
-            cpu: 1
             memory: 1536Mi
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
@@ -80,7 +80,6 @@ spec:
             cpu: 0.1
             memory: 240Mi
           limits:
-            cpu: 1
             memory: 1536Mi
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-validator/values-template.yaml
+++ b/cluster/helm/splice-validator/values-template.yaml
@@ -13,7 +13,6 @@ pod:
 defaultJvmOptions: -XX:+UseG1GC -XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=75 -Dscala.concurrent.context.numThreads=8 -XX:ActiveProcessorCount=8 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/persistent-data -Dpekko.http.server.idle-timeout=20m -Dpekko.http.client.idle-timeout=20m
 resources:
   limits:
-    cpu: 3
     memory: 8Gi
   requests:
     cpu: 1


### PR DESCRIPTION
Linux and k8s already enforce fair CPU sharing through requests and scheduling, preventing any container from monopolizing or destabilizing the node. CPU's are not a rigid resource (best effort, throttling / scheduling), unlike memory which is rigid.

related: https://github.com/hyperledger-labs/splice/pull/3326 (istio is being a bit annoying about not picking up the removal of limits so in a separate PR)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
