### PR TITLE
Backport Add daml2js to static_test nix def

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -116,6 +116,7 @@ let
     actionlint
     ammonite
     curl
+    daml2js
     git
     hub # Github CLI for todo checker
     jq


### PR DESCRIPTION
Manual backport of https://github.com/hyperledger-labs/splice/pull/3829, broken static tests on the most recent release line are annoying.