### PR TITLE
ans/splitwell/token-standard integration test clues for list size assertions

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsAuth0FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsAuth0FrontendIntegrationTest.scala
@@ -49,7 +49,10 @@ class AnsAuth0FrontendIntegrationTest
               s"http://localhost:$aliceAnsUIPort",
               user.email,
               user.password,
-              () => seleniumText(find(id("logged-in-user"))) should not be empty,
+              () =>
+                seleniumText(
+                  find(id("logged-in-user"))
+                ) should not be empty withClue "CurrentUser onboarded",
             )
           }
       }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsFrontendIntegrationTest.scala
@@ -26,7 +26,8 @@ class AnsFrontendIntegrationTest
       val entryName = s"mycool_entry.unverified.$ansAcronym"
       val entryNameWithoutSufffix = "mycool_entry"
 
-      aliceWalletClient.listSubscriptionRequests() shouldBe empty
+      aliceWalletClient
+        .listSubscriptionRequests() shouldBe empty withClue "alice SubscriptionRequests"
 
       withFrontEnd("alice") { implicit webDriver =>
         // login to wallet UI once to create saved localstorage auth session
@@ -61,7 +62,8 @@ class AnsFrontendIntegrationTest
       val suffix = s".unverified.$ansAcronym"
       val entryNameJustReachesLimit = "a" * (60 - suffix.length) + suffix
 
-      aliceWalletClient.listSubscriptionRequests() shouldBe empty
+      aliceWalletClient
+        .listSubscriptionRequests() shouldBe empty withClue "alice SubscriptionRequests"
 
       withFrontEnd("alice") { implicit webDriver =>
         // login to wallet UI once to create saved localstorage auth session

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AnsIntegrationTest.scala
@@ -118,7 +118,7 @@ class AnsIntegrationTest
                 DsoAnsResolver.svAnsNameSuffix(ansAcronym)
               ) && entry.name != DsoAnsResolver.dsoAnsName(ansAcronym)
             )
-          userEntries shouldBe empty
+          userEntries shouldBe empty withClue "user entries"
         }
 
         clue("Creating an ANS entry that expires immediately") {
@@ -253,12 +253,14 @@ class AnsIntegrationTest
         requestEntry(aliceRefs, testEntryName),
       )(
         "alice sees subscription request",
-        _ => aliceRefs.wallet.listSubscriptionRequests() should have size 1,
+        _ =>
+          aliceRefs.wallet
+            .listSubscriptionRequests() should have size 1 withClue "alice SubscriptionRequests",
       )
       aliceRefs.validator.participantClientWithAdminToken.ledger_api_extensions.acs
         .filterJava(codegen.AnsEntryContext.COMPANION)(
           aliceRefs.userParty
-        ) should have size 1
+        ) should have size 1 withClue "AnsEntryContext"
       actAndCheck(
         "alice rejects subscription request",
         aliceWalletClient.rejectSubscriptionRequest(subscriptionRequest),
@@ -268,7 +270,7 @@ class AnsIntegrationTest
           aliceRefs.validator.participantClientWithAdminToken.ledger_api_extensions.acs
             .filterJava(codegen.AnsEntryContext.COMPANION)(
               aliceRefs.userParty
-            ) should have size 0,
+            ) should have size 0 withClue "AnsEntryContext",
       )
     }
 
@@ -316,12 +318,12 @@ class AnsIntegrationTest
           )
         }
         clue("Checking payload of new entry") {
-          entry.contractId should not be empty
+          entry.contractId should not be empty withClue "contractId"
           entry.user shouldBe aliceUserParty.toProtoPrimitive
           entry.name shouldBe testEntryName
           entry.url shouldBe testEntryUrl
           entry.description shouldBe testEntryDescription
-          entry.expiresAt should not be empty
+          entry.expiresAt should not be empty withClue "expiresAt"
         }
 
         aliceSubscriptionReadyForPaymentTrigger.resume()
