### PR TITLE
vagrant: Fetch package index files first

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", name: "system", upload_path: "/tmp/vagrant-shell-system", reset: true do |s|
     s.inline = shell_variables + shell_common + shell_helpers + <<~'SHELL'
+      apt-get update
+
       apt-get install -y \
         bash-completion \
         command-not-found \


### PR DESCRIPTION
Package index files have to be refreshed before installing packages to avoid 404s.