### PR TITLE
Add static_test variant to nix setup

### DIFF
--- a/.github/actions/nix/run_bash_command_in_nix/action.yml
+++ b/.github/actions/nix/run_bash_command_in_nix/action.yml
@@ -29,13 +29,9 @@ runs:
         echo "sourcing nix profile"
         export USER=$(whoami)
         . ~/.nix-profile/etc/profile.d/nix.sh
-        if [ -f /tmp/oss-only ]; then
-          target="oss"
-        else
-          target="default"
-        fi
+        target="$(cat /tmp/nix_target)"
 
-        echo "Running command with nix version $(nix --version)"
+        echo "Running command with nix version $(nix --version) and nix target $target"
 
         # Attempt to build the nix env with retries to work around transient download failures
         echo "building nix env"

--- a/.github/actions/nix/setup_nix/action.yml
+++ b/.github/actions/nix/setup_nix/action.yml
@@ -7,10 +7,14 @@ inputs:
   artifactory_password:
     description: "The Artifactory password"
     required: true
-  oss_only:
-    description: "Restrict upstream dependencies (e.g. Canton) to OSS versions (the equivalent of OSS_ONLY=1 in local checkouts)"
-    default: "false"
-    required: false
+  target:
+    description: "Choose nix target: oss - restrict upstream dependencies (e.g. Canton) to OSS versions (the equivalent of OSS_ONLY=1 in local checkouts), static_tests - for static tests, default - for enterprise dependencies"
+    type: choice
+    options:
+      - oss
+      - default
+      - static_tests
+    required: true
   cache_version:
     description: "The cache version"
     required: true
@@ -46,10 +50,10 @@ runs:
         echo "gh_cache_version: ${{ inputs.cache_version }}" >> /tmp/nix-cache-key # Add cache version to the cache key
         echo "home: $HOME" >> /tmp/nix-cache-key # important when restoring simlinks from cache, apparently
         echo "nix binary version: $NIX_BINARY_VERSION" >> /tmp/nix-cache-key # different nix versions might behave differently and corrupt the caches
-        if [ "${{ inputs.oss_only }}" == true ]; then
+        echo ${{ inputs.target }} > /tmp/nix_target # Create a file to indicate which target are we using (so we don't need to re-specifify target to run_bash_command_in_nix)
+        echo "target: ${{ inputs.target }}" >> /tmp/nix-cache-key
+        if [ "${{ inputs.target }}" != 'default' ]; then
           echo "Using OSS only dependencies"
-          echo "oss_only: ${{ inputs.oss_only }}" >> /tmp/nix-cache-key
-          touch /tmp/oss-only # Create a file to indicate that we are using OSS only dependencies (so we don't need to re-specifify oss_only to run_bash_command_in_nix)
         fi
         cat /tmp/nix-cache-key
         cache_key=($(md5sum "/tmp/nix-cache-key"))
@@ -61,7 +65,7 @@ runs:
       run: |
         set -euxo pipefail
 
-        if [ ${{ inputs.oss_only }} != 'true' ]; then
+        if [[ ${{ inputs.target }} == 'default' ]]; then
           echo "Must use OSS only dependencies in GitHub-hosted runners"
           exit 1
         fi
@@ -138,7 +142,7 @@ runs:
           sh <(curl -fsSL --retry 8 "https://releases.nixos.org/nix/nix-$NIX_BINARY_VERSION/install") --no-daemon
           sudo mkdir -p /etc/nix
           sudo chmod a+rw /etc/nix
-          if [[ "${{ inputs.oss_only }}" == true ]]; then
+          if [[ "${{ inputs.target }}" != 'default' ]]; then
             echo "Using OSS only dependencies, not setting up Artifactory credentials"
           else
             cat <<EOF > /etc/nix/netrc
@@ -150,12 +154,7 @@ runs:
           export USER=$(whoami)
           echo "Running nix.sh"
           . ~/.nix-profile/etc/profile.d/nix.sh