@@ -398,11 +400,11 @@ class AnsIntegrationTest
         )
 
         eventually() {
-          lookupEntryByName(testEntryName) shouldBe empty
+          lookupEntryByName(testEntryName) shouldBe empty withClue s"ANS entry $testEntryName"
         }
         withClue("subscription expires even with disabled trigger") {
           eventually() {
-            aliceWalletClient.listSubscriptions() shouldBe empty
+            aliceWalletClient.listSubscriptions() shouldBe empty withClue "alice Subscriptions"
           }
         }
         setTriggersWithin(
@@ -445,7 +447,7 @@ class AnsIntegrationTest
         DsoAnsResolver.dsoAnsName(ansAcronym)
       ) shouldBe expectedDsoEntry
       sv1ScanBackend.lookupEntryByParty(dsoParty).value shouldBe expectedDsoEntry
-      sv1ScanBackend.listEntries("", 100) should contain(expectedDsoEntry)
+      sv1ScanBackend.listEntries("", 100) should contain(expectedDsoEntry) withClue "ANS entries"
     }
 
     "an SV's ANS entry can be seen via scan api" in { implicit env =>
@@ -458,7 +460,7 @@ class AnsIntegrationTest
         sv1ScanBackend
           .lookupEntryByParty(PartyId.tryFromProtoPrimitive(svParty))
           .value shouldBe expectedSvEntry
-        sv1ScanBackend.listEntries("", 100) should contain(expectedSvEntry)
+        sv1ScanBackend.listEntries("", 100) should contain(expectedSvEntry) withClue "ANS entries"
       }
     }
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -142,7 +142,7 @@ class SplitwellFrontendIntegrationTest
 
           eventually() {
             val rows = findAll(className("balance-updates-list-item")).toSeq
-            rows should have size 4
+            rows should have size 4 withClue "'Balance Updates' list items"
             // We don't guarantee an order on ACS requests atm so we assert independent of the specific order.
             forExactly(1, rows)(row =>
               matchRow(
@@ -319,20 +319,24 @@ class SplitwellFrontendIntegrationTest
       // Alice accepts all requests
       withFrontEnd("aliceSplitwell") { implicit webDriver =>
         eventually(timeUntilSuccess = 20.minute) {
-          findAll(className("add-user-link")) should have length 4
-          getGroupContractIds() should have size 3
+          findAll(
+            className("add-user-link")
+          ) should have length 4 withClue "'Add' button in 'Membership Requests'"
+          getGroupContractIds() should have size 3 withClue "Group contractIds"
         }
         val allLinks = findAll(className("add-user-link")).toSeq
         (allLinks zip (4L to 1 by -1)).foreach { case (elem, i) =>
           val groupsBefore = getGroupContractIds()
-          groupsBefore should have size 3
+          groupsBefore should have size 3 withClue "groups before click"
           click on elem
           // Wait for the join to finish. Otherwise we get contention on the group contract.
           eventually() {
-            findAll(className("add-user-link")) should have length i - 1
+            findAll(
+              className("add-user-link")
+            ) should have length (i - 1) withClue "'Add' button in 'Membership Requests'"
             // Wait for the contract id to change.
             val groupsAfter = getGroupContractIds()
-            groupsAfter should have size 3
+            groupsAfter should have size 3 withClue "groups after click"
             groupsAfter should not equal groupsBefore
           }
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellIntegrationTest.scala
@@ -56,7 +56,7 @@ class SplitwellIntegrationTest
               .filterJava(splitwellCodegen.GroupRequest.COMPANION)(
                 aliceUserParty,
                 (request: splitwellCodegen.GroupRequest.Contract) => request.id == groupRequest,
-              ) shouldBe empty
+              ) shouldBe empty withClue "GroupRequest group1"
           }
         }
 
@@ -76,7 +76,7 @@ class SplitwellIntegrationTest
         val groups =
           aliceSplitwellClient.ledgerApi.ledger_api_extensions.acs
             .filterJava(splitwellCodegen.Group.COMPANION)(aliceUserParty)
-        groups should have size 1
+        groups should have size 1 withClue "alice Groups"
     }
 
     "use its own app domain" in { implicit env =>
@@ -138,7 +138,7 @@ class SplitwellIntegrationTest
       createSplitwellInstalls(aliceSplitwellClient, alice)
       actAndCheck("alice creates group1", aliceSplitwellClient.requestGroup("group1"))(
         "alice observes group",
-        _ => aliceSplitwellClient.listGroups() should have size 1,
+        _ => aliceSplitwellClient.listGroups() should have size 1 withClue "alice Groups",
       )
       try {
         splitwellBackend.participantClient.synchronizers
@@ -150,7 +150,7 @@ class SplitwellIntegrationTest
       }
       actAndCheck("alice creates group2", aliceSplitwellClient.requestGroup("group2"))(
         "alice observes group",
-        _ => aliceSplitwellClient.listGroups() should have size 2,
+        _ => aliceSplitwellClient.listGroups() should have size 2 withClue "alice Groups",
       )
     }
 
@@ -179,7 +179,7 @@ class SplitwellIntegrationTest
       aliceSplitwellClient.ledgerApi.ledger_api_extensions.acs
         .filterJava(splitwellCodegen.TransferInProgress.COMPANION)(
           aliceUserParty
-        ) should have size 1
+        ) should have size 1 withClue "alice TransferInProgress"
 
       actAndCheck(
         "alice reject payment request",
@@ -190,7 +190,7 @@ class SplitwellIntegrationTest
           aliceSplitwellClient.ledgerApi.ledger_api_extensions.acs
             .filterJava(splitwellCodegen.TransferInProgress.COMPANION)(
               aliceUserParty
-            ) should have size 0,
+            ) should have size 0 withClue "alice TransferInProgress",
       )
     }
 
