### PR TITLE
Fix `bootstrap-canton-with-unsigned-keys.sc` after recent Canton bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,6 +345,7 @@ jobs:
     - scala_test_record_time_tolerance
     - scala_test_disaster_recovery
     - scala_test_with_cometbft
+    - scala_test_signatures
     - scala_test_wall_clock_time
     - scala_test_permissioned_canton
     - scala_test_frontend_wall_clock_time

--- a/scripts/bootstrap/bootstrap-canton-with-unsigned-keys.sc
+++ b/scripts/bootstrap/bootstrap-canton-with-unsigned-keys.sc
@@ -71,7 +71,7 @@ def bootstrapDomainWithUnsignedKeys(
   val synchronizerId = SynchronizerId(
     UniqueIdentifier.tryCreate(synchronizerName, synchronizerNamespace)
   )
-  val physicalSynchronizerId = PhysicalSynchronizerId(synchronizerId, ProtocolVersion.v34, NonNegativeInt.zero)
+  val physicalSynchronizerId = PhysicalSynchronizerId(synchronizerId, NonNegativeInt.zero, ProtocolVersion.v34)
 
   val tempStoreForBootstrap = synchronizerOwners
     .map(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7319

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
