### PR TITLE
[ci] de-flake app rewards test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletManualRoundsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletManualRoundsIntegrationTest.scala
@@ -41,7 +41,6 @@ import com.digitalasset.canton.logging.SuppressionRule
 import org.slf4j.event.Level
 
 import java.time.Duration
-import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
 
 class WalletManualRoundsIntegrationTest


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/6698

I actually disagree with @nicu-da .
The contract that fails this check is a leftover from a previous test, and AFAICT the only reason we're waiting for it to not exist is to not pollute this test. It eventually does get collected by a purchase-traffic automation, but that's not of interest to this test. I therefore propose to just not wait for that at all, and handle the existence of such contracts in the test.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
