### PR TITLE
Add volume for persistent heap dumps to participant charts

### DIFF
--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -124,7 +124,7 @@ spec:
         {{- with .Values.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if and .Values.extraVolumeMounts (gt (len .Values.extraVolumeMounts) 0) }}
+        {{- if or (and .Values.extraVolumeMounts (gt (len .Values.extraVolumeMounts) 0)) .Values.pvc }}
         volumeMounts:
           {{- range .Values.extraVolumeMounts }}
           - name: {{ .name }}
@@ -136,6 +136,10 @@ spec:
             readOnly: {{ .readOnly }}
             {{- end }}
           {{- end }}
+        {{- if .Values.pvc }}
+          - name: participant-volume
+            mountPath: /persistent-data
+        {{- end }}
         {{- end }}
       {{- if or (.Values.persistence.enablePgInitContainer) (.Values.extraInitContainers) }}
       initContainers:
@@ -178,7 +182,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.extraVolumes (gt (len .Values.extraVolumes) 0) }}
+      {{- if or (and .Values.extraVolumes (gt (len .Values.extraVolumes) 0)) .Values.pvc }}
       volumes:
         {{- range .Values.extraVolumes }}
         - name: {{ .name }}
@@ -191,7 +195,31 @@ spec:
             claimName: {{ .persistentVolumeClaim.claimName }}
           {{- end }}
         {{- end }}
+        {{- if .Values.pvc }}
+          - name: participant-volume
+            persistentVolumeClaim:
+              claimName: {{ .Release.Name }}-participant-pvc
+        {{- end }}
       {{- end }}
+---
+{{-  if .Values.pvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-participant-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "splice-util-lib.default-labels" (set . "app" $.Release.Name) | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.pvc.size }}
+  storageClassName: {{ .Values.pvc.volumeStorageClass }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/cluster/pulumi/sv-canton/src/participant.ts
+++ b/cluster/pulumi/sv-canton/src/participant.ts
@@ -13,6 +13,7 @@ import {
   installSpliceHelmChart,
   loadYamlFromFile,
   SPLICE_ROOT,
+  spliceConfig,
   SpliceCustomResourceOptions,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 import { SingleSvConfiguration } from '@lfdecentralizedtrust/splice-pulumi-common-sv';
@@ -86,6 +87,12 @@ export function installSvParticipant(
       enablePostgresMetrics: true,
       serviceAccountName: imagePullServiceAccountName,
       resources: svConfig.participant?.resources,
+      pvc: spliceConfig.configuration.persistentHeapDumps
+        ? {
+            size: '10Gi',
+            volumeStorageClass: 'standard-rwo',
+          }
+        : undefined,
     },
     version,
     {


### PR DESCRIPTION
This matches the mediator and sequencer where we already have it. I didn't go through extraVolumes since that only does the mounting and not creating the pvc and having pvc not do everything like it does for sequencer + mediator seemed more confusing than helpful.

[static]

Tested on scratch that I can deploy with and without this and if I produce an OOM the dump persists.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
