### PR TITLE
wallet integration test clues for list size assertions

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AllocationsFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AllocationsFrontendIntegrationTest.scala
@@ -221,7 +221,8 @@ class AllocationsFrontendIntegrationTest
         }
 
         clue("sanity check: alice has no allocations yet") {
-          aliceWalletClient.listAmuletAllocations() shouldBe empty
+          aliceWalletClient
+            .listAmuletAllocations() shouldBe empty withClue "alice AmuletAllocations"
         }
 
         val (_, allocationElement) = actAndCheck(
@@ -261,7 +262,7 @@ class AllocationsFrontendIntegrationTest
         )(
           "the allocation is not shown anymore",
           _ => {
-            findAll(className("allocation")).toSeq shouldBe empty
+            findAll(className("allocation")).toSeq shouldBe empty withClue "Allocation Cards"
           },
         )
 
@@ -274,7 +275,9 @@ class AllocationsFrontendIntegrationTest
         )(
           "the allocation request is not shown anymore",
           _ => {
-            findAll(className("allocation-request")).toSeq shouldBe empty
+            findAll(
+              className("allocation-request")
+            ).toSeq shouldBe empty withClue "Allocation Request Cards"
           },
         )
       }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AmuletExpiryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AmuletExpiryIntegrationTest.scala
@@ -115,8 +115,8 @@ class AmuletExpiryIntegrationTest
     )(
       "Check that dust amulet gets expired",
       _ => {
-        sv1WalletClient.list().amulets shouldBe empty
-        sv1WalletClient.list().lockedAmulets shouldBe empty
+        sv1WalletClient.list().amulets shouldBe empty withClue "dust amulets"
+        sv1WalletClient.list().lockedAmulets shouldBe empty withClue "dust lockedAmulets"
       },
     )
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisabledWalletTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisabledWalletTimeBasedIntegrationTest.scala
@@ -83,7 +83,7 @@ class DisabledWalletTimeBasedIntegrationTest
               coupon.data.sv == sv1Backend.getDsoInfo().svParty.toProtoPrimitive &&
               coupon.data.round.number == currentRound
             },
-          ) should not be empty
+          ) should not be empty withClue "current round SvRewardCoupons"
 
         advanceRoundsToNextRoundOpening
         currentRound += 1
@@ -95,11 +95,11 @@ class DisabledWalletTimeBasedIntegrationTest
             .filterJava(UnclaimedReward.COMPANION)(
               dsoParty,
               reward => BigDecimal(reward.data.amount) >= expectedMinAmount,
-            ) should not be empty
+            ) should not be empty withClue s"UnclaimedRewards >= $expectedMinAmount"
         }
 
         sv1Backend.participantClient.ledger_api_extensions.acs
-          .filterJava(Amulet.COMPANION)(dsoParty, _ => true) shouldBe empty
+          .filterJava(Amulet.COMPANION)(dsoParty, _ => true) shouldBe empty withClue "Amulets"
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RewardExpiryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RewardExpiryIntegrationTest.scala
@@ -113,7 +113,7 @@ class RewardExpiryIntegrationTest
           .filterJava(ValidatorLivenessActivityRecord.COMPANION)(
             aliceValidatorBackend.getValidatorPartyId(),
             _.data.round.number == 0,
-          ) should have size (1)
+          ) should have size (1) withClue "ValidatorLivenessActivityRecords"
       }
     }
     actAndCheck("Advance by one tick", advanceRoundsByOneTickViaAutomation())(
@@ -167,7 +167,7 @@ class RewardExpiryIntegrationTest
           .filterJava(ValidatorLivenessActivityRecord.COMPANION)(
             aliceValidatorBackend.getValidatorPartyId(),
             _.data.round.number == 0,
-          ) shouldBe empty,
+          ) shouldBe empty withClue "ValidatorLivenessActivityRecords",
     )
   }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvExpiredRewardsCollectionTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvExpiredRewardsCollectionTimeBasedIntegrationTest.scala
@@ -72,10 +72,12 @@ class SvExpiredRewardsCollectionTimeBasedIntegrationTest
     )(
       "Wait for all unclaimed coupons to be archived and the closed round to be archived",
       _ => {
-        getRewardCoupons(round) shouldBe empty
+        getRewardCoupons(round) shouldBe empty withClue s"reward coupons round $round"
         sv1ScanBackend
           .getClosedRounds()
-          .filter(r => r.payload.round.number == round.payload.round.number) should be(empty)
+          .filter(r => r.payload.round.number == round.payload.round.number) should be(
+          empty
+        ) withClue s"ClosedRound $round"
         val (lastRound, _) = sv1ScanBackend.getRoundOfLatestData()
         sv1WalletClient
           .listSvRewardCoupons()

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeSvRewardStateIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeSvRewardStateIntegrationTest.scala
@@ -63,7 +63,7 @@ class SvMergeSvRewardStateIntegrationTest extends SvIntegrationTestBase with Tri
         "Two reward states get created",
         _ => {
           val newRewardStates = getRewardStates()
-          newRewardStates should have size 2
+          newRewardStates should have size 2 withClue "SvRewardStates"
         },
       )
       loggerFactory.assertLogs(
@@ -72,7 +72,7 @@ class SvMergeSvRewardStateIntegrationTest extends SvIntegrationTestBase with Tri
           clue("Trigger merges SvRewardState contracts") {
             eventually() {
               val newRewardStates = getRewardStates()
-              newRewardStates should have size 1
+              newRewardStates should have size 1 withClue "SvRewardStates"
             }
           }
         },

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedAmuletPriceIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedAmuletPriceIntegrationTest.scala
@@ -80,7 +80,7 @@ class SvTimeBasedAmuletPriceIntegrationTest
           sv1Backend.metrics.list(
             s"$MetricsPrefix.amulet_price.voted_price",
             Map("sv" -> sv),
-          ) should not be empty
+          ) should not be empty withClue "voted_price metrics"
 
           sv1Backend.metrics
             .get(
@@ -94,7 +94,7 @@ class SvTimeBasedAmuletPriceIntegrationTest
           sv1Backend.metrics.list(
             s"$MetricsPrefix.amulet_price.voted_price",
             Map("sv" -> sv),
-          ) shouldBe empty
+          ) shouldBe empty withClue "voted_price metrics after get"
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponIntegrationTest.scala
@@ -115,7 +115,7 @@ class SvTimeBasedRewardCouponIntegrationTest
               _.item.packages.map(_.packageId)
             )
         forAll(expectedVettedPackages) { expectedPackage =>
-          vettedByAlice should contain(expectedPackage)
+          vettedByAlice should contain(expectedPackage) withClue "alice vetted packages"
         }
       }
       // now that we know that alice has vetted the latest packages, we can resume the trigger for the rest of the test
@@ -132,15 +132,15 @@ class SvTimeBasedRewardCouponIntegrationTest
           .getOpenAndIssuingMiningRounds()
           ._1
           .filter(_.payload.opensAt <= env.environment.clock.now.toInstant)