@@ -214,17 +214,21 @@ class SplitwellIntegrationTest
       )
 
       eventually() {
-        bobSplitwellClient.listBalanceUpdates(key) should have size 2
+        bobSplitwellClient.listBalanceUpdates(key) should have size 2 withClue "bob BalanceUpdates"
       }
       bobSplitwellClient.listBalances(key) shouldBe Seq(aliceUserParty -> -1100).toMap
 
-      aliceSplitwellClient.listBalanceUpdates(key) should have size 2
+      aliceSplitwellClient.listBalanceUpdates(
+        key
+      ) should have size 2 withClue "alice BalanceUpdates"
       aliceSplitwellClient.listBalances(key) shouldBe Seq(bobUserParty -> 1100).toMap
 
       charlieSplitwellClient.acceptInvite(invite)
 
       eventually() {
-        aliceSplitwellClient.listAcceptedGroupInvites("group1") should have size 1
+        aliceSplitwellClient.listAcceptedGroupInvites(
+          "group1"
+        ) should have size 1 withClue "group1 AcceptedGroupInvites"
       }
       inside(aliceSplitwellClient.listAcceptedGroupInvites("group1")) { case Seq(accepted) =>
         aliceSplitwellClient.joinGroup(accepted.contractId)
@@ -245,7 +249,11 @@ class SplitwellIntegrationTest
         )
       }
 
-      eventually()(aliceSplitwellClient.listBalanceUpdates(key) should have size 3)
+      eventually()(
+        aliceSplitwellClient.listBalanceUpdates(
+          key
+        ) should have size 3 withClue "alice BalanceUpdates"
+      )
       aliceSplitwellClient.listBalances(key) shouldBe Map(
         bobUserParty -> 1100,
         charlieUserParty -> -1100,
@@ -310,11 +318,16 @@ class SplitwellIntegrationTest
           triggersToResumeAtStart = Seq(),
         ) {
           bobWalletClient.acceptAppPaymentRequest(request.contractId)
-          eventually()(bobWalletClient.listAppPaymentRequests() shouldBe empty)
+          eventually()(
+            bobWalletClient
+              .listAppPaymentRequests() shouldBe empty withClue "bob AppPaymentRequests"
+          )
         }
       }
       eventually() {
-        aliceSplitwellClient.listBalanceUpdates(key) should have size 2
+        aliceSplitwellClient.listBalanceUpdates(
+          key
+        ) should have size 2 withClue "alice BalanceUpdates"
       }
       aliceSplitwellClient.listBalances(key) shouldBe Seq(bobUserParty -> 0).toMap
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellTestUtil.scala
@@ -50,7 +50,9 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
       _ => {
         splitwellBackend
           .getConnectedDomains(ensurePartyIsOnNewDomain)
-          .map(_.uid.identifier.str) should contain("splitwellUpgrade")
+          .map(_.uid.identifier.str) should contain(
+          "splitwellUpgrade"
+        ) withClue "connected domains"
       },
     )
   }
