### PR TITLE
[ci] Prevent javaValue deserialization when updates are requested in protobuf-json daml value encoding.

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -1013,7 +1013,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                   .getAllUpdates(None, PageLimit.tryCreate(1000))
                   .futureValue
               backfilledUpdates.collect {
-                case TreeUpdateWithMigrationId(tree, migrationId)
+                case TreeUpdateWithMigrationId(tree, migrationId, _)
                     if tree.update.recordTime == CantonTimestamp.MinValue && migrationId == 1L =>
                   tree
               } should not be empty withClue "ACS import updates"

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
@@ -7,6 +7,7 @@ import cats.data.{NonEmptyList, OptionT}
 import cats.syntax.semigroup.*
 import com.daml.ledger.api.v2.TraceContextOuterClass
 import com.daml.ledger.javaapi.data.codegen.{ContractId, DamlRecord}
+import com.daml.ledger.javaapi.{data as javaApi}
 import com.daml.ledger.javaapi.data.{CreatedEvent, Event, ExercisedEvent, Identifier, Transaction}
 import com.daml.metrics.api.MetricsContext
 import com.google.protobuf.ByteString
@@ -1090,6 +1091,7 @@ class UpdateHistory(
       filters: NonEmptyList[SQLActionBuilder],
       orderBy: SQLActionBuilder,
       limit: Limit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     def makeSubQuery(afterFilter: SQLActionBuilder): SQLActionBuilderChain = {
       sql"""
@@ -1121,13 +1123,16 @@ class UpdateHistory(
       exercises <- queryExerciseEvents(rows.map(_.rowId))
     } yield {
       rows.map { row =>
+        val (response, rawData) = decodeTransaction(
+          row,
+          creates.getOrElse(row.rowId, Seq.empty),
+          exercises.getOrElse(row.rowId, Seq.empty),
+          valueDeserializer,
+        )
         TreeUpdateWithMigrationId(
-          decodeTransaction(
-            row,
-            creates.getOrElse(row.rowId, Seq.empty),
-            exercises.getOrElse(row.rowId, Seq.empty),
-          ),
+          response,
           row.migrationId,
+          rawProtobufJsonEventData = rawData,
         )
       }
     }
@@ -1137,6 +1142,7 @@ class UpdateHistory(
       filters: NonEmptyList[SQLActionBuilder],
       orderBy: SQLActionBuilder,
       limit: Limit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
 
     def makeSubQuery(afterFilter: SQLActionBuilder): SQLActionBuilderChain = {
@@ -1176,7 +1182,10 @@ class UpdateHistory(
           "getAssignmentUpdates",
         )
     } yield {
-      rows.map { row => TreeUpdateWithMigrationId(decodeAssignment(row), row.migrationId) }
+      rows.map { row =>
+        val (response, rawData) = decodeAssignment(row, valueDeserializer)
+        TreeUpdateWithMigrationId(response, row.migrationId, rawProtobufJsonEventData = rawData)
+      }
     }
   }
 
@@ -1220,12 +1229,13 @@ class UpdateHistory(
   def getUpdatesWithoutImportUpdates(
       afterO: Option[(Long, CantonTimestamp)],
       limit: Limit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val filters = afterFilters(afterO, includeImportUpdates = false)
     val orderBy = sql"migration_id, record_time, domain_id"
     for {
-      txs <- getTxUpdates(filters, orderBy, limit)
-      assignments <- getAssignmentUpdates(filters, orderBy, limit)
+      txs <- getTxUpdates(filters, orderBy, limit, valueDeserializer)
+      assignments <- getAssignmentUpdates(filters, orderBy, limit, valueDeserializer)
       unassignments <- getUnassignmentUpdates(filters, orderBy, limit)
     } yield {
       (txs ++ assignments ++ unassignments).sorted.take(limit.limit)
@@ -1251,14 +1261,15 @@ class UpdateHistory(
   def getAllUpdates(
       afterO: Option[(Long, CantonTimestamp)],
       limit: PageLimit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val filters = afterFilters(afterO, includeImportUpdates = true)
     // With import updates, we have to include the update id to get a deterministic order.
     // We don't have an index for this order, but this is only used in test code and deprecated scan endpoints.
     val orderBy = sql"migration_id, record_time, domain_id, update_id"
     for {
-      txs <- getTxUpdates(filters, orderBy, limit)
-      assignments <- getAssignmentUpdates(filters, orderBy, limit)
+      txs <- getTxUpdates(filters, orderBy, limit, valueDeserializer)
+      assignments <- getAssignmentUpdates(filters, orderBy, limit, valueDeserializer)
       unassignments <- getUnassignmentUpdates(filters, orderBy, limit)
     } yield {
       (txs ++ assignments ++ unassignments).sorted.take(limit.limit)
@@ -1271,12 +1282,13 @@ class UpdateHistory(
       beforeRecordTime: CantonTimestamp,
       atOrAfterRecordTime: Option[CantonTimestamp],
       limit: PageLimit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val filters = beforeFilters(migrationId, synchronizerId, beforeRecordTime, atOrAfterRecordTime)
     val orderBy = sql"record_time desc"
     for {
-      txs <- getTxUpdates(filters, orderBy, limit)
-      assignments <- getAssignmentUpdates(filters, orderBy, limit)
+      txs <- getTxUpdates(filters, orderBy, limit, valueDeserializer)
+      assignments <- getAssignmentUpdates(filters, orderBy, limit, valueDeserializer)
       unassignments <- getUnassignmentUpdates(filters, orderBy, limit)
     } yield {
       (txs ++ assignments ++ unassignments).sorted.reverse.take(limit.limit)
@@ -1302,6 +1314,7 @@ class UpdateHistory(
       migrationId: Long,
       afterUpdateId: String,
       limit: PageLimit,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Seq[TreeUpdateWithMigrationId]] = {
     val query =
       sql"""
@@ -1344,18 +1357,19 @@ class UpdateHistory(
         )
     } yield {
       rows.map { row =>
+        val (response, rawData) = decodeImportTransaction(row, valueDeserializer)
         TreeUpdateWithMigrationId(
-          decodeImportTransaction(
-            row
-          ),
+          response,
           row.migrationId,
+          rawProtobufJsonEventData = rawData,
         )
       }
     }
   }
 
   def getUpdate(
-      updateId: String
+      updateId: String,
+      valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue,
   )(implicit tc: TraceContext): Future[Option[TreeUpdateWithMigrationId]] = {
     val safeUpdateId = lengthLimited(updateId)
     val query =
@@ -1386,13 +1400,16 @@ class UpdateHistory(
       exercises <- queryExerciseEvents(rows.map(_.rowId))
     } yield {
       rows.map { row =>
+        val (response, rawData) = decodeTransaction(
+          row,
+          creates.getOrElse(row.rowId, Seq.empty),
+          exercises.getOrElse(row.rowId, Seq.empty),
+          valueDeserializer,
+        )
         TreeUpdateWithMigrationId(
-          decodeTransaction(
-            row,
-            creates.getOrElse(row.rowId, Seq.empty),
-            exercises.getOrElse(row.rowId, Seq.empty),
-          ),
+          response,
           row.migrationId,
+          rawProtobufJsonEventData = rawData,
         )
       }.headOption
     }
@@ -1514,13 +1531,13 @@ class UpdateHistory(
     * warnings until all SV nodes have deployed the new version.
     */
   private def decodeImportTransaction(
-      updateRow: SelectFromImportUpdates
-  ): UpdateHistoryResponse = {
+      updateRow: SelectFromImportUpdates,
+      valueDeserializer: String => Option[javaApi.Value],
+  ): (UpdateHistoryResponse, Map[Int, RawProtobufJsonEventData]) = {
     // We don't use any prefix so that we can use an index on contract ids when fetching import updates.
     val updateId = updateRow.contractId
     val eventNodeId = 0
-    // The prefix needs to be preserved, because we're relying on it to determine whether a given update
-    // was an import update.
+    // ...existing code...
     val workflowId = s"${IMPORT_ACS_WORKFLOW_ID_PREFIX}-${updateId}"
     // Command id and participant offset are not included in API responses,
     // but we're making them consistent anyway.
@@ -1538,11 +1555,13 @@ class UpdateHistory(
       ),
       /* packageName = */ updateRow.packageName,
       /*contractId = */ updateRow.contractId,
-      /*arguments = */ ProtobufCodec.deserializeValue(updateRow.createArguments).asRecord().get(),
+      /*arguments = */ valueDeserializer(updateRow.createArguments)
+        .map(_.asRecord().get())
+        .getOrElse(UpdateHistory.emptyRecord),
       /*createdEventBlob = */ ByteString.EMPTY,
       /*interfaceViews = */ java.util.Collections.emptyMap(),
       /*failedInterfaceViews = */ java.util.Collections.emptyMap(),
-      /*contractKey = */ updateRow.contractKey.map(ProtobufCodec.deserializeValue).toJava,
+      /*contractKey = */ updateRow.contractKey.flatMap(valueDeserializer).toJava,
       /*signatories = */ updateRow.signatories.getOrElse(missingStringSeq).asJava,
       /*observers = */ updateRow.observers.getOrElse(missingStringSeq).asJava,
       /*createdAt = */ updateRow.createdAt.toInstant,
@@ -1550,7 +1569,7 @@ class UpdateHistory(
       /*representativePackageId = */ updateRow.templatePackageId,
     )
 
-    UpdateHistoryResponse(
+    val response = UpdateHistoryResponse(
       update = TransactionTreeUpdate(
         new Transaction(
           /*updateId = */ updateId,
@@ -1567,15 +1586,28 @@ class UpdateHistory(
       ),
       synchronizerId = SynchronizerId.tryFromString(updateRow.synchronizerId),
     )
+
+    val rawData = Map(
+      eventNodeId -> RawProtobufJsonEventData(createArguments = Some(updateRow.createArguments))
+    )
+    (response, rawData)
   }
 
   private def decodeTransaction(
       updateRow: SelectFromTransactions,
       createRows: Seq[SelectFromCreateEvents],
       exerciseRows: Seq[SelectFromExerciseEvents],
-  ): UpdateHistoryResponse = {
+      valueDeserializer: String => Option[javaApi.Value],
+  ): (UpdateHistoryResponse, Map[Int, RawProtobufJsonEventData]) = {
 
-    val createEvents = createRows.map(_.toCreatedEvent.event)
+    val createEvents = createRows.map(_.toCreatedEvent(valueDeserializer).event)
+
+    val createRawData: Map[Int, RawProtobufJsonEventData] = createRows.map { row =>
+      EventId.nodeIdFromEventId(row.eventId) -> RawProtobufJsonEventData(
+        createArguments = Some(row.createArguments)
+      )
+    }.toMap
+
     // TODO(#640) - remove this conversion as it's costly
     val nodesWithChildren = exerciseRows
       .map(exercise =>
@@ -1602,20 +1634,28 @@ class UpdateHistory(
         ).toJava,
         /*contractId = */ row.contractId,
         /*choice = */ row.choice,
-        /*choiceArgument = */ ProtobufCodec.deserializeValue(row.argument),
+        /*choiceArgument = */ valueDeserializer(row.argument).getOrElse(UpdateHistory.emptyRecord),
         /*actingParties = */ row.actingParties.getOrElse(missingStringSeq).asJava,
         /*consuming = */ row.consuming,
         /*lastDescendedNodeId = */ Integer.valueOf(
           EventId.lastDescendedNodeFromChildNodeIds(nodeId, nodesWithChildren)
         ),
-        /*exerciseResult = */ ProtobufCodec.deserializeValue(row.result),
+        /*exerciseResult = */ valueDeserializer(row.result).getOrElse(UpdateHistory.emptyRecord),
         /*implementedInterfaces = */ java.util.Collections.emptyList(),
         /*acsDelta = */ false,
       )
     }
+
+    val exerciseRawData: Map[Int, RawProtobufJsonEventData] = exerciseRows.map { row =>
+      EventId.nodeIdFromEventId(row.eventId) -> RawProtobufJsonEventData(
+        choiceArgument = Some(row.argument),
+        exerciseResult = Some(row.result),
+      )
+    }.toMap
+
     val events: Seq[Event] = (createEvents ++ exerciseEvents).sortBy(_.getNodeId)
 
-    UpdateHistoryResponse(
+    val response = UpdateHistoryResponse(
       update = TransactionTreeUpdate(
         new Transaction(
           /*updateId = */ updateRow.updateId,
@@ -1632,12 +1672,16 @@ class UpdateHistory(
       ),
       synchronizerId = SynchronizerId.tryFromString(updateRow.synchronizerId),
     )
+
+    (response, createRawData ++ exerciseRawData)
   }
 
   private def decodeAssignment(
-      row: SelectFromAssignments
-  ): UpdateHistoryResponse = {
-    UpdateHistoryResponse(
+      row: SelectFromAssignments,
+      valueDeserializer: String => Option[javaApi.Value],
+  ): (UpdateHistoryResponse, Map[Int, RawProtobufJsonEventData]) = {
+    val nodeId = EventId.nodeIdFromEventId(row.eventId)
+    val response = UpdateHistoryResponse(
       ReassignmentUpdate(
         Reassignment[Assign](
           updateId = row.updateId,
@@ -1651,7 +1695,7 @@ class UpdateHistory(
             createdEvent = new CreatedEvent(
               /*witnessParties = */ java.util.Collections.emptyList(),
               /*offset = */ 0, // not populated
-              /*nodeId = */ EventId.nodeIdFromEventId(row.eventId),
+              /*nodeId = */ nodeId,
               /*templateId = */ tid(
                 row.templatePackageId,
                 row.templateModuleName,
@@ -1659,7 +1703,9 @@ class UpdateHistory(
               ),
               /*packageName = */ row.packageName,
               /*contractId = */ row.contractId,
-              /*arguments = */ ProtobufCodec.deserializeValue(row.createArguments).asRecord().get(),
+              /*arguments = */ valueDeserializer(row.createArguments)
+                .map(_.asRecord().get())
+                .getOrElse(UpdateHistory.emptyRecord),
               /*createdEventBlob = */ ByteString.EMPTY,
               /*interfaceViews = */ java.util.Collections.emptyMap(),
               /*failedInterfaceViews = */ java.util.Collections.emptyMap(),
@@ -1676,6 +1722,10 @@ class UpdateHistory(
       ),
       row.synchronizerId,
     )
+    val rawData = Map(
+      nodeId -> RawProtobufJsonEventData(createArguments = Some(row.createArguments))
+    )
+    (response, rawData)
   }
 
   private def decodeUnassignment(
@@ -2358,6 +2408,20 @@ class UpdateHistory(
 
 object UpdateHistory {
 
+  /** A value deserializer that skips deserialization entirely.
+    * Use this when the deserialized Value objects are not needed (e.g., when serving
+    * ProtobufJson-encoded responses where the raw DB strings are passed through directly).
+    */
+  val noValueDeserialization: String => Option[javaApi.Value] = _ => None
+
+  /** The default value deserializer that performs real protobuf JSON deserialization. */
+  val deserializeValue: String => Option[javaApi.Value] = s =>
+    Some(ProtobufCodec.deserializeValue(s))
+
+  /** Provides a dummy empty DamlRecord when deserialization is skipped. */
+  private[store] val emptyRecord: javaApi.DamlRecord =
+    new javaApi.DamlRecord(new java.util.ArrayList[javaApi.DamlRecord.Field]())
+
   // Separate method so we can use this without a full UpdateHistory instance.
   // Since we're interested in the highest known migration id, we don't need to filter by anything
   // (store ID, participant ID, etc. are not even known at the time we want to call this).
@@ -2456,7 +2520,7 @@ object UpdateHistory {
         companion: Contract.Companion.Template[TCId, T]
     ): Contract[TCId, T] = {
       Contract
-        .fromCreatedEvent(companion)(this.toCreatedEvent.event)
+        .fromCreatedEvent(companion)(this.toCreatedEvent().event)
         .getOrElse(
           throw new IllegalStateException(
             s"Stored a contract that cannot be decoded as ${companion.TEMPLATE_ID}: $this"
@@ -2464,7 +2528,9 @@ object UpdateHistory {
         )
     }
 
-    def toCreatedEvent: SpliceCreatedEvent = {
+    def toCreatedEvent(
+        valueDeserializer: String => Option[javaApi.Value] = UpdateHistory.deserializeValue
+    ): SpliceCreatedEvent = {
       SpliceCreatedEvent(
         eventId,
         new CreatedEvent(
@@ -2478,11 +2544,13 @@ object UpdateHistory {
           ),
           /* packageName = */ packageName,
           /*contractId = */ contractId,
-          /*arguments = */ ProtobufCodec.deserializeValue(createArguments).asRecord().get(),
+          /*arguments = */ valueDeserializer(createArguments)
+            .map(_.asRecord().get())
+            .getOrElse(UpdateHistory.emptyRecord),
           /*createdEventBlob = */ ByteString.EMPTY,
           /*interfaceViews = */ java.util.Collections.emptyMap(),
           /*failedInterfaceViews = */ java.util.Collections.emptyMap(),
-          /*contractKey = */ contractKey.map(ProtobufCodec.deserializeValue).toJava,
+          /*contractKey = */ contractKey.flatMap(valueDeserializer).toJava,
           /*signatories = */ signatories.getOrElse(missingStringSeq).asJava,
           /*observers = */ observers.getOrElse(missingStringSeq).asJava,
           /*createdAt = */ createdAt.toInstant,
@@ -2625,9 +2693,23 @@ object TimestampWithMigrationId {
     Ordering.by(x => (x.migrationId, x.timestamp))
 }
 
+/** Raw protobuf-JSON strings from the database for a single event.
+  * Used to skip unnecessary deserialization/serialization roundtrips
+  * when serving ProtobufJson-encoded responses.
+  */
+final case class RawProtobufJsonEventData(
+    createArguments: Option[String] = None,
+    choiceArgument: Option[String] = None,
+    exerciseResult: Option[String] = None,
+)
+
 final case class TreeUpdateWithMigrationId(
     update: UpdateHistory.UpdateHistoryResponse,
     migrationId: Long,
+    // Raw protobuf-JSON strings from the DB, keyed by event node ID.
+    // When available, ProtobufJsonScanHttpEncodings can use these directly
+    // instead of deserializing and re-serializing javaapi.data.Value objects.
+    rawProtobufJsonEventData: Map[Int, RawProtobufJsonEventData] = Map.empty,
 )
 
 object TreeUpdateWithMigrationId {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryQueries.scala
@@ -20,7 +20,7 @@ trait UpdateHistoryQueries extends AcsJdbcTypes {
       companionClass: ContractCompanion[C, TCId, T]
   ): Contract[TCId, T] = {
     companionClass
-      .fromCreatedEvent(companion)(row.toCreatedEvent.event)
+      .fromCreatedEvent(companion)(row.toCreatedEvent().event)
       .getOrElse(throw new RuntimeException("Failed to decode contract"))
   }
 

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTest.scala
@@ -430,7 +430,7 @@ class UpdateHistoryTest extends UpdateHistoryTestBase {
               .futureValue
           result.lastOption match {
             case None => acc // done
-            case Some(TreeUpdateWithMigrationId(last, migrationId)) =>
+            case Some(TreeUpdateWithMigrationId(last, migrationId, _)) =>
               last.update match {
                 case tree: TransactionTreeUpdate =>
                   allHistoryPaginated(
@@ -492,7 +492,7 @@ class UpdateHistoryTest extends UpdateHistoryTestBase {
             (1 to 10).map(i =>
               (2L, CantonTimestamp.assertFromInstant(defaultEffectiveAt.plusMillis(i.toLong)))
             ))
-          all.map { case TreeUpdateWithMigrationId(u, migrationId) =>
+          all.map { case TreeUpdateWithMigrationId(u, migrationId, _) =>
             (migrationId, u.update.recordTime)
           } shouldBe expected
         }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -741,17 +741,20 @@ class HttpScanHandler(
       )
     }
     confirmBackfillingIsCompleteThen(updateHistory) {
+      val valueDeserializer = ScanHttpEncodings.valueDeserializerFor(encoding)
       for {
         txs <-
           if (includeImportUpdates)
             updateHistory.getAllUpdates(
               afterO,
               PageLimit.tryCreate(pageSize),
+              valueDeserializer = valueDeserializer,
             )
           else
             updateHistory.getUpdatesWithoutImportUpdates(
               afterO,
               PageLimit.tryCreate(pageSize),
+              valueDeserializer = valueDeserializer,
             )
       } yield txs
         .map(
@@ -1761,7 +1764,7 @@ class HttpScanHandler(
   ): Future[Either[ErrorResponse, UpdateHistoryItem]] = {
     implicit val tc = extracted
     for {
-      tx <- updateHistory.getUpdate(updateId)
+      tx <- updateHistory.getUpdate(updateId, ScanHttpEncodings.valueDeserializerFor(encoding))
     } yield {
       tx.fold[Either[ErrorResponse, UpdateHistoryItem]](
         Left(
@@ -2100,6 +2103,7 @@ class HttpScanHandler(
           atOrAfterRecordTime =
             body.atOrAfter.map(x => CantonTimestamp.assertFromInstant(x.toInstant)),
           limit = PageLimit.tryCreate(body.count),
+          valueDeserializer = UpdateHistory.noValueDeserialization,
         )
         .map { txs =>
           definitions.GetUpdatesBeforeResponse(
@@ -2127,6 +2131,7 @@ class HttpScanHandler(
           migrationId = body.migrationId,
           afterUpdateId = body.afterUpdateId,
           limit = PageLimit.tryCreate(body.limit),
+          valueDeserializer = UpdateHistory.noValueDeserialization,
         )
         .map { txs =>
           definitions.GetImportUpdatesResponse(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
@@ -22,7 +22,8 @@ import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore.{
   VerdictResultDbValue,
   VerdictT,
 }
-import org.lfdecentralizedtrust.splice.store.TreeUpdateWithMigrationId
+import org.lfdecentralizedtrust.splice.store.{RawProtobufJsonEventData, TreeUpdateWithMigrationId}
+import org.lfdecentralizedtrust.splice.store.UpdateHistory
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.UpdateHistoryResponse
 import org.lfdecentralizedtrust.splice.util.{Codec, Contract, EventId, LegacyOffset, Trees}
 
@@ -43,6 +44,8 @@ sealed trait ScanHttpEncodings {
       updateWithMigrationId: TreeUpdateWithMigrationId,
       eventIdBuilder: (String, Int) => String,
   )(implicit elc: ErrorLoggingContext): httpApi.UpdateHistoryItem = {
+
+    val rawDataMap = updateWithMigrationId.rawProtobufJsonEventData
 
     updateWithMigrationId.update.update match {
       case ledgerApi.TransactionTreeUpdate(tree) =>
@@ -66,6 +69,7 @@ sealed trait ScanHttpEncodings {
                   eventId,
                   treeEvent,
                   eventIdBuilder,
+                  rawDataMap,
                 )
               }.toMap,
             )
@@ -94,6 +98,7 @@ sealed trait ScanHttpEncodings {
                   javaToHttpCreatedEvent(
                     eventIdBuilder(update.updateId, createdEvent.getNodeId),
                     createdEvent,
+                    rawDataMap.get(createdEvent.getNodeId),
                   ),
                   counter,
                 ),
@@ -132,15 +137,17 @@ sealed trait ScanHttpEncodings {
       eventId: String,
       treeEvent: javaApi.Event,
       eventIdBuild: (String, Int) => String,
+      rawDataMap: Map[Int, RawProtobufJsonEventData],
   )(implicit
       elc: ErrorLoggingContext
   ): httpApi.TreeEvent = {
     treeEvent match {
       case event: javaApi.CreatedEvent =>
         httpApi.TreeEvent.fromCreatedEvent(
-          javaToHttpCreatedEvent(eventId, event)
+          javaToHttpCreatedEvent(eventId, event, rawDataMap.get(event.getNodeId))
         )
       case event: javaApi.ExercisedEvent =>
+        val rawData = rawDataMap.get(event.getNodeId)
         httpApi.TreeEvent.fromExercisedEvent(
           httpApi
             .ExercisedEvent(
@@ -150,7 +157,7 @@ sealed trait ScanHttpEncodings {
               templateIdString(event.getTemplateId),
               event.getPackageName,
               event.getChoice,
-              encodeChoiceArgument(event),
+              encodeChoiceArgument(event, rawData),
               tree
                 .getChildNodeIds(event)
                 .asScala
@@ -158,7 +165,7 @@ sealed trait ScanHttpEncodings {
                   eventIdBuild(tree.getUpdateId, _)
                 )
                 .toVector,
-              encodeExerciseResult(event),
+              encodeExerciseResult(event, rawData),
               event.isConsuming,
               event.getActingParties.asScala.toVector,
               event.getInterfaceId.map(templateIdString(_)).toScala,
@@ -169,7 +176,11 @@ sealed trait ScanHttpEncodings {
     }
   }
 
-  def javaToHttpCreatedEvent(eventId: String, event: javaApi.CreatedEvent)(implicit
+  def javaToHttpCreatedEvent(
+      eventId: String,
+      event: javaApi.CreatedEvent,
+      rawEventData: Option[RawProtobufJsonEventData] = None,
+  )(implicit
       elc: ErrorLoggingContext
   ): httpApi.CreatedEvent = {
     event.getContractKey.toScala.foreach { _ =>
@@ -184,7 +195,7 @@ sealed trait ScanHttpEncodings {
         event.getContractId,
         templateIdString(event.getTemplateId),
         event.getPackageName,
-        encodeContractPayload(event),
+        encodeContractPayload(event, rawEventData),
         event.getCreatedAt.atOffset(ZoneOffset.UTC),
         event.getSignatories.asScala.toVector.sorted,
         event.getObservers.asScala.toVector.sorted,
@@ -396,13 +407,19 @@ sealed trait ScanHttpEncodings {
       .parse(validJsonString)
       .fold(err => failedToWriteToJson(err.message), identity)
 
-  def encodeContractPayload(event: javaApi.CreatedEvent)(implicit
+  def encodeContractPayload(
+      event: javaApi.CreatedEvent,
+      rawEventData: Option[RawProtobufJsonEventData] = None,
+  )(implicit
       elc: ErrorLoggingContext
   ): io.circe.Json
 
   def decodeContractPayload(templateId: javaApi.Identifier, json: io.circe.Json): javaApi.DamlRecord
 
-  def encodeChoiceArgument(event: javaApi.ExercisedEvent)(implicit
+  def encodeChoiceArgument(
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData] = None,
+  )(implicit
       elc: ErrorLoggingContext
   ): io.circe.Json
 
@@ -413,7 +430,10 @@ sealed trait ScanHttpEncodings {
       json: io.circe.Json,
   ): javaApi.Value
 
-  def encodeExerciseResult(event: javaApi.ExercisedEvent)(implicit
+  def encodeExerciseResult(
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData] = None,
+  )(implicit
       elc: ErrorLoggingContext
   ): io.circe.Json
 
@@ -519,6 +539,20 @@ object ScanHttpEncodings {
     )
   }
 
+  /** Returns the appropriate value deserializer for the given encoding.
+    * For ProtobufJson, returns None (skips the costly deserialization since
+    * the raw DB strings are passed through directly).
+    * For CompactJson, returns the real deserializer wrapped in Some since re-encoding is needed.
+    */
+  def valueDeserializerFor(
+      encoding: definitions.DamlValueEncoding
+  ): String => Option[javaApi.Value] = encoding match {
+    case definitions.DamlValueEncoding.members.ProtobufJson =>
+      UpdateHistory.noValueDeserialization
+    case definitions.DamlValueEncoding.members.CompactJson =>
+      UpdateHistory.deserializeValue
+  }
+
   def encodeUpdate(
       update: TreeUpdateWithMigrationId,
       encoding: definitions.DamlValueEncoding,
@@ -557,7 +591,20 @@ object ScanHttpEncodings {
   def makeConsistentAcrossSvs(
       update: TreeUpdateWithMigrationId
   ): TreeUpdateWithMigrationId = {
-    update.copy(update = makeConsistentAcrossSvs(update.update))
+    update.update.update match {
+      case ledgerApi.TransactionTreeUpdate(tree) =>
+        val mapping = Trees.getLocalEventIndices(tree)
+        val remappedRawData = update.rawProtobufJsonEventData.map { case (nodeId, data) =>
+          mapping.getOrElse(nodeId, nodeId) -> data
+        }
+        update.copy(
+          update = makeConsistentAcrossSvs(update.update),
+          rawProtobufJsonEventData = remappedRawData,
+        )
+      case _ =>
+        // For reassignments, node IDs don't change
+        update.copy(update = makeConsistentAcrossSvs(update.update))
+    }
   }
 
   def makeConsistentAcrossSvs(
@@ -729,7 +776,8 @@ case class CompactJsonScanHttpEncodings(
 ) extends ScanHttpEncodings {
   import org.lfdecentralizedtrust.splice.util.ValueJsonCodecCodegen
   override def encodeContractPayload(
-      event: javaApi.CreatedEvent
+      event: javaApi.CreatedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     ValueJsonCodecCodegen
       .serializableContractPayload(event)
@@ -742,7 +790,8 @@ case class CompactJsonScanHttpEncodings(
       )
 
   override def encodeChoiceArgument(
-      event: javaApi.ExercisedEvent
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     ValueJsonCodecCodegen
       .serializeChoiceArgument(event)
@@ -755,7 +804,8 @@ case class CompactJsonScanHttpEncodings(
       )
 
   override def encodeExerciseResult(
-      event: javaApi.ExercisedEvent
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     ValueJsonCodecCodegen
       .serializeChoiceResult(event)
@@ -821,27 +871,33 @@ object CompactJsonScanHttpEncodings {
 case object ProtobufJsonScanHttpEncodings extends ScanHttpEncodings {
   import org.lfdecentralizedtrust.splice.util.ValueJsonCodecProtobuf
   override def encodeContractPayload(
-      event: javaApi.CreatedEvent
+      event: javaApi.CreatedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     tryParseJson(
-      ValueJsonCodecProtobuf
-        .serializeValue(event.getArguments)
+      rawEventData
+        .flatMap(_.createArguments)
+        .getOrElse(ValueJsonCodecProtobuf.serializeValue(event.getArguments))
     )
 
   override def encodeChoiceArgument(
-      event: javaApi.ExercisedEvent
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     tryParseJson(
-      ValueJsonCodecProtobuf
-        .serializeValue(event.getChoiceArgument)
+      rawEventData
+        .flatMap(_.choiceArgument)
+        .getOrElse(ValueJsonCodecProtobuf.serializeValue(event.getChoiceArgument))
     )
 
   override def encodeExerciseResult(
-      event: javaApi.ExercisedEvent
+      event: javaApi.ExercisedEvent,
+      rawEventData: Option[RawProtobufJsonEventData],
   )(implicit elc: ErrorLoggingContext): Json =
     tryParseJson(
-      ValueJsonCodecProtobuf
-        .serializeValue(event.getExerciseResult)
+      rawEventData
+        .flatMap(_.exerciseResult)
+        .getOrElse(ValueJsonCodecProtobuf.serializeValue(event.getExerciseResult))
     )
 
   override def decodeContractPayload(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -331,7 +331,7 @@ class AcsSnapshotStore(
         )
     } yield {
       val eventsInPage =
-        applyLimitOrFail("queryAcsSnapshot", limit, events.map(_._2.toCreatedEvent))
+        applyLimitOrFail("queryAcsSnapshot", limit, events.map(_._2.toCreatedEvent()))
       val afterToken = if (eventsInPage.size == limit.limit) events.lastOption.map(_._1) else None
       QueryAcsSnapshotResult(
         migrationId = migrationId,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerTest.scala
@@ -1,5 +1,6 @@
 package org.lfdecentralizedtrust.splice.scan.automation
 
+import com.daml.ledger.javaapi.data as javaApi
 import com.daml.ledger.api.v2.TraceContextOuterClass
 import com.daml.ledger.javaapi.data.Transaction
 import com.daml.metrics.api.noop.NoOpMetricsFactory
@@ -59,6 +60,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, lastSnapshotTime.plusSeconds(3600L)))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(Future.successful(Seq.empty))
 
@@ -100,6 +102,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(Future.successful(Seq.empty))
 
@@ -116,6 +119,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(
           Future.successful(
@@ -135,6 +139,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, firstSnapshotTime))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(Future.successful(Seq.empty))
 
@@ -151,6 +156,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(
           Future.successful(
@@ -171,6 +177,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, firstSnapshotTime))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(
           Future.successful(
@@ -200,6 +207,7 @@ class AcsSnapshotTriggerTest
             updateHistory.getUpdatesWithoutImportUpdates(
               eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
               eqTo(PageLimit.tryCreate(1)),
+              any[String => Option[javaApi.Value]],
             )(any[TraceContext])
           ).thenReturn(
             Future.successful(
@@ -227,6 +235,7 @@ class AcsSnapshotTriggerTest
             updateHistory.getUpdatesWithoutImportUpdates(
               eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
               eqTo(PageLimit.tryCreate(1)),
+              any[String => Option[javaApi.Value]],
             )(any[TraceContext])
           ).thenReturn(
             Future.successful(
@@ -259,6 +268,7 @@ class AcsSnapshotTriggerTest
             updateHistory.getUpdatesWithoutImportUpdates(
               eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
               eqTo(PageLimit.tryCreate(1)),
+              any[String => Option[javaApi.Value]],
             )(any[TraceContext])
           ).thenReturn(
             Future.successful(
@@ -292,6 +302,7 @@ class AcsSnapshotTriggerTest
             updateHistory.getUpdatesWithoutImportUpdates(
               eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
               eqTo(PageLimit.tryCreate(1)),
+              any[String => Option[javaApi.Value]],
             )(any[TraceContext])
           ).thenReturn(
             Future.successful(
@@ -314,6 +325,7 @@ class AcsSnapshotTriggerTest
             updateHistory.getUpdatesWithoutImportUpdates(
               eqTo(Some((currentMigrationId, firstSnapshotTime))),
               eqTo(PageLimit.tryCreate(1)),
+              any[String => Option[javaApi.Value]],
             )(any[TraceContext])
           ).thenReturn(
             Future.successful(
@@ -518,6 +530,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, CantonTimestamp.MinValue))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(
           Future.successful(
@@ -538,6 +551,7 @@ class AcsSnapshotTriggerTest
           updateHistory.getUpdatesWithoutImportUpdates(
             eqTo(Some((currentMigrationId, firstSnapshotTime))),
             eqTo(PageLimit.tryCreate(1)),
+            any[String => Option[javaApi.Value]],
           )(any[TraceContext])
         ).thenReturn(
           Future.successful(
@@ -690,6 +704,7 @@ class AcsSnapshotTriggerTest
         updateHistory.getUpdatesWithoutImportUpdates(
           eqTo(Some((migrationId, queryRecordTime))),
           eqTo(PageLimit.tryCreate(1)),
+          any[String => Option[javaApi.Value]],
         )(any[TraceContext])
       ).thenReturn(
         Future.successful(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.store.bulk
 
+import com.daml.ledger.javaapi.data as javaApi
 import com.daml.metrics.api.MetricsContext
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.daml.metrics.api.testing.InMemoryMetricsFactory
@@ -352,6 +353,7 @@ class UpdateHistoryBulkStorageTest
         store.getUpdatesWithoutImportUpdates(
           any[Option[(Long, CantonTimestamp)]],
           any[Limit],
+          any[String => Option[javaApi.Value]],
         )(any[TraceContext])
       ).thenAnswer {
         (


### PR DESCRIPTION
Related to #4308 
Removed the RawJson type since it is confusing in the openAPI spec, and doesn't improve performance, circe marshalling is required in how guardrails + pekko + circe is used.

The protobuf-json damlValueEncoding side of the code paths gets more complicated, with raw data passed along everywhere, and dummy records in the events that can get confusing, so not sure if this PR is very useful right now, especially since we don't know yet how many people opt in for the protobuf-json format which is harder to parse.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
