### PR TITLE
add config resolution to the _update_cluster_config script

### DIFF
--- a/build-tools/lib/pulumi-helpers
+++ b/build-tools/lib/pulumi-helpers
@@ -177,4 +177,5 @@ function _update_cluster_config() {
   tmp_file=$(mktemp)
   echo "$yaml_content" > "$tmp_file"
   yq eval-all --inplace ".${field} = load(\"${tmp_file}\")" "$file"
+  "${SPLICE_ROOT}/cluster/scripts/resolve-config.sh"
 }

--- a/cluster/scripts/get-resolved-config.sh
+++ b/cluster/scripts/get-resolved-config.sh
@@ -17,11 +17,7 @@ fi
 resolved_config_file="$cluster_dir/config.resolved.yaml"
 # if we are not in CI we might have some local config changes and the resolved config was not yet updated
 if [ -z "${CI:-}" ]; then
-  # resolve make parameters to allow running both for splice and internal clusters
-  make_directory="${cluster_dir}/../../.."
-  resolved_config_target="$(realpath --no-symlinks --relative-to "$make_directory" "$resolved_config_file")"
-  # make resolved config to apply local config changes
-  make --directory "$make_directory" "$resolved_config_target" > /dev/null
+  "${SPLICE_ROOT}/cluster/scripts/resolve-config.sh"
 fi
 
 # using resolved config to avoid duplicating config loader implementation

--- a/cluster/scripts/resolve-config.sh
+++ b/cluster/scripts/resolve-config.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+# Updates the resolved config for the current cluster which is specified either with TARGET_CLUSTER
+# or the current working directory.
+
+if [ -z "${TARGET_CLUSTER-}" ]; then
+  cluster_dir="."
+else
+  cluster_dir="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}"
+fi
+resolved_config_file="$cluster_dir/config.resolved.yaml"
+
+# resolve make parameters to allow running both for splice and internal clusters
+make_directory="${cluster_dir}/../../.."
+resolved_config_target="$(realpath --no-symlinks --relative-to "$make_directory" "$resolved_config_file")"
+# make resolved config to apply local config changes
+make --directory "$make_directory" "$resolved_config_target" > /dev/null


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7065

The problem that these changes solve was that CI in some cases does indeed modify the config and later reads the field that it modified. So the assumption in `get-resolved-config.sh` the config resolution in CI can be skipped was wrong. The proposed fix extends the config modification command with immediate config resolution.