### PR TITLE
[0.5.5] support de-whitelisting an IP locally in pulumi (#3510)

### DIFF
--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -91,6 +91,7 @@ export const InfraConfigSchema = z.object({
     ipWhitelisting: z
       .object({
         extraWhitelistedIngress: z.array(z.string()).default([]),
+        excludedIps: z.array(z.string()).default([]),
       })
       .optional(),
     enableGCReaperJob: z.boolean().default(false),
@@ -163,8 +164,12 @@ export function loadIPRanges(svsOnly: boolean = false): pulumi.Output<string[]> 
   });
 
   const configWhitelistedIps = infraConfig.ipWhitelisting?.extraWhitelistedIngress || [];
+  const excludedIps = infraConfig.ipWhitelisting?.excludedIps || [];
 
   return internalWhitelistedIps.apply(whitelists =>
-    whitelists.concat(externalIpRanges).concat(configWhitelistedIps)
+    whitelists
+      .concat(externalIpRanges)
+      .concat(configWhitelistedIps)
+      .filter(ip => excludedIps.indexOf(ip) < 0)
   );
 }


### PR DESCRIPTION
Missing backport of #3510

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
