### PR TITLE
Make sbt actions reusable between repos in backwards compatible way

### DIFF
--- a/.github/actions/sbt/execute_sbt_command/action.yml
+++ b/.github/actions/sbt/execute_sbt_command/action.yml
@@ -41,6 +41,9 @@ inputs:
     description: "Whether to fail if the SBT command output contains errors"
     required: false
     default: "true"
+  splice_root:
+    description: "Path to splice repo"
+    default: ${{ github.repository == 'hyperledger-labs/splice' && '.' || 'splice' }}
 
 runs:
   using: 'composite'
@@ -48,7 +51,7 @@ runs:
     - name: Execute SBT command"
       uses: ./.github/actions/nix/run_bash_command_in_nix
       with:
-        additional_nix_args: "--keep ARTIFACTORY_USER --keep ARTIFACTORY_PASSWORD ${{ inputs.additional_nix_args }}"
+        additional_nix_args: "--keep GITHUB_ACTION_PATH --keep ARTIFACTORY_USER --keep ARTIFACTORY_PASSWORD ${{ inputs.additional_nix_args }}"
         cmd: |
             # This might help resolve https://github.com/DACH-NY/canton-network-node/issues/8146
             export PROTOCBRIDGE_NO_CLEANUP="1"
@@ -82,11 +85,22 @@ runs:
               echo "After SBT"
 
               if [[ "${{ inputs.fail_on_error_in_output }}" == "true" ]]; then
-                .github/actions/scripts/check-sbt-output.sh "sbt_output"
+                # Note that we're using GITHUB_ACTION_PATH 
+                # because of a GHA bug - using ${{ github.action_path }} won't work
+                # https://github.com/actions/runner/issues/2185#issuecomment-1750670864
+                $GITHUB_ACTION_PATH/../../scripts/check-sbt-output.sh "sbt_output"
               fi
             }
             export ARTIFACTORY_USER="${{ inputs.artifactory_user }}"
             export ARTIFACTORY_PASSWORD="${{ inputs.artifactory_password }}"
+
+            # Ensure that we're in the root of splice before execution
+            pushd ${{ inputs.splice_root }} &> /dev/null
+
             ${{ inputs.pre_sbt_cmd }}
             run_sbt
             ${{ inputs.post_sbt_cmd }}
+
+            # Move back to the original directory
+            # || true because if we did a pushd . before the stack is considered to be empty
+            popd &> /dev/null || true

--- a/.github/actions/sbt/post_sbt/action.yml
+++ b/.github/actions/sbt/post_sbt/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: "If set to false, no caches will be saved"
     required: false
     default: "true"
+  splice_root:
+    description: "Path to splice repo"
+    default: ${{ github.repository == 'hyperledger-labs/splice' && '.' || 'splice' }}
 
 runs:
   using: 'composite'
