### PR TITLE
Unify configuration option names used in ValidatorApp Scan and Sequencer configs

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -711,11 +711,11 @@ object SpliceConfig {
           )
           _ <- Either.cond(
             conf.domains.global.trustedSynchronizerConfig.forall(c =>
-              c.sequencerNames.length >= c.threshold
+              c.svNames.length >= c.threshold
             ),
             (),
             ConfigValidationFailed(
-              "Configuration error: Length of sequencerNames should be greater than or equal to threshold."
+              "Configuration error: Length of svNames should be greater than or equal to threshold."
             ),
           )
           _ <- Either.cond(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorSequencerConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorSequencerConnectionIntegrationTest.scala
@@ -42,7 +42,7 @@ class ValidatorSequencerConnectionIntegrationTest
                 global = c.domains.global.copy(
                   trustedSynchronizerConfig = Some(
                     ValidatorTrustedSynchronizerConfig(
-                      sequencerNames = NonEmptyList.of(getSvName(1), getSvName(2), getSvName(3)),
+                      svNames = NonEmptyList.of(getSvName(1), getSvName(2), getSvName(3)),
                       threshold = 2,
                     )
                   )
@@ -56,7 +56,7 @@ class ValidatorSequencerConnectionIntegrationTest
       )
       .withManualStart
 
-  "validator with 'sequencerNames' set in config connects to specified sequencers and tracks URL changes of sequencers" in {
+  "validator with 'svNames' set in config connects to specified sequencers and tracks URL changes of sequencers" in {
     implicit env =>
       startAllSync(
         sv1Backend,

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -110,9 +110,9 @@ case class ValidatorDecentralizedSynchronizerConfig(
 
 case class ValidatorTrustedSynchronizerConfig(
     /** static list of trusted sequencer names to connect to.
-      * sequencerNames is mutually exclusive with `url`.
+      * svNames is mutually exclusive with `url`.
       */
-    sequencerNames: NonEmptyList[String],
+    svNames: NonEmptyList[String],
 
     /** parameter to specify the BFT threshold for the domain connections.
       * If not specified, f +1 will be used.

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -214,7 +214,7 @@ class DomainConnector(
         )
       val svFilteredSequencers = config.domains.global.trustedSynchronizerConfig match {
         case Some(config) =>
-          val allowedNamesSet = config.sequencerNames.toList.toSet
+          val allowedNamesSet = config.svNames.toList.toSet
           logger.debug(
             s"Filtering sequencers to only include: ${allowedNamesSet.toList.mkString(", ")}"
           )

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -139,7 +139,7 @@ spec:
             {{- else if eq .Values.synchronizer.connectionType "bft-custom" }}
         - name: ADDITIONAL_CONFIG_SYNCHRONIZER_TRUSTED
           value: |
-            canton.validator-apps.validator_backend.domains.global.trusted-synchronizer-config.sequencer-names = {{ .Values.synchronizer.sequencerNames | toJson}}
+            canton.validator-apps.validator_backend.domains.global.trusted-synchronizer-config.sv-names = {{ .Values.synchronizer.svNames | toJson}}
             canton.validator-apps.validator_backend.domains.global.trusted-synchronizer-config.threshold = {{ .Values.synchronizer.threshold }}
             {{- end }}
         {{ end }}

--- a/cluster/helm/splice-validator/tests/validator_test.yaml
+++ b/cluster/helm/splice-validator/tests/validator_test.yaml
@@ -246,11 +246,11 @@ tests:
           path: spec.template.spec.containers[?(@.name=='validator-app')].env[?(@.name=='ADDITIONAL_CONFIG_SYNCHRONIZER_URL')].value
           pattern: 'canton\.validator-apps\.validator_backend\.domains\.global\.url = "https://new-sequencer\.mock\.com"'
 
-  - it: "uses synchronizer.sequencerNames as a JSON array when provided"
+  - it: "uses synchronizer.svNames as a JSON array when provided"
     set:
       synchronizer:
         connectionType: "bft-custom"
-        sequencerNames: [ "sequencer-1", "sequencer-2" ]
+        svNames: [ "sequencer-1", "sequencer-2" ]
         threshold: 2
     documentSelector:
       path: kind
@@ -258,7 +258,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[?(@.name=='validator-app')].env[?(@.name=='ADDITIONAL_CONFIG_SYNCHRONIZER_TRUSTED')].value
-          pattern: 'canton\.validator-apps\.validator_backend\.domains\.global\.trusted-synchronizer-config\.sequencer-names = \["sequencer-1","sequencer-2"\]'
+          pattern: 'canton\.validator-apps\.validator_backend\.domains\.global\.trusted-synchronizer-config\.sv-names = \["sequencer-1","sequencer-2"\]'
       - matchRegex:
           path: spec.template.spec.containers[?(@.name=='validator-app')].env[?(@.name=='ADDITIONAL_CONFIG_SYNCHRONIZER_TRUSTED')].value
           pattern: 'canton\.validator-apps\.validator_backend\.domains\.global\.trusted-synchronizer-config\.threshold = 2'

--- a/cluster/helm/splice-validator/values.schema.json
+++ b/cluster/helm/splice-validator/values.schema.json
@@ -25,7 +25,7 @@
           "type": "string",
           "description": "Trusted sequencer Url."
         },
-        "sequencerNames": {
+        "svNames": {
           "type": "array",
           "items": {
             "type": "string"
@@ -607,7 +607,7 @@
             "then": {
               "properties": {
                 "synchronizer": {
-                  "not": { "required": ["url", "sequencerNames", "threshold"] }
+                  "not": { "required": ["url", "svNames", "threshold"] }
                 }
               }
             }
@@ -622,7 +622,7 @@
                   "required": ["url"],
                   "properties": {
                     "url": { "minLength": 1 },
-                    "sequencerNames": false,
+                    "svNames": false,
                     "threshold": false
                   }
                 }
@@ -636,10 +636,10 @@
             "then": {
               "properties": {
                 "synchronizer": {
-                  "required": ["sequencerNames", "threshold"],
+                  "required": ["svNames", "threshold"],
                   "properties": {
                     "url": false,
-                    "sequencerNames": { "minItems": 1 }
+                    "svNames": { "minItems": 1 }
                   }
                 }
               }

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -20,12 +20,12 @@ export const SynchronizerConfigSchema = z.union([
   z
     .object({
       connectionType: z.literal('bft-custom'),
-      sequencerNames: z.array(z.string()).min(1),
+      svNames: z.array(z.string()).min(1),
       threshold: z.number().int().min(1),
     })
     .strict()
-    .refine(data => data.sequencerNames.length >= data.threshold, {
-      message: 'sequencerNames length must be greater than or equal to the threshold',
+    .refine(data => data.svNames.length >= data.threshold, {
+      message: 'svNames length must be greater than or equal to the threshold',
       path: ['threshold'], // Point the error to the threshold field
     }),
   z


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice/issues/3496

```
decentralizedSynchronizerUrl: "https://sequencer-0.sv-1.scratchb.network.canton.global"
useSequencerConnectionsFromScan: false
```

```
Ensuring domain Synchronizer 'global' registered with config SynchronizerConnectionConfig
https://sequencer-0.sv-1.scratchb.network.canton.global
```


Nothing

```
Digital-Asset-1::
https://sequencer-0.sv-1.scratchb.network.canton.global/,


Digital-Asset-2::
[https://sequencer-0.sv-2.scratchb.network.canton.global,Digital-Asset-2](about:blank)

Digital-Asset-Eng-2
[https://sequencer-0.sv-2-eng.scratchb.network.canton.global,Digital-Asset-Eng-2](about:blank)

Digital-Asset-Eng-3:
https://sequencer-0.sv-3-eng.scratchb.network.canton.global,Digital-Asset-Eng-3

```


```
synchronizer:
 connectionType: "trust-single"
 url: "https://sequencer-0.sv-2.scratchb.network.canton.global"
```
          
```
Ensuring domain Synchronizer 'global' registered with config SynchronizerConnectionConfig

https://sequencer-0.sv-2.scratchb.network.canton.global:443

```

```
synchronizer:
 connectionType: "bft-custom"
 svNames: [ "Digital-Asset-Eng-2","Digital-Asset-Eng-3" ]
 threshold: 2

```

```
Digital-Asset-Eng-2::
https://sequencer-0.sv-2-eng.scratchb.network.canton.global/


Digital-Asset-Eng-3:
https://sequencer-0.sv-3-eng.scratchb.network.canton.global,


```

```
synchronizer:
 connectionType: "bft"

```

```
Digital-Asset-1:
https://sequencer-0.sv-1.scratchb.network.canton.global,,

Digital-Asset-2::
https://sequencer-0.sv-2.scratchb.network.canton.global/,

Digital-Asset-Eng-2::
https://sequencer-0.sv-2-eng.scratchb.network.canton.global/,

Digital-Asset-Eng-3: 
https://sequencer-0.sv-3-eng.scratchb.network.canton.global/,
```