### PR TITLE
scan: adapt ACS-snapshot related rate limits

### DIFF
--- a/cluster/images/scan-app/app.conf
+++ b/cluster/images/scan-app/app.conf
@@ -60,6 +60,8 @@ canton {
           }
           rate-limiters {
             getAcsSnapshot.rate-per-second = 20
+            getAcsSnapshotAt.rate-per-second = 10
+            getDateOfMostRecentSnapshotBefore.rate-per-second = 10
           }
         }
         # TODO(DACH-NY/canton-network-internal#2125) Revisit timeouts on 3.4


### PR DESCRIPTION
Based on recent experience: https://github.com/DACH-NY/canton-network-internal/pull/3172

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
