### PR TITLE
Retry various API calls in preflights

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
@@ -258,23 +258,29 @@ abstract class RunbookSvPreflightIntegrationTestBase
     val svScanClient = scancl("svTestScan")
     val sv1ScanClient = scancl("sv1Scan")
     val participantId = clue("Can dump participant identities from SV validator") {
-      svValidatorClient.dumpParticipantIdentities().id
+      // retry to guard against badly timed restarts
+      eventuallySucceeds() {
+        svValidatorClient.dumpParticipantIdentities().id
+      }
     }
     val activeSynchronizer = clue("Can get active domain from Scan") {
-      val svActiveDomain = SynchronizerId.tryFromString(
-        svScanClient
-          .getAmuletConfigAsOf(env.environment.clock.now)
-          .decentralizedSynchronizer
-          .activeSynchronizer
-      )
-      val sv1ActiveDomain = SynchronizerId.tryFromString(
-        sv1ScanClient
-          .getAmuletConfigAsOf(env.environment.clock.now)
-          .decentralizedSynchronizer
-          .activeSynchronizer
-      )
-      svActiveDomain shouldBe sv1ActiveDomain
-      svActiveDomain
+      // retry to guard against badly timed restarts
+      eventuallySucceeds() {
+        val svActiveDomain = SynchronizerId.tryFromString(
+          svScanClient
+            .getAmuletConfigAsOf(env.environment.clock.now)
+            .decentralizedSynchronizer
+            .activeSynchronizer
+        )
+        val sv1ActiveDomain = SynchronizerId.tryFromString(
+          sv1ScanClient
+            .getAmuletConfigAsOf(env.environment.clock.now)
+            .decentralizedSynchronizer
+            .activeSynchronizer
+        )
+        svActiveDomain shouldBe sv1ActiveDomain
+        svActiveDomain
+      }
     }
     clue("Can get hosting participant id for a party from Scan") {
       eventually() {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvSequencerInfoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvSequencerInfoPreflightIntegrationTest.scala
@@ -21,7 +21,9 @@ class RunbookSvSequencerInfoPreflightIntegrationTest extends IntegrationTest {
 
   "The SV sequencer public url has been published to DsoRules" in { implicit env =>
     val sv = sv_client("sv")
-    val dsoInfo = sv.getDsoInfo()
+    val dsoInfo = eventuallySucceeds() {
+      sv.getDsoInfo()
+    }
     val nodeState: SvNodeState = dsoInfo.svNodeStates.get(dsoInfo.svParty).value.payload
     val domainConfig = nodeState.state.synchronizerNodes.asScala.values.headOption.value
     val sequencer = domainConfig.sequencer.toScala.value

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -264,9 +264,11 @@ abstract class ValidatorPreflightIntegrationTestBase
     if (isAuth0) {
       val charlieUser = auth0Users.get("charlie").value
       clue("Onboard charlie manually to share a party with Bob") {
-        validatorClient().onboardUser(
-          charlieUser.id,
-          Some(PartyId.tryFromProtoPrimitive(bobPartyId)),
+        eventuallySucceeds()(
+          validatorClient().onboardUser(
+            charlieUser.id,
+            Some(PartyId.tryFromProtoPrimitive(bobPartyId)),
+          )
         )
       }
 
@@ -467,7 +469,8 @@ abstract class ValidatorPreflightIntegrationTestBase
             .fromUris(NonEmpty.from(availableConnections.map(conn => new URI(conn.url))).value)
             .value
 
-        val domainConnectionConfig = validatorClient().decentralizedSynchronizerConnectionConfig()
+        val domainConnectionConfig =
+          eventuallySucceeds()(validatorClient().decentralizedSynchronizerConnectionConfig())
         val connectedEndpointSet =
           domainConnectionConfig.sequencerConnections.connections.flatMap(_.endpoints).toSet
 
@@ -618,7 +621,8 @@ class RunbookValidatorPreflightIntegrationTest extends ValidatorPreflightIntegra
         val (svSequencerEndpoint, _) = Endpoint
           .fromUris(NonEmpty.from(Seq(new URI(domainConfig.sequencer.toScala.value.url))).value)
           .value
-        val domainConnectionConfig = validatorClient().decentralizedSynchronizerConnectionConfig()
+        val domainConnectionConfig =
+          eventuallySucceeds()(validatorClient().decentralizedSynchronizerConnectionConfig())
         val connectedEndpointSet =
           domainConnectionConfig.sequencerConnections.connections.flatMap(_.endpoints).toSet
         connectedEndpointSet should contain(svSequencerEndpoint.forgetNE.loneElement.toString)


### PR DESCRIPTION
[ci]

Fixes https://github.com/DACH-NY/cn-test-failures/issues/7367 and maybe also prevents some future flake.

I skimmed all preflight tests for "naked" API calls; no guarantees for completeness.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
