### PR TITLE
Revert "Root Alertmanager's InfoInhibitor to null (#4323)"

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2852,7 +2852,7 @@
                 {
                   "continue": false,
                   "matchers": [
-                    "alertname=\"Watchdog|InfoInhibitor\""
+                    "alertname=\"Watchdog\""
                   ],
                   "receiver": "null"
                 }

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -172,7 +172,7 @@ export function configureObservability(dependsOn: pulumi.Resource[] = []): pulum
               routes: [
                 {
                   receiver: 'null',
-                  matchers: ['alertname="Watchdog|InfoInhibitor"'],
+                  matchers: ['alertname="Watchdog"'],
                   continue: false,
                 },
               ],


### PR DESCRIPTION
This reverts commit 0419d7b95b2177f81338a529423ea05c1d101515.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/7444