### PR TITLE
Disable traffic topups in multi host validator operator test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
@@ -20,6 +20,9 @@ class MultiHostValidatorOperatorIntegrationTest
       .simpleTopology1Sv(this.getClass.getSimpleName)
       // TODO(#979) Consider removing this once domain config updates are less disruptive to carefully-timed batching tests.
       .withSequencerConnectionsFromScanDisabled()
+      // Disable traffic topups as they can end up failing if we disconnect the node at the same time
+      // which then results in record order publishing issues on SV1's participant.
+      .withTrafficTopupsDisabled
 
   "validator operator can be multi-hosted and work with transfer preapprovals" in { implicit env =>
     val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7184

See issue for detailed writeup of why it breaks. Disabling traffic topups is a bit of a crude solution but we do that in a bunch of places so seems fine.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
