### PR TITLE
temporarily detach resolved config targets from update-expected to prevent issues in bump-splice until a proper fix

### DIFF
--- a/cluster/pulumi/local.mk
+++ b/cluster/pulumi/local.mk
@@ -26,10 +26,12 @@ $(dir)/unit-test: $(dir)/.build
 
 pulumi_projects ::= operator deployment gcp infra canton-network sv-runbook validator-runbook multi-validator cluster sv-canton validator1 splitwell
 
+# TODO(#3237) Reattach resolved config targets to test and update-expected after resolving issues
+#             with loading scratchnet configs in the internal repository.
 .PHONY: $(dir)/test $(dir)/update-expected
-$(dir)/test: $(dir)/unit-test $(deployment_dir)/check-resolved-config $(foreach project,$(pulumi_projects),$(dir)/$(project)/test)
+$(dir)/test: $(dir)/unit-test $(foreach project,$(pulumi_projects),$(dir)/$(project)/test) # $(deployment_dir)/check-resolved-config 
 
 .PHONY: $(dir)/update-expected
-$(dir)/update-expected: $(deployment_dir)/update-resolved-config $(foreach project,$(pulumi_projects),$(dir)/$(project)/update-expected)
+$(dir)/update-expected: $(foreach project,$(pulumi_projects),$(dir)/$(project)/update-expected) # $(deployment_dir)/update-resolved-config
 
 include $(pulumi_projects:%=$(dir)/%/local.mk)


### PR DESCRIPTION
fixes https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/43593/workflows/89a139f6-835e-4dc3-ae1d-983cecac6bf5/jobs/238732

This is a temporary fix. A proper fix that alters the config loader will follow soon but with no pressure to merge it quickly.