### PR TITLE
Revert "Update Helm docs to include new configuration option…

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/validator-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/validator-values.yaml
@@ -1,72 +1,17 @@
-# SCAN_CLIENT_CONFIGURATION_START
-scanClient:
-  scanType: "bft"
-  seedUrls: ["TRUSTED_SCAN_URL"] # replace with scan seed url. Supports multiple urls, separated by comma.
+scanAddress: "TRUSTED_SCAN_URL"
+# TRUSTED_SINGLE_SCAN_START
+# If you want to configure validator to use a single trusted scan, set ``nonSvValidatorTrustSingleScan`` to true.
+# It will only connect to the scan specified in ``scanAddress``. This does mean that you depend on that single SV and if it is broken or malicious you will be unable to use the network so usually you want to default to not enabling this.
+# nonSvValidatorTrustSingleScan: true
+# TRUSTED_SINGLE_SCAN_END
 
-# scanClient denotes how the validator makes connections to scan service and supports three modes of operation.
-
-# Mode 1: bft (Byzantine Fault Tolerance)
-# Connects to all available scans in the network. It validates responses by ensuring
-# at least f+1 matching responses are received.
-
-# scanClient:
-#   scanType: "bft"
-#   seedUrls: ["TRUSTED_SCAN_URL"] # replace with scan seed url(s).  Supports multiple urls, separated by comma.
-
-# Mode 2: bft-custom
-# A specialized version of bft where you specify a subset of trusted SVs.
-# The validator connects only to the scans of the SVs listed in 'svNames'.
-# 'threshold' defines how many identical responses are required to consider the scan responses valid.
-
-# scanClient:
-#   scanType: "bft-custom"
-#   svNames: ["TRUSTED_SV"] # replace with trusted SV names(s)
-#   seedUrls: ["TRUSTED_SCAN_URL"] # replace with actual scan seed urls(s)
-#   threshold: <TRUST_THRESHOLD> # replace with the integer number of matching responses required for validation
-
-# Mode 3: trust-single
-# Connects to a single trusted scan address.
-# This means that you depend on that single SV and if it is broken or malicious you will be unable to use the network.
-# Hence, usually you want to default to not enabling this
-
-# scanClient:
-#   scanType: "trust-single"
-#   scanAddress: "TRUSTED_SCAN_URL" # replace with the trusted scan url
-
-# SCAN_CLIENT_CONFIGURATION_END
-
-# SYNCHRONIZER_CONFIGURATION_START
-synchronizer:
-  connectionType: "bft"
-
-# synchronizer configuration enables to configure how the validator's participant connects to the synchronizer.
-# synchronizer configuration has three modes of operation.
-
-# Mode 1: bft (Byzantine Fault Tolerance)
-# Uses all available synchronizer connections provided by the scan service.
-# Responses are validated against the network's f+1 fault tolerance logic.
-
-# synchronizer:
-#   connectionType: "bft"
-
-# Mode 2: bft-custom
-# Connects only to sequencers operated by the specific SVs listed in 'svNames'.
-# 'threshold' defines the minimum number of matching responses required for validation.
-
-# synchronizer:
-#   connectionType: "bft-custom"
-#   svNames: ["TRUSTED_SV"] # replace with trusted SV name(s)
-#   threshold: <TRUST_THRESHOLD> # replace with the integer number of matching responses required for validation
-
-# Mode 3: trust-Single
-# Connects to a single specified sequencer URL.
-# trust-single makes you dependent on a single SV; if it is malicious or down, you will be unable to use the network.
-
-#synchronizer:
-#   connectionType: "trust-single"
-#   url: "TRUSTED_SYNCHRONIZER_SEQUENCER_URL" # replace with the trusted synchronizer sequencer url
-
-# SYNCHRONIZER_CONFIGURATION_END
+# TRUSTED_SINGLE_SEQUENCER_START
+# If you want to configure validator to connect to a single trusted sequencer, set ``useSequencerConnectionsFromScan`` to false.
+# and replace ``TRUSTED_SYNCHRONIZER_SEQUENCER_URL`` with the publicly accessible URL of the trusted sequencer.
+# This does mean that you depend on that single SV and if it is broken or malicious you will be unable to use the network so usually you want to default to not enabling this.
+# decentralizedSynchronizerUrl: "TRUSTED_SYNCHRONIZER_SEQUENCER_URL"
+# useSequencerConnectionsFromScan: false
+# TRUSTED_SINGLE_SEQUENCER_END
 
 # Replace OPERATOR_WALLET_USER_ID with the user id in your IAM that you want to use to log into
 # the wallet as the SV party. Note that this should be the full user id, e.g., ``auth0|43b68e1e4978b000cefba352``

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1328,12 +1328,7 @@
             "memory": "2Gi"
           }
         },