@@ -21,6 +24,7 @@ runs:
       with:
         cache_version: ${{ inputs.cache_version }}
         load_cache_hit: ${{ fromJson(inputs.setup_sbt_cache_hits).classes }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Store SBT Cache
       if: ${{ fromJson(inputs.save_caches) }}
@@ -28,6 +32,7 @@ runs:
       with:
         cache_version: ${{ inputs.cache_version }}
         load_cache_hit: ${{ fromJson(inputs.setup_sbt_cache_hits).sbt }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Store frontend node_modules
       if: ${{ fromJson(inputs.save_caches) }}
@@ -35,6 +40,7 @@ runs:
       with:
         cache_version: ${{ inputs.cache_version }}
         load_cache_hit: ${{ fromJson(inputs.setup_sbt_cache_hits).node_modules }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Store Daml artifacts
       if: ${{ fromJson(inputs.save_caches) }}
@@ -42,13 +48,14 @@ runs:
       with:
         cache_version: ${{ inputs.cache_version }}
         load_cache_hit: ${{ fromJson(inputs.setup_sbt_cache_hits).daml }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Collect test reports
       shell: bash
       run: |
         sudo mkdir -p /cache/test-reports
         sudo chown $(whoami):$(whoami) "/cache/test-reports"
-        for subproject in `find . -path "*/target/test-reports" | sed -e 's/^\.\///' -e 's/\/target\/test-reports$//'`
+        for subproject in `find ${{ inputs.splice_root }} -path "*/target/test-reports" | sed -e 's/^\.\///' -e 's/\/target\/test-reports$//'`
         do
           # `|| true` to avoid failing if there are no test reports
           cp -v "$subproject"/target/test-reports/TEST-*.xml /cache/test-reports/ || true

--- a/.github/actions/sbt/setup_sbt/action.yml
+++ b/.github/actions/sbt/setup_sbt/action.yml
@@ -4,6 +4,9 @@ inputs:
   cache_version:
     description: "Version of the cache"
     required: true
+  splice_root:
+    description: "Path to splice repo"
+    default: ${{ github.repository == 'hyperledger-labs/splice' && '.' || 'splice' }}
 outputs:
   cache_hits:
     description: "Cache hits"
@@ -23,24 +26,28 @@ runs:
       uses: ./.github/actions/cache/precompiled_classes/restore
       with:
         cache_version: ${{ inputs.cache_version }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Restore SBT cache
       id: sbt
       uses: ./.github/actions/cache/sbt/restore
       with:
         cache_version: ${{ inputs.cache_version }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Restore frontend node_modules
       id: frontend_node_modules
       uses: ./.github/actions/cache/frontend_node_modules/restore
       with:
         cache_version: ${{ inputs.cache_version }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Restore Daml artifacts
       id: daml
       uses: ./.github/actions/cache/daml_artifacts/restore
       with:
         cache_version: ${{ inputs.cache_version }}
+        splice_root: ${{ inputs.splice_root }}
 
     - name: Collect cache hits
       id: cache_hits

--- a/.github/actions/sbt/upload_logs/action.yml
+++ b/.github/actions/sbt/upload_logs/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: "Name of the artifact"
     required: false
     default: log
+  splice_root:
+    description: "Path to splice repo"
+    default: ${{ github.repository == 'hyperledger-labs/splice' && '.' || 'splice' }}
 
 runs:
   using: 'composite'
@@ -19,7 +22,7 @@ runs:
       run: |
         if [[ -d log ]]; then
           # pigz fails if there is no file to compress, which can be the case if Canton just rolled its logs
-          pigz -r log/* || true
+          pigz -r ${{ inputs.splice_root }}/log/* || true
         fi
 
     - name: Move potential additional debugging artifacts to log directory
@@ -27,9 +30,9 @@ runs:
       run: |
         mkdir -p log
         # When Java crashes, it sometimes saves an error report such as hs_err_pid*.log to the working directory.
-        mv *.log log/ || true
+        mv ${{ inputs.splice_root }}/*.log log/ || true
         # Possible locations of core dumps (/ is apparently a default, but who knows)
-        mv core* log/ || true
+        mv ${{ inputs.splice_root }}/core* log/ || true
         mv /core* log/ || true
 
     # Certain characters are disallowed in artifact filenames in GHA, so we need to sanitize them
@@ -38,13 +41,13 @@ runs:
       uses: ./.github/actions/nix/run_bash_command_in_nix
       with:
         cmd: |
-          rename -a : . log/* || true
+          rename -a : . ${{ inputs.splice_root }}/log/* || true
 
     - name: Upload logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
-        path: log
+        path: '${{ inputs.splice_root }}/log'
 
     - name: Upload runner logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/3469

Make sbt actions reusable between repos in backwards compatible way.

This PR makes sure that both splice and internal repo can use those actions with the same arguments transparently while giving an option to a third party user to use them independently of our usage.

### Pull Request Checklist

#### Cluster Testing
- [x] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [x] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [x] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