-        openRounds should not be empty
+        openRounds should not be empty withClue "OpenMiningRounds"
         openRounds
       }
       eventually() {
         val expectedSize = openRounds.size.toLong
         val sv1Coupons = sv1WalletClient.listSvRewardCoupons()
         val aliceCoupons = aliceValidatorWalletClient.listSvRewardCoupons()
-        sv1Coupons should have size expectedSize
-        aliceCoupons should have size expectedSize
+        sv1Coupons should have size expectedSize withClue "sv1 SvRewardCoupons"
+        aliceCoupons should have size expectedSize withClue "alice SvRewardCoupons"
         sv1Coupons.map(_.payload.weight) should be(
           Seq.fill(expectedSize.toInt)(BigDecimal(SvUtil.DefaultSV1Weight))
         )
@@ -165,8 +165,10 @@ class SvTimeBasedRewardCouponIntegrationTest
       advanceRoundsToNextRoundOpening
       eventually() {
         val expectedSize = (openRounds.size - 1).toLong
-        sv1WalletClient.listSvRewardCoupons() should have size expectedSize
-        aliceValidatorWalletClient.listSvRewardCoupons() should have size expectedSize
+        sv1WalletClient
+          .listSvRewardCoupons() should have size expectedSize withClue "sv1 SvRewardCoupons"
+        aliceValidatorWalletClient
+          .listSvRewardCoupons() should have size expectedSize withClue "alice SvRewardCoupons"
       }
 
       val eachSvGetInRound0 =
@@ -194,7 +196,7 @@ class SvTimeBasedRewardCouponIntegrationTest
           sv1WalletClient,
           Seq[CheckTxHistoryFn] { case b: TransferTxLogEntry =>
             b.subtype.value shouldBe TransferTransactionSubtype.WalletAutomation.toProto
-            b.receivers shouldBe empty
+            b.receivers shouldBe empty withClue "tx receivers"
             b.sender.value.party should be(sv1Party.toProtoPrimitive)
             b.sender.value.amount should beWithin(
               BigDecimal(eachSvGetInRound0) - feesUpperBoundCC,
@@ -209,7 +211,7 @@ class SvTimeBasedRewardCouponIntegrationTest
           aliceValidatorWalletClient,
           Seq[CheckTxHistoryFn] { case b: TransferTxLogEntry =>
             b.subtype.value shouldBe TransferTransactionSubtype.WalletAutomation.toProto
-            b.receivers shouldBe empty
+            b.receivers shouldBe empty withClue "tx receivers"
             b.sender.value.party should be(aliceValidatorParty.toProtoPrimitive)
             b.sender.value.amount should beWithin(
               BigDecimal(expectedAliceAmount) - feesUpperBoundCC,
@@ -342,7 +344,9 @@ class SvTimeBasedRewardCouponIntegrationTest
         sv4ValidatorBackend.appState.participantAdminConnection
           .listVettedPackages(aliceParticipantId, decentralizedSynchronizerId, AuthorizedState)
           .futureValue
-          .flatMap(_.mapping.packages.map(_.packageId)) should not contain latestAmuletPackageId
+          .flatMap(
+            _.mapping.packages.map(_.packageId)
+          ) should not contain latestAmuletPackageId withClue "alice vetted packages"
       },
     )
 
@@ -358,7 +362,7 @@ class SvTimeBasedRewardCouponIntegrationTest
                 .getOpenAndIssuingMiningRounds()
                 ._1
                 .filter(_.payload.opensAt <= env.environment.clock.now.toInstant)
-              openRounds should not be empty
+              openRounds should not be empty withClue "OpenMiningRounds"
               openRounds
             }
             val aliceRewards = getSvRewardCoupon("alice")

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponMissingPartyIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponMissingPartyIntegrationTest.scala
@@ -77,7 +77,7 @@ class SvTimeBasedRewardCouponMissingPartyIntegrationTest
                     .getOpenAndIssuingMiningRounds()
                     ._1
                     .filter(_.payload.opensAt <= env.environment.clock.now.toInstant)
-                  openRounds should not be empty
+                  openRounds should not be empty withClue "OpenMiningRounds"
                 }
               }
             }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnclaimedSvRewardsScriptIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnclaimedSvRewardsScriptIntegrationTest.scala
@@ -83,7 +83,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
       }
 
       clue("SV reward coupons for round 0,1,2 have been created") {
-        sv1WalletClient.listSvRewardCoupons() should have size 3
+        sv1WalletClient.listSvRewardCoupons() should have size 3 withClue "sv1 SvRewardCoupons"
       }
 
       val (_, svRewardCoupons) = actAndCheck(
@@ -93,7 +93,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
         "All reward coupons got created",
         _ => {
           val svRewardCoupons = sv1WalletClient.listSvRewardCoupons()
-          svRewardCoupons should have size svRewardCouponsCount
+          svRewardCoupons should have size svRewardCouponsCount withClue "sv1 svRewardCoupons"
           svRewardCoupons
         },
       )
@@ -113,7 +113,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
         "Coupons for round 0,1,2 get expired",
         _ => {
           sv1WalletClient
-            .listSvRewardCoupons() should have size (svRewardCouponsCount - svRewardCouponsExpiredCount)
+            .listSvRewardCoupons() should have size (svRewardCouponsCount - svRewardCouponsExpiredCount) withClue "sv1 SvRewardCoupons"
           // Pause trigger once we have some coupons expired
           expireRewardCouponsTrigger.pause().futureValue
         },
@@ -136,7 +136,8 @@ class UnclaimedSvRewardsScriptIntegrationTest
           _ =>
             sv1WalletClient
               .listSvRewardCoupons() should have size
-              (svRewardCouponsCount - svRewardCouponsExpiredCount - svRewardCouponsClaimedCount),
+              (svRewardCouponsCount - svRewardCouponsExpiredCount - svRewardCouponsClaimedCount)
+              withClue "SvRewardCoupons",
         )
       }
       val svRewardCouponsAfterClaiming = sv1WalletClient.listSvRewardCoupons()
@@ -206,7 +207,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
             .!(errorProcessor)
 
           assert(exitCode == 0, s"Script exited with code $exitCode")
-          readLines.filter(_.startsWith("ERROR:")) shouldBe empty
+          readLines.filter(_.startsWith("ERROR:")) shouldBe empty withClue "ERROR lines"
           forExactly(6, readLines) {
             _ should include("WARNING:global:Invalid weight input for round")
           }
@@ -277,7 +278,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
             .!(errorProcessor)
 
           assert(exitCode == 0, s"Script exited with code $exitCode")
-          readLines.filter(_.startsWith("ERROR:")) shouldBe empty
+          readLines.filter(_.startsWith("ERROR:")) shouldBe empty withClue "ERROR lines"
           forExactly(6, readLines) {
             _ should include("WARNING:global:Invalid weight input for round")
           }
@@ -347,7 +348,7 @@ class UnclaimedSvRewardsScriptIntegrationTest
             .!(errorProcessor)
 
           assert(exitCode == 0, s"Script exited with code $exitCode")
-          readLines.filter(_.startsWith("ERROR:")) shouldBe empty
+          readLines.filter(_.startsWith("ERROR:")) shouldBe empty withClue "ERROR lines"
           forExactly(1, readLines) {
             _ should include(s"reward_expired_count = $svRewardCouponsExpiredCount")
           }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletAuth0FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletAuth0FrontendIntegrationTest.scala
@@ -63,7 +63,10 @@ class WalletAuth0FrontendIntegrationTest
               },
             )(
               "The user sees the login screen again",
-              _ => find(id("oidc-login-button")) should not be empty,
+              _ =>
+                find(
+                  id("oidc-login-button")
+                ) should not be empty withClue "'Log In with OAuth2' button",
             )
         }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletExpirationsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletExpirationsIntegrationTest.scala
@@ -80,7 +80,8 @@ class WalletExpirationsIntegrationTest
 
       clue("The payment request has been expired after resuming the trigger") {
         eventually() {
-          aliceWalletClient.listAppPaymentRequests() shouldBe empty
+          aliceWalletClient
+            .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
         }
       }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletFrontendIntegrationTest.scala
@@ -215,9 +215,9 @@ class WalletFrontendIntegrationTest
             webDriver: WebDriver
         ): Unit = {
           val proposalRows = findAll(className("proposal-row")).toSeq
-          proposalRows should have size proposalCount
+          proposalRows should have size proposalCount withClue "'Proposed Minting Delegations' row"
           val delegationRows = findAll(className("delegation-row")).toSeq
-          delegationRows should have size activeCount
+          delegationRows should have size activeCount withClue "'Active Minting Delegations' row"
         }
 
         // 1. Setup
@@ -240,10 +240,14 @@ class WalletFrontendIntegrationTest
 
         // 2. Verify empty initial state via API
         clue("Check that no minting delegation proposals exist initially") {
-          aliceWalletClient.listMintingDelegationProposals().proposals shouldBe empty
+          aliceWalletClient
+            .listMintingDelegationProposals()
+            .proposals shouldBe empty withClue "MintingDelegationProposals"
         }
         clue("Check that no minting delegations exist initially") {
-          aliceWalletClient.listMintingDelegations().delegations shouldBe empty
+          aliceWalletClient
+            .listMintingDelegations()
+            .delegations shouldBe empty withClue "MintingDelegations"
         }
 
         // 3. Create three proposals, one from each beneficiary
@@ -261,7 +265,7 @@ class WalletFrontendIntegrationTest
           _ => {
             aliceWalletClient
               .listMintingDelegationProposals()
-              .proposals should have size 3
+              .proposals should have size 3 withClue "MintingDelegationProposals"
           },
         )
 
