### PR TITLE
Revert Canton back to 3.4.9

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.10",
+  "version": "3.4.9",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:0vb0ym6xlk7l62sy6bi4k1zkv68s44s2pk3xi9ym2syy6z8nbydh",
-  "oss_sha256": "sha256:02rm44kv31dhanv2hj56y8hw5r2hwp4n82n0bjj7izi6hbhg2xcs"
+  "enterprise_sha256": "sha256:16v5dfsiykizq8xy374d0ks52cqv7kndlzhl84hl5k1i1jhf9217",
+  "oss_sha256": "sha256:1s6qcvmbp95ydi52y6zc27rw6ij3hzvnaxvk7611k5jyxv54dp60"
 }


### PR DESCRIPTION
[ci]

To unblock https://github.com/DACH-NY/canton-network-internal/issues/3045

3.4.10 is not working well enough to release at this point.

Note that the snapshot we had in the meantime doesn't seem to add anything significant, so opting for the nicer (i.e., non-snapshot) release here.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
