### PR TITLE
[ci] handle empty update segments gracefully

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -139,16 +139,24 @@ class UpdateHistorySegmentBulkStorage(
     Source
       .unfoldAsync(segment.fromTimestamp)(ts => getUpdatesChunk(ts))
       .via(
-        S3ZstdObjects(
-          storageConfig,
-          appConfig,
-          s3Connection,
-          { objIdx =>
-            s"${storageConfig.getSegmentKeyPrefix(segment.fromTimestamp, Some(segment.toTimestamp))}/updates_$objIdx.zstd"
-          },
-          loggerFactory,
+        // We use lazyFlow, so that in the case where no updates are emitted, we don't instantiate the S3ZstdObjects at all,
+        // since it assumes that it gets at least one chunk to write.
+        Flow.lazyFlow(() =>
+          S3ZstdObjects(
+            storageConfig,
+            appConfig,
+            s3Connection,
+            { objIdx =>
+              s"${storageConfig.getSegmentKeyPrefix(segment.fromTimestamp, Some(segment.toTimestamp))}/updates_$objIdx.zstd"
+            },
+            loggerFactory,
+          )
         )
       )
+      .orElse(Source.lazySource { () =>
+        logger.warn(s"No updates found in segment ${segment.fromTimestamp}-${segment.toTimestamp}")
+        Source.empty
+      })
       .map((o: GroupedWeightS3ObjectFlow.Output) => {
         historyMetrics.BulkStorage.incUpdateObjects()
         UpdateHistorySegmentBulkStorage.Output(segment, o.objectKey, o.isLastObject)

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -10,6 +10,7 @@ import com.digitalasset.canton.concurrent.FutureSupervisor
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.protocol.LfContractId
 import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.time.WallClock
@@ -27,6 +28,7 @@ import org.lfdecentralizedtrust.splice.scan.store.{ScanKeyValueProvider, ScanKey
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.UpdateHistoryResponse
 import org.lfdecentralizedtrust.splice.store.*
 import org.lfdecentralizedtrust.splice.store.db.SplicePostgresTest
+import org.slf4j.event.Level
 
 import java.time.{Instant, LocalDate, ZoneOffset}
 import scala.concurrent.Future
@@ -166,6 +168,49 @@ class UpdateHistoryBulkStorageTest
             ) should contain theSameElementsInOrderAs segmentUpdates
         }
       }
+    }
+
+    "successfully handle an empty segment" in {
+      val bucketConnection = S3BucketConnectionForUnitTests(s3ConfigMock, loggerFactory)
+      val mockStore =
+        new MockUpdateHistoryStore(10, { i => Instant.ofEpochMilli(i + 1000) })
+      val fromTimestamp =
+        CantonTimestamp.tryFromInstant(Instant.ofEpochMilli(100L))
+      val toTimestamp =
+        CantonTimestamp.tryFromInstant(Instant.ofEpochMilli(200L))
+
+      val segment = UpdatesSegment(
+        TimestampWithMigrationId(fromTimestamp, 0),
+        TimestampWithMigrationId(toTimestamp, 0),
+      )
+      val metricsFactory = new InMemoryMetricsFactory
+
+      loggerFactory.assertEventuallyLogsSeq(SuppressionRule.Level(Level.WARN))(
+        {
+          val probe = UpdateHistorySegmentBulkStorage
+            .asSource(
+              bulkStorageTestConfig,
+              appConfig,
+              mockStore.store,
+              bucketConnection,
+              segment,
+              new HistoryMetrics(metricsFactory)(MetricsContext.Empty),
+              loggerFactory,
+            )
+            .toMat(TestSink.probe[UpdateHistorySegmentBulkStorage.Output])(Keep.right)
+            .run()
+          probe.request(1)
+
+          probe.expectComplete()
+        },
+        logEntries =>
+          forExactly(1, logEntries)(logEntry =>
+            logEntry.message should (include("No updates found in segment"))
+          ),
+      )
+
+      succeed
+
     }
 
     "successfully dump all segments" in {


### PR DESCRIPTION
We've had full days of downtime in CILR, so this definitely happens there, and currently breaks it (because an s3 object is created, but then closed while being empty which breaks an assumption that we have elsewhere).
Shouldn't happen in prod, hence the warning log.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
