### PR TITLE
Bump Canton to `3.4.12-snapshot.20260304.17610.0.vc052e3d4`

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,11 +1,11 @@
 {
-  "version": "3.4.12-snapshot.20260302.17606.0.v32062524",
+  "version": "3.4.12-snapshot.20260304.17610.0.vc052e3d4",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:1jc3m8v9jf5cqqnfhknydqcwfjjnzkcakkjydpp3hlwxi7h2s8xj",
-  "oss_sha256": "sha256:18l96518adqjzmmvkwqbi3iyl61wa4l0wf2lfwcdvw2lzzn5n2fd",
-  "canton_base_image_sha256": "sha256:3bc4564f409849f27c5ba8142dda3e7e7409a4629ce9250eec4d091e27c1fcd9",
-  "canton_participant_image_sha256": "sha256:b755714bfa68cda66dc37c0919f66511f4778a00c84d8be9c69ab14cfa85c065",
-  "canton_mediator_image_sha256": "sha256:9aea7f5ab34282a4d33b6029afac1e176929d4f6a0597f35439eee3ba65eb82d",
-  "canton_sequencer_image_sha256": "sha256:36116e87b4744601a5495b5ef606a6d3a5fae59668f21b764fa72fb6de871d7c"
+  "enterprise_sha256": "sha256:1jjpqk4yh0gizcrxygpmzr98d2qcmp49v1gdisjp8ykj1w5fkqi7",
+  "oss_sha256": "sha256:1jmn6ysq8w6j0d94vl97l25rw12w316xy77biibk4mna0ihs34ry",
+  "canton_base_image_sha256": "sha256:c82b811745f4e6b5ad85695b2bed6681350f7077773692684721d4334116f4d1",
+  "canton_participant_image_sha256": "sha256:8e0e8bbaeab7c0f00c165e4bd63fc2de68e5cd0887217cc435e396f7092afc30",
+  "canton_mediator_image_sha256": "sha256:a49d57e0751e935d6d4ef5e9668a3d1d0321e0335c22866c9ece65fd122f7800",
+  "canton_sequencer_image_sha256": "sha256:1150c63d1b9dc19824145e684cbd871a2eb191fdc8aebf4065475692ccbac8b6"
 }


### PR DESCRIPTION
This looked like a nice change to consume: https://github.com/DACH-NY/canton/pull/31105

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