@@ -287,7 +291,7 @@ class WalletFrontendIntegrationTest
             _ => {
               find(id("proposals-label")).valueOrFail("Proposed heading not found!")
               val proposalRows = findAll(className("proposal-row")).toSeq
-              proposalRows should have size 3
+              proposalRows should have size 3 withClue "'Proposed Minting Delegations' row"
 
               proposalRows.foreach { row =>
                 row
@@ -417,7 +421,7 @@ class WalletFrontendIntegrationTest
               eventually() {
                 aliceWalletClient
                   .listMintingDelegationProposals()
-                  .proposals should have size 2
+                  .proposals should have size 2 withClue "MintingDelegationProposals"
                 checkRowCounts(2, 2)
               }
             },

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletFrontendTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletFrontendTimeBasedIntegrationTest.scala
@@ -64,7 +64,10 @@ class WalletFrontendTimeBasedIntegrationTest
           "Alice logs out", {
             eventuallyClickOn(id("logout-button"))
           },
-        )("Alice sees the login screen again", _ => find(id("login-button")) should not be empty)
+        )(
+          "Alice sees the login screen again",
+          _ => find(id("login-button")) should not be empty withClue "'Log In' button",
+        )
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -228,7 +228,7 @@ class WalletIntegrationTest
           aliceValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.acs
             .filterJava(
               walletCodegen.AppPaymentRequest.COMPANION
-            )(alice) should have size (batchSize.toLong + 2)
+            )(alice) should have size (batchSize.toLong + 2) withClue "AppPaymentRequests"
         }
 
         val offsetBefore =
@@ -398,7 +398,7 @@ class WalletIntegrationTest
       )(
         "splitwell provider is no longer featured",
         { _ =>
-          sv1ScanBackend.listFeaturedAppRights() shouldBe empty
+          sv1ScanBackend.listFeaturedAppRights() shouldBe empty withClue "FeaturedAppRights"
           splitwellWalletClient.userStatus().hasFeaturedAppRight shouldBe false
         },
       )
@@ -537,7 +537,7 @@ class WalletIntegrationTest
       )
 
       clue("Alice is listed as a user") {
-        aliceValidatorBackend.listUsers() should contain(aliceUser)
+        aliceValidatorBackend.listUsers() should contain(aliceUser) withClue "Users"
       }
       actAndCheck(
         "We offboard Alice",

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletManualRoundsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletManualRoundsIntegrationTest.scala
@@ -230,7 +230,7 @@ class WalletManualRoundsIntegrationTest
         )(
           "SubscriptionInitialPayment is created",
           _ => {
-            aliceWalletClient.listSubscriptions() shouldBe empty
+            aliceWalletClient.listSubscriptions() shouldBe empty withClue "Subscriptions"
             inside(aliceWalletClient.listSubscriptionInitialPayments()) {
               case Seq(initialPayment) => initialPayment
             }
@@ -287,7 +287,8 @@ class WalletManualRoundsIntegrationTest
             )(
               "The payment is rejected due to the round for collecting payment is no longer active",
               _ => {
-                aliceWalletClient.listSubscriptionInitialPayments() shouldBe empty
+                aliceWalletClient
+                  .listSubscriptionInitialPayments() shouldBe empty withClue "SubscriptionInitialPayments"
               },
             )
           },
@@ -318,7 +319,7 @@ class WalletManualRoundsIntegrationTest
       val initialAppRewardCoupons = aliceValidatorWalletClient.listAppRewardCoupons()
 
       clue("Check that no payment requests exist") {
-        aliceWalletClient.listAppPaymentRequests() shouldBe empty
+        aliceWalletClient.listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
       }
 
       actAndCheck(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -75,8 +75,12 @@ class WalletMintingDelegationTimeBasedIntegrationTest
           createAndAcceptExternalPartySetupProposal(aliceValidatorBackend, beneficiary2Party)
 
           // Verify initial state
-          aliceValidatorWalletClient.listMintingDelegationProposals().proposals shouldBe empty
-          aliceValidatorWalletClient.listMintingDelegations().delegations shouldBe empty
+          aliceValidatorWalletClient
+            .listMintingDelegationProposals()
+            .proposals shouldBe empty withClue "MintingDelegationProposals"
+          aliceValidatorWalletClient
+            .listMintingDelegations()
+            .delegations shouldBe empty withClue "MintingDelegations"
 
           val (_, proposal0Cid) = actAndCheck(
             "Create minting delegation proposal for beneficiary2",
@@ -85,7 +89,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible to validator",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 1
+              proposals.proposals should have size 1 withClue "proposals"
               proposals.proposals.head.contract.contractId
             },
           )
@@ -97,7 +101,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Delegation is created",
             _ => {
               val delegations = aliceValidatorWalletClient.listMintingDelegations()
-              delegations.delegations should have size 1
+              delegations.delegations should have size 1 withClue "delegations"
             },
           )
 
@@ -108,7 +112,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible to validator",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 1
+              proposals.proposals should have size 1 withClue "proposals"
             },
           )
         }
@@ -122,7 +126,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible with beneficiaryHosted = false",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
               val beneficiaryProposal = proposals.proposals
                 .find(
                   _.contract.payload.hcursor
@@ -144,7 +148,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Delegation is visible with beneficiaryHosted = false",
             _ => {
               val delegations = aliceValidatorWalletClient.listMintingDelegations()
-              delegations.delegations should have size 2
+              delegations.delegations should have size 2 withClue "delegations"
               val beneficiaryDelegation = delegations.delegations
                 .find(
                   _.contract.payload.hcursor
@@ -181,7 +185,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible to validator",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
               proposals.proposals
                 .find(
                   _.contract.payload.hcursor
@@ -203,7 +207,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             _ =>
               aliceValidatorWalletClient
                 .listMintingDelegationProposals()
-                .proposals should have size 1,
+                .proposals should have size 1 withClue "proposals",
           )
         }
 
@@ -216,7 +220,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible to validator",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
               proposals.proposals
                 .find(
                   _.contract.payload.hcursor
@@ -238,9 +242,9 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             delegationCid => {
               aliceValidatorWalletClient
                 .listMintingDelegationProposals()
-                .proposals should have size 1
+                .proposals should have size 1 withClue "proposals"
               val delegations = aliceValidatorWalletClient.listMintingDelegations()
-              delegations.delegations should have size 2
+              delegations.delegations should have size 2 withClue "delegations"
               delegationCid
             },
           )
@@ -255,7 +259,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible to validator",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
               proposals.proposals
                 .find(
                   _.contract.payload.hcursor
@@ -277,9 +281,9 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             newDelegationCid => {
               aliceValidatorWalletClient
                 .listMintingDelegationProposals()
-                .proposals should have size 1
+                .proposals should have size 1 withClue "proposals"
               val delegations = aliceValidatorWalletClient.listMintingDelegations()
-              delegations.delegations should have size 2
+              delegations.delegations should have size 2 withClue "delegations"
               val beneficiaryDelegation = delegations.delegations
                 .find(
                   _.contract.payload.hcursor
@@ -310,7 +314,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Proposal is visible",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
               proposals.proposals
                 .find(
                   _.contract.payload.hcursor
@@ -331,7 +335,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Delegation is created",
             _ => {
               val delegations = aliceValidatorWalletClient.listMintingDelegations()
-              delegations.delegations should have size 3
+              delegations.delegations should have size 3 withClue "delegations"
             },
           )
 
@@ -343,7 +347,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
             "Second proposal is visible",
             _ => {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals()
-              proposals.proposals should have size 2
+              proposals.proposals should have size 2 withClue "proposals"
             },
           )
 
@@ -360,7 +364,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
           clue("Expired proposal should be auto-rejected") {
             eventually() {
               val proposals = aliceValidatorWalletClient.listMintingDelegationProposals().proposals
-              proposals should have size 1
+              proposals should have size 1 withClue "proposals"
             }
           }
         }
@@ -392,7 +396,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         "Proposal is visible",
         _ => {
           val proposals = aliceWalletClient.listMintingDelegationProposals()
-          proposals.proposals should have size 1
+          proposals.proposals should have size 1 withClue "proposals"
           proposals.proposals.head.contract.contractId
         },
       )
@@ -405,7 +409,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         "Delegation is created",
         _ => {
           val delegations = aliceWalletClient.listMintingDelegations()
-          delegations.delegations should have size 1
+          delegations.delegations should have size 1 withClue "delegations"
         },
       )
 
@@ -553,19 +557,21 @@ class WalletMintingDelegationTimeBasedIntegrationTest
 
         clue("All reward contracts should be consumed") {
           eventually() {
-            externalPartyWallet.store.listUnclaimedActivityRecords().futureValue shouldBe empty
+            externalPartyWallet.store
+              .listUnclaimedActivityRecords()
+              .futureValue shouldBe empty withClue "UnclaimedActivityRecord"
             externalPartyWallet.store
               .listSortedAppRewards(issuingRoundsMap)
-              .futureValue shouldBe empty
+              .futureValue shouldBe empty withClue "AppReward"
             externalPartyWallet.store
               .listSortedValidatorRewards(Some(issuingRoundsMap.keySet.map(_.number)))
-              .futureValue shouldBe empty
+              .futureValue shouldBe empty withClue "ValidatorReward"
             externalPartyWallet.store
               .listSortedLivenessActivityRecords(issuingRoundsMap)
-              .futureValue shouldBe empty
+              .futureValue shouldBe empty withClue "LivenessActivityRecord"
             externalPartyWallet.store
               .listDevelopmentFundCoupons()
-              .futureValue shouldBe empty
+              .futureValue shouldBe empty withClue "DevelopmentFundCoupon"
           }
         }
       }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentFrontendIntegrationTest.scala
