### PR TITLE
Add random_page_cost flag to cloudsql in pulumi

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1341,12 +1341,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2273,12 +2273,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -653,12 +653,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -795,12 +795,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -865,12 +865,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1994,12 +1994,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2065,12 +2065,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2136,12 +2136,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2207,12 +2207,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2278,12 +2278,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2349,12 +2349,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2420,12 +2420,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2591,12 +2591,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2762,12 +2762,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2833,12 +2833,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2904,12 +2904,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -2975,12 +2975,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4264,12 +4264,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4335,12 +4335,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4406,12 +4406,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4477,12 +4477,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4548,12 +4548,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4619,12 +4619,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4690,12 +4690,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -4886,12 +4886,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -5082,12 +5082,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -5153,12 +5153,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -5224,12 +5224,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -5295,12 +5295,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -5998,12 +5998,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6069,12 +6069,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6140,12 +6140,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6211,12 +6211,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6282,12 +6282,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6353,12 +6353,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6424,12 +6424,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6595,12 +6595,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6766,12 +6766,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6837,12 +6837,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6908,12 +6908,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,
@@ -6979,12 +6979,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": false,

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -718,12 +718,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,
@@ -855,12 +855,12 @@
         },
         "databaseFlags": [
           {
-            "name": "temp_file_limit",
-            "value": "2147483647"
-          },
-          {
             "name": "random_page_cost",
             "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
         ],
         "deletionProtectionEnabled": true,

--- a/cluster/pulumi/common/src/config/cloudSql.ts
+++ b/cluster/pulumi/common/src/config/cloudSql.ts
@@ -14,7 +14,10 @@ export const CloudSqlConfigSchema = z.object({
   protected: z.boolean(),
   tier: z.string(),
   enterprisePlus: z.boolean(),
-  flags: z.record(z.string()).default({}),
+  flags: z.record(z.string()).default({
+    random_page_cost: '1.1',
+    temp_file_limit: '2147483647',
+  }),
   // https://cloud.google.com/sql/docs/mysql/backup-recovery/backups#retained-backups
   // controls the number of automated gcp sql backups to retain
   backupsToRetain: z.number().optional(),


### PR DESCRIPTION
This is already manually applied to mainnet (where it matters), so I'd say we don't need to expedite it's deployment.

Two notes:
- It's now the default for all apps (not just sequencer). Shout if you disagree
- It's made configurable just in case things break, though I find that unlikely