### PR TITLE
Read topology snapshot for party hosting at sequenced time

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
@@ -63,6 +63,7 @@ import org.lfdecentralizedtrust.splice.environment.ParticipantAdminConnection.{
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
   RecreateOnAuthorizedStateChange,
   TopologyResult,
+  TopologySnapshot,
 }
 
 import java.time.Instant
@@ -636,6 +637,7 @@ class ParticipantAdminConnection(
       party: PartyId,
       newParticipant: ParticipantId,
       expectedSerial: PositiveInt,
+      topologySnapshot: TopologySnapshot = TopologySnapshot.Sequenced,
   )(implicit traceContext: TraceContext): Future[TopologyResult[PartyToParticipant]] = {
     ensureTopologyMapping[PartyToParticipant](
       TopologyStoreId.Synchronizer(synchronizerId),
@@ -646,6 +648,7 @@ class ParticipantAdminConnection(
             synchronizerId = synchronizerId,
             partyId = party,
             topologyTransactionType = topologyTransactionType,
+            topologySnapshot = topologySnapshot,
           )
             .map(result =>
               Either

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
@@ -36,6 +36,7 @@ import com.digitalasset.canton.crypto.{
   SigningKeyUsage,
   SigningPublicKey,
 }
+import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.grpc.ByteStringStreamObserver
 import com.digitalasset.canton.logging.NamedLoggerFactory
@@ -66,6 +67,7 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.Topol
 }
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
   AuthorizedStateChanged,
+  TopologySnapshot,
   TopologyTransactionType,
 }
 
@@ -218,6 +220,7 @@ abstract class TopologyAdminConnection(
       partyId: PartyId,
       operation: Option[TopologyChangeOp],
       topologyTransactionType: TopologyTransactionType,
+      snapshot: TopologySnapshot,
   )(implicit traceContext: TraceContext): OptionT[Future, TopologyResult[PartyToParticipant]] =
     OptionT(
       listPartyToParticipant(
@@ -225,6 +228,7 @@ abstract class TopologyAdminConnection(
         filterParty = partyId.filterString,
         operation = operation,
         topologyTransactionType = topologyTransactionType,
+        timeQuery = snapshot.timeQuery,
       ).map { txs =>
         txs.headOption
       }
@@ -236,8 +240,15 @@ abstract class TopologyAdminConnection(
       // get only active (non-removed) mappings by default; this matches the Canton console defaults
       operation: Option[TopologyChangeOp] = Some(TopologyChangeOp.Replace),
       topologyTransactionType: TopologyTransactionType = AuthorizedState,
+      topologySnapshot: TopologySnapshot = TopologySnapshot.Effective,
   )(implicit traceContext: TraceContext): Future[TopologyResult[PartyToParticipant]] =
-    findPartyToParticipant(synchronizerId, partyId, operation, topologyTransactionType).getOrElse {
+    findPartyToParticipant(
+      synchronizerId,
+      partyId,
+      operation,
+      topologyTransactionType,
+      topologySnapshot,
+    ).getOrElse {
       throw Status.NOT_FOUND
         .withDescription(s"No PartyToParticipant state for $partyId on domain $synchronizerId")
         .asRuntimeException
@@ -1600,6 +1611,25 @@ object TopologyAdminConnection {
 
     }
 
+  }
+
+  sealed abstract class TopologySnapshot {
+    def timeQuery: TimeQuery
+  }
+
+  object TopologySnapshot {
+
+    /** Read the latest sequenced state, note that due to the topologyChangeDelay the topology transaction you get from this may not yet be valid.
+      */
+    case object Sequenced extends TopologySnapshot {
+      override def timeQuery: TimeQuery = TimeQuery.Snapshot(CantonTimestamp.MaxValue)
+    }
+
+    /** Read the latest effective state, updates will only be returned after the node has observed a record time >= topologyChangeDelay.
+      */
+    case object Effective extends TopologySnapshot {
+      override def timeQuery: TimeQuery = TimeQuery.HeadState
+    }
   }
 
   sealed abstract class RecreateOnAuthorizedStateChange {


### PR DESCRIPTION
part of #4271

This should generally speed things up a bit, make things less
confusing as retries will never fail due to reading scale state and in
particular make the issue from
https://github.com/DACH-NY/canton-network-internal/issues/3857 less
likely to hit us badly.

Plan is to switch over all topology calls but wanted to do one first
as an example in case reviewers see big issues with it and add the
basic infra before adding it everywhere.

Note that as documented in #4271, some code paths likely do need to
wait for effectivity. But triggers generally do not which is the
majority of changes we make as we just care about changing topology
and waiting for it to be effective does nothing.

[ci]

Signed-off-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
