### PR TITLE
Remove k8sApi from constructor

### DIFF
--- a/cluster/pulumi/common/src/auth0/auth0.ts
+++ b/cluster/pulumi/common/src/auth0/auth0.ts
@@ -47,14 +47,9 @@ export class Auth0Fetch implements Auth0Client {
   private auth0Cache: Auth0CacheMap | undefined;
   private hasDiffsToSave = false;
 
-  private k8sApi: CoreV1Api;
   private cfg: Auth0Config;
 
   constructor(cfg: Auth0Config) {
-    const kc = new KubeConfig();
-    kc.loadFromDefault();
-
-    this.k8sApi = kc.makeApiClient(CoreV1Api);
     this.cfg = cfg;
   }
 
@@ -109,6 +104,12 @@ export class Auth0Fetch implements Auth0Client {
     }
   }
 
+  private getK8sClient(): CoreV1Api {
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+    return kc.makeApiClient(CoreV1Api);
+  }
+
   public async loadAuth0Cache(): Promise<void> {
     if (!fixedTokens()) {
       await pulumi.log.debug('Fixed tokens not enabled, skipping Auth0 cache load');
@@ -120,7 +121,8 @@ export class Auth0Fetch implements Auth0Client {
     const cacheMap = {} as Auth0CacheMap;
 
     try {
-      const cacheSecret = await this.k8sApi.readNamespacedSecret({
+      const k8sApi = this.getK8sClient();
+      const cacheSecret = await k8sApi.readNamespacedSecret({
         name: this.cfg.fixedTokenCacheName,
         namespace: 'default',
       });
@@ -161,7 +163,8 @@ export class Auth0Fetch implements Auth0Client {
 
     try {
       await pulumi.log.info('Attempting to create secret');
-      await this.k8sApi.createNamespacedSecret({
+      const k8sApi = this.getK8sClient();
+      await k8sApi.createNamespacedSecret({
         namespace: 'default',
         body: {
           apiVersion: 'v1',
@@ -175,13 +178,14 @@ export class Auth0Fetch implements Auth0Client {
     } catch (_) {
       try {
         await pulumi.log.info('Deleting existing secret');
-        await this.k8sApi.deleteNamespacedSecret({
+        const k8sApi = this.getK8sClient();
+        await k8sApi.deleteNamespacedSecret({
           name: this.cfg.fixedTokenCacheName,
           namespace: 'default',
         });
 
         await pulumi.log.info('Creating new secret');
-        await this.k8sApi.createNamespacedSecret({
+        await k8sApi.createNamespacedSecret({
           namespace: 'default',
           body: {
             apiVersion: 'v1',

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -48,9 +48,6 @@
                 "prettier": "^3.8.1",
                 "ts-jest": "^29.4.6",
                 "typescript": "^5.9.3"
-            },
-            "engines": {
-                "npm": ">=11.6.2"
             }
         },
         "canton-network": {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7505

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
