### PR TITLE
Avoid scan rate limiting in `TokenStandardCliTestDataTimeBasedIntegrationTest`

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
@@ -690,7 +690,8 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
         )
       def replaceStringsInJson(viewValue: Json) = {
         val current = viewValue.spaces2SortKeys
-        val amuletRulesId = eventuallySucceeds()(sv1ScanBackend.getAmuletRules().contractId.contractId)
+        val amuletRulesId =
+          eventuallySucceeds()(sv1ScanBackend.getAmuletRules().contractId.contractId)
         val allContracts =
           "\"([0-9a-fA-F]{138})\"".r.findAllIn(current).matchData.map(_.group(1)).toSeq
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6839

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
