### PR TITLE
enable topology cache by default

### DIFF
--- a/cluster/images/canton-mediator/additional-config.conf
+++ b/cluster/images/canton-mediator/additional-config.conf
@@ -1,4 +1,8 @@
 # Configurations here will be applied after app.conf, and before any ADDITIONAL_CONFIG env vars
 # Please use this file for temporary changes that require quick iterations. Once made permanent,
 # please upstream the change to the Canton repo.
-
+canton.mediators.mediator.topology {
+    enable-topology-state-cache-consistency-checks = false
+    use-new-processor = true
+    use-new-client = true
+}

--- a/cluster/images/canton-participant/additional-config.conf
+++ b/cluster/images/canton-participant/additional-config.conf
@@ -2,3 +2,8 @@
 # Please use this file for temporary changes that require quick iterations. Once made permanent,
 # please upstream the change to the Canton repo.
 
+canton.participants.participant.topology {
+    enable-topology-state-cache-consistency-checks = false
+    use-new-processor = true
+    use-new-client = true
+}

--- a/cluster/images/canton-sequencer/additional-config.conf
+++ b/cluster/images/canton-sequencer/additional-config.conf
@@ -2,3 +2,8 @@
 # Please use this file for temporary changes that require quick iterations. Once made permanent,
 # please upstream the change to the Canton repo.
 
+canton.sequencers.sequencer.topology {
+    enable-topology-state-cache-consistency-checks = false
+    use-new-processor = true
+    use-new-client = true
+}


### PR DESCRIPTION
this basically keeps the existing behavior 

canton disabled it now by default to reflect the release notes, but it should be enabled actually, so to avoid another round of back and forward we just keep the current behavior but enabling it on our side

[ci]

https://github.com/hyperledger-labs/splice/issues/3849

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
