### PR TITLE
add missing submodule checkout in GHA runner updater

### DIFF
--- a/.github/workflows/bump_gha_runner_version.yml
+++ b/.github/workflows/bump_gha_runner_version.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
 
       - name: Setup
         shell: bash


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/6806