### PR TITLE
scan integration test clues for list size assertions

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
@@ -217,7 +217,7 @@ class BftScanConnectionIntegrationTest
     )
 
     withClue("Persisted state should contain the expected internal scan configurations") {
-      persistedState.value.futureValue.value should contain theSameElementsAs expectedConfigs
+      persistedState.value.futureValue.value should contain theSameElementsAs expectedConfigs withClue "ScanUrlInternalConfig"
     }
 
     loggerFactory.assertEventuallyLogsSeq(SuppressionRule.LevelAndAbove(Level.INFO))(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanEventHistoryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanEventHistoryIntegrationTest.scala
@@ -67,14 +67,14 @@ class ScanEventHistoryIntegrationTest
       after = Some(cursorBeforeTap),
       encoding = CompactJson,
     )
-    eventHistoryAfterLastCursor shouldBe empty
+    eventHistoryAfterLastCursor shouldBe empty withClue "EventHistory after pre-tap cursor"
 
     aliceWalletClient.tap(1)
 
     // Verify that new events are visible after the cursor
     val eventHistory = eventually() {
       val eh = getEventHistoryAndCheckTxVerdicts(after = Some(cursorBeforeTap))
-      eh should not be empty
+      eh should not be empty withClue "EventHistory after tap"
       eh
     }
 
@@ -185,7 +185,7 @@ class ScanEventHistoryIntegrationTest
         after = Some(cursorBefore),
         encoding = CompactJson,
       )
-      historyWhileDown shouldBe empty
+      historyWhileDown shouldBe empty withClue "EventHistory while mediator ingestion down"
     }
 
     val expectedUpdateIds = clue("Fetch the updateIds for the taps from wallet history") {
@@ -218,7 +218,7 @@ class ScanEventHistoryIntegrationTest
 
       eventually() {
         val eventHistory = getEventHistoryAndCheckTxVerdicts(after = Some(cursorBefore))
-        eventHistory should not be empty
+        eventHistory should not be empty withClue "EventHistory after ingestion resume"
       }
       expectedUpdateIds.foreach { id =>
         val eventByIdO = sv1ScanBackend.getEventById(
@@ -359,7 +359,7 @@ class ScanEventHistoryIntegrationTest
 
       silentClue(s"Missing expected updateIds: ${missing
           .mkString(",")} | expected=${expectedSet.size}, present=${presentSet.size}") {
-        missing shouldBe empty
+        missing shouldBe empty withClue "missing updateIds"
       }
       eh
     }
@@ -398,7 +398,7 @@ class ScanEventHistoryIntegrationTest
     }
 
     silentClue("Update events with missing verdict: " + missing.mkString(",")) {
-      missing shouldBe empty
+      missing shouldBe empty withClue "updates missing verdict"
     }
 
     eventHistory

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanFrontendTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanFrontendTimeBasedIntegrationTest.scala
@@ -332,9 +332,9 @@ class ScanFrontendTimeBasedIntegrationTest
               ._1
               .map(_.payload)
               .sortBy(_.round.number)
-            openRounds should not be empty
+            openRounds should not be empty withClue "open rounds"
             val shownRounds = findAll(className("open-mining-round-row")).toList
