### PR TITLE
Added more conditions for GC-Reaper-Job pod selection

### DIFF
--- a/cluster/pulumi/infra/src/maintenance.ts
+++ b/cluster/pulumi/infra/src/maintenance.ts
@@ -36,7 +36,7 @@ const deleteBadPodsCommand = [
               (.status.reason == "Evicted") or
               (.status.containerStatuses[]?.state.terminated? | .reason == "Error" and .exitCode == 137) or
               (.status.initContainerStatuses[]?.state.waiting?.reason == "ContainerStatusUnknown")
-            ) | .metadata.name' | sort -u | xargs
+            ) | .metadata.name' | sort -u
         );
         if [ -z "$BAD_PODS" ]; then
             echo "No bad pods found in $NAMESPACE. Skipping.";


### PR DESCRIPTION
Extending support to delete pods in the mult-validator name space, under "evicted" status.

Fixes https://github.com/DACH-NY/canton-network-internal/issues/1418