### PR TITLE
Revert "Increase backup wait time and delete timeouts in nod…

### DIFF
--- a/cluster/scripts/node-backup.sh
+++ b/cluster/scripts/node-backup.sh
@@ -11,7 +11,6 @@ source "${TOOLS_LIB}/libcli.source"
 source "${SPLICE_ROOT}/cluster/scripts/utils.source"
 
 RUN_ID=$(date +%s)
-WAIT_FOR_BACKUP_RETRIES=450
 
 ##### PVC Backup & Restore
 
@@ -55,7 +54,7 @@ function wait_for_pvc_backup() {
       _info "Backup of $description PVC ready!"
       break
     else
-      (( i++ )) && (( i > WAIT_FOR_BACKUP_RETRIES )) && {
+      (( i++ )) && (( i > 300 )) && {
         # remove the finalizers to allow fully deleting them
         kubectl patch -n "$namespace" volumesnapshot "$pvc_name" -p '{"metadata":{"finalizers": []}}' --type=merge
         kubectl delete volumesnapshot -n "$namespace" "$backupName";
@@ -154,10 +153,7 @@ function wait_for_cloudsql_backup() {
       _info "Backup of $description ready! Backup ID: $id "
       break
     else
-      (( i++ ))&& (( i > WAIT_FOR_BACKUP_RETRIES )) && {
-        # gcloud sql backups delete "$id" --instance "$db_id" --quiet;
-        _error "Timed out waiting for backup of $description db";
-      }
+      (( i++ ))&& (( i > 300 )) &&_error "Timed out waiting for backup of $description db"
       sleep 5
       _info "still waiting..."
     fi


### PR DESCRIPTION
…e-backup (#3662)"

This reverts commit 925dcf9a4fd594a62b0d1e01d8e3cf628052bd9d.
I don't think this actually works, probably some bash shenanigans... This was looping forever until I manually killed it: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/48725/workflows/d5c250b8-ad53-480e-9a2d-480bf598b434/jobs/265826/parallel-runs/2?filterBy=ALL

I also don't think it's really required or helpful, the backup was not slow, it was failing, so waiting for longer doesn't actually help us. Sorry for misleading you...



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
