### PR TITLE
Add support to upgrade node pools in place

### DIFF
--- a/cluster/expected/cluster/expected.json
+++ b/cluster/expected/cluster/expected.json
@@ -9,7 +9,7 @@
       },
       "cluster": "cn-mocknet",
       "initialNodeCount": 0,
-      "name": "cn-apps-pool",
+      "namePrefix": "cn-apps-pool",
       "nodeConfig": {
         "labels": {
           "cn_apps": "true"
@@ -38,7 +38,7 @@
       },
       "cluster": "cn-mocknet",
       "initialNodeCount": 1,
-      "name": "cn-infra-pool",
+      "namePrefix": "cn-infra-pool",
       "nodeConfig": {
         "labels": {
           "cn_infra": "true"

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -11,51 +11,59 @@ export function installNodePools(): void {
     ? `projects/${GCP_PROJECT}/locations/${config.requireEnv('CLOUDSDK_COMPUTE_ZONE')}/clusters/${clusterName}`
     : clusterName;
 
-  new gcp.container.NodePool('cn-apps-node-pool', {
-    name: 'cn-apps-pool',
-    cluster,
-    nodeConfig: {
-      machineType: gkeClusterConfig.nodePools.apps.nodeType,
-      taints: [
-        {
-          effect: 'NO_SCHEDULE',
-          key: 'cn_apps',
-          value: 'true',
+  new gcp.container.NodePool(
+    'cn-apps-node-pool',
+    {
+      namePrefix: 'cn-apps-pool',
+      cluster,
+      nodeConfig: {
+        machineType: gkeClusterConfig.nodePools.apps.nodeType,
+        taints: [
+          {
+            effect: 'NO_SCHEDULE',
+            key: 'cn_apps',
+            value: 'true',
+          },
+        ],
+        labels: {
+          cn_apps: 'true',
         },
-      ],
-      labels: {
-        cn_apps: 'true',
+      },
+      initialNodeCount: 0,
+      autoscaling: {
+        minNodeCount: gkeClusterConfig.nodePools.apps.minNodes,
+        maxNodeCount: gkeClusterConfig.nodePools.apps.maxNodes,
       },
     },
-    initialNodeCount: 0,
-    autoscaling: {
-      minNodeCount: gkeClusterConfig.nodePools.apps.minNodes,
-      maxNodeCount: gkeClusterConfig.nodePools.apps.maxNodes,
-    },
-  });
+    { aliases: [{ name: 'cn-apps-pool' }] }
+  );
 
-  new gcp.container.NodePool('cn-infra-node-pool', {
-    name: 'cn-infra-pool',
-    cluster,
-    nodeConfig: {
-      machineType: gkeClusterConfig.nodePools.infra.nodeType,
-      taints: [
-        {
-          effect: 'NO_SCHEDULE',
-          key: 'cn_infra',
-          value: 'true',
+  new gcp.container.NodePool(
+    'cn-infra-node-pool',
+    {
+      namePrefix: 'cn-infra-pool',
+      cluster,
+      nodeConfig: {
+        machineType: gkeClusterConfig.nodePools.infra.nodeType,
+        taints: [
+          {
+            effect: 'NO_SCHEDULE',
+            key: 'cn_infra',
+            value: 'true',
+          },
+        ],
+        labels: {
+          cn_infra: 'true',
         },
-      ],
-      labels: {
-        cn_infra: 'true',
+      },
+      initialNodeCount: 1,
+      autoscaling: {
+        minNodeCount: gkeClusterConfig.nodePools.infra.minNodes,
+        maxNodeCount: gkeClusterConfig.nodePools.infra.maxNodes,
       },
     },
-    initialNodeCount: 1,
-    autoscaling: {
-      minNodeCount: gkeClusterConfig.nodePools.infra.minNodes,
-      maxNodeCount: gkeClusterConfig.nodePools.infra.maxNodes,
-    },
-  });
+    { aliases: [{ name: 'cn-infra-pool' }] }
+  );
 
   new gcp.container.NodePool('gke-node-pool', {
     name: 'gke-pool',


### PR DESCRIPTION
Node pool recreation should be done by creating a new pool and then deleting the old one. WIth static names this cannot be done.

[static]

add support for https://github.com/DACH-NY/canton-network-internal/issues/3139

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
