### PR TITLE
do not attempt to delete unused DBs that are protected from deletion

### DIFF
--- a/cluster/pulumi/purge_unused_dbs.ts
+++ b/cluster/pulumi/purge_unused_dbs.ts
@@ -78,9 +78,13 @@ async function deleteDb(db: cloudsql.protos.google.cloud.sql.v1.IDatabaseInstanc
     instance: db.name,
     project: db.project,
   };
-  console.log(`Deleting ${db.name}...`);
-  await gcpSqlClient.delete(request);
-  console.log(`Done deleting ${db.name}`);
+  if (db.settings?.deletionProtectionEnabled?.value ?? false) {
+    console.warn(`Skipping ${db.name} deletion due to active deletion protection.`);
+  } else {
+    console.log(`Deleting ${db.name}...`);
+    await gcpSqlClient.delete(request);
+    console.log(`Done deleting ${db.name}`);
+  }
 }
 
 async function runPurgeUnusedDbs() {


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7406

IMO there is no point in attempting to delete DBs that have protection on. Besides, failing the whole process could prevent us from successfully deleting other unused DBs.