-            shownRounds should have size openRounds.size.toLong
+            shownRounds should have size openRounds.size.toLong withClue "'Open Mining Rounds' table rows"
             forEvery(shownRounds zip openRounds) { case (shownRound, openRound) =>
               def rt(n: String) = shownRound.childElement(className(n)).text
               rt("round-number") should matchText(openRound.round.number.toString)
@@ -517,7 +517,7 @@ class ScanFrontendTimeBasedIntegrationTest
                 .number
             val actual =
               findAll(className("validator-faucets-leaderboard-row")).toSeq.map(seleniumText)
-            actual should have length 4
+            actual should have length 4 withClue "'Validator Liveness Leaderboard' table rows"
             actual.head should be(
               s"${aliceValidatorWalletParty} ${openRounds.size} 0 $firstCollectedInRound $lastCollectedInRound"
             )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanHistoryBackfillingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanHistoryBackfillingIntegrationTest.scala
@@ -195,7 +195,7 @@ class ScanHistoryBackfillingIntegrationTest
     val sv1updatesBeforeBackfill = clue(s"SV1 scan has ingested the latest update") {
       eventually() {
         val updates = allUpdatesFromScanBackend(sv1ScanBackend)
-        updates should not be empty
+        updates should not be empty withClue "scan updates"
         containsCreateEvent(updates, latestAmuletCid) should be(true)
         updates
       }
@@ -203,7 +203,7 @@ class ScanHistoryBackfillingIntegrationTest
     val sv2updatesBeforeBackfill = clue(s"SV2 scan has ingested the latest update") {
       eventually() {
         val updates = allUpdatesFromScanBackend(sv2ScanBackend)
-        updates should not be empty
+        updates should not be empty withClue "scan updates"
         containsCreateEvent(updates, latestAmuletCid) should be(true)
         updates
       }
@@ -216,7 +216,7 @@ class ScanHistoryBackfillingIntegrationTest
       val N = 10
       val sv1times = sv1updatesBeforeBackfill.take(N).map(itemTime).toSet
       val sv2times = sv2updatesBeforeBackfill.map(itemTime).toSet
-      sv1times.foreach(sv1time => sv2times should not contain sv1time)
+      sv1times.foreach(sv1time => sv2times should not contain sv1time withClue "SV2 history times")
     }
 
     clue(
@@ -313,7 +313,9 @@ class ScanHistoryBackfillingIntegrationTest
         // Update history is complete at this point, but the status endpoint only reports
         // as complete if the txlog is also backfilled
         sv1ScanBackend.getBackfillingStatus().complete shouldBe false
-        readUpdateHistoryFromScan(sv1ScanBackend) should not be empty
+        readUpdateHistoryFromScan(
+          sv1ScanBackend
+        ) should not be empty withClue "sv1 scan update history"
 
         sv2ScanBackend.appState.automation.updateHistory
           .getBackfillingState()
@@ -387,7 +389,7 @@ class ScanHistoryBackfillingIntegrationTest
       // Again we can't compare using strict equality, as the items contain offsets which are participant-local.
       val sv1Times = sv1updatesBeforeBackfill.map(itemTime)
       val sv2Times = sv2updatesAfterBackfill.take(sv1Times.length).map(itemTime)
-      sv1Times should contain theSameElementsInOrderAs sv2Times
+      sv1Times should contain theSameElementsInOrderAs sv2Times withClue "SV1/2 history times"
     }
 
     clue("Compare scan histories with each other using the v0 HTTP endpoint") {
@@ -406,7 +408,7 @@ class ScanHistoryBackfillingIntegrationTest
       // Responses are not consistent across SVs, only compare record times
       val sv1ItemTimes = sv1HttpUpdates.take(commonLength).map(httpItemTime)
       val sv2ItemTimes = sv2HttpUpdates.take(commonLength).map(httpItemTime)
-      sv1ItemTimes should contain theSameElementsInOrderAs sv2ItemTimes
+      sv1ItemTimes should contain theSameElementsInOrderAs sv2ItemTimes withClue "SV1/2 update times"
     }
 
     clue("Compare scan histories with each other using the v1 HTTP endpoint") {
@@ -424,7 +426,7 @@ class ScanHistoryBackfillingIntegrationTest
       commonLength should be > 10
       val sv1Items = sv1HttpUpdates.take(commonLength)
       val sv2Items = sv2HttpUpdates.take(commonLength)
-      sv1Items should contain theSameElementsInOrderAs sv2Items
+      sv1Items should contain theSameElementsInOrderAs sv2Items withClue "SV1/2 update times"
     }
 
     clue("Compare scan histories with each other using the v2 HTTP endpoint") {
@@ -438,7 +440,7 @@ class ScanHistoryBackfillingIntegrationTest
       commonLength should be > 10
       val sv1Items = sv1HttpUpdates.take(commonLength)
       val sv2Items = sv2HttpUpdates.take(commonLength)
-      sv1Items should contain theSameElementsInOrderAs sv2Items
+      sv1Items should contain theSameElementsInOrderAs sv2Items withClue "SV1/2 update times"
     }
 
     clue("Compare scan history with participant update stream") {
@@ -471,11 +473,11 @@ class ScanHistoryBackfillingIntegrationTest
         sv2ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
 
       // We tapped 4 times before SV2 joined, and once after
-      sv1Transactions.size should be >= 5
-      sv2Transactions.size should be >= 1
-      sv1Transactions.size should be > sv2Transactions.size
-      sv1Transactions should contain allElementsOf sv2Transactions
-      sv2Transactions should not contain sv1Transactions.headOption.value
+      sv1Transactions.size should be >= 5 withClue "SV1 txns"
+      sv2Transactions.size should be >= 1 withClue "SV2 txns"
+      sv1Transactions.size should be > sv2Transactions.size withClue "SV1 txns"
+      sv1Transactions should contain allElementsOf sv2Transactions withClue "sv1 transactions"
+      sv2Transactions should not contain sv1Transactions.headOption.value withClue "sv2 transactions"
     }
 
     actAndCheck(
@@ -529,7 +531,7 @@ class ScanHistoryBackfillingIntegrationTest
         sv2ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
 
       // TODO(#666): switch to theSameElementsInOrderAs once the endpoint sorts by record time instead of row id.
-      sv1Transactions should contain theSameElementsAs sv2Transactions
+      sv1Transactions should contain theSameElementsAs sv2Transactions withClue "SV1/2 txns"
     }
 
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
@@ -212,7 +212,9 @@ class ScanIntegrationTest
       val desc = TransactionHistoryRequest.SortOrder.Desc
       val allPagesAsc = collectAllTapPagesForAlice(asc)
       val allPagesDesc = collectAllTapPagesForAlice(desc)
-      allPagesAsc.map(_.round) should contain only Some(latestRound)
+      allPagesAsc.map(_.round) should contain only Some(
+        latestRound
+      ) withClue "alice tap pages' rounds"
 
       val tapsFirstPageAscending = allPagesAsc.take(pageSize)
 
@@ -308,7 +310,7 @@ class ScanIntegrationTest
           tap.amuletOwner
         ) == aliceUserParty
       }
