### PR TITLE
Add default retry for downloading missing artifacts

### DIFF
--- a/project/DamlPlugin.scala
+++ b/project/DamlPlugin.scala
@@ -470,7 +470,8 @@ object DamlPlugin extends AutoPlugin {
       if (!artifact.exists) {
         log.info(s"Downloading missing ${artifactFilename} to ${root.path}")
         root.createDirectoryIfNotExists(createParents = true)
-        val curlWithBasicOptions = "curl" :: "-sSL" :: "--fail" :: Nil
+        val curlWithBasicOptions =
+          "curl" :: "-sSL" :: "--fail" :: "--retry" :: "3" :: "--retry-connrefused" :: Nil
         val credentials = url match {
           case artifactory if artifactory.startsWith("https://digitalasset.jfrog.io/") =>
             // CircleCI specifies ARTIFACTORY_ env variables


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7394

this change allows to silently absorb transient network drops causing the exit code 35 instead of instantly crashing or reporting an error

[static]


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
