### PR TITLE
allow referencing environment variables in include paths

### DIFF
--- a/cluster/deployment/config.yaml
+++ b/cluster/deployment/config.yaml
@@ -1,3 +1,3 @@
 # This config is part of a legacy config loader feature which will soon be removed.
 # Please refrain from editing it. Instead edit cluster/configs/shared/base.yaml
-!include(../configs/shared/base.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/base.yaml) {}

--- a/cluster/deployment/scratchneta/config.yaml
+++ b/cluster/deployment/scratchneta/config.yaml
@@ -1,1 +1,1 @@
-!include(../../configs/shared/scratchnet.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/scratchnet.yaml) {}

--- a/cluster/deployment/scratchnetb/config.yaml
+++ b/cluster/deployment/scratchnetb/config.yaml
@@ -1,1 +1,1 @@
-!include(../../configs/shared/scratchnet.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/scratchnet.yaml) {}

--- a/cluster/deployment/scratchnetc/config.yaml
+++ b/cluster/deployment/scratchnetc/config.yaml
@@ -1,1 +1,1 @@
-!include(../../configs/shared/scratchnet.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/scratchnet.yaml) {}

--- a/cluster/deployment/scratchnetd/config.yaml
+++ b/cluster/deployment/scratchnetd/config.yaml
@@ -1,1 +1,1 @@
-!include(../../configs/shared/scratchnet.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/scratchnet.yaml) {}

--- a/cluster/deployment/scratchnete/config.yaml
+++ b/cluster/deployment/scratchnete/config.yaml
@@ -1,1 +1,1 @@
-!include(../../configs/shared/scratchnet.yaml) {}
+!include($SPLICE_ROOT/cluster/configs/shared/scratchnet.yaml) {}

--- a/cluster/pulumi/common/src/config/configLoader.test.ts
+++ b/cluster/pulumi/common/src/config/configLoader.test.ts
@@ -3,6 +3,7 @@
 import { expect, jest, test } from '@jest/globals';
 import dedent from 'dedent';
 import { readFileSync } from 'fs';
+import { env } from 'process';
 
 import { readAndParseYaml } from './configLoader';
 
@@ -323,6 +324,32 @@ test('detect cyclic dependency between multiple files', () => {
   });
   expect(() => readAndParseYaml('a.yaml')).toThrow(
     'Cyclic dependency detected: [/test/a.yaml -> /test/b.yaml -> /test/c.yaml -> /test/a.yaml].'
+  );
+});
+
+test('reference defined environment variable', () => {
+  env['COMMONS'] = '/test/common';
+  mockFiles({
+    '/test/common/base.yaml': dedent`
+      prop: test
+    `,
+    '/test/config.yaml': dedent`
+      !include($COMMONS/base.yaml)
+    `,
+  });
+  expect(readAndParseYaml('config.yaml')).toEqual({
+    prop: 'test',
+  });
+});
+
+test('reference undefined environment variable', () => {
+  mockFiles({
+    '/test/config.yaml': dedent`
+      !include($UNDEFINED/base.yaml)
+    `,
+  });
+  expect(() => readAndParseYaml('config.yaml')).toThrow(
+    `Included path [$UNDEFINED/base.yaml] references variable [UNDEFINED] that is not defined.`
   );
 });
 

--- a/cluster/pulumi/common/src/config/configLoader.ts
+++ b/cluster/pulumi/common/src/config/configLoader.ts
@@ -3,7 +3,8 @@
 import * as Yaml from 'js-yaml';
 import { existsSync, readFileSync, realpathSync } from 'fs';
 import { merge, mergeWith } from 'lodash';
-import { dirname, join, resolve } from 'path';
+import { dirname, join, resolve, sep as pathSeparator } from 'path';
+import { env } from 'process';
 
 import { spliceEnvConfig } from './envConfig';
 
@@ -11,10 +12,7 @@ export function readAndParseYaml(
   path: string,
   context: ConfigLoaderContext = initializeContext()
 ): unknown {
-  const resolvedPath =
-    context.pathStack.length === 0
-      ? resolve(path) // resolve against CWD
-      : resolve(dirname(context.pathStack[context.pathStack.length - 1]), path);
+  const resolvedPath = resolveIncludedPath(path, context);
   if (resolvedPath in context.loadedFilesByPath) {
     return context.loadedFilesByPath[resolvedPath];
   } else if (context.pathStack.includes(resolvedPath)) {
@@ -58,6 +56,34 @@ type ConfigLoaderContext = {
   loadedFilesByPath: Partial<Record<string, unknown>>;
   schema: Yaml.Schema;
 };
+
+function resolveIncludedPath(path: string, context: ConfigLoaderContext): string {
+  const pathWithVariableSubstitutions = join(
+    ...path.split(pathSeparator).map(segment => {
+      if (segment === '') {
+        return '/';
+      } else if (segment.startsWith('$')) {
+        const variableName = segment.slice(1);
+        const variableValue = env[variableName];
+        return variableValue === undefined || variableValue === ''
+          ? reportError(
+              `Included path [${path}] references variable [${variableName}] that is not defined.`,
+              context
+            )
+          : variableValue;
+      } else {
+        return segment;
+      }
+    })
+  );
+
+  return context.pathStack.length === 0
+    ? resolve(pathWithVariableSubstitutions) // resolve against CWD
+    : resolve(
+        dirname(context.pathStack[context.pathStack.length - 1]),
+        pathWithVariableSubstitutions
+      );
+}
 
 function makeIncludeTagDefinition(context: ConfigLoaderContext): Yaml.Type {
   return new Yaml.Type('!include', {


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/canton-network-internal/issues/4010

This will provide an easy solution to changing relative paths going from the splice repo to internal without using symlinks.

Backport PRs for these and previous changes:
- [0.5.14](https://github.com/hyperledger-labs/splice/pull/4331)
- [0.5.13](https://github.com/hyperledger-labs/splice/pull/4332)
- [0.5.12](https://github.com/hyperledger-labs/splice/pull/4333)