### PR TITLE
Revert changes to pulumi nix plugins

### DIFF
--- a/nix/extra-pulumi-packages.nix
+++ b/nix/extra-pulumi-packages.nix
@@ -8,8 +8,28 @@
         sha256 = "7ab3ad4f7437d1a3d1b54cc01e4ab88548bafdb4ee09b96260022883fb9442f2";
       }
       {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-linux-amd64.tar.gz";
+        sha256 = "008f8afbe723cc38ac5f557031dadc6324435d1c8dcb4037f32be856d87d0425";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-linux-amd64.tar.gz";
+        sha256 = "f9175cc253c4db42dac07a2a8242f036f248af9981cff2d9700ca3e33f70be9d";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-linux-amd64.tar.gz";
+        sha256 = "1fb8955dabbe81a767791e9769a32bd895dfee68d2bcc8ffd3dbd560cd5bcf0d";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-command/releases/download/v1.1.0/pulumi-resource-command-v1.1.0-linux-amd64.tar.gz";
         sha256 = "2b4785052f935178cd471dde5eb3ad00d8d20cd5529218805ed127cf5aca236b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-linux-amd64.tar.gz";
+        sha256 = "2c5f29ac9bc058bb9377b906e7630947add587b69040c63af5a8fd4ff95c9e52";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.38.0/pulumi-resource-gcp-v7.38.0-linux-amd64.tar.gz";
+        sha256 = "1acca6e3b5b8bc673889333ddc7e22ad3b7c54c12feb612bfb1f85605bebd2ce";
       }
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v8.32.1/pulumi-resource-gcp-v8.32.1-linux-amd64.tar.gz";
@@ -24,16 +44,40 @@
         sha256 = "4bbb9ad5ff6be2d74ad678c0dba925f95b770d05b5b2845829cea1871c863144";
       }
       {
+        url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.4.2/pulumi-resource-grafana-v0.4.2-linux-amd64.tar.gz";
+        sha256 = "ad6675574e75c6984ab79a2ff9f4ee6c4859d46a41a7d73ef35c84f05a00b407";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.21.1/pulumi-resource-kubernetes-v4.21.1-linux-amd64.tar.gz";
+        sha256 = "8ddd4ef54778577478e79dc4fcbef3d92ffbf92a5b6fcc4de9e36efe23cd5efd";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.22.0/pulumi-resource-kubernetes-v4.22.0-linux-amd64.tar.gz";
+        sha256 = "bd8f963417c4b24f504de30cca7332fd8f977c6ebe33f90583431b9d258477a3";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.23.0/pulumi-resource-kubernetes-v4.23.0-linux-amd64.tar.gz";
         sha256 = "823677f41ab024d88897d412873676edd0feea7b60a1ee1435e5b6542a9a2122";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-amd64.tar.gz";
+        sha256 = "449d19d54d606cf723bed76f24c821e2c963a04297e6d12f35b91576254aed2f";
       }
       {
         url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.2.0/pulumi-resource-kubernetes-cert-manager-v0.2.0-linux-amd64.tar.gz";
         sha256 = "d7f0dd82911e62b33d76558dfdb3c1605fb2b55cc2685015984b3e31211dd608";
       }
       {
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-linux-amd64.tar.gz";
+        sha256 = "af44caea25e0e0a94307264ee36f927cb182d2b29f74d1d62e4de54c2a98a9ec";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-random/releases/download/v4.18.2/pulumi-resource-random-v4.18.2-linux-amd64.tar.gz";
         sha256 = "04eec786fef023788ded191ee3667fce3f4a1ca2e3db6c3685e4ff1fa5bfff47";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-linux-amd64.tar.gz";
+        sha256 = "44f937ce4ab4662f7b335e0677797539caebb083a23479b6df95072a503f2995";
       }
       {
         url = "https://github.com/pulumi/pulumi-std/releases/download/v2.2.0/pulumi-resource-std-v2.2.0-linux-amd64.tar.gz";
@@ -46,8 +90,28 @@
         sha256 = "79f470ca4db8bd1ef47ad008e956bec0abe6a814d8c957d54274f6b33bc375fc";
       }
       {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-darwin-amd64.tar.gz";
+        sha256 = "c02df58f6a43d18fd7d275d28d46bf527a087d290a62b252a1da74e129ddc90c";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-darwin-amd64.tar.gz";
+        sha256 = "f3518d84aa024fabba4e4ed6757c5a1349814792d798ca43262245978269991b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-darwin-amd64.tar.gz";
+        sha256 = "0b33689487f8297642336bab2e7fe6c83813d2f694a21ba397e851a5a3215696";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-command/releases/download/v1.1.0/pulumi-resource-command-v1.1.0-darwin-amd64.tar.gz";
         sha256 = "48d97828a34c68a0452aa732786cfee70f02c1a9eb37c3cc9d5e478ccd857876";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-darwin-amd64.tar.gz";
+        sha256 = "08ee93595be215736c834d75012704713738b6a1452cc21813a84612c950e424";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.38.0/pulumi-resource-gcp-v7.38.0-darwin-amd64.tar.gz";
+        sha256 = "09f7ccc14c2c968536404d222038d8ec0dd0e5cfa65a56ababfd4f447338c8bd";
       }
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v8.32.1/pulumi-resource-gcp-v8.32.1-darwin-amd64.tar.gz";
@@ -62,16 +126,40 @@
         sha256 = "769e1c309bb8def7724f47e2cb6a7bcc01884e3bb3f3f718bd71749a1054d968";
       }
       {
+        url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.4.2/pulumi-resource-grafana-v0.4.2-darwin-amd64.tar.gz";
+        sha256 = "f4d065bd98b30b0f1ea2185ccb2f4c447c80f71992779ad820fc524f011d403d";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.21.1/pulumi-resource-kubernetes-v4.21.1-darwin-amd64.tar.gz";
+        sha256 = "37be280d4a76ef005053859199dd84bdcb715e28823f8754d536861e18230785";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.22.0/pulumi-resource-kubernetes-v4.22.0-darwin-amd64.tar.gz";
+        sha256 = "64c0804bdcfc0dbf563c2512288a66c0566929cf770a2b20a88dcf14000f1387";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.23.0/pulumi-resource-kubernetes-v4.23.0-darwin-amd64.tar.gz";
         sha256 = "9b06147363fa2b139c714d2d318009efb4b2abc860a007012cc232b29dc7bbdd";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-amd64.tar.gz";
+        sha256 = "0cdd4ae517668d364a2c7beed21d838fd25921e4b615fe2e2cbbc628c5308a83";
       }
       {
         url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.2.0/pulumi-resource-kubernetes-cert-manager-v0.2.0-darwin-amd64.tar.gz";
         sha256 = "1da3dfe8b9d3688924abe389af6a662144a822104f309b75253a71d628b9e851";
       }
       {
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-darwin-amd64.tar.gz";
+        sha256 = "bcb16a5d53cf7eddeb35e54050a19541342a5a07d8b81705b6bb85316ac3e3c9";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-random/releases/download/v4.18.2/pulumi-resource-random-v4.18.2-darwin-amd64.tar.gz";
         sha256 = "42f9f7d08d1cc13f80110f5aad8e26ab51d6c2b8f4f29676b6b54f35636440fa";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-darwin-amd64.tar.gz";
+        sha256 = "782e620c8587bd13ece55b298652009609d4892258d513462dc07720ea77e930";
       }
       {
         url = "https://github.com/pulumi/pulumi-std/releases/download/v2.2.0/pulumi-resource-std-v2.2.0-darwin-amd64.tar.gz";
@@ -84,8 +172,28 @@
         sha256 = "59239620d898be5e4fae88f4fbff670db994666ea2167cc1f7ef3ca3cc30f2c9";
       }
       {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-linux-arm64.tar.gz";
+        sha256 = "c2b1d68b75ad613a7ed01c322609d03a9fa727d5833a0f4bb8ab037578502a82";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-linux-arm64.tar.gz";
+        sha256 = "c78c7b172940b43098dae3235a4606cae7fc37795e79f0b5620569258a59eb9b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-linux-arm64.tar.gz";
+        sha256 = "0ef3b81713728d17c9d55e894c66d2c51658ce3bbe682559d1517fdd49ba126e";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-command/releases/download/v1.1.0/pulumi-resource-command-v1.1.0-linux-arm64.tar.gz";
         sha256 = "13b2b8c5b3539bf3582f8e1bd4cb54744437ca7b7962ab3144c3fb46471d9661";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-linux-arm64.tar.gz";
+        sha256 = "4cddd536e4e28caba68919ba2d051442595ef0c0c139a7779108b579bf596901";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.38.0/pulumi-resource-gcp-v7.38.0-linux-arm64.tar.gz";
+        sha256 = "d442eff25b9ec56a19e604ccedcaba6c1072108b448970b019b59856180d9265";
       }
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v8.32.1/pulumi-resource-gcp-v8.32.1-linux-arm64.tar.gz";
@@ -100,16 +208,40 @@
         sha256 = "993abf5c2d4e0fe4d3e36523eecb864503426c9c2ebfce1dde830d3f51f0faf4";
       }
       {
+        url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.4.2/pulumi-resource-grafana-v0.4.2-linux-arm64.tar.gz";
+        sha256 = "dbf59982dcd94e50b9241e9501dc531bad2a9faac47aa5ecce8e5bb1bfc2e9ff";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.21.1/pulumi-resource-kubernetes-v4.21.1-linux-arm64.tar.gz";
+        sha256 = "34cdcf8f8bdebdcbebfb9011529bd0ae5ab7f57c51c56422b26e0f2b817d5a28";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.22.0/pulumi-resource-kubernetes-v4.22.0-linux-arm64.tar.gz";
+        sha256 = "583e315d3ed5926f2a2a86fd88f70723ed429648592ce1056b164bfff21dcdd3";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.23.0/pulumi-resource-kubernetes-v4.23.0-linux-arm64.tar.gz";
         sha256 = "a859b436c3f12899696bd56f00fbce24dc8d4b59b3849d07bfff271bfcf91d4f";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-linux-arm64.tar.gz";
+        sha256 = "33b645af0f32e36a7dc1468a65a4b55c01ccd0c0dc85506e2ff42f8fd69d0082";
       }
       {
         url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.2.0/pulumi-resource-kubernetes-cert-manager-v0.2.0-linux-arm64.tar.gz";
         sha256 = "5fe23d29e6cf73a8543d5d56bf98ac231864e05a3f9c9258e4b6345c8d3e40a6";
       }
       {
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-linux-arm64.tar.gz";
+        sha256 = "5376484af2484e7f7dac6c61cfa6bf18358eb07d0d0e46565a6827e574c993a3";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-random/releases/download/v4.18.2/pulumi-resource-random-v4.18.2-linux-arm64.tar.gz";
         sha256 = "61b93340ddd5ec0d75ccaf0696e6f7770b6148dfe49fe76cb05680381e5b95b7";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-linux-arm64.tar.gz";
+        sha256 = "cc2f838a4df1b8f5466a1192d5f16a51761062ff695aea92fc52d241701a60fe";
       }
       {
         url = "https://github.com/pulumi/pulumi-std/releases/download/v2.2.0/pulumi-resource-std-v2.2.0-linux-arm64.tar.gz";
@@ -122,8 +254,28 @@
         sha256 = "eefa22ce0f6fb3121ad26d3a34bce092434e83ba55c96da8ec64dc34536a6199";
       }
       {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.1/pulumi-resource-auth0-v3.3.1-darwin-arm64.tar.gz";
+        sha256 = "35f76da2d17846c5772b55195c7ace2bd889f03b4b66dfbe78eb910c3e024549";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-auth0/releases/download/v3.3.2/pulumi-resource-auth0-v3.3.2-darwin-arm64.tar.gz";
+        sha256 = "240ae83b53065d15c41990ade21284d4c64c1915559d5b2ed2c0fcea0f415b9b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-command/releases/download/v0.9.2/pulumi-resource-command-v0.9.2-darwin-arm64.tar.gz";
+        sha256 = "15b1f11b1d7329733337605f78eaf1612e2c3bf8bb4afbb43146f418dd6f4526";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-command/releases/download/v1.1.0/pulumi-resource-command-v1.1.0-darwin-arm64.tar.gz";
         sha256 = "80c147a2acb0b91f2b7a6f21256b08a3883f3948b1ae245e479c9c19e56740ca";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.2.1/pulumi-resource-gcp-v7.2.1-darwin-arm64.tar.gz";
+        sha256 = "4bb52f6d510772d53e0ed88153bd237703610cb1ff7b4e40558c493c45405991";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-gcp/releases/download/v7.38.0/pulumi-resource-gcp-v7.38.0-darwin-arm64.tar.gz";
+        sha256 = "44883ff3b848c2a8ce19531586967f096b6f803398842cbaa6b9b900f0e20cc5";
       }
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v8.32.1/pulumi-resource-gcp-v8.32.1-darwin-arm64.tar.gz";
@@ -138,16 +290,40 @@
         sha256 = "a047ae041dd0814b3b76a06cdf16b2323f1e8c8fbce4321295da73430bd26379";
       }
       {
+        url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.4.2/pulumi-resource-grafana-v0.4.2-darwin-arm64.tar.gz";
+        sha256 = "76ff2462fa5b85023948f5e7139b28a08af4a50ae80077e3c24ff8723203a603";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.21.1/pulumi-resource-kubernetes-v4.21.1-darwin-arm64.tar.gz";
+        sha256 = "99a8c1922c28109c594d56087cee282e8d77cc4e5afcfdb8f8cb1f03ceea5d6b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.22.0/pulumi-resource-kubernetes-v4.22.0-darwin-arm64.tar.gz";
+        sha256 = "cdbcf56533325f59ec0aa95d3be19f6df23172bfabdfa1d2e96b24649bed88d4";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-kubernetes/releases/download/v4.23.0/pulumi-resource-kubernetes-v4.23.0-darwin-arm64.tar.gz";
         sha256 = "c80572b71e0e9922d1cb146e277a80ddcee0497400eb70bf74917c6aaf42d49d";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.0.5/pulumi-resource-kubernetes-cert-manager-v0.0.5-darwin-arm64.tar.gz";
+        sha256 = "8d393dc2d633ed5ad7e291a70d513a340505a3dcb5684b5000c883fb4137dca3";
       }
       {
         url = "https://github.com/pulumi/pulumi-kubernetes-cert-manager/releases/download/v0.2.0/pulumi-resource-kubernetes-cert-manager-v0.2.0-darwin-arm64.tar.gz";
         sha256 = "039dc2334e253bf0741f44732fa80760913a9755d7fd0d9b6ace06bbd35e2638";
       }
       {
+        url = "https://github.com/pulumi/pulumi-random/releases/download/v4.14.0/pulumi-resource-random-v4.14.0-darwin-arm64.tar.gz";
+        sha256 = "920f2f3f8fa9ad78d3077d81debd29861afac72cf852ca9605ba2550dcc79422";
+      }
+      {
         url = "https://github.com/pulumi/pulumi-random/releases/download/v4.18.2/pulumi-resource-random-v4.18.2-darwin-arm64.tar.gz";
         sha256 = "506892a5b6482ef498a0d0f72dfb0a6017f874b4038d97eba97700879df63346";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-std/releases/download/v1.7.3/pulumi-resource-std-v1.7.3-darwin-arm64.tar.gz";
+        sha256 = "cad5c31ed137e6653ab53947fdae6343dd2b41f486790de40535cb36eb76351f";
       }
       {
         url = "https://github.com/pulumi/pulumi-std/releases/download/v2.2.0/pulumi-resource-std-v2.2.0-darwin-arm64.tar.gz";

--- a/nix/generate_pulumi_packages.sh
+++ b/nix/generate_pulumi_packages.sh
@@ -22,9 +22,22 @@ plugins=(
   "pulumi/command=1.1.0"
   "pulumi/kubernetes-cert-manager=0.2.0"
   "pulumiverse/grafana=0.16.3"
+  # used by cert manager
+  "pulumi/kubernetes=4.22.0"
+  "pulumi/kubernetes=4.21.1"
   # old versions so that old pulumi state can be interpreted
   # each can be removed once MainNet uses a newer version
+  "pulumi/auth0=3.3.1"
+  "pulumi/auth0=3.3.2"
+  "pulumi/command=0.9.2"
+  "pulumi/gcp=7.2.1"
+  "pulumi/gcp=7.38.0"
   "pulumi/gcp=8.32.1"
+  "pulumi/kubernetes-cert-manager=0.0.5"
+  "pulumi/random=4.14.0"
+  "pulumi/std=1.7.3"
+  "pulumiverse/grafana=0.4.2"
+  "pulumi/kubernetes=4.21.1"
 )
 
 function genSrc() {


### PR DESCRIPTION
It seems cert manager has a dependency on an older k8s plugin

[static]

will cleanup in another PR 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
