### PR TITLE
make participant_console command work with an LSU participant

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -436,9 +436,9 @@ function subcmd_logs() {
 function k8s_labels_for_app() {
     local global_domain_specific_apps=("global-domain-cometbft" "global-domain-sequencer" "global-domain-mediator")
     local domain_specific_apps="@(participant|multi-participant-[0-9][0-9])"
-    local logical_synchronizer_deployment_mode=$(
-        "${SPLICE_ROOT}/cluster/scripts/get-resolved-config.sh"
-        | yq ".synchronizerMigration[] | select(.id == ${domain}).enableLogicalSynchronizerDeploymentMode"
+    local logical_synchronizer_deployment_mode
+    logical_synchronizer_deployment_mode=$( \
+        get_resolved_config | yq ".synchronizerMigration[] | select(.id == ${domain}).enableLogicalSynchronizerDeploymentMode" \
     )
 
     # shellcheck disable=SC2076


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice/issues/4391

As the participant in the logical synchronizer deployment scheme does not have a migration ID in its name, the `participant_console` subcommand needed a way to specify that when looking for the participant pod it should not expect a migration ID in its name.