### PR TITLE
Bump testcontainers dependency

### DIFF
--- a/canton/community/testing/src/main/scala/com/digitalasset/canton/store/db/DbStorageSetup.scala
+++ b/canton/community/testing/src/main/scala/com/digitalasset/canton/store/db/DbStorageSetup.scala
@@ -25,7 +25,7 @@ import com.github.dockerjava.api.model.Bind
 import com.typesafe.config.{Config, ConfigFactory}
 import org.postgresql.util.PSQLException
 import org.scalatest.Assertions.fail
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*

--- a/project/CantonDependencies.scala
+++ b/project/CantonDependencies.scala
@@ -231,9 +231,10 @@ object CantonDependencies {
   lazy val slick = "com.typesafe.slick" %% "slick" % slick_version
   lazy val slick_hikaricp = "com.typesafe.slick" %% "slick-hikaricp" % slick_version
 
-  lazy val testcontainers_version = "1.15.3"
+  lazy val testcontainers_version = "2.0.2"
   lazy val testcontainers = "org.testcontainers" % "testcontainers" % testcontainers_version
-  lazy val testcontainers_postgresql = "org.testcontainers" % "postgresql" % testcontainers_version
+  lazy val testcontainers_postgresql =
+    "org.testcontainers" % "testcontainers-postgresql" % testcontainers_version
 
   lazy val sttp_version = "3.8.16"
   lazy val sttp = "com.softwaremill.sttp.client3" %% "core" % sttp_version


### PR DESCRIPTION
Fixes compatibility with docker:
```
Cause: com.github.dockerjava.api.exception.BadRequestException: Status 400: {"message":"client version 1.30 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
```

Tested locally with `Docker Desktop Version 4.52.0 (210994)`.

Canton did the same change in https://github.com/DACH-NY/canton/pull/29436.