@@ -72,7 +74,7 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
         splitwell.ledgerApi.ledger_api_extensions.acs
           .filterJava(splitwellCodegen.SplitwellInstall.COMPANION)(
             party
-          ) should have size requests.size.toLong
+          ) should have size requests.size.toLong withClue "SplitwellInstalls"
       },
     )
   }
@@ -102,7 +104,7 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
 
     actAndCheck("create 'group1'", aliceSplitwellClient.requestGroup(group))(
       "Alice sees 'group1'",
-      _ => aliceSplitwellClient.listGroups() should have size 1,
+      _ => aliceSplitwellClient.listGroups() should have size 1 withClue "alice Groups",
     )
 
     // Wait for the group contract to be visible to Alice's Ledger API
@@ -121,7 +123,10 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
 
     actAndCheck("bob asks to join 'group1'", bobSplitwellClient.acceptInvite(invite))(
       "Alice sees the accepted invite",
-      _ => aliceSplitwellClient.listAcceptedGroupInvites(group) should not be empty,
+      _ =>
+        aliceSplitwellClient.listAcceptedGroupInvites(
+          group
+        ) should not be empty withClue "alice group1 AcceptedGroupInvites",
     )
 
     actAndCheck(
@@ -132,8 +137,10 @@ trait SplitwellTestUtil extends TestCommon with WalletTestUtil with TimeTestUtil
     )(
       "bob is in 'group1'",
       _ => {
-        bobSplitwellClient.listGroups() should have size 1
-        aliceSplitwellClient.listAcceptedGroupInvites(group) should be(empty)
+        bobSplitwellClient.listGroups() should have size 1 withClue "bob Groups"
+        aliceSplitwellClient.listAcceptedGroupInvites(group) should be(
+          empty
+        ) withClue "alice group1 AcceptedGroupInvites"
       },
     )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeFrontendIntegrationTest.scala
@@ -75,7 +75,7 @@ class SplitwellUpgradeFrontendIntegrationTest
               .filterJava(splitwellCodegen.SplitwellInstallRequest.COMPANION)(
                 splitwellBackend.getProviderPartyId()
               )
-            contracts shouldBe empty
+            contracts shouldBe empty withClue "SplitwellInstallRequests"
           }
         }
       }
@@ -123,13 +123,15 @@ class SplitwellUpgradeFrontendIntegrationTest
         withFrontEnd(aliceSplitwellFE) { implicit webDriver =>
           val groupsBefore = eventually() {
             val groupsBefore = getGroupContractIds()
-            groupsBefore should have size 2
+            groupsBefore should have size 2 withClue "groups before"
             groupsBefore
           }
 
           clue("Alice sees bob’s accepted invite") {
             eventually() {
-              findAll(className("add-user-link")).toSeq should have size 1
+              findAll(
+                className("add-user-link")
+              ).toSeq should have size 1 withClue "'Add' button under 'Membership Requests'"
             }
           }
 
@@ -140,7 +142,7 @@ class SplitwellUpgradeFrontendIntegrationTest
             "Group contract id changes",
             _ => {
               val groupsAfter = getGroupContractIds()
-              groupsAfter should have size 2
+              groupsAfter should have size 2 withClue "groups after"
               groupsAfter should not equal groupsBefore
             },
           )
@@ -268,7 +270,7 @@ class SplitwellUpgradeFrontendIntegrationTest
                   currentUrl should startWith(s"http://localhost:${bobSplitwellUIPort}")
                   val balanceUpdates =
                     bobSplitwellClient.listBalanceUpdates(GroupKey(abGroupName, alice))