@@ -464,9 +464,9 @@ class WalletPaymentFrontendIntegrationTest
     )(
       "The payment is processed",
       _ => {
-        aliceWalletClient.listAppPaymentRequests() shouldBe empty
+        aliceWalletClient.listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
         val acceptedPayments = aliceWalletClient.listAcceptedAppPayments()
-        acceptedPayments should have size 1
+        acceptedPayments should have size 1 withClue "AcceptedAppPayments"
         acceptedPayments.head
       },
     )._2

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
@@ -38,7 +38,7 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
       val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
 
       clue("Check that no payment requests exist") {
-        aliceWalletClient.listAppPaymentRequests() shouldBe empty
+        aliceWalletClient.listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
       }
 
       val description = "a payment for cool stuff"
@@ -72,7 +72,9 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
         aliceWalletClient.rejectAppPaymentRequest(reqFound.contractId),
       )(
         "Rejected request disappears from list",
-        _ => aliceWalletClient.listAppPaymentRequests() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests",
       )
     }
 
@@ -93,7 +95,7 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
       clue("Tap 50 amulets") {
         aliceWalletClient.tap(50)
         eventually() {
-          aliceWalletClient.list().amulets should not be empty
+          aliceWalletClient.list().amulets should not be empty withClue "amulets"
         }
       }
 