-          if [[ "${{ inputs.oss_only }}" == true ]]; then
-            target="oss"
-          else
-            target="default"
-          fi
-          nix develop path:nix#${target} -v --profile "$HOME/.nix-shell" --command echo "Done loading packages"
+          nix develop path:nix#${{ inputs.target }} -v --profile "$HOME/.nix-shell" --command echo "Done loading packages"
         fi
 
     - name: Invoke nix before saving cache

--- a/.github/actions/tests/common_test_setup/action.yml
+++ b/.github/actions/tests/common_test_setup/action.yml
@@ -22,10 +22,15 @@ inputs:
   artifactory_password:
     description: "The Artifactory password"
     required: false
-  oss_only:
-    description: "Restrict upstream dependencies (e.g. Canton) to OSS versions (the equivalent of OSS_ONLY=1 in local checkouts)"
+  target:
+    description: "Choose nix target: oss - restrict upstream dependencies (e.g. Canton) to OSS versions (the equivalent of OSS_ONLY=1 in local checkouts), static_tests - for static tests, default - for enterprise dependencies"
+    default: 'default'
+    type: choice
+    options:
+      - oss
+      - default
+      - static_tests
     required: false
-    default: "false"
   upload_workload_identity_provider:
     description: "The workload identity provider to use for uploading the cache"
     required: false
@@ -44,7 +49,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate input
-      if: inputs.oss_only != 'true' && (inputs.artifactory_password == '' || inputs.artifactory_user == '')
+      if: inputs.target == 'default' && (inputs.artifactory_password == '' || inputs.artifactory_user == '')
       shell: bash
       run: |
         echo "artifactory_user and artifactory_password must be provided if not using OSS only dependencies."
@@ -67,7 +72,7 @@ runs:
         cache_version: 7
         should_save: ${{ inputs.save_nix_cache }}
         should_save_gcp: ${{ inputs.save_nix_cache_to_gcp }}
-        oss_only: ${{ inputs.oss_only }}
+        target: ${{ inputs.target }}
         upload_workload_identity_provider: ${{ inputs.upload_workload_identity_provider }}
         upload_service_account: ${{ inputs.upload_service_account }}
 

--- a/.github/actions/tests/scala_test/action.yml
+++ b/.github/actions/tests/scala_test/action.yml
@@ -101,7 +101,7 @@ runs:
         with_sbt: false # we setup SBT later while canton is starting up
         artifactory_user: ${{ inputs.artifactory_user }}
         artifactory_password: ${{ inputs.artifactory_password }}
-        oss_only: ${{ inputs.oss_only }}
+        target: ${{ inputs.oss_only }} && 'oss' || 'default'
         # The docs job saves the oss nix cache, here we save the non-oss one, but only in one runner to reduce contention
         # TODO(#1296): When this runner stops using non-oss, move this to one that does
         save_nix_cache: ${{ inputs.runner_index == 0 && inputs.test_suite_name == 'canton-enterprise' }}

--- a/.github/workflows/build.daml_test.yml
+++ b/.github/workflows/build.daml_test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/tests/common_test_setup
         with:
           test_name: daml_test
-          oss_only: true
+          target: 'oss'
 
       - name: Run Daml tests
         if: steps.skip.outputs.skip != 'true'

--- a/.github/workflows/build.deployment_test.yml
+++ b/.github/workflows/build.deployment_test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           test_name: deployment_test
           with_sbt: false
-          oss_only: true
+          target: 'oss'
 
       - name: Helm tests
         uses: ./.github/actions/nix/run_bash_command_in_nix

--- a/.github/workflows/build.docs.yml
+++ b/.github/workflows/build.docs.yml
@@ -26,7 +26,7 @@ jobs:
           test_name: docs
           save_nix_cache: true
           save_nix_cache_to_gcp: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-          oss_only: true
+          target: 'oss'
           upload_workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER_SPLICE }}
           upload_service_account: ${{ secrets.CACHE_UPLOADER_SA }}
 

--- a/.github/workflows/build.static_tests.yml
+++ b/.github/workflows/build.static_tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/tests/common_test_setup
         with:
           test_name: static_tests
