### PR TITLE
Add daml2js to static_test nix def

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -116,6 +116,7 @@ let
     actionlint
     ammonite
     curl
+    daml2js
     git
     hub # Github CLI for todo checker
     jq


### PR DESCRIPTION
See
https://github.com/hyperledger-labs/splice/actions/runs/21668800038/job/62471631981?pr=3822 for an example where it failed because we don't have it. I don't fully understand why it's non-deterministic but my guess is if another job runs on the same node first that does pull it it may work.

[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/7118



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