@@ -104,7 +106,9 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
             aliceWalletClient.acceptAppPaymentRequest(cid),
           )(
             "Payment request disappears from list",
-            _ => aliceWalletClient.listAppPaymentRequests() shouldBe empty,
+            _ =>
+              aliceWalletClient
+                .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests",
           )
         inside(aliceWalletClient.listAcceptedAppPayments()) { case Seq(r) =>
           r.contractId shouldBe acceptedPaymentId

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
@@ -35,7 +35,7 @@ class WalletRewardsTimeBasedIntegrationTest
 
       // Retrieve transferred amulet in bob's wallet and transfer part of it back to alice;
       // bob's validator will receive some app rewards
-      eventually()(bobWalletClient.list().amulets should have size 1)
+      eventually()(bobWalletClient.list().amulets should have size 1 withClue "amulets")
       p2pTransfer(bobWalletClient, aliceWalletClient, alice, 30.0)
 
       val openRounds = eventually() {
@@ -44,21 +44,25 @@ class WalletRewardsTimeBasedIntegrationTest
           .getOpenAndIssuingMiningRounds()
           ._1
           .filter(_.payload.opensAt <= env.environment.clock.now.toInstant)
-        openRounds should not be empty
+        openRounds should not be empty withClue "openRounds"
         openRounds
       }
 
       advanceTimeForRewardAutomationToRunForCurrentRound
 
       eventually(40.seconds) {
-        bobValidatorWalletClient.listAppRewardCoupons() should have size 1
-        bobValidatorWalletClient.listValidatorRewardCoupons() should have size 1
-        aliceValidatorWalletClient.listAppRewardCoupons() should have size 1
-        aliceValidatorWalletClient.listValidatorRewardCoupons() should have size 1
         bobValidatorWalletClient
-          .listValidatorLivenessActivityRecords() should have size openRounds.size.toLong
+          .listAppRewardCoupons() should have size 1 withClue "AppRewardCoupons"
+        bobValidatorWalletClient
+          .listValidatorRewardCoupons() should have size 1 withClue "ValidatorRewardCoupons"
         aliceValidatorWalletClient
-          .listValidatorLivenessActivityRecords() should have size openRounds.size.toLong
+          .listAppRewardCoupons() should have size 1 withClue "AppRewardCoupons"
+        aliceValidatorWalletClient
+          .listValidatorRewardCoupons() should have size 1 withClue "ValidatorRewardCoupons"
+        bobValidatorWalletClient
+          .listValidatorLivenessActivityRecords() should have size openRounds.size.toLong withClue "bob ValidatorLivenessActivityRecords"
+        aliceValidatorWalletClient
+          .listValidatorLivenessActivityRecords() should have size openRounds.size.toLong withClue "alice ValidatorLivenessActivityRecords"
       }
 
       // avoid messing with the computation of balance
@@ -77,9 +81,12 @@ class WalletRewardsTimeBasedIntegrationTest
       advanceTimeForRewardAutomationToRunForCurrentRound
 
       eventually() {
-        bobValidatorWalletClient.listAppRewardCoupons() should have size 0
-        bobValidatorWalletClient.listValidatorRewardCoupons() should have size 0
-        bobValidatorWalletClient.listValidatorLivenessActivityRecords() should have size 0
+        bobValidatorWalletClient
+          .listAppRewardCoupons() should have size 0 withClue "AppRewardCoupons"
+        bobValidatorWalletClient
+          .listValidatorRewardCoupons() should have size 0 withClue "ValidatorRewardCoupons"
+        bobValidatorWalletClient
+          .listValidatorLivenessActivityRecords() should have size 0 withClue "ValidatorLivenessActivityRecords"
 
         val newBalance = bobValidatorWalletClient.balance().unlockedQty
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsFrontendIntegrationTest.scala
@@ -65,7 +65,7 @@ class WalletSubscriptionsFrontendIntegrationTest
           "Alice sees her subscriptions",
           _ => {
             val subscriptionRows = findAll(className("subscription-row")).toSeq
-            subscriptionRows should have size 2
+            subscriptionRows should have size 2 withClue "'Your Subscriptions' rows"
             matchSubscription(subscriptionRows.head)(
               expectedReceiver = dsoEntry,
               expectedProvider = dsoEntry,
@@ -89,7 +89,7 @@ class WalletSubscriptionsFrontendIntegrationTest
           "Alice sees only one subscription",
           _ => {
             val subscriptionRowsAfterCancel = findAll(className("subscription-row")).toSeq
-            subscriptionRowsAfterCancel should have size 1
+            subscriptionRowsAfterCancel should have size 1 withClue "'Your Subscriptions' rows after cancel"
             matchSecondSubscription(subscriptionRowsAfterCancel.head)
           },
         )
@@ -118,7 +118,7 @@ class WalletSubscriptionsFrontendIntegrationTest
           "Alice sees the subscription, but cannot cancel it",
           _ => {
             val subscriptionRows = findAll(className("subscription-row")).toSeq
-            subscriptionRows should have size 1
+            subscriptionRows should have size 1 withClue "'Your Subscriptions' rows"
             cancelIsEnabled(subscriptionRows.head, expectedButtonEnabled = false)
           },
         )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSubscriptionsIntegrationTest.scala
@@ -40,7 +40,8 @@ class WalletSubscriptionsIntegrationTest extends IntegrationTest with WalletTest
     "allow a user to get, list and reject subscription requests" in { implicit env =>
       val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
 
-      aliceWalletClient.listSubscriptionRequests() shouldBe empty
+      aliceWalletClient
+        .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
 
       val description = "this will be rejected"
       val request = createSelfSubscriptionRequest(
@@ -70,7 +71,9 @@ class WalletSubscriptionsIntegrationTest extends IntegrationTest with WalletTest
         aliceWalletClient.rejectSubscriptionRequest(requestId),
       )(
         "alice sees empty list of subscription requests",
-        _ => aliceWalletClient.listSubscriptionRequests() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests",
       )
     }
 
@@ -82,8 +85,9 @@ class WalletSubscriptionsIntegrationTest extends IntegrationTest with WalletTest
         val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
         val aliceValidatorParty = aliceValidatorBackend.getValidatorPartyId()
 
-        aliceWalletClient.listSubscriptionRequests() shouldBe empty
-        aliceWalletClient.listSubscriptions() shouldBe empty
+        aliceWalletClient
+          .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
+        aliceWalletClient.listSubscriptions() shouldBe empty withClue "Subscriptions"
 
         val description = "this will be accepted"
         val (request, requestId) = actAndCheck(
@@ -114,7 +118,8 @@ class WalletSubscriptionsIntegrationTest extends IntegrationTest with WalletTest
         )(
           "initial subscription payment is listed correctly",
           initialPaymentId => {
-            aliceWalletClient.listSubscriptionRequests() shouldBe empty
+            aliceWalletClient
+              .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
             inside(aliceWalletClient.listSubscriptionInitialPayments()) { case Seq(r) =>
               r.contractId shouldBe initialPaymentId
               r.payload.subscriptionData should equal(request.subscriptionData)
@@ -216,7 +221,10 @@ class WalletSubscriptionsIntegrationTest extends IntegrationTest with WalletTest
         actAndCheck(
           "Cancel the subscription",
           aliceWalletClient.cancelSubscription(subscriptionStateId2),
-        )("no more subscriptions exist", _ => aliceWalletClient.listSubscriptions() shouldBe empty)
+        )(
+          "no more subscriptions exist",
+          _ => aliceWalletClient.listSubscriptions() shouldBe empty withClue "Subscriptions",
+        )
       }
   }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletSweepIntegrationTest.scala
@@ -113,8 +113,9 @@ abstract class WalletSweepIntegrationTest
                   eventually() {
                     sv1Balance() shouldBe >(maxBalanceUsd)
                     val txOffers = walletClient.listTransferOffers()
-                    txOffers should have size 1
-                    walletClient.listAcceptedTransferOffers() shouldBe empty
+                    txOffers should have size 1 withClue "TransferOffers"
+                    walletClient
+                      .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
                     ccToDollars(
                       txOffers.headOption.value.payload.amount.amount,
                       amuletPrice.bigDecimal,
@@ -139,16 +140,18 @@ abstract class WalletSweepIntegrationTest
             { _ =>
               sv1Balance() - firstTransferAmountUsd shouldBe >(maxBalanceUsd)
               eventually() {
-                walletClient.listTransferOffers() should have size 2
-                walletClient.listAcceptedTransferOffers() shouldBe empty
+                walletClient.listTransferOffers() should have size 2 withClue "TransferOffers"
+                walletClient
+                  .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
               }
             },
           )
         }
         clue("After resuming auto-accept, SV1 is drained and Alice receives funds") {
           eventually(40.seconds) {
-            walletClient.listTransferOffers() shouldBe empty
-            walletClient.listAcceptedTransferOffers() shouldBe empty
+            walletClient.listTransferOffers() shouldBe empty withClue "TransferOffers"
+            walletClient
+              .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
 
             assertSweepCompleted()
             walletClient
@@ -175,8 +178,9 @@ abstract class WalletSweepIntegrationTest
         "Alice sees exactly one transfer offer",
         { _ =>
           eventually() {
-            walletClient.listTransferOffers() should have size 1
-            walletClient.listAcceptedTransferOffers() shouldBe empty
+            walletClient.listTransferOffers() should have size 1 withClue "TransferOffers"
+            walletClient
+              .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
           }
         },
       )
@@ -188,8 +192,9 @@ abstract class WalletSweepIntegrationTest
     }
     clue("After resuming auto-accept, SV1 is drained and Alice receives funds") {
       eventually(40.seconds) {
-        walletClient.listTransferOffers() shouldBe empty
-        walletClient.listAcceptedTransferOffers() shouldBe empty
+        walletClient.listTransferOffers() shouldBe empty withClue "TransferOffers"
+        walletClient
+          .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
         assertSweepCompleted()
         walletClient
           .balance()
@@ -280,8 +285,9 @@ abstract class WalletSweepIntegrationTest
     clue("There are no outstanding transfer offers to accept or complete") {
       eventually() {
         sv1Balance() shouldBe <(maxBalanceUsd)
-        walletClient.listTransferOffers() shouldBe empty
-        walletClient.listAcceptedTransferOffers() shouldBe empty
+        walletClient.listTransferOffers() shouldBe empty withClue "TransferOffers"
+        walletClient
+          .listAcceptedTransferOffers() shouldBe empty withClue "AcceptedTransferOffers"
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTimeBasedIntegrationTest.scala
@@ -60,7 +60,7 @@ class WalletTimeBasedIntegrationTest
       clue("Alice gets some amulets") {
         aliceWalletClient.tap(50)
       }
-      aliceWalletClient.listSubscriptions() shouldBe empty
+      aliceWalletClient.listSubscriptions() shouldBe empty withClue "Subscriptions"
 
       bracket(
         clue("Creating 3 subscriptions, 10 days apart") {
@@ -205,7 +205,9 @@ class WalletTimeBasedIntegrationTest
           activeSvs.map(_.dsoDelegateBasedAutomation.trigger[ExpiredLockedAmuletTrigger]),
       ) {
         clue("Check wallet after advancing to next 2 rounds") {
-          eventually()(aliceWalletClient.list().lockedAmulets shouldBe empty)
+          eventually()(
+            aliceWalletClient.list().lockedAmulets shouldBe empty withClue "lockedAmulets"
+          )
         }
       }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendIntegrationTest.scala
@@ -83,7 +83,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
           "Alice sees no transactions",
           _ => {
             val txs = findAll(className("tx-row")).toSeq
-            txs should have size 0
+            txs should have size 0 withClue "txs"
           },
         )
 
@@ -127,7 +127,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
           "Alice sees the transactions",
           _ => {
             val txs = findAll(className("tx-row")).toSeq
-            txs should have size 6
+            txs should have size 6 withClue "txs"
             txs
           },
         )
@@ -187,7 +187,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
         txs
           .map(row => {
             val updateId = readTransactionFromRow(row).updateId
-            updateId should not be empty
+            updateId should not be empty withClue "updateId"
             updateId
           })
           // remove the balance change tx for scan comparison
@@ -269,7 +269,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
         )(
           "Alice sees no transactions",
           _ => {
-            txRows should have size 0
+            txRows should have size 0 withClue "txs"
           },
         )
 
@@ -456,7 +456,7 @@ class WalletTransactionHistoryFrontendIntegrationTest
         "The coupon is created",
         _ => {
           aliceWalletClient
-            .listActiveDevelopmentFundCoupons() should have size 1
+            .listActiveDevelopmentFundCoupons() should have size 1 withClue "ActiveDevelopmentFundCoupons"
         },
       )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransactionHistoryFrontendTimeBasedIntegrationTest.scala
@@ -54,7 +54,7 @@ class WalletTransactionHistoryFrontendTimeBasedIntegrationTest
           "Alice sees the transactions",
           _ => {
             val txs = findAll(className("tx-row")).toSeq
-            txs should have size 3
+            txs should have size 3 withClue "txs"
             forAll(txs.take(2))(readPartyDescriptionFromRow(_) shouldBe defined)
             txs
           },
@@ -75,7 +75,7 @@ class WalletTransactionHistoryFrontendTimeBasedIntegrationTest
           "Alice sees the new transactions",
           _ => {
             val txs = findAll(className("tx-row")).toSeq
-            txs should have size 5
+            txs should have size 5 withClue "txs"
             forAll(txs.take(2))(readPartyDescriptionFromRow(_) shouldBe defined)
             txs
           },

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransfersFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTransfersFrontendIntegrationTest.scala
@@ -69,7 +69,9 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
       )
       createAnsEntry(bobAnsExternalClient, bobAnsName, bobWalletClient, cc)
 
-      listTransferOffersViaBackend(bobWalletClient) shouldBe empty
+      listTransferOffersViaBackend(
+        bobWalletClient
+      ) shouldBe empty withClue "bob TransferOffers"
 
       withFrontEnd("alice") { implicit webDriver =>
         browseToAliceWallet(aliceDamlUser)
@@ -89,7 +91,7 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
             currentUrl should endWith("/transactions")
 
             val offers = listTransferOffersViaBackend(bobWalletClient)
-            offers should have size 1
+            offers should have size 1 withClue "TransferOffers"
             val transfer = offers.head
             val tenDaysFromNow = Instant.now().plus(expiryDays.toLong, ChronoUnit.DAYS)
             val timeDiff = ChronoUnit.MINUTES.between(transfer.expiry, tenDaysFromNow)
@@ -115,7 +117,7 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
           _ => {
             val offerCards = findAll(className("transfer-offer")).toList
 
-            offerCards should have size (1)
+            offerCards should have size (1) withClue "Transfer Offer card"
 
             inside(offerCards) { case Seq(offerCard) =>
               seleniumText(
@@ -175,7 +177,10 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         ),
       )(
         "alice observes transfer offer",
-        _ => listTransferOffersViaBackend(aliceWalletClient) should have size 1,
+        _ =>
+          listTransferOffersViaBackend(
+            aliceWalletClient
+          ) should have size 1 withClue "alice TransferOffers",
       )
 
       withFrontEnd("alice") { implicit webDriver =>
@@ -183,7 +188,7 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         eventually() {
           val offerCards = findAll(className("transfer-offer")).toList
 
-          offerCards should have size (1)
+          offerCards should have size (1) withClue "Transfer Offer card"
 
           inside(offerCards) { case Seq(offerCard) =>
             seleniumText(
@@ -237,14 +242,19 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         ),
       )(
         "alice has an outgoing transfer offer",
-        _ => listTransferOffersViaBackend(aliceWalletClient) should have size 1,
+        _ =>
+          listTransferOffersViaBackend(
+            aliceWalletClient
+          ) should have size 1 withClue "alice TransferOffers",
       )
 
       withFrontEnd("alice") { implicit webDriver =>
         browseToAliceWallet(aliceDamlUser)
         clue("Alice can't see transfer offers she created") {
           eventually() {
-            findAll(className("transfer-offer")).toList should have size 0
+            findAll(
+              className("transfer-offer")
+            ).toList should have size 0 withClue "Transfer Offer cards"
           }
         }
       }
@@ -285,14 +295,19 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         },
       )(
         "alice observes transfer offer",
-        _ => listTransferOffersViaBackend(aliceWalletClient) should have size 1,
+        _ =>
+          listTransferOffersViaBackend(
+            aliceWalletClient
+          ) should have size 1 withClue "alice TransferOffers",
       )
 
       withFrontEnd("alice") { implicit webDriver =>
         browseToAliceWallet(aliceDamlUser)
 
         eventually() {
-          findAll(className("transfer-offer")).toList should have size (1)
+          findAll(
+            className("transfer-offer")
+          ).toList should have size (1) withClue "Transfer Offer cards"
         }
 
         actAndCheck(
@@ -302,7 +317,9 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         )(
           "Alice sees no more pending transfer offers",
           _ => {
-            findAll(className("transfer-offer")).toList should have size (0)
+            findAll(
+              className("transfer-offer")
+            ).toList should have size (0) withClue "Transfer Offer cards"
             assertInRange(bobWalletClient.balance().unlockedQty, (BigDecimal(6), BigDecimal(7)))
             assertInRange(aliceWalletClient.balance().unlockedQty, (BigDecimal(12), BigDecimal(13)))
           },
@@ -345,14 +362,17 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         },
       )(
         "alice observes transfer offer",
-        _ => listTransferOffersViaBackend(aliceWalletClient) should have size 1,
+        _ =>
+          listTransferOffersViaBackend(
+            aliceWalletClient
+          ) should have size 1 withClue "alice TransferOffers",
       )
 
       withFrontEnd("alice") { implicit webDriver =>
         browseToAliceWallet(aliceDamlUser)
 
         eventually() {
-          findAll(className("transfer-offer")) should have size 1
+          findAll(className("transfer-offer")) should have size 1 withClue "Transfer Offer cards"
         }
 
         actAndCheck(
@@ -362,7 +382,7 @@ abstract class BaseWalletTransfersFrontendIntegrationTest
         )(
           "Alice sees no more pending transfer offers",
           _ => {
-            findAll(className("transfer-offer")) should have size 0
+            findAll(className("transfer-offer")) should have size 0 withClue "Transfer Offer cards"
             assertInRange(bobWalletClient.balance().unlockedQty, (BigDecimal(9), BigDecimal(10)))
             assertInRange(aliceWalletClient.balance().unlockedQty, (BigDecimal(9), BigDecimal(10)))
           },

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogIntegrationTest.scala
@@ -173,7 +173,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Alice sees the self-payment request",
-        _ => aliceWalletClient.listAppPaymentRequests() should not be empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() should not be empty withClue "AppPaymentRequests",
       )
 
       val (_, acceptedPayment) = actAndCheck(
@@ -182,7 +184,8 @@ class WalletTxLogIntegrationTest
       )(
         "Payment request disappears from list",
         acceptedPaymentCid => {
-          aliceWalletClient.listAppPaymentRequests() shouldBe empty
+          aliceWalletClient
+            .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
           aliceWalletClient.listAcceptedAppPayments().find(_.contractId == acceptedPaymentCid).value
         },
       )
@@ -197,7 +200,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Accepted app payment disappears",
-        _ => aliceWalletClient.listAcceptedAppPayments() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listAcceptedAppPayments() shouldBe empty withClue "AcceptedAppPayments",
       )
 
       checkTxHistory(
@@ -211,7 +216,7 @@ class WalletTxLogIntegrationTest
               selfPaymentAmount - smallAmount,
               selfPaymentAmount,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: TransferTxLogEntry =>
@@ -223,7 +228,7 @@ class WalletTxLogIntegrationTest
               -selfPaymentAmount - smallAmount,
               -selfPaymentAmount,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -260,7 +265,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Alice sees the self-payment request",
-        _ => aliceWalletClient.listAppPaymentRequests() should not be empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() should not be empty withClue "AppPaymentRequests",
       )
 
       val (acceptedPaymentCid, _) = actAndCheck(
@@ -268,7 +275,9 @@ class WalletTxLogIntegrationTest
         aliceWalletClient.acceptAppPaymentRequest(reqCid),
       )(
         "Payment request disappears from list",
-        _ => aliceWalletClient.listAppPaymentRequests() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests",
       )
 
       actAndCheck(
@@ -281,7 +290,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Accepted app payment disappears",
-        _ => aliceWalletClient.listAcceptedAppPayments() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listAcceptedAppPayments() shouldBe empty withClue "AcceptedAppPayments",
       )
 
       checkTxHistory(
@@ -301,7 +312,7 @@ class WalletTxLogIntegrationTest
               -selfPaymentAmount - smallAmount,
               -selfPaymentAmount,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -350,7 +361,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Alice sees the payment request",
-        _ => aliceWalletClient.listAppPaymentRequests() should not be empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() should not be empty withClue "AppPaymentRequests",
       )
 
       val (_, acceptedPayment) = actAndCheck(
@@ -359,7 +372,8 @@ class WalletTxLogIntegrationTest
       )(
         "Payment request disappears from list",
         acceptedPaymentCid => {
-          aliceWalletClient.listAppPaymentRequests() shouldBe empty
+          aliceWalletClient
+            .listAppPaymentRequests() shouldBe empty withClue "AppPaymentRequests"
           aliceWalletClient.listAcceptedAppPayments().find(_.contractId == acceptedPaymentCid).value
         },
       )
@@ -374,7 +388,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Accepted app payment disappears",
-        _ => aliceWalletClient.listAcceptedAppPayments() shouldBe empty,
+        _ =>
+          aliceWalletClient
+            .listAcceptedAppPayments() shouldBe empty withClue "AcceptedAppPayments",
       )
 
       checkTxHistory(
@@ -406,7 +422,7 @@ class WalletTxLogIntegrationTest
               -BigDecimal(transferAmountTotalCC) - smallAmount,
               -BigDecimal(transferAmountTotalCC),
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -441,7 +457,7 @@ class WalletTxLogIntegrationTest
 
       actAndCheck("Bob accepts transfer offer", bobWalletClient.acceptTransferOffer(offerCid))(
         "Alice does not see transfer offer anymore",
-        _ => aliceWalletClient.listTransferOffers() shouldBe empty,
+        _ => aliceWalletClient.listTransferOffers() shouldBe empty withClue "TransferOffers",
       )
 
       // Both Alice and Bob see the same representation of the transfer
@@ -489,7 +505,10 @@ class WalletTxLogIntegrationTest
         charlieSplitwellClient.acceptInvite(invite),
       )(
         "Alice sees the accepted invite",
-        _ => aliceSplitwellClient.listAcceptedGroupInvites(key.id) should not be empty,
+        _ =>
+          aliceSplitwellClient.listAcceptedGroupInvites(
+            key.id
+          ) should not be empty withClue "AcceptedGroupInvites",
       )
 
       actAndCheck(
@@ -500,8 +519,10 @@ class WalletTxLogIntegrationTest
       )(
         "Charlie sees the group and Alice doesn't see any accepted invite",
         _ => {
-          charlieSplitwellClient.listGroups() should have size 1
-          aliceSplitwellClient.listAcceptedGroupInvites(key.id) should be(empty)
+          charlieSplitwellClient.listGroups() should have size 1 withClue "Groups"
+          aliceSplitwellClient.listAcceptedGroupInvites(key.id) should be(
+            empty
+          ) withClue "AcceptedGroupInvites"
         },
       )
 
@@ -530,7 +551,8 @@ class WalletTxLogIntegrationTest
       )(
         "All parties see the new balances",
         _ => {
-          aliceWalletClient.listAcceptedAppPayments() shouldBe empty
+          aliceWalletClient
+            .listAcceptedAppPayments() shouldBe empty withClue "AcceptedAppPayments"
           bobWalletClient.balance().unlockedQty should be > BigDecimal(0.0)
           charlieWalletClient.balance().unlockedQty should be > BigDecimal(0.0)
         },
@@ -565,7 +587,7 @@ class WalletTxLogIntegrationTest
             logEntry.subtype.value shouldBe walletLogEntry.TransferTransactionSubtype.AppPaymentAccepted.toProto
             logEntry.sender.value.party shouldBe aliceUserParty.toProtoPrimitive
             logEntry.sender.value.amount should beWithin(-50 - smallAmount, -50)
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -624,7 +646,8 @@ class WalletTxLogIntegrationTest
       )(
         "Request disappears from Alice's list",
         initPaymentCid => {
-          aliceWalletClient.listSubscriptionRequests() shouldBe empty
+          aliceWalletClient
+            .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
           aliceWalletClient
             .listSubscriptionInitialPayments()
             .find(_.contractId == initPaymentCid)
@@ -712,7 +735,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           checkSubscriptionPaymentTransfer(
@@ -727,7 +750,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -789,7 +812,8 @@ class WalletTxLogIntegrationTest
         "Request disappears from Alice's list",
         _ => {
           charlieWalletClient.listSubscriptionInitialPayments()
-          aliceWalletClient.listSubscriptionRequests() shouldBe empty
+          aliceWalletClient
+            .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
         },
       )
 
@@ -823,7 +847,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -877,7 +901,8 @@ class WalletTxLogIntegrationTest
       )(
         "Request disappears from Alice's list",
         initPaymentCid => {
-          aliceWalletClient.listSubscriptionRequests() shouldBe empty
+          aliceWalletClient
+            .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
           aliceWalletClient
             .listSubscriptionInitialPayments()
             .find(_.contractId == initPaymentCid)
@@ -969,7 +994,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             // Depending on timing we may have incurred holding fees at this point.
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
@@ -985,7 +1010,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -1038,7 +1063,8 @@ class WalletTxLogIntegrationTest
         )(
           "Request disappears from Alice's list",
           _ => {
-            aliceWalletClient.listSubscriptionRequests() shouldBe empty
+            aliceWalletClient
+              .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
             aliceWalletClient
               .listSubscriptions()
               .find(
@@ -1092,7 +1118,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: TransferTxLogEntry =>
@@ -1115,7 +1141,7 @@ class WalletTxLogIntegrationTest
               -subscriptionPrice - smallAmount,
               -subscriptionPrice,
             )
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.senderHoldingFees should beWithin(0, smallAmount)
           },
           { case logEntry: BalanceChangeTxLogEntry =>
@@ -1146,7 +1172,7 @@ class WalletTxLogIntegrationTest
           -preapprovalFee - smallAmount,
           -preapprovalFee,
         )
-        logEntry.receivers shouldBe empty
+        logEntry.receivers shouldBe empty withClue "receivers"
         logEntry.senderHoldingFees should beWithin(0, smallAmount)
       }
       val tapTxLog: CheckTxHistoryFn = { case logEntry: BalanceChangeTxLogEntry =>
@@ -1185,7 +1211,7 @@ class WalletTxLogIntegrationTest
           -preapprovalFee - smallAmount,
           -preapprovalFee,
         )
-        logEntry.receivers shouldBe empty
+        logEntry.receivers shouldBe empty withClue "receivers"
         logEntry.senderHoldingFees should beWithin(0, smallAmount)
       }
       val expectedTxLogEntries = Seq(renewTxLog, creationTxLog, tapTxLog)
@@ -1301,7 +1327,9 @@ class WalletTxLogIntegrationTest
       eventually() {
         val txs = aliceWalletClient.listTransactions(None, pageSize = offerCids.size)
         // mapping to make it readable
-        txs.map(_.eventId) should have size offerCids.size.toLong
+        txs.map(
+          _.eventId
+        ) should have size offerCids.size.toLong withClue "alice Transaction event IDs"
         forAll(txs) {
           case logEntry: NotificationTxLogEntry =>
             logEntry.subtype.value shouldBe walletLogEntry.NotificationTransactionSubtype.DirectTransferFailed.toProto
@@ -1324,7 +1352,9 @@ class WalletTxLogIntegrationTest
         ),
       )(
         "Alice sees the self-payment request",
-        _ => aliceWalletClient.listAppPaymentRequests() should not be empty,
+        _ =>
+          aliceWalletClient
+            .listAppPaymentRequests() should not be empty withClue "AppPaymentRequests",
       )
 
       clue("Alice tries to accept the self-payment request and fails") {
@@ -1412,7 +1442,8 @@ class WalletTxLogIntegrationTest
       )(
         "Request disappears from Alice's list",
         initPaymentCid => {
-          aliceWalletClient.listSubscriptionRequests() shouldBe empty
+          aliceWalletClient
+            .listSubscriptionRequests() shouldBe empty withClue "SubscriptionRequests"
           inside(
             aliceWalletClient.listSubscriptionInitialPayments().find(_.contractId == initPaymentCid)
           ) { case Some(initPayment) =>
@@ -1463,7 +1494,7 @@ class WalletTxLogIntegrationTest
             ),
           )(
             "Alice doesn't see any subscription",
-            _ => aliceWalletClient.listSubscriptions() shouldBe empty,
+            _ => aliceWalletClient.listSubscriptions() shouldBe empty withClue "Subscriptions",
           )
 
           eventually() {
@@ -1626,7 +1657,10 @@ class WalletTxLogIntegrationTest
           )
         )
 
-        aliceWalletClient.listTransactions(None, Limit.DefaultMaxPageSize) shouldBe empty
+        aliceWalletClient.listTransactions(
+          None,
+          Limit.DefaultMaxPageSize,
+        ) shouldBe empty withClue "Transactions"
       }
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogTimeBasedIntegrationTest.scala
@@ -85,8 +85,10 @@ class WalletTxLogTimeBasedIntegrationTest
 
         clue("Everyone still has their reward coupons") {
           eventually() {
-            aliceValidatorWalletClient.listAppRewardCoupons() should have size 1
-            aliceValidatorWalletClient.listValidatorRewardCoupons() should have size 1
+            aliceValidatorWalletClient
+              .listAppRewardCoupons() should have size 1 withClue "AppRewardCoupons"
+            aliceValidatorWalletClient
+              .listValidatorRewardCoupons() should have size 1 withClue "ValidatorRewardCoupons"
           }
         }
 
@@ -257,7 +259,7 @@ class WalletTxLogTimeBasedIntegrationTest
         aliceWalletClient.tap(0.000005),
       )(
         "Wait for amulet to appear",
-        _ => aliceWalletClient.list().amulets should have size (1),
+        _ => aliceWalletClient.list().amulets should have size (1) withClue "amulets",
       )
 
       setTriggersWithin(
@@ -270,7 +272,7 @@ class WalletTxLogTimeBasedIntegrationTest
           Range(0, 4).foreach(_ => advanceRoundsToNextRoundOpening),
         )(
           "Wait for amulet to disappear",
-          _ => aliceWalletClient.list().amulets should have size (0),
+          _ => aliceWalletClient.list().amulets should have size (0) withClue "amulets",
         )
       }
 
