### PR TITLE
Bump sequencer `payload-queue-size` and cometbft mempool defaults

### DIFF
--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -101,7 +101,7 @@ enableAntiAffinity: true
 logLevel: info
 mempool:
   # max number of transactions kept in the mempool
-  size: 2000
+  size: 4000
   # number of transactions to keep to deduplicate new transactions
   deduplicationCacheSize: 200000
   # max number of seconds that a transaction will be kept in the mempool without being included in a block before being discarded

--- a/cluster/images/canton-sequencer/additional-config.conf
+++ b/cluster/images/canton-sequencer/additional-config.conf
@@ -12,4 +12,6 @@ canton.sequencers.sequencer {
     confirmation-request.strict = false
     topology.strict = false
   }
+  #TODO(DACH-NY/cn-test-failures#7365) Remove once upstreamed
+  sequencer.block.writer.payload-queue-size = 5000
 }


### PR DESCRIPTION
[static]

Part of https://github.com/DACH-NY/cn-test-failures/issues/7365

Notably the mempool change is not new - SVs already set that value on MainNet.

Fill follow up to upstream the config change.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
