### PR TITLE
Expose jvm buffer metrics

### DIFF
--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/MetricsRegistry.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/metrics/MetricsRegistry.scala
@@ -29,6 +29,7 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer
 import io.opentelemetry.instrumentation.runtimemetrics.java8.*
+import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalBufferPools
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
 import io.opentelemetry.sdk.metrics.`export`.{MetricExporter, MetricReader, PeriodicMetricReader}
 import io.opentelemetry.sdk.metrics.internal.state.MetricStorage
@@ -86,6 +87,7 @@ object MetricsConfig {
       memoryPools: Boolean = true,
       threads: Boolean = true,
       gc: Boolean = true,
+      buffers: Boolean = true,
   ) extends UniformCantonConfigValidation
 
   object JvmMetrics {
@@ -99,6 +101,7 @@ object MetricsConfig {
         if (config.memoryPools) MemoryPools.registerObservers(openTelemetry).discard
         if (config.threads) Threads.registerObservers(openTelemetry).discard
         if (config.gc) GarbageCollector.registerObservers(openTelemetry).discard
+        if (config.buffers) ExperimentalBufferPools.registerObservers(openTelemetry).discard
       }
   }
 


### PR DESCRIPTION
This exposes jvm buffer metrics which might help debug some k8s OOM's as those don't count to the heap size and could then help us tune max direct memory size (see
https://github.com/hyperledger-labs/splice/issues/434)

While this is marked experimental, this just seems to because the API can still change. For reference here is the code
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/internal/ExperimentalBufferPools.java which is trivial and the underlying java API is not experimental https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html. The API is not experimental anymore in the opentelemetry java17 API but switching to that seems like a more involved change from a quick look.

Tested locally that the metrics do get exposed. Will also upstream to Canton.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
