### PR TITLE
Add `nc` to `debug_shell`

### DIFF
--- a/cluster/images/splice-debug/Dockerfile
+++ b/cluster/images/splice-debug/Dockerfile
@@ -6,7 +6,7 @@
 FROM --platform=linux/amd64 ubuntu:24.04@sha256:440dcf6a5640b2ae5c77724e68787a906afb8ddee98bf86db94eea8528c2c076
 LABEL org.opencontainers.image.base.name="ubuntu:24.04"
 
-RUN apt-get update && apt-get install -y postgresql-client curl
+RUN apt-get update && apt-get install -y postgresql-client curl netcat-openbsd
 RUN curl -sSLO https://github.com/fullstorydev/grpcurl/releases/download/v1.9.2/grpcurl_1.9.2_linux_amd64.deb && dpkg -i grpcurl_1.9.2_linux_amd64.deb && rm grpcurl_1.9.2_linux_amd64.deb
 
 COPY target/LICENSE .


### PR DESCRIPTION
Needed it today, was surprised it wasn't already there.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
