### PR TITLE
Change dependabot config to create less PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,28 @@ updates:
       - "static"
     commit-message:
       prefix: "[ci] "
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    # minor and patch version upgrades get pulled into a single PR
+    # major versions create PRs one by one (for easier resolution)
+    groups: 
+      production-dependencies:
+        IDENTIFIER: "pulumi-production-dependencies"
+        dependency-type: "production"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        IDENTIFIER: "pulumi-development-dependencies"
+        dependency-type: "development"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/load-tester"
     schedule:
@@ -24,6 +46,28 @@ updates:
       - "static"
     commit-message:
       prefix: "[ci] "
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    # minor and patch version upgrades get pulled into a single PR
+    # major versions create PRs one by one (for easier resolution)
+    groups:
+      production-dependencies:
+        IDENTIFIER: "load-tester-production-dependencies"
+        dependency-type: "production"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        IDENTIFIER: "load-tester-development-dependencies"
+        dependency-type: "development"
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/" # For GitHub Actions '/' means .github/workflows/**/*.{yaml,yml}
     # Check for updates to GitHub Actions every week


### PR DESCRIPTION
Note that this does not change anything for security updates, which still will create PRs as is.

### Pull Request Checklist

#### Cluster Testing
- [x] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [x] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [x] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