-                  balanceUpdates should have size 3
+                  balanceUpdates should have size 3 withClue "bob BalanceUpdates"
                   assertAllOn(splitwellUpgradeAlias)(balanceUpdates.map(_.contractId)*)
                 },
               )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellUpgradeIntegrationTest.scala
@@ -73,7 +73,7 @@ class SplitwellUpgradeIntegrationTest
                 )
               )
             } else {
-              logs shouldBe empty
+              logs shouldBe empty withClue "log warnings"
             }
           },
         )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardAllocationIntegrationTest.scala
@@ -145,7 +145,7 @@ class TokenStandardAllocationIntegrationTest
       show"There exists an allocation from $senderParty",
       _ => {
         val allocations = walletClient.listAmuletAllocations()
-        allocations should have size 1
+        allocations should have size 1 withClue "AmuletAllocations"
         allocations.head
       },
     )
@@ -311,14 +311,14 @@ class TokenStandardAllocationIntegrationTest
               templateId.getEntityName,
             )
           ),
-        ) shouldBe empty,
+        ) shouldBe empty withClue "Allocations",
     )
   }
 
   "Withdraw an allocation" in { implicit env =>
     val allocatedOtcTrade = setupAllocatedOtcTrade()
     // sanity check
-    aliceWalletClient.listAmuletAllocations() should have size (1)
+    aliceWalletClient.listAmuletAllocations() should have size (1) withClue "AmuletAllocations"
     actAndCheck(
       "Settlement venue withdraw the trade", {
         aliceWalletClient.withdrawAmuletAllocation(
@@ -329,15 +329,17 @@ class TokenStandardAllocationIntegrationTest
       },
     )(
       "Allocation is archived",
-      _ => aliceWalletClient.listAmuletAllocations() shouldBe empty,
+      _ => aliceWalletClient.listAmuletAllocations() shouldBe empty withClue "AmuletAllocations",
     )
   }
 
   "Reject an allocation request" in { implicit env =>
     val allocatedOtcTrade = setupAllocatedOtcTrade()
     // sanity checks
-    aliceWalletClient.listAllocationRequests() should have size (1)
-    bobWalletClient.listAllocationRequests() should have size (1)
+    aliceWalletClient
+      .listAllocationRequests() should have size (1) withClue "alice AllocationRequests"
+    bobWalletClient
+      .listAllocationRequests() should have size (1) withClue "bob AllocationRequests"
 
     actAndCheck(
       "Alice rejects the allocation request", {
@@ -349,9 +351,9 @@ class TokenStandardAllocationIntegrationTest
       "Allocation request is archived",
       _ => {
         val aliceRequests = aliceWalletClient.listAllocationRequests()
-        aliceRequests shouldBe empty
+        aliceRequests shouldBe empty withClue "alice Requests"
         val bobRequests = bobWalletClient.listAllocationRequests()
-        bobRequests shouldBe empty
+        bobRequests shouldBe empty withClue "bob Requests"
       },
     )
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliIntegrationTest.scala
@@ -49,7 +49,9 @@ class TokenStandardCliIntegrationTest
 
       // only alice will have a transfer preapproval
       aliceValidatorBackend.participantClient.parties
-        .hosted(filterParty = onboardingAlice.party.filterString) should not be empty
+        .hosted(filterParty =
+          onboardingAlice.party.filterString
+        ) should not be empty withClue "alice hosted"
 
       createAndAcceptExternalPartySetupProposal(
         aliceValidatorBackend,
@@ -60,10 +62,10 @@ class TokenStandardCliIntegrationTest
       eventually() {
         aliceValidatorBackend.lookupTransferPreapprovalByParty(
           onboardingAlice.party
-        ) should not be empty
+        ) should not be empty withClue "alice preapproval"
         aliceValidatorBackend.scanProxy.lookupTransferPreapprovalByParty(
           onboardingAlice.party
-        ) should not be empty
+        ) should not be empty withClue "alice scan preapproval"
       }
 
       // Transfers from non-external parties are not supported by the CLI
@@ -174,7 +176,7 @@ class TokenStandardCliIntegrationTest
           listTransferInstructions(
             aliceValidatorBackend.participantClientWithAdminToken,
             bobParty,
-          ) shouldBe empty
+          ) shouldBe empty withClue "bob TransferInstructions"
         },
       )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardCliTestDataTimeBasedIntegrationTest.scala
