### PR TITLE
Update pinned JDK base image to move from JDK 21.0.7 to 21.0.10

### DIFF
--- a/cluster/images/splice-app/Dockerfile
+++ b/cluster/images/splice-app/Dockerfile
@@ -1,7 +1,10 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM eclipse-temurin:21-jdk-noble@sha256:5a65f334da5a91a66076735d78e3ae30483a2593ac108f830dcd59521f2535cd
+# docker run --rm -it eclipse-temurin:21-jdk-noble java -version
+# openjdk version "21.0.10" 2026-01-20 LTS
+# OpenJDK 64-Bit Server VM Temurin-21.0.10+7 (build 21.0.10+7-LTS, mixed mode, sharing)
+FROM eclipse-temurin:21-jdk-noble@sha256:efec1fca48fed530d4727c1ecd9c48d955153bad24067ee43ccf55e6e0d727c7
 
 # Install:
 # - screen for running the console in a headless server


### PR DESCRIPTION
OpenJDK 21.0.10 includes a fix for https://bugs.openjdk.org/browse/JDK-8347811 which caused affected Java runtime environments to incorrectly determine that cgroup controllers were not present on cgroupv2 hosts.

The image pinning is good, but missed out on the underlying patch version bumps in the eclipse-temurin:21-jdk-noble base image:
```
$ docker run --rm -it eclipse-temurin:21-jdk-noble@sha256:5a65f334da5a91a66076735d78e3ae30483a2593ac108f830dcd59521f2535cd java -version
...
Digest: sha256:5a65f334da5a91a66076735d78e3ae30483a2593ac108f830dcd59521f2535cd
Status: Downloaded newer image for eclipse-temurin@sha256:5a65f334da5a91a66076735d78e3ae30483a2593ac108f830dcd59521f2535cd
openjdk version "21.0.7" 2025-04-15 LTS
OpenJDK Runtime Environment Temurin-21.0.7+6 (build 21.0.7+6-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.7+6 (build 21.0.7+6-LTS, mixed mode, sharing)


$ docker run --rm -it eclipse-temurin:21-jdk-noble java -version
...
Digest: sha256:efec1fca48fed530d4727c1ecd9c48d955153bad24067ee43ccf55e6e0d727c7
Status: Downloaded newer image for eclipse-temurin:21-jdk-noble
openjdk version "21.0.10" 2026-01-20 LTS
OpenJDK Runtime Environment Temurin-21.0.10+7 (build 21.0.10+7-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.10+7 (build 21.0.10+7-LTS, mixed mode, sharing)
```