### PR TITLE
docs: Fix giscus comments after org renaming

### DIFF
--- a/docs/src/_templates/page.html
+++ b/docs/src/_templates/page.html
@@ -4,7 +4,7 @@
 <section id="comments">
   <h2>Comments<a class="headerlink" href="#comments"></a></h2>
   <script src="https://giscus.app/client.js"
-    data-repo="global-synchronizer-foundation/docs"
+    data-repo="canton-foundation/docs"
     data-repo-id="R_kgDONbkPcQ"
     data-category="comments-for-docs"
     data-category-id="DIC_kwDONbkPcc4Cnaia"


### PR DESCRIPTION
global-synchronizer-foundation has been renamed to canton-foundation