### PR TITLE
`cncluster wait` a bit longer

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -128,9 +128,11 @@ function _retry_until_success() {
         exit 1
     fi
 
-    # with 5 second sleep + 1 second kubectl timeout, this is roughly 15 minutes
-    # See also max_wait which caps the overall wait time
-    local -i -r max_retries=$((150))
+    # With 5 second sleep and 3 second kubectl timeout, this is between
+    # 16 minutes (no kubectl timeout triggered, for example because `no matching resources found`)
+    # and 27 minutes (if we hit the kubectil timeout every time).
+    # See also max_wait which caps the overall wait time.
+    local -i -r max_retries=$((200))
     local -i num_retries=0
     local -i -r max_wait=$((60*60)) # do not wait longer than 60m in any case
     local -i -r start_time=$(date +%s)


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7341 (once splice bumped)

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
