### PR TITLE
add necessary permissions to the bump_gha_runner_version workflow for failure_notifications

### DIFF
--- a/.github/workflows/bump_gha_runner_version.yml
+++ b/.github/workflows/bump_gha_runner_version.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: self-hosted-k8s-small
     container:
       image: us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/splice-test-ci:0.3.12
+    permissions:
+      id-token: write # Required for GCP Workload Identity for failure notifications
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
I'm adding this after I learned it is required for failure_notifications when working on the workflow in the internal repo.