@@ -178,10 +178,12 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
       )(
         "Bob's preapproval is visible",
         bob => {
-          bobValidatorBackend.lookupTransferPreapprovalByParty(bob.partyId) should not be empty
+          bobValidatorBackend.lookupTransferPreapprovalByParty(
+            bob.partyId
+          ) should not be empty withClue "bob preapproval"
           bobValidatorBackend.scanProxy.lookupTransferPreapprovalByParty(
             bob.partyId
-          ) should not be empty
+          ) should not be empty withClue "bob scan preapproval"
         },
       )
 
@@ -202,7 +204,10 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
         bobValidatorBackend.cancelTransferPreapprovalByParty(bob.partyId),
       )(
         "Bob's preapproval is no longer visible",
-        _ => bobValidatorBackend.lookupTransferPreapprovalByParty(bob.partyId) shouldBe empty,
+        _ =>
+          bobValidatorBackend.lookupTransferPreapprovalByParty(
+            bob.partyId
+          ) shouldBe empty withClue "bob TransferPreapproval",
       )
 
       // Onboard alice as a local party
@@ -307,7 +312,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                   bobValidatorBackend.participantClientWithAdminToken,
                   bob.partyId,
                 )
-                instructions should have size 5
+                instructions should have size 5 withClue "TransferInstructions"
                 instructions.map(_._1)
               },
             )
@@ -352,7 +357,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                   bobValidatorBackend.participantClientWithAdminToken,
                   bob.partyId,
                 )
-                instructions should have size 2
+                instructions should have size 2 withClue "TransferInstructions"
                 getBobPartyBalance().unlockedQty should beAround(BigDecimal("1000.0"))
                 inside(aliceWalletClient.balance()) { aliceBalance =>
                   aliceBalance.unlockedQty should beWithin(
@@ -436,15 +441,15 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                     aliceValidatorBackend.participantClientWithAdminToken,
                     alice.partyId,
                   )
-                  instructions should have size 3
+                  instructions should have size 3 withClue "TransferInstructions"
                   val bobHoldings = listHoldings(
                     bobValidatorBackend.participantClientWithAdminToken,
                     bob.partyId,
                   )
                   val (unlockedHoldings, lockedHoldings) =
                     bobHoldings.partition(h => h._2.lock.isEmpty)
-                  unlockedHoldings should have size 4
-                  lockedHoldings should have size 1
+                  unlockedHoldings should have size 4 withClue "unlocked holdings"
+                  lockedHoldings should have size 1 withClue "locked holdings"
                 },
               )
             }
@@ -469,7 +474,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                 listHoldings(
                   bobValidatorBackend.participantClientWithAdminToken,
                   bob.partyId,
-                ) should have size 3
+                ) should have size 3 withClue "holdings"
                 inside(getBobPartyBalance()) { balance =>
                   balance.unlockedQty should beWithin(
                     BigDecimal("450.0"),
@@ -511,7 +516,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                 listHoldings(
                   aliceValidatorBackend.participantClientWithAdminToken,
                   alice.partyId,
-                ) should have size 3
+                ) should have size 3 withClue "holdings"
                 inside(aliceWalletClient.balance()) { aliceBalance =>
                   aliceBalance.unlockedQty should beWithin(
                     BigDecimal("4100.0"),
@@ -561,7 +566,7 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
                   aliceValidatorBackend.participantClientWithAdminToken,
                   alice.partyId,
                 )
-                instructions should have size 2
+                instructions should have size 2 withClue "TransferInstructions"
               },
             )
 
@@ -611,12 +616,12 @@ class TokenStandardCliTestDataTimeBasedIntegrationTest
             val activeHoldingsResponse =
               listContractsOfInterface(alice, holdingv1.Holding.TEMPLATE_ID)
 
