### PR TITLE
grafana: Add Grafana dashboards check to pre-commit

### DIFF
--- a/.github/workflows/build.static_tests.yml
+++ b/.github/workflows/build.static_tests.yml
@@ -35,6 +35,11 @@ jobs:
           test_name: static_tests
           target: 'static_tests'
 
+      - name: Check Grafana Dashboards
+        uses: ./.github/actions/nix/run_bash_command_in_nix
+        with:
+          cmd: ./scripts/check-grafana-dashboards.sh
+
       - name: Check trailing whitespace
         uses: ./.github/actions/nix/run_bash_command_in_nix
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,11 @@ repos:
         entry: "./scripts/check-daml-return-types.sh"
         pass_filenames: false
         always_run: true
+      - id: check-grafana-dashboards
+        name: Check Grafana Dashboards
+        language: script
+        entry: "./scripts/check-grafana-dashboards.sh"
+        files: 'cluster/pulumi/infra/grafana-dashboards/.*\.json'
   -  repo: https://github.com/rstcheck/rstcheck
      rev: v6.2.5
      hooks:

--- a/scripts/check-grafana-dashboards.sh
+++ b/scripts/check-grafana-dashboards.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# check-grafana-dashboards.sh
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [dashboard_file ...]"
+  echo ""
+  echo "Check and update Grafana dashboard JSON files to ensure they meet the required standards."
+  echo
+  echo "Positional arguments:"
+  echo "  dashboard_file    One or more paths to Grafana dashboard JSON files to check."
+  echo "                    If no files are provided, all dashboard files in the default directory will be checked."
+}
+
+check_grafana_dashboards() {
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  dashboard_dir="$script_dir/../cluster/pulumi/infra/grafana-dashboards"
+
+  if [[ $# -gt 0 ]]; then
+    dashboard_files=("$@")
+  else
+    IFS=$'\n' read -d '' -ra \
+      dashboard_files < <(
+        git ls-files -- "$dashboard_dir/*.json"
+        printf '\0'
+      )
+  fi
+
+  changed=false
+
+  for dashboard_file in "${dashboard_files[@]}"; do
+    dashboard_data=$(jq . "$dashboard_file")
+
+    dashboard_data_modified=$(
+      echo "$dashboard_data" | jq '
+        .timezone = "" # Reset timezone to default
+      '
+    )
+
+    if [[ $dashboard_data != "$dashboard_data_modified" ]]; then
+      echo "Updating dashboard: $dashboard_file" >&2
+      echo "$dashboard_data_modified" > "$dashboard_file"
+      changed=true
+    fi
+  done
+
+  if [[ $changed == true ]]; then
+    if [[ ${CI-} == true ]]; then
+      echo "ERROR: Some dashboards needed changes." >&2
+      git diff --color=always "$dashboard_dir" >&2
+      echo "INFO: Please run '$0' locally and commit the changes." >&2
+    fi
+
+    return 1
+  fi
+}
+
+main() {
+  if [[ $# -gt 0 && ( $1 == "-h" || $1 == "--help" ) ]]; then
+    usage
+    exit 0
+  fi
+
+  check_grafana_dashboards "$@"
+}
+
+main "$@"


### PR DESCRIPTION
This check verifies Grafana dashboards and updates them if necessary.
There is only one check at this point:
- timezone is set to default

More checks can be added later if needed.

The check runs from:
- pre-commit hook for changed dashboard files
- CI for all dashboard files