### PR TITLE
Switch secretmanager to top level import in auth0.ts

### DIFF
--- a/cluster/pulumi/common/src/auth0/auth0.ts
+++ b/cluster/pulumi/common/src/auth0/auth0.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import { KubeConfig, CoreV1Api } from '@kubernetes/client-node';
-import { getSecretVersionOutput } from '@pulumi/gcp/secretmanager';
 import { Output } from '@pulumi/pulumi';
 import { AuthenticationClient, ManagementClient, TokenSet } from 'auth0';
 
@@ -576,7 +576,7 @@ export function getNamespaceConfig(
 }
 
 export const svUserIds = (auth0Cfg: Auth0Config): Output<string[]> => {
-  const temp = getSecretVersionOutput({
+  const temp = gcp.secretmanager.getSecretVersionOutput({
     secret: `pulumi-user-configs-${auth0Cfg.auth0Domain.replace('.us.auth0.com', '')}`,
   });
   return temp.apply(config => {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/6750

`TS7016` can be caused by deep-importing @pulumi/gcp/secretmanager. Pulumi actually exports its type defs at the package root, so deep imports miss them on fresh CI runs and can trigger such errors. 

[static]


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