-            activeHoldingsResponse should have size 6 // 3 unlocked amulets, 1 locked amulet, 2 sample holdings
+            activeHoldingsResponse should have size 6 withClue "3 unlocked + 1 locked + 2 sample holdings"
 
             val activeTransferInstructionsResponse =
               listContractsOfInterface(bob, transferinstructionv1.TransferInstruction.TEMPLATE_ID)
 
-            activeTransferInstructionsResponse should have size 2
+            activeTransferInstructionsResponse should have size 2 withClue "TransferInstructions"
 
             val getUpdatesPayload = JsUpdateServiceCodecs.getUpdatesRequestRW(
               GetUpdatesRequest(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardFetchFallbackIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardFetchFallbackIntegrationTest.scala
@@ -51,7 +51,7 @@ class TokenStandardFetchFallbackIntegrationTest
             "Alice and Bob see it",
             _ => {
               Seq(aliceWalletClient, bobWalletClient).foreach(
-                _.listTokenStandardTransfers() should have size 1
+                _.listTokenStandardTransfers() should have size 1 withClue "TokenStandardTransfers"
               )
             },
           )._1

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTest.scala
@@ -89,7 +89,7 @@ trait TokenStandardTest extends ExternallySignedPartyTestUtil {
       trackingHoldingCid => {
         participant.ledger_api.event_query
           .by_contract_id(trackingHoldingCid.contractId, requestingParties = Seq(sender.partyId))
-          .archived should not be empty
+          .archived should not be empty withClue "archived holding"
       },
     )
   }
@@ -392,13 +392,13 @@ trait TokenStandardTest extends ExternallySignedPartyTestUtil {
             val aliceRequest = clue("Alice sees the allocation request") {
               val requests = listAllocationRequests(aliceWalletClient)
               val request = requests.loneElement
-              request.transferLegs.asScala should have size (2)
+              request.transferLegs.asScala should have size (2) withClue "transferLegs"
               request
             }
             val bobRequest = clue("Bob sees the allocation request") {
               val requests = listAllocationRequests(aliceWalletClient)
               val request = requests.loneElement
-              request.transferLegs.asScala should have size (2)
+              request.transferLegs.asScala should have size (2) withClue "transferLegs"
               request
             }
             (trade, aliceRequest, bobRequest)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTransferIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTransferIntegrationTest.scala
@@ -91,7 +91,7 @@ class TokenStandardTransferIntegrationTest
           "Alice and Bob see it",
           _ => {
             Seq(aliceWalletClient, bobWalletClient).foreach(
-              _.listTokenStandardTransfers() should have size i.toLong
+              _.listTokenStandardTransfers() should have size i.toLong withClue "TokenStandardTransfers"
             )
           },
         )._1
@@ -122,7 +122,7 @@ class TokenStandardTransferIntegrationTest
           result => {
             inside(result.output) { case members.TransferInstructionFailed(_) => () }
             Seq(aliceWalletClient, bobWalletClient).foreach(
-              _.listTokenStandardTransfers() should have size (cids.length.toLong - 1L)
+              _.listTokenStandardTransfers() should have size (cids.length.toLong - 1L) withClue "TokenStandardTransfers"
             )
             bobWalletClient.balance().unlockedQty should be(BigDecimal(0))
           },
@@ -136,7 +136,7 @@ class TokenStandardTransferIntegrationTest
           result => {
             inside(result.output) { case members.TransferInstructionFailed(_) => () }
             Seq(aliceWalletClient, bobWalletClient).foreach(
-              _.listTokenStandardTransfers() should have size (cids.length.toLong - 2L)
+              _.listTokenStandardTransfers() should have size (cids.length.toLong - 2L) withClue "TokenStandardTransfers"
             )
             bobWalletClient.balance().unlockedQty should be(BigDecimal(0))
           },
@@ -150,7 +150,7 @@ class TokenStandardTransferIntegrationTest
           result => {
             inside(result.output) { case members.TransferInstructionCompleted(_) => () }
             Seq(aliceWalletClient, bobWalletClient).foreach(
-              _.listTokenStandardTransfers() should have size (cids.length.toLong - 3L)
+              _.listTokenStandardTransfers() should have size (cids.length.toLong - 3L) withClue "TokenStandardTransfers"
             )
             bobWalletClient.balance().unlockedQty should be > BigDecimal(0)
           },
