### PR TITLE
fix labels in GHA runner images

### DIFF
--- a/cluster/images/splice-test-docker-runner/Dockerfile
+++ b/cluster/images/splice-test-docker-runner/Dockerfile
@@ -4,6 +4,9 @@ ARG RUNNER_DIGEST=sha256:ee54ad8776606f29434f159196529b7b9c83c0cb9195c1ff5a7817e
 # Note that we don't currently support arm64 runners, so we build this only for amd64
 FROM --platform=$BUILDPLATFORM ghcr.io/actions/actions-runner:${RUNNER_VERSION}@${RUNNER_DIGEST}
 
+# required to get the org.opencontainers.image.base.name label to render correctly
+ARG RUNNER_VERSION
+
 LABEL org.opencontainers.image.base.name="ghcr.io/actions/actions-runner:${RUNNER_VERSION}"
 #Ideally, we'd reduce duplication between this and splice-test-ci, but we're not tackling that right now
 

--- a/cluster/images/splice-test-runner-hook/Dockerfile
+++ b/cluster/images/splice-test-runner-hook/Dockerfile
@@ -4,6 +4,9 @@ ARG RUNNER_DIGEST=sha256:ee54ad8776606f29434f159196529b7b9c83c0cb9195c1ff5a7817e
 # Note that we don't currently support arm64 runners, so we build this only for amd64
 FROM --platform=$BUILDPLATFORM ghcr.io/actions/actions-runner:${RUNNER_VERSION}@${RUNNER_DIGEST}
 
+# required to get the org.opencontainers.image.base.name label to render correctly
+ARG RUNNER_VERSION
+
 LABEL org.opencontainers.image.base.name="ghcr.io/actions/actions-runner:${RUNNER_VERSION}"
 
 COPY target/index.js /home/runner/k8s/index.js


### PR DESCRIPTION
More on why this was needed can be found [here](https://docs.docker.com/build/building/variables/#scoping).