### PR TITLE
Add pulumi code for validators participant pruning

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -4,6 +4,10 @@ validator1:
     locationId: us-central1
     projectId: da-cn-devnet
     keyRingId: validator1_mock
+  participantPruningSchedule:
+    cron: "0 /10 * * * ?" # Run every 10min
+    maxDuration: "5m"
+    retention: "30d"
 multiValidator:
   postgresPvcSize: '100Gi'
   # Dummy values for testing
@@ -12,6 +16,13 @@ multiValidator:
       value: |
         canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += "org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger"
         canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += "org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger"
+    - name: MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING
+      value: |
+        canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {
+          cron = "0 /10 * * * ?"
+          max-duration = "5m"
+          retention = "25h"
+        }
   extraParticipantEnvVars:
     - name: MULTI_PARTICIPANT_ADDITIONAL_CONFIG_MAX_CONNECTIONS
       value: canton.participants.participant_INDEX.storage.parameters.max-connections = 33
@@ -20,6 +31,10 @@ sv:
     skipInitialization: true
 splitwell:
   maxDarVersion: '0.1.8'
+  participantPruningSchedule:
+    cron: "0 /10 * * * ?" # Run every 10min
+    maxDuration: "5m"
+    retention: "30d"
 synchronizerMigration:
   archived:
     - id: 1
@@ -261,6 +276,10 @@ validators:
       parallelism: 321
       preapprovalRetries: 9876
       preapprovalRetryDelayMs: 42
+    participantPruningSchedule:
+      cron: "0 /10 * * * ?" # Run every 10min
+      maxDuration: "5m"
+      retention: "30d"
     participant:
       additionalEnvVars:
         - name: ADDITIONAL_ENV_VAR_VALIDATOR_PARTICIPANT_NAME

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -2642,6 +2642,10 @@
                   {
                     "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_YOLO",
                     "value": "canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger\"\ncanton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger\"\n"
+                  },
+                  {
+                    "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+                    "value": "canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {\n  cron = \"0 /10 * * * ?\"\n  max-duration = \"5m\"\n  retention = \"25h\"\n}\n"
                   }
                 ],
                 "image": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/multi-validator:0.3.20",
@@ -3080,6 +3084,10 @@
                   {
                     "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_YOLO",
                     "value": "canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger\"\ncanton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger\"\n"
+                  },
+                  {
+                    "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+                    "value": "canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {\n  cron = \"0 /10 * * * ?\"\n  max-duration = \"5m\"\n  retention = \"25h\"\n}\n"
                   }
                 ],
                 "image": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/multi-validator:0.3.20",
@@ -3518,6 +3526,10 @@
                   {
                     "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_YOLO",
                     "value": "canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger\"\ncanton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger\"\n"
+                  },
+                  {
+                    "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+                    "value": "canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {\n  cron = \"0 /10 * * * ?\"\n  max-duration = \"5m\"\n  retention = \"25h\"\n}\n"
                   }
                 ],
                 "image": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/multi-validator:0.3.20",
@@ -3956,6 +3968,10 @@
                   {
                     "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_YOLO",
                     "value": "canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger\"\ncanton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger\"\n"
+                  },
+                  {
+                    "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+                    "value": "canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {\n  cron = \"0 /10 * * * ?\"\n  max-duration = \"5m\"\n  retention = \"25h\"\n}\n"
                   }
                 ],
                 "image": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/multi-validator:0.3.20",
@@ -4394,6 +4410,10 @@
                   {
                     "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_YOLO",
                     "value": "canton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger\"\ncanton.validator-apps.validator_backend_INDEX.automation.paused-triggers += \"org.lfdecentralizedtrust.splice.wallet.automation.ExpireAcceptedTransferOfferTrigger\"\n"
+                  },
+                  {
+                    "name": "MULTI_VALIDATOR_ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+                    "value": "canton.validator-apps.validator_backend_INDEX.participant-pruning-schedule {\n  cron = \"0 /10 * * * ?\"\n  max-duration = \"5m\"\n  retention = \"25h\"\n}\n"
                   }
                 ],
                 "image": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/multi-validator:0.3.20",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -957,6 +957,11 @@
             "prefix": "mock/splitwell"
           }
         },
+        "participantPruningSchedule": {
+          "cron": "0 /10 * * * ?",
+          "maxDuration": "5m",
+          "retention": "30d"
+        },
         "persistence": {
           "databaseName": "val_splitwell",
           "port": 5432,

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -714,6 +714,11 @@
             "prefix": "mock/validator"
           }
         },
+        "participantPruningConfig": {
+          "cron": "0 /10 * * * ?",
+          "maxDuration": "5m",
+          "retention": "30d"
+        },
         "persistence": {
           "host": "postgres",
           "postgresName": "postgres",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -945,6 +945,11 @@
             "prefix": "mock/validator1"
           }
         },
+        "participantPruningSchedule": {
+          "cron": "0 /10 * * * ?",
+          "maxDuration": "5m",
+          "retention": "30d"
+        },
         "persistence": {
           "databaseName": "validator1",
           "port": 5432,

--- a/cluster/pulumi/splitwell/src/splitwell.ts
+++ b/cluster/pulumi/splitwell/src/splitwell.ts
@@ -132,6 +132,8 @@ export async function installSplitwell(
     await installLedgerApiSecret(auth0Client, xns, 'splitwell')
   );
 
+  const participantPruningConfig = splitwellConfig?.participantPruningSchedule;
+
   return await installValidatorApp({
     xns,
     extraDependsOn,
@@ -156,6 +158,7 @@ export async function installSplitwell(
     participantAddress: participant.participantAddress,
     topupConfig: topupConfig,
     svValidator: false,
+    participantPruningConfig: participantPruningConfig,
     persistenceConfig: {
       host: validatorPostgres.address,
       databaseName: pulumi.Output.create(validatorDbName),

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -148,6 +148,8 @@ async function installValidator(
     topupConfig,
   } = validatorDeploymentConfig;
 
+  const participantPruningConfig = validatorConfig?.participantPruningSchedule;
+
   const supportsValidatorRunbookReset = config.envFlag('SUPPORTS_VALIDATOR_RUNBOOK_RESET', false);
   const postgresValues: ChartValues = loadYamlFromFile(
     `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/postgres-values-validator-participant.yaml`
@@ -232,6 +234,7 @@ async function installValidator(
           newParticipantIdentifier,
         }
       : undefined,
+    participantPruningConfig: participantPruningConfig,
     ...(participantBootstrapDumpSecret ? { nodeIdentifier: newParticipantIdentifier } : {}),
     persistence: {
       ...validatorValuesFromYamlFiles.persistence,


### PR DESCRIPTION
part of https://github.com/DACH-NY/cn-test-failures/issues/6701

Explicitly not setting validator1, splitwell, validator-runbook and multi-validators deployments defaults to force us to write the schedule in individual configs to avoid pruning production data (even if this seems unlikely here).

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
