### PR TITLE
Bump CPU limit on GHA runners

### DIFF
--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -56,7 +56,7 @@ const runnerSpecs = [
         memory: '10Gi',
       },
       limits: {
-        cpu: '4',
+        cpu: '6',
         memory: '10Gi',
       },
     },
@@ -71,7 +71,7 @@ const runnerSpecs = [
         memory: '18Gi',
       },
       limits: {
-        cpu: '4',
+        cpu: '6',
         memory: '18Gi',
       },
     },
@@ -86,7 +86,7 @@ const runnerSpecs = [
         memory: '24Gi',
       },
       limits: {
-        cpu: '5',
+        cpu: '7',
         memory: '24Gi',
       },
     },
@@ -101,7 +101,7 @@ const runnerSpecs = [
         memory: '32Gi',
       },
       limits: {
-        cpu: '6',
+        cpu: '8',
         memory: '32Gi',
       },
     },
@@ -116,7 +116,7 @@ const runnerSpecs = [
         memory: '52Gi',
       },
       limits: {
-        cpu: '8',
+        cpu: '10',
         memory: '52Gi',
       },
     },


### PR DESCRIPTION
[ci]

Another attempt at improving on https://github.com/DACH-NY/cn-test-failures/issues/6681

See the last few comments there.

I thought about picking a bigger runner just for the ones that failed. But:

- it seems like arbitrary large ones could fail atm
- we don't need more memory, just more CPU
- I don't see a significant downside in bumping limits; I'm keeping requests the same, so shouldn't impact costs, and it seems like we get those CPU usage spikes rarely enough to not interfere with other workloads... will monitor the situation ofc

Open to reverting this again if we do find a better theory / solution... Specifically I still have no idea why we sometimes need more CPU.

Maybe we're getting CPU throttled for some weird k8s reason (that should improve by raising limits). Maybe we should configure more verbose logging on the runners and that will tell us. But honestly if this bump fixes it I'm happy enough to not dig deeper...

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