@@ -297,7 +299,7 @@ class WalletTxLogTimeBasedIntegrationTest
         aliceWalletClient.tap(100),
       )(
         "Wait for amulet to appear",
-        _ => aliceWalletClient.list().amulets should have size (1),
+        _ => aliceWalletClient.list().amulets should have size (1) withClue "amulets",
       )
 
       actAndCheck(
@@ -314,7 +316,7 @@ class WalletTxLogTimeBasedIntegrationTest
         ),
       )(
         "Wait for locked amulet to appear",
-        _ => aliceWalletClient.list().lockedAmulets should have size (1),
+        _ => aliceWalletClient.list().lockedAmulets should have size (1) withClue "lockedAmulets",
       )
 
       setTriggersWithin(
@@ -327,7 +329,7 @@ class WalletTxLogTimeBasedIntegrationTest
           Range(0, 4).foreach(_ => advanceRoundsToNextRoundOpening),
         )(
           "Wait for locked amulet to disappear",
-          _ => aliceWalletClient.list().lockedAmulets should have size (0),
+          _ => aliceWalletClient.list().lockedAmulets should have size (0) withClue "lockedAmulets",
         )
       }
 
@@ -385,7 +387,7 @@ class WalletTxLogTimeBasedIntegrationTest
           )(
             "Wait for locked amulet to appear",
             _ => {
-              aliceWalletClient.list().lockedAmulets should have size (1)
+              aliceWalletClient.list().lockedAmulets should have size (1) withClue "lockedAmulets"
             },
           )
 
