### PR TITLE
Fix failing "Set Amulet Rules" integration test

### DIFF
--- a/apps/sv/frontend/src/utils/buildAmuletRulesConfigFromChanges.ts
+++ b/apps/sv/frontend/src/utils/buildAmuletRulesConfigFromChanges.ts
@@ -62,6 +62,9 @@ export function buildAmuletRulesConfigFromChanges(
   const futureValues: Tuple2<RelTime, IssuanceConfig>[] = [];
   for (let i = 0; i < futureValuesCount; i++) {
     const time = { microseconds: getValue(`issuanceCurveFutureValues${i}`) };
+    const futureOptDevelopmentFundPercentage = getValue(
+      `issuanceCurveFutureValues${i}OptDevelopmentFundPercentage`
+    );
     const config: IssuanceConfig = {
       amuletToIssuePerYear: getValue(`issuanceCurveFutureValues${i}AmuletToIssuePerYear`),
       validatorRewardPercentage: getValue(`issuanceCurveFutureValues${i}ValidatorRewardPercentage`),
@@ -70,19 +73,22 @@ export function buildAmuletRulesConfigFromChanges(
       featuredAppRewardCap: getValue(`issuanceCurveFutureValues${i}FeaturedAppRewardCap`),
       unfeaturedAppRewardCap: getValue(`issuanceCurveFutureValues${i}UnfeaturedAppRewardCap`),
       optValidatorFaucetCap: getValue(`issuanceCurveFutureValues${i}OptValidatorFaucetCap`),
-      optDevelopmentFundPercentage: getValue(
-        `issuanceCurveFutureValues${i}OptDevelopmentFundPercentage`
-      ),
+      optDevelopmentFundPercentage:
+        futureOptDevelopmentFundPercentage === '' ? null : futureOptDevelopmentFundPercentage,
     };
     futureValues.push({ _1: time, _2: config });
   }
 
   const transferPreapprovalFee = getValue('transferPreapprovalFee');
+  const optDevelopmentFundManager = getValue('optDevelopmentFundManager');
+  const initialOptDevelopmentFundPercentage = getValue(
+    'issuanceCurveInitialValueOptDevelopmentFundPercentage'
+  );
   const amuletConfig: AmuletConfig<'USD'> = {
     tickDuration: { microseconds: getValue('tickDuration') },
     transferPreapprovalFee: transferPreapprovalFee === '' ? null : transferPreapprovalFee,
     featuredAppActivityMarkerAmount: getValue('featuredAppActivityMarkerAmount'),
-    optDevelopmentFundManager: getValue('optDevelopmentFundManager'),
+    optDevelopmentFundManager: optDevelopmentFundManager === '' ? null : optDevelopmentFundManager,
 
     transferConfig: {
       createFee: { fee: getValue('transferConfigCreateFee') },
@@ -107,9 +113,8 @@ export function buildAmuletRulesConfigFromChanges(
         featuredAppRewardCap: getValue('issuanceCurveInitialValueFeaturedAppRewardCap'),
         unfeaturedAppRewardCap: getValue('issuanceCurveInitialValueUnfeaturedAppRewardCap'),
         optValidatorFaucetCap: getValue('issuanceCurveInitialValueOptValidatorFaucetCap'),
-        optDevelopmentFundPercentage: getValue(
-          'issuanceCurveInitialValueOptDevelopmentFundPercentage'
-        ),
+        optDevelopmentFundPercentage:
+          initialOptDevelopmentFundPercentage === '' ? null : initialOptDevelopmentFundPercentage,
       },
       futureValues: futureValues,
     },


### PR DESCRIPTION
Fixes failing tests due to deserialization error:
```
Request to http://localhost:5114/api/sv/v0/admin/sv/voterequest/create resulted in an unexpected exception: Daml-LF Party is empty
HTTP POST /api/sv/v0/admin/sv/voterequest/create from (127.0.0.1:44050): Responding with status code: 500 Internal Server Error
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
