### PR TITLE
Fix cncluster backup_nodes ignoring supplied nodes

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -1746,10 +1746,12 @@ function subcmd_backup_nodes() {
     fi
     migration_id=$1
 
-    if [ $# -eq 2 ]; then
+    # If only migration is set, backup everything, otherwise backup specified nodes
+    # Notably, prod networks which don't have sv-2 % sv-3
+    if [ $# -eq 1 ]; then
         nodes="sv-1 sv-2 sv-3 sv-da-1 validator1 splitwell"
     else
-        shift 2
+        shift 1
         nodes="$*"
     fi
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7034
Looks like fallout from the "internal" flag changes.

Bash strikes again!
It's late, it's Friday and it's bash - so please make triple sure that I didn't mess something up.

Needs backport to release-line-0.5.7 where things are breaking