### PR TITLE
add alert on large seq scans

### DIFF
--- a/cluster/pulumi/infra/grafana-alerting/db_perf.yaml
+++ b/cluster/pulumi/infra/grafana-alerting/db_perf.yaml
@@ -1,0 +1,56 @@
+apiVersion: 1
+groups:
+    - orgId: 1
+      name: Performance
+      folder: database
+      interval: 1m
+      rules:
+        - uid: cff8qodcdd3i8a
+          title: PG Sequential Scans
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 600
+                to: 0
+              datasourceUid: prometheus
+              model:
+                editorMode: code
+                expr: sum by(datname, namespace, relname, schemaname) (rate(pg_stat_user_tables_seq_tup_read{namespace=~"sv-da-1"}[1m]))
+                instant: true
+                intervalMs: 1000
+                legendFormat: '{{namespace}}/{{schemaname}}.{{relname}}'
+                maxDataPoints: 43200
+                range: false
+                refId: A
+            - refId: C
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 200000
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params: []
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 1000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          noDataState: NoData
+          execErrState: Error
+          keepFiringFor: 5m
+          annotations:
+            summary: Large DB sequential scan detected
+          labels: {}
+          isPaused: false


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/3280

Catches the recent seq scans on devnet:


<img width="711" height="586" alt="Screenshot from 2026-03-06 18-13-12" src="https://github.com/user-attachments/assets/5c161716-f027-4cad-9c10-5e41fa1aceda" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
