### PR TITLE
Fix batched featured app marker compat tests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BatchedFeaturedAppActivityMarkerIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BatchedFeaturedAppActivityMarkerIntegrationTest.scala
@@ -127,6 +127,10 @@ class BatchedFeaturedAppActivityMarkerIntegrationTest
       )
 
   "Batched activity marker creation produces only one view" in { implicit env =>
+    val amuletVersion =
+      sv1ScanBackend.getAmuletRules().payload.configSchedule.initialValue.packageConfig.amulet
+    // check that the test actually uses a different version
+    amuletVersion should not be "0.1.15"
     clue("Bob unvets amulet > 0.1.15") {
       bobValidatorBackend.validatorAutomation
         .trigger[ValidatorPackageVettingTrigger]
@@ -268,7 +272,7 @@ class BatchedFeaturedAppActivityMarkerIntegrationTest
         }
         forAtLeast(1, entries) { line =>
           line.message should (include(
-            s"vettedAmuletVersion = ${DarResources.amulet.latest.metadata.version}"
+            s"vettedAmuletVersion = ${amuletVersion}"
           ) and include("Processing"))
         }
       },


### PR DESCRIPTION
When testing Daml version compatibility latest is not the one actually used. Reading from amulet config should do the same for both the regular tests and the compat tests.

fixes https://github.com/DACH-NY/cn-test-failures/issues/7521

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
