### PR TITLE
lsu - Increase time in test between freeze time and upgrade time

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -61,7 +61,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
 
   lazy val scheduledLsu = ScheduledLsuConfig(
     Instant.now().plusSeconds(150).truncatedTo(ChronoUnit.SECONDS),
-    Instant.now().plusSeconds(180).truncatedTo(ChronoUnit.SECONDS),
+    Instant.now().plusSeconds(210).truncatedTo(ChronoUnit.SECONDS),
     NonNegativeInt.one,
     ProtocolVersion.v34,
   )


### PR DESCRIPTION
Some sequencencers weren't fast enough to publish the successor

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
