### PR TITLE
Set autovacuum and autoanalyze settings for common_sequenced_events

### DIFF
--- a/cluster/images/canton-participant/Dockerfile
+++ b/cluster/images/canton-participant/Dockerfile
@@ -7,6 +7,7 @@ ARG image_sha256
 FROM europe-docker.pkg.dev/da-images/public-all/docker/canton-participant:${canton_version}@${image_sha256}
 
 COPY additional-config.conf /app/
+COPY R__repeatable-migration.sql /app/
 USER root
 RUN chown -R nonroot:nonroot /app/additional-config.conf
 USER nonroot

--- a/cluster/images/canton-participant/R__repeatable-migration.sql
+++ b/cluster/images/canton-participant/R__repeatable-migration.sql
@@ -1,0 +1,12 @@
+-- Tweak autoanalze and vacuum settings to make sure it kicks in reasonably quickly after pruning.
+alter table common_sequenced_events
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );

--- a/cluster/images/canton-participant/local.mk
+++ b/cluster/images/canton-participant/local.mk
@@ -4,4 +4,4 @@
 dir := $(call current_dir)
 
 $(dir)/$(docker-build): build_arg := --build-arg canton_version=${CANTON_VERSION} --build-arg image_sha256=${CANTON_PARTICIPANT_IMAGE_SHA256}
-
+$(dir)/$(docker-build): $(dir)/additional-config.conf $(dir)/R__repeatable-migration.sql


### PR DESCRIPTION
[ci]

Didn't do a super comprehensive check for what other tables may matter but this was the only one we actually saw issues with so seems good enough for enabling pruning for SVs. Worst case we can easily overwrite it now without a new release.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
