### PR TITLE
DO NOT MERGE: debug build performance

### DIFF
--- a/.envrc.vars
+++ b/.envrc.vars
@@ -17,7 +17,7 @@ export PUBLIC_CONFIGS_PATH=${SPLICE_ROOT}/cluster/configs/configs
 # Inrease code heap sizes to avoid issues
 # Defaults NonNMethodCodeHeapSize=7M,NonProfiledCodeHeapSize=122M,ProfiledCodeHeapSize=122M
 mkdir -p ./log
-export SBT_OPTS="-XX:MaxRAMPercentage=90.0 -Xmx16G -Xms4G -Xss6M -XX:+UseG1GC -XX:ReservedCodeCacheSize=1G -Xlog:gc*=debug:file=./log/sbt-gc.log:time,level,tags:filecount=5,filesize=20m -Xlog:class+load=info,class+unload=info:file=./log/sbt-classloading.log -XX:StartFlightRecording=filename=./log/sbt-build.jfr,dumponexit=true,settings=profile"
+export SBT_OPTS="-XX:MaxRAMPercentage=90.0 -Xmx16G -Xms4G -Xss6M -XX:+UseG1GC -XX:ReservedCodeCacheSize=1G -Xlog:gc*=debug:file=./log/sbt-gc.log:time,level,tags:filecount=5,filesize=20m -Xlog:class+load=info,class+unload=info:file=./log/sbt-classloading.log -XX:StartFlightRecording=filename=./log/sbt-build.jfr,dumponexit=true,settings=profile -XX:FlightRecorderOptions=stackdepth=64"
 
 # Provide a simple way to get the path to `sbt-launch.jar` for IntelliJ setup
 export SBT_LAUNCH_PATH="$(dirname "$(dirname "$(which sbt)")")/share/sbt/bin/sbt-launch.jar"


### PR DESCRIPTION
This PR adds some heavy instrumentation to debug why CI builds are sometimes very slow (see https://github.com/DACH-NY/cn-test-failures/issues/6681).