### PR TITLE
make cluster config access outside of Pulumi use resolved config

### DIFF
--- a/.github/actions/scripts/backport_reminder.js
+++ b/.github/actions/scripts/backport_reminder.js
@@ -10,7 +10,7 @@ async function getFileFromGit(deps, path, ref) {
 }
 
 async function getBranchesForCluster(deps, cluster) {
-  const configYaml = await getFileFromGit(deps, `cluster/deployment/${cluster}/config.yaml`, 'main');
+  const configYaml = await getFileFromGit(deps, `cluster/deployment/${cluster}/config.resolved.yaml`, 'main');
   const config = deps.jsyaml.load(configYaml);
   const active = config.synchronizerMigration.active.releaseReference.gitReference;
   const upgrade = config.synchronizerMigration.upgrade?.releaseReference.gitReference;

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -1469,7 +1469,7 @@ subcommand_whitelist[debug_shell]='Spin up a debug container on the cluster, and
 function subcmd_debug_shell() {
   _cluster_must_exist
 
-  VERSION_NUMBER=${OVERRIDE_VERSION:-$(yq ".synchronizerMigration.active.version" < config.yaml)}
+  VERSION_NUMBER=${OVERRIDE_VERSION:-$("${SPLICE_ROOT}/cluster/scripts/get-resolved-config.sh" | yq ".synchronizerMigration.active.version")}
   if [ -z "$VERSION_NUMBER" ] || [ "$VERSION_NUMBER" = "null" ]; then
     VERSION_NUMBER=$(get-snapshot-version)
   fi

--- a/cluster/scripts/get-resolved-config.sh
+++ b/cluster/scripts/get-resolved-config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+# Updates and prints the resolved config to stdout for the current cluster which is specified
+# either with TARGET_CLUSTER or the current working directory.
+
+if [ -z "${TARGET_CLUSTER-}" ]; then
+  cluster_dir="."
+else
+  cluster_dir="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}"
+fi
+
+resolved_config_file="$cluster_dir/config.resolved.yaml"
+# if we are not in CI we might have some local config changes and the resolved config was not yet updated
+if [ -z "${CI:-}" ]; then
+  # resolve make parameters to allow running both for splice and internal clusters
+  make_directory="${cluster_dir}/../../.."
+  resolved_config_target="$(realpath --no-symlinks --relative-to "$make_directory" "$resolved_config_file")"
+  # make resolved config to apply local config changes
+  make --directory "$make_directory" "$resolved_config_target" > /dev/null
+fi
+
+# using resolved config to avoid duplicating config loader implementation
+cat "$resolved_config_file"

--- a/cluster/scripts/vote-for-migration.sh
+++ b/cluster/scripts/vote-for-migration.sh
@@ -81,15 +81,8 @@ vote_data='{
 }'
 echo "Casting votes on $vote_request_cid with: $vote_data"
 
-function get_merged_config() {
-  local cluster_dir
-  if [ -z "${TARGET_CLUSTER-}" ]; then
-    cluster_dir="."
-  else
-    cluster_dir="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}"
-  fi
-  # the most local config.yaml takes precedence, and if ../config.yaml is the same as the SPLICE_ROOT one, merging is a NOP
-  yq ". *= load(\"$cluster_dir/../config.yaml\") | . *= load(\"$cluster_dir/config.yaml\")" < "$SPLICE_ROOT/cluster/deployment/config.yaml"
+function get_resolved_config() {
+  "${SPLICE_ROOT}/cluster/scripts/get-resolved-config.sh"
 }
 
 other_svs=()
@@ -101,7 +94,7 @@ for ((i=2; i<=DSO_SIZE; i++)); do
 done
 
 # extra SVs from all the config.yaml files
-extra_svs=$(get_merged_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+)$") | not)')
+extra_svs=$(get_resolved_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+)$") | not)')
 for sv in $extra_svs; do
   other_svs+=("$sv")
 done
@@ -110,7 +103,7 @@ for sv in "${other_svs[@]}"
 do
   token=$(cncluster get_token "$sv" sv)
   echo "Casting vote on $sv"
-  subdomain=$(get_merged_config | yq ".svs.$sv.subdomain // \"$sv-eng\"")
+  subdomain=$(get_resolved_config | yq ".svs.$sv.subdomain // \"$sv-eng\"")
 
   curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
     -X POST "https://sv.$subdomain.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/votes" \

--- a/cluster/scripts/vote-for-offboard-sv-runbook.sh
+++ b/cluster/scripts/vote-for-offboard-sv-runbook.sh
@@ -66,15 +66,8 @@ echo "Casting votes on $vote_request_cid with: $vote_data"
 
 # The other SVs vote in favor of the offboarding
 
-function get_merged_config() {
-  local cluster_dir
-  if [ -z "${TARGET_CLUSTER-}" ]; then
-    cluster_dir="."
-  else
-    cluster_dir="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}"
-  fi
-  # the most local config.yaml takes precedence, and if ../config.yaml is the same as the SPLICE_ROOT one, merging is a NOP
-  yq ". *= load(\"$cluster_dir/../config.yaml\") | . *= load(\"$cluster_dir/config.yaml\")" < "$SPLICE_ROOT/cluster/deployment/config.yaml"
+function get_resolved_config() {
+  "${SPLICE_ROOT}/cluster/scripts/get-resolved-config.sh"
 }
 
 other_svs=()
@@ -86,7 +79,7 @@ for ((i=2; i<=DSO_SIZE; i++)); do
 done
 
 # extra SVs from all the config.yaml files
-extra_svs=$(get_merged_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+)$") | not)')
+extra_svs=$(get_resolved_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+)$") | not)')
 for sv in $extra_svs; do
   other_svs+=("$sv")
 done
@@ -95,7 +88,7 @@ for sv in "${other_svs[@]}"
 do
   token=$(cncluster get_token "$sv" sv)
   echo "Casting vote on $sv"
-  subdomain=$(get_merged_config | yq ".svs.$sv.subdomain // \"$sv-eng\"")
+  subdomain=$(get_resolved_config | yq ".svs.$sv.subdomain // \"$sv-eng\"")
 
   curl -s --fail-with-body --show-error --retry 10 --retry-delay 10 --retry-all-errors \
     -X POST "https://sv.$subdomain.$GCP_CLUSTER_HOSTNAME/api/sv/v0/admin/sv/votes" \


### PR DESCRIPTION
These changes are an attempt to address the problem with accessing cluster configuration outside of Pulumi projects as described in https://github.com/DACH-NY/canton-network-internal/issues/3270.