### PR TITLE
Remove now-obsolete sequencer `payload-queue-size` override

### DIFF
--- a/cluster/images/canton-sequencer/additional-config.conf
+++ b/cluster/images/canton-sequencer/additional-config.conf
@@ -12,6 +12,4 @@ canton.sequencers.sequencer {
     confirmation-request.strict = false
     topology.strict = false
   }
-  #TODO(DACH-NY/cn-test-failures#7365) Remove once upstreamed
-  sequencer.block.writer.payload-queue-size = 5000
 }


### PR DESCRIPTION
This value has become the default upstream now: https://github.com/DACH-NY/canton/pull/30993

S.a. https://github.com/DACH-NY/cn-test-failures/issues/7365

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
