### PR TITLE
Enable and document pruning for SV participants

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/sv-validator-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/sv-validator-values.yaml
@@ -20,3 +20,10 @@ topup:
 scanClient:
   scanType: "trust-single"
   scanAddress: "TRUSTED_SCAN_URL"
+
+# SV_PARTICIPANT_PRUNING_SCHEDULE_START
+participantPruningSchedule:
+  cron: 0 /10 * * * ? # Run every 10min
+  maxDuration: 5m # Run for a max of 5min per iteration
+  retention: 30d # Retain history that is newer than 30d.
+# SV_PARTICIPANT_PRUNING_SCHEDULE_END

--- a/cluster/deployment/config.yaml
+++ b/cluster/deployment/config.yaml
@@ -171,6 +171,11 @@ svs:
     pruning:
       sequencer:
         enabled: false
+      participant:
+        enabled: true
+        cron: '0 /10 * * * ?'
+        maxDuration: 5m
+        retentionPeriod: 30d
     participant:
       bftSequencerConnection: true
       resources:
@@ -178,6 +183,10 @@ svs:
           memory: '12Gi'
         limits:
           memory: '18Gi'
+      additionalEnvVars:
+        - name: ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS
+          value: |
+            canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = "all"
     validatorApp:
       additionalEnvVars:
         # enable https://github.com/hyperledger-labs/splice/pull/2499

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -154,6 +154,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     participant:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS'
+          value: "canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
       bftSequencerConnection: true
       resources:
         limits:
@@ -164,6 +167,11 @@ svs:
     pruning:
       cometbft:
         retainBlocks: 2000
+      participant:
+        cron: '0 /10 * * * ?'
+        enabled: true
+        maxDuration: '5m'
+        retentionPeriod: '30d'
       sequencer:
         enabled: false
     scanApp:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -154,6 +154,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     participant:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS'
+          value: "canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
       bftSequencerConnection: true
       resources:
         limits:
@@ -164,6 +167,11 @@ svs:
     pruning:
       cometbft:
         retainBlocks: 2000
+      participant:
+        cron: '0 /10 * * * ?'
+        enabled: true
+        maxDuration: '5m'
+        retentionPeriod: '30d'
       sequencer:
         enabled: false
     scanApp:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -154,6 +154,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     participant:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS'
+          value: "canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
       bftSequencerConnection: true
       resources:
         limits:
@@ -164,6 +167,11 @@ svs:
     pruning:
       cometbft:
         retainBlocks: 2000
+      participant:
+        cron: '0 /10 * * * ?'
+        enabled: true
+        maxDuration: '5m'
+        retentionPeriod: '30d'
       sequencer:
         enabled: false
     scanApp:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -154,6 +154,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     participant:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS'
+          value: "canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
       bftSequencerConnection: true
       resources:
         limits:
@@ -164,6 +167,11 @@ svs:
     pruning:
       cometbft:
         retainBlocks: 2000
+      participant:
+        cron: '0 /10 * * * ?'
+        enabled: true
+        maxDuration: '5m'
+        retentionPeriod: '30d'
       sequencer:
         enabled: false
     scanApp:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -154,6 +154,9 @@ svs:
           cpu: '1'
           memory: '2Gi'
     participant:
+      additionalEnvVars:
+        - name: 'ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS'
+          value: "canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
       bftSequencerConnection: true
       resources:
         limits:
@@ -164,6 +167,11 @@ svs:
     pruning:
       cometbft:
         retainBlocks: 2000
+      participant:
+        cron: '0 /10 * * * ?'
+        enabled: true
+        maxDuration: '5m'
+        retentionPeriod: '30d'
       sequencer:
         enabled: false
     scanApp:

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2094,6 +2094,10 @@
           {
             "name": "ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT",
             "value": "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
+          },
+          {
+            "name": "ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+            "value": "canton.validator-apps.validator_backend.participant-pruning-schedule {\n                    cron = \"0 /10 * * * ?\"\n                    max-duration = \"5m\"\n                    retention = \"30d\"\n                  }"
           }
         ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1260,6 +1260,10 @@
           {
             "name": "ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT",
             "value": "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
+          },
+          {
+            "name": "ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
+            "value": "canton.validator-apps.validator_backend.participant-pruning-schedule {\n                    cron = \"0 /10 * * * ?\"\n                    max-duration = \"5m\"\n                    retention = \"30d\"\n                  }"
           }
         ],
         "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
@@ -1314,6 +1318,11 @@
             },
             "prefix": "mock/sv"
           }
+        },
+        "participantPruningSchedule": {
+          "cron": "0 /10 * * * ?",
+          "maxDuration": "5m",
+          "retention": "30d"
         },
         "persistence": {
           "host": "apps-pg.sv.svc.cluster.local",

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -9,6 +9,13 @@
 
 .. release-notes:: Upcoming
 
+    - SV Participant
+
+      - Participant pruning for super validators is now supported and
+        recommended. Follow the :ref:`documentation
+        <sv_participant_pruning>` for instructions on how to enable
+        it.
+
     - Canton
 
       - JSON Ledger API OpenAPI/AsyncAPI Specification Updates

--- a/docs/src/sv_operator/sv_pruning.rst
+++ b/docs/src/sv_operator/sv_pruning.rst
@@ -8,7 +8,7 @@
 Pruning
 =======
 
-The sequencer and CometBFT have pruning options that can be used to ensure storage use is kept within reasonable bounds.
+The sequencer, participant and CometBFT have pruning options that can be used to ensure storage use is kept within reasonable bounds.
 
 Pruning can also be configured for the participant, but we don't currently recommend enabling it for the SVs.
 
@@ -42,3 +42,26 @@ The number of blocks to keep can be configured under the `node` helm values key.
     :language: yaml
     :start-after: DOCS_COMETBFT_PRUNING_START
     :end-before: DOCS_COMETBFT_PRUNING_END
+
+.. _sv_participant_pruning:
+
+Participant pruning
+-------------------
+
+Participant pruning is also supported and recommend. To enable it, set the following helm value on your validator chart:
+
+.. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/sv-validator-values.yaml
+    :language: yaml
+    :start-after: SV_PARTICIPANT_PRUNING_SCHEDULE_START
+    :end-before: SV_PARTICIPANT_PRUNING_SCHEDULE_END
+
+You also need to tell the participant to continue pruning even if it has not received an ACS commitment from one of its counter participant
+in the last 30 days. Without this pruning will essentially never run on mainnet as validators get shut down relatively frequently:
+To do so, set the following through the ``additionalEnvVars`` on your participant:
+
+.. code-block:: yaml
+
+    additionalEnvVars:
+        - name: ADDITIONAL_CONFIG_PRUNING_ACS_COMITMENTS
+          value: |
+            canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = "all"


### PR DESCRIPTION
[ci]

Couldn't get agreement to enable the force pruning for all participants by default and we don't have a great way to enable it just for participants. So for now it's just a bunch of docs which honestly seems fine given that the impact of someone not pruning is fairly limited.

fixes #2472



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
