### PR TITLE
[static] Clarify that devnet onboarding endpoint requires SV app URL (#4187)

### DIFF
--- a/docs/src/validator_operator/required_network_parameters.rst
+++ b/docs/src/validator_operator/required_network_parameters.rst
@@ -24,11 +24,13 @@ ONBOARDING_SECRET
    .. admonition:: DevNet-only
 
      On DevNet, you can obtain an onboarding secret automatically by
-     calling the following endpoint on any SV (replace ``SPONSOR_SV_URL`` with the URL of your SV sponsor):
+     calling the following endpoint on any SV (replace ``SPONSOR_SV_URL`` with the SV app URL defined above):
 
      .. parsed-literal::
 
         curl -X POST SPONSOR_SV_URL/api/sv/v0/devnet/onboard/validator/prepare
+
+     Make sure to use the **SV app URL** (starting with ``sv.``), not the Scan URL (starting with ``scan.``).
 
      Note that this self-served secret is only valid for 1 hour.
 


### PR DESCRIPTION
Users were hitting a 405 error when calling the devnet onboarding
secret endpoint because they used a Scan URL (scan.sv-1...) instead
of the SV app URL (sv.sv-1...). Add a note clarifying the distinction.

Fixes: https://github.com/hyperledger-labs/splice/issues/4187

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