-          oss_only: true
+          target: 'static_tests'
 
       - name: Check trailing whitespace
         uses: ./.github/actions/nix/run_bash_command_in_nix

--- a/.github/workflows/build.ts_cli_tests.yml
+++ b/.github/workflows/build.ts_cli_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/tests/common_test_setup
         with:
           test_name: ts_cli
-          oss_only: true
+          target: 'oss'
 
       - name: Run Token Standard CLI tests
         if: steps.skip.outputs.skip != 'true'

--- a/.github/workflows/build.ui_tests.yml
+++ b/.github/workflows/build.ui_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/tests/common_test_setup
         with:
           test_name: ui_tests
-          oss_only: true
+          target: 'oss'
 
       - name: Run UI tests
         if: steps.skip.outputs.skip != 'true'

--- a/.github/workflows/bump_gha_runner_version.yml
+++ b/.github/workflows/bump_gha_runner_version.yml
@@ -29,6 +29,7 @@ jobs:
           cache_version: 7
           artifactory_user: dummy
           artifactory_password: dummy
+          target: default
       
       - name: Check for the latest version and create a PR to splice
         uses: ./.github/actions/nix/run_bash_command_in_nix

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -32,13 +32,19 @@
             inherit npmPkgs;
             x86Pkgs = enterprise_x86Pkgs;
             pkgs = enterprise_pkgs;
-            use_enterprise = true;
+            variant = "enterprise";
           };
           devShells.oss = import ./shell.nix {
             inherit npmPkgs;
             x86Pkgs = oss_x86Pkgs;
             pkgs = oss_pkgs;
-            use_enterprise = false;
+            variant = "oss";
+          };
+          devShells.static_tests = import ./shell.nix {
+            inherit npmPkgs;
+            x86Pkgs = oss_x86Pkgs;
+            pkgs = oss_pkgs;
+            variant = "static_tests";
           };
         }
       );

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,6 @@
-{ pkgs, x86Pkgs, npmPkgs, use_enterprise }:
+{ pkgs, x86Pkgs, npmPkgs, variant }:
 let
+  use_enterprise = if variant == "enterprise" then true else false;
   inherit (pkgs) stdenv fetchzip;
   sources = builtins.fromJSON (builtins.readFile ./canton-sources.json);
   cometbftDriverSources = builtins.fromJSON (builtins.readFile ./cometbft-driver-sources.json);
@@ -8,10 +9,7 @@ let
   # No macOS support for firefox
   linuxOnly = if stdenv.isDarwin then [ ] else with pkgs; [ firefox iproute2 rust-parallel util-linux ];
 
-in pkgs.mkShell {
-  PULUMI_SKIP_UPDATE_CHECK = 1;
-  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-  packages = with pkgs; [
+  standard_packages = with pkgs; [
 
     # NOTE: please keep this list sorted for an easy overview and to avoid merge noise.
     istioctl
@@ -112,6 +110,31 @@ in pkgs.mkShell {
     # Package required to install daml studio
     yq-go
   ] ++ linuxOnly;
+
+  packages_for_static_tests = with pkgs; [
+    # NOTE: please keep this list sorted for an easy overview and to avoid merge noise.
+    actionlint
+    ammonite
+    curl
+    git
+    hub # Github CLI for todo checker
+    jq
+    nodejs
+    npmPkgs.syncpack
+    openapi-generator-cli
+    pre-commit
+    python3
+    python3Packages.dockerfile-parse
+    ripgrep
+    sbt
+    scala_2_13
+    shellcheck
+  ] ++ linuxOnly;
+
+in pkgs.mkShell {
+  PULUMI_SKIP_UPDATE_CHECK = 1;
+  SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  packages = if variant == "static_tests" then packages_for_static_tests else standard_packages;
 
   CANTON = "${pkgs.canton}";
   CANTON_VERSION = "${sources.version}";


### PR DESCRIPTION
This PR creates a new target for nix called #static_tests which includes only dependencies needed for running static tests. This should make the cache small enough to fit into GH-hosted runners.

Fixes #3448

### Pull Request Checklist

#### Cluster Testing
- [x] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [x] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [x] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
