### PR TITLE
make the failure_notficiations action usable from a repo with a splice submodule

### DIFF
--- a/.github/actions/tests/failure_notifications/action.yml
+++ b/.github/actions/tests/failure_notifications/action.yml
@@ -45,6 +45,6 @@ runs:
       run: |
         if [[ "${RUNNER_ENVIRONMENT}" != "self-hosted" ]]; then
           echo "Not a self-hosted runner. Installing required Python packages..."
-          python3 -m pip install git requests
+          python3 -m pip install GitPython requests
         fi
         ${GITHUB_ACTION_PATH}/../../scripts/notification-scripts/failure_notification.py --job_subname "${{ inputs.job_subname }}"


### PR DESCRIPTION
This change makes it possible to use this action from the internal repo.