### PR TITLE
Revert "Fix validator restart error resulting from failed scan service (#4255)"

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
@@ -36,7 +36,6 @@ class BftScanConnectionIntegrationTest
     with HasActorSystem {
 
   override protected def runEventHistorySanityCheck: Boolean = false
-  override protected def runUpdateHistorySanityCheck: Boolean = false
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
@@ -247,33 +246,6 @@ class BftScanConnectionIntegrationTest
       }
     }
 
-  }
-
-  "validator reboots when initial bootstrap scan is offline" in { implicit env =>
-    clue("Initialize the DSO") {
-      initDso()
-    }
-
-    clue("Start Alice validator") {
-      aliceValidatorBackend.startSync()
-    }
-
-    clue("Stop SV1 scan") {
-      sv1ScanBackend.stop()
-    }
-
-    clue("Stop Alice validator") {
-      aliceValidatorBackend.stop()
-    }
-
-    loggerFactory.assertEventuallyLogsSeq(SuppressionRule.LevelAndAbove(Level.INFO))(
-      {
-        // need to supress due to connection attempts to failed scan of Sv1
-        aliceValidatorBackend.startSync()
-        aliceValidatorBackend.onboardUser("Test")
-      },
-      _ => succeed,
-    )
   }
 
   private val bootstrapsWith1UrlLog =

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
@@ -1332,25 +1332,9 @@ abstract class TopologyAdminConnection(
     )
 
   def initId(id: NodeIdentity)(implicit traceContext: TraceContext): Future[Unit] = {
-    retryProvider.ensureThatB(
-      RetryFor.WaitingOnInitDependency,
-      "init_id",
-      show"Node is initialized with ID $id",
-      getIdOption().map {
-        case GetIdResult(true, Some(uid)) if uid == id.uid => true
-        case GetIdResult(true, Some(uid)) =>
-          throw Status.FAILED_PRECONDITION
-            .withDescription(
-              s"Node is already initialized with a different ID: $uid (expected ${id.uid})"
-            )
-            .asRuntimeException()
-        case _ => false
-      },
-      runCmd(
-        TopologyAdminCommands.Init
-          .InitId(id.uid.identifier.toProtoPrimitive, id.uid.namespace.toProtoPrimitive, Seq.empty)
-      ).map(_ => ()),
-      logger,
+    runCmd(
+      TopologyAdminCommands.Init
+        .InitId(id.uid.identifier.toProtoPrimitive, id.uid.namespace.toProtoPrimitive, Seq.empty)
     )
   }
 

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -55,8 +55,10 @@ import org.lfdecentralizedtrust.splice.migration.{
   ParticipantUsersDataRestorer,
 }
 import org.lfdecentralizedtrust.splice.scan.admin.api.client
+import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection.BftScanClientConfig
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.{
   BftScanConnection,
+  MinimalScanConnection,
   SingleScanConnection,
 }
 import org.lfdecentralizedtrust.splice.scan.config.ScanAppClientConfig
@@ -139,6 +141,8 @@ class ValidatorApp(
   override def preInitializeBeforeLedgerConnection()(implicit
       traceContext: TraceContext
   ): Future[Unit] = for {
+    // TODO(tech-debt) consider removing early version check once we switch to a non-dev Canton protocol version
+    _ <- ensureVersionMatch(config.scanClient)
     _ <- withParticipantAdminConnection { participantAdminConnection =>
       readRestoreDump match {
         case Some(migrationDump) =>
@@ -306,13 +310,7 @@ class ValidatorApp(
             // before the automation kicks in.
             _ <- appInitStep("Vet packages") {
               for {
-                amuletRules <- retryProvider.retry(
-                  RetryFor.WaitingOnInitDependency,
-                  "get_amulet_rules_init",
-                  "retrieving AmuletRules from scan",
-                  scanConnection.getAmuletRules(),
-                  logger,
-                )
+                amuletRules <- scanConnection.getAmuletRules()
                 globalSynchronizerId: SynchronizerId <- scanConnection.getAmuletRulesDomain()(
                   traceContext
                 )
@@ -479,7 +477,6 @@ class ValidatorApp(
       logger: TracedLogger,
       retryProvider: RetryProvider,
   )(implicit traceContext: TraceContext): Future[ByteString] =
-    // TODO (hyperledger-labs/splice#4026) use the standard BftScanConnection instead of creating a new SingleScanConnection.
     retryProvider.retry(
       RetryFor.WaitingOnInitDependency,
       "get_acs_snapshot_from_single_scan",
@@ -593,6 +590,51 @@ class ValidatorApp(
       logger,
     )
   }
+
+  private def ensureVersionMatch(scanClientConfig: BftScanClientConfig)(implicit
+      traceContext: TraceContext
+  ): Future[Unit] =
+    retryProvider.waitUntil(
+      RetryFor.WaitingOnInitDependency,
+      "version_check",
+      "version checked via scan",
+      // we checkVersionCompatibility on every Splice app connection
+      scanClientConfig match {
+        case BftScanClientConfig.TrustSingle(url, _) =>
+          val config = ScanAppClientConfig(NetworkAppClientConfig(url))
+          MinimalScanConnection(
+            config,
+            amuletAppParameters.upgradesConfig,
+            retryProvider,
+            loggerFactory,
+          ).flatMap(con => con.checkActive().andThen(_ => con.close()))
+        case BftScanClientConfig.BftCustom(seedUrls, _, _, _, _, _) =>
+          seedUrls
+            .traverse { url =>
+              val config = ScanAppClientConfig(NetworkAppClientConfig(url))
+              MinimalScanConnection(
+                config,
+                amuletAppParameters.upgradesConfig,
+                retryProvider,
+                loggerFactory,
+              ).flatMap(con => con.checkActive().andThen(_ => con.close()))
+            }
+            .map(_ => ())
+        case BftScanClientConfig.Bft(seedUrls, _, _, _) =>
+          seedUrls
+            .traverse { url =>
+              val config = ScanAppClientConfig(NetworkAppClientConfig(url))
+              MinimalScanConnection(
+                config,
+                amuletAppParameters.upgradesConfig,
+                retryProvider,
+                loggerFactory,
+              ).flatMap(con => con.checkActive().andThen(_ => con.close()))
+            }
+            .map(_ => ())
+      },
+      logger,
+    )
 
   private def withSvConnection[T](
       svConfig: NetworkAppClientConfig

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -134,7 +134,7 @@ class DomainConnector(
       // The only case where this can happen is during a domain migration and even then
       // it is fairly unlikely outside of tests for validators to come up fast enough that
       // scan has not yet updated.
-      RetryFor.WaitingOnInitDependency, // because the scan connections might still be in bootstrap phase
+      RetryFor.ClientCalls,
       "scan_sequencer_connections",
       "non-empty sequencer connections from scan",
       getSequencerConnectionsFromScan(Right(clock))

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -16,11 +16,6 @@
        safely remove it regardless of whether you disabled the new sequencer connection
        pools in the participant or not.
 
-       Fix a bug that caused the Validator App to fail during restarts when the Scan Apps defined
-       in ``scanClient.seedUrls`` were unavailable. This fix ensures the Validator App uses its
-       persisted scan connections from previous runs, removing the dependency on seedUrls
-       scan availability for successful reboots.
-
    - Scan
 
      - **Experimental**: Added an optional ``traffic_summary`` field to the response of ``GET /v0/events/{update-id}`` and ``POST /v0/events`` endpoints.


### PR DESCRIPTION
This reverts commit aae4f8b7f15b51e2643d37417526c544f1670d7d.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/7483 I guess

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