@@ -161,10 +161,10 @@ class TokenStandardTransferIntegrationTest
         eventually() {
           val aliceTxs = aliceWalletClient.listTransactions(None, 1000)
           // tap + 4 transfer instructions + accept + withdraw + reject
-          aliceTxs should have size 8
+          aliceTxs should have size 8 withClue "aliceTxs"
           val bobTxs = bobWalletClient.listTransactions(None, 1000)
           // 4 transfer instructions + accept + withdraw + reject
-          bobTxs should have size 7
+          bobTxs should have size 7 withClue "bobTxs"
           (aliceTxs, bobTxs)
         }
       }
@@ -211,7 +211,7 @@ class TokenStandardTransferIntegrationTest
             logEntry.transferInstructionAmount shouldBe Some(BigDecimal(10))
             logEntry.description shouldBe "Transfer #4"
             // No balance is transferred here so receivers is empty
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // The wallet counts moving the balance to a locked amulet as a negative balance change
             logEntry.sender.value.amount shouldBe (BigDecimal(-10))
           },
@@ -222,7 +222,7 @@ class TokenStandardTransferIntegrationTest
             logEntry.transferInstructionAmount shouldBe Some(BigDecimal(10))
             logEntry.description shouldBe "Transfer #3"
             // No balance is transferred here so receivers is empty
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // The wallet counts moving the balance to a locked amulet as a negative balance change
             logEntry.sender.value.amount shouldBe (BigDecimal(-10))
           },
@@ -233,7 +233,7 @@ class TokenStandardTransferIntegrationTest
             logEntry.transferInstructionAmount shouldBe Some(BigDecimal(10))
             logEntry.description shouldBe "Transfer #2"
             // No balance is transferred here so receivers is empty
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // The wallet counts moving the balance to a locked amulet as a negative balance change
             logEntry.sender.value.amount shouldBe (BigDecimal(-10))
           },
@@ -244,7 +244,7 @@ class TokenStandardTransferIntegrationTest
             logEntry.transferInstructionAmount shouldBe Some(BigDecimal(10))
             logEntry.description shouldBe "Transfer #1"
             // No balance is transferred here so receivers is empty
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // The wallet counts moving the balance to a locked amulet as a negative balance change
             logEntry.sender.value.amount shouldBe (BigDecimal(-10))
           },
@@ -322,7 +322,7 @@ class TokenStandardTransferIntegrationTest
           .listActivity(None, 1000)
           .filter(t => t.transfer.isDefined || t.abortTransferInstruction.isDefined)
         // 4 transfer instructions + accept + withdraw + reject
-        activityTxs should have size (7)
+        activityTxs should have size (7) withClue "activityTxs"
         activityTxs
       }
 
@@ -434,10 +434,10 @@ class TokenStandardTransferIntegrationTest
         eventually() {
           val aliceTxs = aliceWalletClient.listTransactions(None, 1000)
           // tap + transfer instruction + unlock + withdraw
-          aliceTxs should have size 4
+          aliceTxs should have size 4 withClue "aliceTxs"
           val bobTxs = bobWalletClient.listTransactions(None, 1000)
           // transfer instruction + withdraw
-          bobTxs should have size 2
+          bobTxs should have size 2 withClue "bobTxs"
           (aliceTxs, bobTxs)
         }
       }
@@ -461,7 +461,7 @@ class TokenStandardTransferIntegrationTest
             logEntry.transferInstructionAmount shouldBe Some(BigDecimal(10))
             logEntry.description shouldBe "transfer offer description"
             // No balance is transferred here so receivers is empty
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // The wallet counts moving the balance to a locked amulet as a negative balance change
             logEntry.sender.value.amount shouldBe (BigDecimal(-10))
           },


### PR DESCRIPTION
Add withClue labels across ANS, Splitwell, and Token Standard integration tests' listlike items.

Part of #4147.