### PR TITLE
Switch Canton logs to info level

### DIFF
--- a/start-canton.sh
+++ b/start-canton.sh
@@ -218,7 +218,7 @@ tmux_cmd_canton() {
      COMETBFT_DOCKER_IP=${COMETBFT_DOCKER_IP-} \
      CANTON_TOKEN_FILENAME=$tokensFile CANTON_PARTICIPANTS_FILENAME=$participantsFile JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS\" $CANTON \
       -c $baseConfig $confOverrides \
-      --log-level-canton=DEBUG \
+      --log-level-canton=INFO \
       --log-encoder json \
       --log-file-name $mainLogFile \
       --bootstrap $bootstrapScriptPath \


### PR DESCRIPTION
[ci]

Log amount gets too large and it seems like this forces us to make sure that the info logs are actually enough to debug stuff in prod as well.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