-        "scanClient": {
-          "scanType": "bft",
-          "seedUrls": [
-            "http://scan-app.sv:5012"
-          ]
-        },
+        "scanAddress": "http://scan-app.sv:5012",
         "spliceInstanceNames": {
           "amuletName": "Amulet",
           "amuletNameAcronym": "AMT",
@@ -1343,9 +1338,6 @@
           "networkName": "Splice"
         },
         "svValidator": true,
-        "synchronizer": {
-          "connectionType": "bft"
-        },
         "tolerations": [
           {
             "effect": "NoSchedule",

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -788,9 +788,6 @@
           "networkName": "Splice"
         },
         "svSponsorAddress": "https://sv.sv-2.mock.global.canton.network.digitalasset.com",
-        "synchronizer": {
-          "connectionType": "bft"
-        },
         "tolerations": [
           {
             "effect": "NoSchedule",

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -221,9 +221,8 @@ async function installValidator(
         ? true
         : validatorValuesFromYamlFiles.migration.migrating,
     },
-    scanClient: validatorConfig.validatorApp?.scanClient ?? validatorValuesFromYamlFiles.scanClient,
-    synchronizer:
-      validatorConfig.validatorApp?.synchronizer ?? validatorValuesFromYamlFiles.synchronizer,
+    scanClient: validatorConfig.validatorApp?.scanClient,
+    synchronizer: validatorConfig.validatorApp?.synchronizer,
     metrics: {
       enable: true,
     },

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -162,14 +162,6 @@
 
     - Expose ``/v0/holdings/summary`` endpoint from scan proxy.
 
-    - Add support for custom fault-tolerance configurations for **scan** and **sequencer** connections.
-      Please see the updated :ref:`documentation for Helm-based deployments <helm-validator-install>`.
-      This introduces the new configuration keys ``scanClient`` and ``synchronizer`` as the new recommended way to configure **scan** and **sequencer** connections.
-      Existing configuration options ``scanAddress``, ``nonSvValidatorTrustSingleScan``, ``decentralizedSynchronizerUrl``, ``useSequencerConnectionsFromScan`` are still supported, but will be deprecated in a future release.
-      We recommend to migrate to the new ``scanClient`` and ``synchronizer`` configuration options as soon as possible.
-      Docker Compose-based deployments do not currently support the new custom configuration options.
-
-
 .. release-notes:: 0.5.6
 
   - Sequencer

--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -379,39 +379,32 @@ Additionally, please modify the file ``splice-node/examples/sv-helm/standalone-p
 
 To configure the validator app, please modify the file ``splice-node/examples/sv-helm/validator-values.yaml`` as follows:
 
-You need to configure how your validator connects to the network's **scan** services by defining a ``scanClient`` block in your ``validator-values.yaml``.
-There are three modes of ``scanClient``:
-
-- ``bft``: (default mode) connects to all scans and validates via majority agreement.
-- ``bft-custom``: connects to a specific list of trusted SVs and validates against a custom threshold. Replace ``TRUSTED_SV`` with the super validator name(s) you trust. Replace ``TRUST_THRESHOLD`` with an integer representing the number of scan responses that need to agree for a response to be considered valid.
-- ``trust-single``: connects to one specific trusted scan.
-
-
-For each scanClient type, replace ``TRUSTED_SCAN_URL`` with a URL of a Scan you host or trust that is reachable by your Validator. For example, the GSF scan URL, |gsf_scan_url|. For ``bft-custom`` and ``bft`` modes of ``scanClient``, you can specify more than one scan seed URL by separating them with commas.
-
-.. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/validator-values.yaml
-    :language: yaml
-    :start-after: SCAN_CLIENT_CONFIGURATION_START
-    :end-before: SCAN_CLIENT_CONFIGURATION_END
-
-
+- Replace ``TRUSTED_SCAN_URL`` with a URL of a Scan you host or trust that is reachable by your Validator. For example, the GSF scan URL, |gsf_scan_url|
+  (This Scan instance will be used for obtaining additional Scan URLs for BFT Scan reads.)
 - If you want to configure the audience for the Validator app backend API, replace ``OIDC_AUTHORITY_VALIDATOR_AUDIENCE`` in the `auth.audience` entry with audience for the Validator app backend API. e.g. ``https://validator.example.com/api``.
 - If you want to configure the audience for the Ledger API, set the ``audience`` field in the `splice-app-validator-ledger-api-auth` k8s secret with the audience for the Ledger API. e.g. ``https://ledger_api.example.com``.
 - Replace ``OPERATOR_WALLET_USER_ID`` with the user ID in your IAM that you want to use to log into the wallet as the validator operator party. Note that this should be the full user id, e.g., ``auth0|43b68e1e4978b000cefba352``, *not* only the suffix ``43b68e1e4978b000cefba352``
 - Replace ``YOUR_CONTACT_POINT`` by a slack user name or email address that can be used by node operators to contact you in case there are issues with your node. Note that this contact information will be publicly visible. If you do not want to share contact information, you can put an empty string.
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing ``OIDC_AUTHORITY_URL`` with your auth provider's OIDC URL, as explained above.
 
-You need to configure how your validator's participant connects to **sequencers** by defining a ``synchronizer`` config in your ``validator-values.yaml``.
-``synchronizer`` supports three modes of operation:
-
-- ``bft``:  (default mode) connects to all available sequencers and validates responses via majority agreement.
-- ``bft-custom``: connects only to specific sequencers from your trusted ``svNames`` using a custom ``threshold``. Replace ``TRUSTED_SV`` with the super validator name(s) you trust. Replace ``TRUST_THRESHOLD`` with an integer representing the number of sequencer responses that need to agree for a response to be considered valid.
-- ``trust-single``: connects to one specific url. Replace ``TRUSTED_SYNCHRONIZER_SEQUENCER_URL`` with the URL of the sequencer you trust.
+If you want to only connect to a single trusted scan at ``TRUSTED_SCAN_URL`` but not obtain additional Scan URLs for BFT Scan reads,
+you can uncomment the following and set ``nonSvValidatorTrustSingleScan`` to ``true``.
+This does mean that you depend on that single SV and if it is broken or malicious you will be unable to use the network so usually you want to default to not enabling this.
 
 .. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/validator-values.yaml
     :language: yaml
-    :start-after: SYNCHRONIZER_CONFIGURATION_START
-    :end-before: SYNCHRONIZER_CONFIGURATION_END
+    :start-after: TRUSTED_SINGLE_SCAN_START
+    :end-before: TRUSTED_SINGLE_SCAN_END
+
+If you want to connect to the decentralized synchronizer via only a single trusted sequencer,
+you can uncomment the following and set ``useSequencerConnectionsFromScan`` to ``false``. Also replace ``TRUSTED_SYNCHRONIZER_SEQUENCER_URL`` with the publicly accessible URL of the trusted sequencer,
+e.g., |gsf_sequencer_url| for the sequencer operated by the GSF.
+This does mean that you depend on that single SV and if it is broken or malicious you will be unable to use the network so usually you want to default to not enabling this.
+
+.. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/validator-values.yaml
+    :language: yaml
+    :start-after: TRUSTED_SINGLE_SEQUENCER_START
+    :end-before: TRUSTED_SINGLE_SEQUENCER_END
 
 Additionally, please modify the file ``splice-node/examples/sv-helm/standalone-validator-values.yaml`` as follows:
 


### PR DESCRIPTION
…s of Validator Scan and Sequencer connections"

This reverts commit 64b1ee04680a0b4f13cc6396200014e5b3dd633d.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/7056

cluster deployments are failing on main with:
```
GENERIC_CONFIG_ERROR(8,0): Cannot convert configuration to a config of class org.lfdecentralizedtrust.splice.config.SpliceConfig. Failures are:
  at 'canton.validator-apps.validator_backend.scan-client.url':
    - (env variables) Empty string found when trying to convert to org.apache.pekko.http.scaladsl.model.Uri.
```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
