### PR TITLE
Log test failures as errors

### DIFF
--- a/canton/community/testing/src/main/scala/com/digitalasset/canton/LogReporter.scala
+++ b/canton/community/testing/src/main/scala/com/digitalasset/canton/LogReporter.scala
@@ -41,8 +41,8 @@ class LogReporter extends Reporter {
       val msg =
         s"Test failed: '${event.suiteName}/${event.testName}', message: ${event.message}$locationMsg"
       event.throwable
-        .map(cause => logger.warn(msg, cause))
-        .getOrElse(logger.warn(msg))
+        .map(cause => logger.error(msg, cause))
+        .getOrElse(logger.error(msg))
     case event: TestCanceled =>
       logger.info(s"Test canceled: '${event.suiteName}/${event.testName}'")
     case event: TestIgnored => logger.info(s"Test ignored: '${event.suiteName}/${event.testName}'")


### PR DESCRIPTION
We log failed clues as errors so right now if your failure is within a clue you get an error log but if it's not you get only a warning log. That seems needlessly confusing.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
