### PR TITLE
docs: establish validator party hint naming convention for multi-environment deployments

### DIFF
--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -421,7 +421,7 @@ Additionally, please modify the file ``splice-node/examples/sv-helm/standalone-v
      ======================== ====================================
 
      The ``<enumerator>`` can be incremented if you run multiple validator nodes
-     within the same environment (e.g., ``mycompany-testnet-2``).
+     within the same environment (e.g., ``MyCompany-testnet-2``).
 - Replace ``YOUR_VALIDATOR_NODE_NAME`` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your ``validatorPartyHint``. When operating across multiple environments, this means the node name will also reflect the target environment (e.g., ``MyCompany-devnet-1``).
 
 If you are redeploying the validator app as part of a :ref:`synchronizer migration <validator-upgrades>`, you will also need to set ``migrating`` to ``true`` in your ``standalone-validator-values.yaml``:

--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -407,7 +407,22 @@ Additionally, please modify the file ``splice-node/examples/sv-helm/standalone-v
 - Replace ``YOUR_VALIDATOR_PARTY_HINT`` with the desired name for your
   validator operator party. It must be of the format
   ``<organization>-<function>-<enumerator>``.
-- Replace ``YOUR_VALIDATOR_NODE_NAME`` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your ``validatorPartyHint``.
+.. note::
+
+     If you operate validators across multiple environments, use the ``<function>`` segment to distinguish them. Each environment should have a unique party hint.
+     For example:
+
+     ======================== ====================================
+     Environment              Party Hint
+     ------------------------ ------------------------------------
+     DevNet                   ``MyCompany-devnet-1``
+     TestNet                  ``MyCompany-testnet-1``
+     MainNet                  ``MyCompany-validator-1``
+     ======================== ====================================
+
+     The ``<enumerator>`` can be incremented if you run multiple validator nodes
+     within the same environment (e.g., ``mycompany-testnet-2``).
+- Replace ``YOUR_VALIDATOR_NODE_NAME`` with the name you want your validator node to be represented as on the network. Usually you can use the same value as for your ``validatorPartyHint``. When operating across multiple environments, this means the node name will also reflect the target environment (e.g., ``MyCompany-devnet-1``).
 
 If you are redeploying the validator app as part of a :ref:`synchronizer migration <validator-upgrades>`, you will also need to set ``migrating`` to ``true`` in your ``standalone-validator-values.yaml``:
 


### PR DESCRIPTION
## Summary

Adds guidance on choosing unique `validatorPartyHint` values when operating
validators across multiple Canton Network environments (DevNet, TestNet, MainNet).

## Context

The `validatorPartyHint` field is constrained to the format
`<organization>-<function>-<enumerator>`, which allows exactly two dashes.
Operators deploying validators to more than one environment need a clear
convention to avoid party hint collisions and to make environment
attribution obvious at a glance.

## Proposed Convention

| Environment | Party Hint Example         |
|-------------|----------------------------|
| DevNet      | `MyCompany-devnet-1`     |
| TestNet     | `MyCompany-testnet-1`    |
| MainNet     | `MyCompany-validator-1`  |

The `<function>` segment encodes the environment (or `validator` for
production), and the `<enumerator>` supports running multiple nodes per
environment if needed.

## Changes

- Adds a "Naming Convention" note/callout near the `YOUR_VALIDATOR_PARTY_HINT`
  replacement instructions in the validator K8s deployment docs.
- Includes an example table showing the recommended pattern.
- Adds a `.. note::` block with an environment-naming convention table
  immediately after the `YOUR_VALIDATOR_PARTY_HINT` format constraint
- Extends the `YOUR_VALIDATOR_NODE_NAME` guidance to reference the
  multi-environment convention since operators typically reuse the same value

## Why This Matters

- Prevents accidental party hint reuse across environments
- Makes it easy to identify which environment a party belongs to from
  its hint alone
- Aligns with the existing format constraint without requiring upstream changes

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