-      taps should have size (2)
+      taps should have size (2) withClue "alice taps"
       taps.map(t =>
         (PartyId.tryFromProtoPrimitive(t.amuletOwner), BigDecimal(t.amuletAmount))
       ) shouldBe
@@ -321,7 +323,7 @@ class ScanIntegrationTest
           ) == aliceUserParty && transfer.receivers.isEmpty
         }
 
-      merges should have size (1)
+      merges should have size (1) withClue "alice merges"
       val mergeTransfer = merges.head
       PartyId.tryFromProtoPrimitive(mergeTransfer.sender.party) shouldBe aliceUserParty
       mergeTransfer.sender.inputAmuletAmount
@@ -405,7 +407,7 @@ class ScanIntegrationTest
                 ) == bobUserParty
               })
 
-          activities should have size (1)
+          activities should have size (1) withClue "bob-sent transfers"
           activities.loneElement.round shouldBe Some(openRoundForTransfer)
           val transfer = activities.flatMap(_.transfer).loneElement
           val inputAmuletAmount =
@@ -424,12 +426,14 @@ class ScanIntegrationTest
 
           // receiverFee is by default set to 0, sender pays all fees.
           transfer.receivers
-            .map(r => BigDecimal(r.receiverFee)) should contain only (BigDecimal(0))
+            .map(r => BigDecimal(r.receiverFee)) should contain only (BigDecimal(
+            0
+          )) withClue "receiverFees"
 
           val taps = sv1ScanBackend.listActivity(None, 10).flatMap(_.tap).filter { tap =>
             PartyId.tryFromProtoPrimitive(tap.amuletOwner) == bobUserParty
           }
-          taps should have size (1)
+          taps should have size (1) withClue "bob taps"
           val tap = taps.head
           // bob tapped
           BigDecimal(tap.amuletAmount) shouldBe walletUsdToAmulet(bobTapAmount)
@@ -457,7 +461,7 @@ class ScanIntegrationTest
               transfer.receivers.size == 1 && PartyId
                 .tryFromProtoPrimitive(transfer.receivers.head.party) == bobUserParty
             }
-          transfers should have size (1)
+          transfers should have size (1) withClue "bob self-transfers"
           val transfer = transfers.head
           val receiver = transfer.receivers.loneElement
           PartyId
@@ -513,7 +517,7 @@ class ScanIntegrationTest
               transfer.receivers.size == 1 && PartyId
                 .tryFromProtoPrimitive(transfer.receivers.head.party) == charlieUserParty
             }
-          transfers should have size (1)
+          transfers should have size (1) withClue "bob self-transfers"
           val transfer = transfers.head
           val receiver = transfer.receivers.loneElement
           PartyId
@@ -579,7 +583,7 @@ class ScanIntegrationTest
         "Bob's validator will receive some rewards",
         _ => {
           bobValidatorWalletClient
-            .listAppRewardCoupons() should have size 1
+            .listAppRewardCoupons() should have size 1 withClue "bob AppRewardCoupons"
           // TODO(DACH-NY/canton-network-node#13038) Add asserts back for listValidatorRewardCoupons
 
           //          bobValidatorWalletClient.listValidatorRewardCoupons() should
@@ -614,7 +618,7 @@ class ScanIntegrationTest
     clue("Checking app and validator reward and faucet amounts") {
       eventually() {
         bobValidatorWalletClient
-          .listAppRewardCoupons() should have size 0
+          .listAppRewardCoupons() should have size 0 withClue "bob AppRewardCoupons"
         // TODO(DACH-NY/canton-network-node#13038) Add asserts back for listValidatorRewardCoupons
         //        bobValidatorWalletClient
         //          .listValidatorRewardCoupons() should have size 0

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTotalSupplyBigQueryIntegrationTest.scala
@@ -322,7 +322,7 @@ class ScanTotalSupplyBigQueryIntegrationTest
             .filterJava(ValidatorLivenessActivityRecord.COMPANION)(
               aliceValidatorBackend.getValidatorPartyId(),
               _.data.round.number == (expectRound - 2),
-            ) should have size (1)
+            ) should have size (1) withClue s"ValidatorLivenessActivityRecords round ${expectRound - 2}"
         }
       }
       actAndCheck(timeUntilSuccess = 30.seconds)(


### PR DESCRIPTION
Add withClue labels across scan integration tests' listlike items.

Part of #4147.
