### PR TITLE
Cluster Reaper job

### DIFF
--- a/cluster/images/splice-debug/Dockerfile
+++ b/cluster/images/splice-debug/Dockerfile
@@ -6,7 +6,15 @@
 FROM --platform=linux/amd64 ubuntu:24.04@sha256:440dcf6a5640b2ae5c77724e68787a906afb8ddee98bf86db94eea8528c2c076
 LABEL org.opencontainers.image.base.name="ubuntu:24.04"
 
-RUN apt-get update && apt-get install -y postgresql-client curl netcat-openbsd
+ARG KUBECTL_VERSION
+
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    curl \
+    netcat-openbsd \
+    jq
+
+RUN curl -fL -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 RUN curl -sSLO https://github.com/fullstorydev/grpcurl/releases/download/v1.9.2/grpcurl_1.9.2_linux_amd64.deb && dpkg -i grpcurl_1.9.2_linux_amd64.deb && rm grpcurl_1.9.2_linux_amd64.deb
 
 COPY target/LICENSE .

--- a/cluster/images/splice-debug/local.mk
+++ b/cluster/images/splice-debug/local.mk
@@ -4,6 +4,6 @@
 dir := $(call current_dir)
 
 $(dir)/$(docker-build): $(dir)/target/LICENSE
-
+$(dir)/$(docker-build): build_arg := --build-arg KUBECTL_VERSION=v${KUBECTL_VERSION}
 $(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
 	cp $< $@

--- a/cluster/pulumi/common/src/version.ts
+++ b/cluster/pulumi/common/src/version.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { activeVersion } from '@lfdecentralizedtrust/splice-pulumi-common';
 
-export const Version = versionFromDefault();
-
-function versionFromDefault() {
+export function versionFromDefault(): string {
   if (activeVersion.type == 'remote') {
     return activeVersion.version;
   } else {

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -93,6 +93,7 @@ export const InfraConfigSchema = z.object({
         extraWhitelistedIngress: z.array(z.string()).default([]),
       })
       .optional(),
+    enableGCReaperJob: z.boolean().default(false),
     prometheus: z.object({
       storageSize: z.string(),
       retentionDuration: z.string(),
@@ -117,7 +118,7 @@ export type Config = z.infer<typeof InfraConfigSchema>;
 // eslint-disable-next-line
 // @ts-ignore
 const fullConfig = InfraConfigSchema.parse(clusterYamlConfig);
-
+export const enableGCReaperJob = fullConfig.infra.enableGCReaperJob;
 console.error(
   `Loaded infra config: ${util.inspect(fullConfig, {
     depth: null,

--- a/cluster/pulumi/infra/src/index.ts
+++ b/cluster/pulumi/infra/src/index.ts
@@ -6,7 +6,13 @@ import { config } from '@lfdecentralizedtrust/splice-pulumi-common';
 import { clusterIsResetPeriodically, enableAlerts } from './alertings';
 import { configureAuth0 } from './auth0';
 import { configureCloudArmorPolicy } from './cloudArmor';
-import { cloudArmorConfig, clusterBaseDomain, clusterBasename, monitoringConfig } from './config';
+import {
+  cloudArmorConfig,
+  clusterBaseDomain,
+  clusterBasename,
+  enableGCReaperJob,
+  monitoringConfig,
+} from './config';
 import { installExtraCustomResources } from './extraCustomResources';
 import {
   getNotificationChannel,
@@ -15,6 +21,7 @@ import {
   installClusterMaintenanceUpdateAlerts,
 } from './gcpAlerts';
 import { configureIstio, istioMonitoring } from './istio';
+import { deployGCPodReaper } from './maintenance';
 import { configureNetwork } from './network';
 import { configureObservability } from './observability';
 import { configureStorage } from './storage';
@@ -47,6 +54,10 @@ configureStorage();
 configureCloudArmorPolicy(cloudArmorConfig);
 
 installExtraCustomResources();
+
+if (enableGCReaperJob) {
+  deployGCPodReaper('cluster-pod-gc-reaper', ['multi-validator'], { parent: network.ingressNs.ns });
+}
 
 let configuredAuth0;
 if (config.envFlag('CLUSTER_CONFIGURE_AUTH0', true)) {

--- a/cluster/pulumi/infra/src/maintenance.ts
+++ b/cluster/pulumi/infra/src/maintenance.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
+import { versionFromDefault } from '@lfdecentralizedtrust/splice-pulumi-common/src/version';
+
+import { DOCKER_REPO, infraAffinityAndTolerations } from '../../common';
+
+const cronJobName = 'gc-pod-reaper-job';
+const reaperNamespace = 'gc-pod-reaper';
+const serviceAccountName = 'gc-pod-reaper-service-account';
+const schedule = '0 * * * *'; // Run once every hour, at minute 0
+
+const deleteBadPodsCommand = [
+  '/bin/bash',
+  '-c',
+  `
+    echo "--- $(date) Starting Pod Reaper ---";
+    TARGET_NAMESPACES_LIST=$(echo "$TARGET_NAMESPACES" | tr ',' ' ');
+    echo "Targeting namespaces: $TARGET_NAMESPACES_LIST";
+    if [ -z "$TARGET_NAMESPACES_LIST" ]; then
+        echo "Error: No target namespaces provided. Exiting.";
+        exit 1
+    fi
+    echo "--- Starting Cleanup Loop ---";
+    for NAMESPACE in $TARGET_NAMESPACES_LIST; do
+        echo "Processing namespace: $NAMESPACE";
+        echo "Listing all pods in $NAMESPACE:";
+        kubectl get pods -n "$NAMESPACE";
+        echo "--- checking PODS with bad status in $NAMESPACE ---";
+        BAD_PODS=$(
+          kubectl get pods -n "$NAMESPACE" -o json | \\
+          jq -r '.items[] |
+              (select(.status.phase == "Unknown" and .status.reason == "ContainerStatusUnknown") |
+                  .metadata.name) //
+              (select(.status.containerStatuses[]?.state.terminated? |
+                  .reason == "Error" and .exitCode == 137) |
+                  .metadata.name)'
+        );
+        if [ -z "$BAD_PODS" ]; then
+            echo "No bad pods found in $NAMESPACE. Skipping.";
+            continue
+        fi
+        echo "Found bad pods in $NAMESPACE: $BAD_PODS";
+        for POD_NAME in $BAD_PODS; do
+            echo "Attempting to delete pod $NAMESPACE/$POD_NAME";
+            kubectl delete pod -n "$NAMESPACE" "$POD_NAME"
+            if [ $? -eq 0 ]; then
+                echo "Successfully deleted $NAMESPACE/$POD_NAME";
+            else
+                echo "Failed to delete $NAMESPACE/$POD_NAME";
+            fi
+        done
+        echo "Finished cleanup for $NAMESPACE.";
+        echo "---"
+    done
+    echo "--- $(date) Pod Reaper Finished ---";
+    true
+  `,
+];
+
+export function deployGCPodReaper(
+  name: string,
+  targetNamespaces: string[],
+  opts?: pulumi.ComponentResourceOptions
+): k8s.batch.v1.CronJob {
+  const ns = new k8s.core.v1.Namespace(name, {
+    metadata: {
+      name: reaperNamespace,
+      labels: {
+        'app.kubernetes.io/name': reaperNamespace,
+      },
+    },
+  });
+
+  targetNamespaces.forEach(namespace => {
+    const podManagementRole = new k8s.rbac.v1.Role(
+      namespace + '-gc-pod-reaper-role',
+      {
+        metadata: {
+          name: namespace + '-gc-pod-reaper-role',
+          namespace: namespace,
+        },
+        rules: [
+          {
+            apiGroups: [''], // Core API group for Pods
+            resources: ['pods'],
+            verbs: ['list', 'create', 'delete', 'update'],
+          },
+        ],
+      },
+      { parent: ns }
+    );
+
+    new k8s.rbac.v1.RoleBinding(
+      namespace + '-gc-pod-reaper-pod-manager-binding',
+      {
+        metadata: {
+          name: namespace + 'gc-pod-reaper-pod-manager-binding',
+          namespace: namespace,
+        },
+        subjects: [
+          {
+            kind: 'ServiceAccount',
+            name: serviceAccountName,
+            namespace: 'gc-pod-reaper',
+          },
+        ],
+        roleRef: {
+          kind: 'Role',
+          name: podManagementRole.metadata.name,
+          apiGroup: 'rbac.authorization.k8s.io',
+        },
+      },
+      { parent: podManagementRole, dependsOn: [podManagementRole] }
+    );
+  });
+
+  const targetNamespacesEnv = targetNamespaces.join(',');
+
+  new k8s.core.v1.ServiceAccount(
+    serviceAccountName,
+    {
+      metadata: {
+        name: serviceAccountName,
+        namespace: ns.metadata.name,
+      },
+    },
+    { parent: ns }
+  );
+
+  return new k8s.batch.v1.CronJob(
+    cronJobName,
+    {
+      metadata: {
+        name: cronJobName,
+        namespace: ns.metadata.name,
+      },
+      spec: {
+        schedule: schedule,
+        concurrencyPolicy: 'Forbid',
+        successfulJobsHistoryLimit: 2,
+        failedJobsHistoryLimit: 2,
+        jobTemplate: {
+          metadata: {
+            labels: {
+              app: 'gc-pod-reaper',
+            },
+          },
+          spec: {
+            template: {
+              spec: {
+                serviceAccountName: serviceAccountName,
+                restartPolicy: 'OnFailure',
+                ...infraAffinityAndTolerations,
+                containers: [
+                  {
+                    name: cronJobName,
+                    image: `${DOCKER_REPO}/splice-debug:${versionFromDefault()}`,
+                    imagePullPolicy: 'Always',
+                    command: deleteBadPodsCommand,
+                    env: [
+                      {
+                        name: 'TARGET_NAMESPACES',
+                        value: targetNamespacesEnv,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    { parent: ns, ...opts }
+  );
+}

--- a/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
+++ b/cluster/pulumi/multi-validator/src/multiNodeDeployment.ts
@@ -10,9 +10,9 @@ import {
   numNodesPerInstance,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 import { ServiceMonitor } from '@lfdecentralizedtrust/splice-pulumi-common/src/metrics';
+import { versionFromDefault } from '@lfdecentralizedtrust/splice-pulumi-common/src/version';
 import _ from 'lodash';
 
-import { Version } from '../version';
 import { EnvironmentVariable, multiValidatorConfig } from './config';
 
 export interface BaseMultiNodeArgs {
@@ -89,7 +89,7 @@ export class MultiNodeDeployment extends pulumi.ComponentResource {
               containers: [
                 {
                   name: args.imageName,
-                  image: `${DOCKER_REPO}/${args.imageName}:${Version}`,
+                  image: `${DOCKER_REPO}/${args.imageName}:${versionFromDefault()}`,
                   ...imagePullPolicy,
                   ...args.container,
                   ports: args.container.ports.concat([

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -133,4 +133,5 @@ in pkgs.mkShell {
 
   PULUMI_VERSION="${pkgs.pulumi-bin.version}";
   GECKODRIVER="${pkgs.geckodriver}/bin/geckodriver";
+  KUBECTL_VERSION="${pkgs.kubectl.version}";
 }


### PR DESCRIPTION
**Fixes version issue**

With **dirty docker version** and `enableGCReaperJob`

```
--- Fri Dec 19 12:36:05 UTC 2025 Starting Pod Reaper ---
Targeting namespaces: multi-validator
--- Starting Cleanup Loop ---
Processing namespace: multi-validator
Listing all pods in multi-validator:
NAME            READY   STATUS    RESTARTS   AGE
validator-1-1   0/1     Pending   0          2d16h
validator-1-2   0/1     Pending   0          2d16h
--- checking PODS with bad status in multi-validator ---
No bad pods found in multi-validator. Skipping.
--- Fri Dec 19 12:36:05 UTC 2025 Pod Reaper Finished —

```

With **version**, `enableGCReaperJob` turned off

`Operation canton-network succeeded`
