### PR TITLE
fix make prerequisites in cluster image builds

### DIFF
--- a/cluster/images/canton-cometbft-sequencer/local.mk
+++ b/cluster/images/canton-cometbft-sequencer/local.mk
@@ -8,7 +8,7 @@ target-driver := $(dir)/target/driver.jar
 $(dir)/$(docker-build): $(target-driver)
 $(dir)/$(docker-build): build_arg := --build-arg base_version=$(shell get-snapshot-version)
 
-$(target-driver): ${COMETBFT_DRIVER}/driver.jar
+$(target-driver): ${COMETBFT_DRIVER}/driver.jar | $(dir)/target
 	cp $< $@
 
 include cluster/images/canton-sequencer-base-image-dep.mk

--- a/cluster/images/cometbft/local.mk
+++ b/cluster/images/cometbft/local.mk
@@ -6,5 +6,5 @@ dir := $(call current_dir)
 $(dir)/$(docker-build): $(dir)/configure-state-sync.sh $(dir)/target/LICENSE
 $(dir)/$(docker-build): build_arg := --build-arg cometbft_version=${COMETBFT_RELEASE_VERSION} --build-arg cometbft_sha=${COMETBFT_IMAGE_SHA256}
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/common/entrypoint-image.mk
+++ b/cluster/images/common/entrypoint-image.mk
@@ -11,9 +11,6 @@ $(dir)/$(docker-build): \
 	$(dir)/target/storage.conf \
 	$(dir)/target/parameters.conf
 
-$(dir)/target:
-	mkdir -p $@
-
 $(dir)/target/entrypoint.sh: $(dir)/../common/entrypoint.sh | $(dir)/target
 	cp $< $@
 

--- a/cluster/images/gcs-proxy/local.mk
+++ b/cluster/images/gcs-proxy/local.mk
@@ -3,10 +3,7 @@
 
 dir := $(call current_dir)
 
-$(dir)/$(docker-build): $(dir)/target/LICENSE $(target-dir)
+$(dir)/$(docker-build): $(dir)/target/LICENSE
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE $(target-dir)
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@
-
-$(target-dir):
-	mkdir -p $(@D)

--- a/cluster/images/load-tester/local.mk
+++ b/cluster/images/load-tester/local.mk
@@ -8,9 +8,8 @@ load-tester := ${SPLICE_ROOT}/load-tester/dist
 
 $(dir)/$(docker-build): $(target-load-tester)  $(dir)/target/LICENSE
 
-$(target-load-tester): $(load-tester)
-	mkdir -p $(@D)
+$(target-load-tester): $(load-tester) | $(dir)/target
 	cp -r $< $@
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/local.mk
+++ b/cluster/images/local.mk
@@ -106,18 +106,18 @@ $(foreach image,$(images),$(eval $(call DEFINE_PHONY_RULES,$(image))))
 # docker pattern rules
 #########
 
-%/$(docker-local-image-tag): force-update-version
-	mkdir -p $(@D)
+cluster/images/%/target:
+	mkdir -p $@
+
+%/$(docker-local-image-tag): force-update-version | %/target
 	overwrite-if-changed $$(basename $$(dirname $(@D))):$(shell get-snapshot-version) $@
 
-%/$(docker-image-tag): force-update-version
-	mkdir -p $(@D)
+%/$(docker-image-tag): force-update-version | %/target
 	get-docker-image-reference $$(basename $$(dirname $(@D))) > $@
 
-%/$(docker-build): %/$(docker-local-image-tag) %/Dockerfile
+%/$(docker-build): %/$(docker-local-image-tag) %/Dockerfile | %/target
 	docker-check-multi-arch
 	docker-check-env-vars
-	mkdir -pv $(@D)
 	@echo docker build triggered because these files changed: $?
 	docker buildx build $(platform_opt) \
 		--label "org.opencontainers.image.ref.name=$$(basename $$(dirname $(@D)))" \

--- a/cluster/images/party-allocator/local.mk
+++ b/cluster/images/party-allocator/local.mk
@@ -8,9 +8,8 @@ party-allocator := ${SPLICE_ROOT}/party-allocator/build/bundle.js
 
 $(dir)/$(docker-build): $(target-party-allocator)  $(dir)/target/LICENSE  $(dir)/entrypoint.sh
 
-$(target-party-allocator): $(party-allocator)
-	mkdir -p $(@D)
+$(target-party-allocator): $(party-allocator) | $(dir)/target
 	cp -r $< $@
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-app/local.mk
+++ b/cluster/images/splice-app/local.mk
@@ -13,13 +13,11 @@ include ${SPLICE_ROOT}/cluster/images/common/entrypoint-image.mk
 
 $(dir)/$(docker-build): $(dir)/target/entrypoint.sh $(dir)/target/LICENSE $(target-bundle) $(target-logback)
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
-	mkdir -p $(@D)
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@
 
