### PR TITLE
Increase default sequencer memory limit

### DIFF
--- a/cluster/helm/splice-global-domain/values-template.yaml
+++ b/cluster/helm/splice-global-domain/values-template.yaml
@@ -26,7 +26,7 @@ sequencer:
     port: 5432
   resources:
     limits:
-      memory: 8Gi
+      memory: 12Gi
     requests:
       cpu: "3"
       memory: 4Gi


### PR DESCRIPTION
On December 8th, we saw MainNet sequencers being OOMkilled while a client was catching up outside of the buffer window. 