### PR TITLE
add destination rules for sequencer high performance gRPC

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3506,11 +3506,11 @@
       "apiVersion": "networking.istio.io/v1beta1",
       "kind": "DestinationRule",
       "metadata": {
-        "name": "sv-2-global-domain-3-sequencer-high-perf-grpc-rule",
+        "name": "sv-da-1-global-domain-3-sequencer-high-perf-grpc-rule",
         "namespace": "cluster-ingress"
       },
       "spec": {
-        "host": "global-domain-3-sequencer.sv-2.svc.cluster.local",
+        "host": "global-domain-3-sequencer.sv-da-1.svc.cluster.local",
         "trafficPolicy": {
           "connectionPool": {
             "http": {
@@ -3529,7 +3529,7 @@
         }
       }
     },
-    "name": "sv-2-global-domain-3-sequencer-high-perf-grpc-rule",
+    "name": "sv-da-1-global-domain-3-sequencer-high-perf-grpc-rule",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1beta1:DestinationRule"
   },
@@ -3540,11 +3540,11 @@
       "apiVersion": "networking.istio.io/v1beta1",
       "kind": "DestinationRule",
       "metadata": {
-        "name": "sv-2-global-domain-4-sequencer-high-perf-grpc-rule",
+        "name": "sv-da-1-global-domain-4-sequencer-high-perf-grpc-rule",
         "namespace": "cluster-ingress"
       },
       "spec": {
-        "host": "global-domain-4-sequencer.sv-2.svc.cluster.local",
+        "host": "global-domain-4-sequencer.sv-da-1.svc.cluster.local",
         "trafficPolicy": {
           "connectionPool": {
             "http": {
@@ -3563,7 +3563,75 @@
         }
       }
     },
-    "name": "sv-2-global-domain-4-sequencer-high-perf-grpc-rule",
+    "name": "sv-da-1-global-domain-4-sequencer-high-perf-grpc-rule",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1beta1:DestinationRule"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1beta1",
+      "kind": "DestinationRule",
+      "metadata": {
+        "name": "sv-global-domain-3-sequencer-high-perf-grpc-rule",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "host": "global-domain-3-sequencer.sv.svc.cluster.local",
+        "trafficPolicy": {
+          "connectionPool": {
+            "http": {
+              "http1MaxPendingRequests": 10000,
+              "http2MaxRequests": 10000,
+              "maxConcurrentStreams": 10000,
+              "maxRequestsPerConnection": 0
+            },
+            "tcp": {
+              "maxConnections": 10000
+            }
+          },
+          "loadBalancer": {
+            "simple": "LEAST_REQUEST"
+          }
+        }
+      }
+    },
+    "name": "sv-global-domain-3-sequencer-high-perf-grpc-rule",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1beta1:DestinationRule"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "networking.istio.io/v1beta1",
+      "kind": "DestinationRule",
+      "metadata": {
+        "name": "sv-global-domain-4-sequencer-high-perf-grpc-rule",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "host": "global-domain-4-sequencer.sv.svc.cluster.local",
+        "trafficPolicy": {
+          "connectionPool": {
+            "http": {
+              "http1MaxPendingRequests": 10000,
+              "http2MaxRequests": 10000,
+              "maxConcurrentStreams": 10000,
+              "maxRequestsPerConnection": 0
+            },
+            "tcp": {
+              "maxConnections": 10000
+            }
+          },
+          "loadBalancer": {
+            "simple": "LEAST_REQUEST"
+          }
+        }
+      }
+    },
+    "name": "sv-global-domain-4-sequencer-high-perf-grpc-rule",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1beta1:DestinationRule"
   },

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -641,10 +641,10 @@ function configureSequencerHighPerformanceGrpcDestinationRules(
   return [
     ...(function* () {
       for (const migration of DecentralizedSynchronizerUpgradeConfig.runningMigrations()) {
-        for (const sv of coreSvsToDeploy) {
+        for (const sv of allSvsToDeploy) {
           yield configureSequencerHighPerformanceGrpcDestinationRule(
             ingressNs,
-            sv.ingressName,
+            sv.nodeName,
             migration.id
           );
         }
@@ -655,11 +655,11 @@ function configureSequencerHighPerformanceGrpcDestinationRules(
 
 function configureSequencerHighPerformanceGrpcDestinationRule(
   ingressNs: k8s.core.v1.Namespace,
-  ingressName: string,
+  nodeName: string,
   migrationId: number
 ): k8s.apiextensions.CustomResource {
   const sequencerName = `global-domain-${migrationId}-sequencer`;
-  const ruleName = `${ingressName}-${sequencerName}-high-perf-grpc-rule`;
+  const ruleName = `${nodeName}-${sequencerName}-high-perf-grpc-rule`;
   return new k8s.apiextensions.CustomResource(ruleName, {
     apiVersion: 'networking.istio.io/v1beta1',
     kind: 'DestinationRule',
@@ -668,7 +668,7 @@ function configureSequencerHighPerformanceGrpcDestinationRule(
       namespace: ingressNs.metadata.name,
     },
     spec: {
-      host: `${sequencerName}.${ingressName}.svc.cluster.local`,
+      host: `${sequencerName}.${nodeName}.svc.cluster.local`,
       trafficPolicy: {
         loadBalancer: {
           simple: 'LEAST_REQUEST',


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/2791

I am not very confident about these changes. I had some difficulties figuring out the sequencer hostname and I'm still not 100% sure I got it right. I'm also not sure if my assumptions about how to iterate through SVs and migrations are correct.