-$(target-bundle): $(app-bundle)
-	mkdir -p $(@D)
+$(target-bundle): $(app-bundle) | $(dir)/target
 	cp $< $@
 
-$(target-logback): ${SPLICE_ROOT}/scripts/canton-logback.xml
+$(target-logback): ${SPLICE_ROOT}/scripts/canton-logback.xml | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-debug/local.mk
+++ b/cluster/images/splice-debug/local.mk
@@ -5,5 +5,5 @@ dir := $(call current_dir)
 
 $(dir)/$(docker-build): $(dir)/target/LICENSE
 $(dir)/$(docker-build): build_arg := --build-arg KUBECTL_VERSION=v${KUBECTL_VERSION}
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-test-ci/local.mk
+++ b/cluster/images/splice-test-ci/local.mk
@@ -6,15 +6,10 @@ dir := $(call current_dir)
 rpc-script := $(dir)/target/gha-runner-rpc.py
 rpc-source := ${SPLICE_ROOT}/.github/runners/runner-container-hooks/packages/k8s-workflow/gha-runner-rpc.py
 
-target-dir := $(dir)/target
+$(dir)/$(docker-build): $(dir)/target/LICENSE $(rpc-script)
 
-$(dir)/$(docker-build): $(target-dir) $(dir)/target/LICENSE $(rpc-script)
-
-$(target-dir):
-	mkdir -p $(target-dir)
-
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@
 
-$(rpc-script): $(rpc-source)
+$(rpc-script): $(rpc-source) | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-test-cometbft/local.mk
+++ b/cluster/images/splice-test-cometbft/local.mk
@@ -14,5 +14,5 @@ $(dir)/clean-configs: $(dir)/configs
 $(dir)/configs: ${SPLICE_ROOT}/apps/sv/src/test/resources/cometbft
 	${SPLICE_ROOT}/cluster/images/splice-test-cometbft/copy-configs.sh $< $@
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-test-docker-runner/local.mk
+++ b/cluster/images/splice-test-docker-runner/local.mk
@@ -6,5 +6,5 @@ dir := $(call current_dir)
 $(dir)/$(docker-build): $(dir)/target/LICENSE
 
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-test-postgres/local.mk
+++ b/cluster/images/splice-test-postgres/local.mk
@@ -5,5 +5,5 @@ dir := $(call current_dir)
 
 $(dir)/$(docker-build): $(dir)/target/LICENSE
 
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@

--- a/cluster/images/splice-test-runner-hook/local.mk
+++ b/cluster/images/splice-test-runner-hook/local.mk
@@ -5,21 +5,17 @@ dir := $(call current_dir)
 src_dir := ${SPLICE_ROOT}/.github/runners/runner-container-hooks
 package_files := $(src_dir)/package.json $(src_dir)/packages/k8s/package.json $(src_dir)/packages/hooklib/package.json
 source_files :=	$(shell find $(src_dir)/packages/k8s/src -name '*.ts') $(shell find $(src_dir)/packages/hooklib/src -name '*.ts')
-target-dir := $(dir)/target
 
-$(dir)/$(docker-build): $(target-dir) $(dir)/target/LICENSE $(dir)/target/.npm_installed $(dir)/target/index.js
+$(dir)/$(docker-build): $(dir)/target/LICENSE $(dir)/target/.npm_installed $(dir)/target/index.js
 
-$(target-dir):
-	mkdir -p $(target-dir)
-
-$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE
+$(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@
 
-$(dir)/target/.npm_installed: $(package_files)
+$(dir)/target/.npm_installed: $(package_files) | $(dir)/target
 	touch $@
 	npm install --prefix $(src_dir)
 	npm run bootstrap --prefix $(src_dir)
 
-$(dir)/target/index.js: $(source_files) $(dir)/target/.npm_installed
+$(dir)/target/index.js: $(source_files) $(dir)/target/.npm_installed | $(dir)/target
 	npm run build-all --prefix $(src_dir)
 	cp $(src_dir)/packages/k8s/dist/index.js $@


### PR DESCRIPTION
Make targets for cluster images are not properly defined. Especially the prerequisite of creating a `target` directory is missing in many places. The actual [failure](https://github.com/hyperledger-labs/splice/actions/runs/21032815660/job/60472834432) that provoked these changes stems from issues with GHA runner updater.