### PR TITLE
Remove upcoming release notes section

### DIFF
--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,4 +7,4 @@
 
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
-.. release-notes:: Upcoming
+.. NOTE: .. release-notes:: Upcoming


### PR DESCRIPTION
I missed that following part is not done automatically by the `build-tools/prep-release-notes.py` script:

```
Comment out the remaining content (should be just a section title) in release_notes_upcoming.rst (to prevent having an "upcoming" section in the release notes)
```