@@ -412,10 +414,10 @@ class WalletTxLogTimeBasedIntegrationTest
             eventually() {
               val aliceTxs = aliceWalletClient.listTransactions(None, 1000)
               // tap + lock + transfer instruction
-              aliceTxs should have size 3
+              aliceTxs should have size 3 withClue "aliceTxs"
               val bobTxs = bobWalletClient.listTransactions(None, 1000)
               // transfer instruction
-              bobTxs should have size 1
+              bobTxs should have size 1 withClue "bobTxs"
               (aliceTxs, bobTxs)
             }
           }
@@ -431,7 +433,7 @@ class WalletTxLogTimeBasedIntegrationTest
                 logEntry.transferInstructionAmount shouldBe Some(BigDecimal(transferAmount))
                 logEntry.description shouldBe "transfer offer description"
                 // No balance is transferred here so receivers is empty
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
                 val expectedExtraLock = BigDecimal(transferAmount - lockAmount)
                 logEntry.sender.value.amount should beWithin(
                   -expectedExtraLock * 1.25,
@@ -447,7 +449,7 @@ class WalletTxLogTimeBasedIntegrationTest
                 logEntry.transferInstructionAmount shouldBe None
                 logEntry.description shouldBe ""
                 // No balance is transferred here so receivers is empty
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
                 logEntry.sender.value.amount should beWithin(
                   -(lockAmount + smallAmount),
                   -lockAmount,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithRewardsCollectionTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithRewardsCollectionTimeBasedIntegrationTest.scala
@@ -53,8 +53,10 @@ class WalletTxLogWithRewardsCollectionTimeBasedIntegrationTest
       )(
         "Bob's validator will receive some rewards",
         _ => {
-          bobValidatorWalletClient.listAppRewardCoupons() should have size 1
-          bobValidatorWalletClient.listValidatorRewardCoupons() should have size 1
+          bobValidatorWalletClient
+            .listAppRewardCoupons() should have size 1 withClue "AppRewardCoupons"
+          bobValidatorWalletClient
+            .listValidatorRewardCoupons() should have size 1 withClue "ValidatorRewardCoupons"
         },
       )
 
@@ -71,8 +73,10 @@ class WalletTxLogWithRewardsCollectionTimeBasedIntegrationTest
       )(
         "Bob's validator collects rewards",
         _ => {
-          bobValidatorWalletClient.listAppRewardCoupons() should have size 0
-          bobValidatorWalletClient.listValidatorRewardCoupons() should have size 0
+          bobValidatorWalletClient
+            .listAppRewardCoupons() should have size 0 withClue "AppRewardCoupons"
+          bobValidatorWalletClient
+            .listValidatorRewardCoupons() should have size 0 withClue "ValidatorRewardCoupons"
           val balanceAfter = bobValidatorWalletClient.balance().unlockedQty
           balanceAfter should be > balanceBefore
           balanceAfter
@@ -91,7 +95,7 @@ class WalletTxLogWithRewardsCollectionTimeBasedIntegrationTest
               .getValidatorPartyId()
               .toProtoPrimitive
             logEntry.sender.value.amount should be(balanceAfter - balanceBefore)
-            logEntry.receivers shouldBe empty
+            logEntry.receivers shouldBe empty withClue "receivers"
             logEntry.appRewardsUsed shouldBe appRewardAmount
             logEntry.validatorRewardsUsed shouldBe validatorRewardAmount
           }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesIntegrationTest.scala
@@ -80,7 +80,7 @@ class WalletTxLogWithSynchronizerFeesIntegrationTest
                   -totalCostCc - smallAmount,
                   -totalCostCc,
                 )
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
               },
               { case logEntry: BalanceChangeTxLogEntry =>
                 logEntry.subtype.value shouldBe walletLogEntry.BalanceChangeTransactionSubtype.Tap.toProto
@@ -115,7 +115,7 @@ class WalletTxLogWithSynchronizerFeesIntegrationTest
                   -totalCostCc - smallAmount,
                   -totalCostCc,
                 )
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
               },
               { case logEntry: BalanceChangeTxLogEntry =>
                 logEntry.subtype.value shouldBe walletLogEntry.BalanceChangeTransactionSubtype.Tap.toProto

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesNoDevNetTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesNoDevNetTimeBasedIntegrationTest.scala
@@ -100,7 +100,7 @@ class WalletTxLogWithSynchronizerFeesNoDevNetTimeBasedIntegrationTest
                   -totalCostCc - smallAmount,
                   -totalCostCc,
                 )
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
               },
               { case logEntry: TransferTxLogEntry =>
                 logEntry.subtype.value shouldBe walletLogEntry.TransferTransactionSubtype.P2PPaymentCompleted.toProto
@@ -122,7 +122,7 @@ class WalletTxLogWithSynchronizerFeesNoDevNetTimeBasedIntegrationTest
               Seq[CheckTxHistoryFn](
                 { case logEntry: TransferTxLogEntry =>
                   logEntry.subtype.value shouldBe walletLogEntry.TransferTransactionSubtype.WalletAutomation.toProto
-                  logEntry.receivers shouldBe empty
+                  logEntry.receivers shouldBe empty withClue "receivers"
                   logEntry.sender.value.party shouldBe sv1ValidatorBackend
                     .getValidatorPartyId()
                     .toProtoPrimitive
@@ -160,7 +160,7 @@ class WalletTxLogWithSynchronizerFeesNoDevNetTimeBasedIntegrationTest
                   -totalCostCc - smallAmount,
                   -totalCostCc,
                 )
-                logEntry.receivers shouldBe empty
+                logEntry.receivers shouldBe empty withClue "receivers"
               },
               { case logEntry: TransferTxLogEntry =>
                 logEntry.subtype.value shouldBe walletLogEntry.TransferTransactionSubtype.P2PPaymentCompleted.toProto


### PR DESCRIPTION
Add withClue labels across wallet, rewards, allocations, and transaction tests' listlike items.

Part of #4147.