### PR TITLE
Move all party to participant queries to read at sequencing time

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvDevNetReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvDevNetReonboardingIntegrationTest.scala
@@ -8,6 +8,7 @@ import com.digitalasset.canton.topology.ParticipantId
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.console.SvAppBackendReference
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 
 import scala.concurrent.duration.DurationInt
@@ -46,7 +47,11 @@ class SvDevNetReonboardingIntegrationTest extends SvIntegrationTestBase {
       def checkPartyToParticipant(expected: Seq[ParticipantId]) = {
         eventually() {
           val mapping = sv1Backend.appState.participantAdminConnection
-            .getPartyToParticipant(decentralizedSynchronizerId, sv1Backend.getDsoInfo().dsoParty)
+            .getPartyToParticipant(
+              decentralizedSynchronizerId,
+              sv1Backend.getDsoInfo().dsoParty,
+              topologySnapshot = TopologySnapshot.Sequenced,
+            )
             .futureValue
             .mapping
           mapping.threshold shouldBe PositiveInt.tryCreate(2)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvInitializationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvInitializationIntegrationTest.scala
@@ -9,6 +9,7 @@ import org.lfdecentralizedtrust.splice.console.{
   ValidatorAppBackendReference,
 }
 import org.lfdecentralizedtrust.splice.environment.RetryFor
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
@@ -215,7 +216,11 @@ class SvInitializationIntegrationTest extends SvIntegrationTestBase {
           .mapping
           .threshold shouldBe PositiveInt.tryCreate(2)
         participantAdminConnection
-          .getPartyToParticipant(decentralizedSynchronizerId, dsoParty)
+          .getPartyToParticipant(
+            decentralizedSynchronizerId,
+            dsoParty,
+            topologySnapshot = TopologySnapshot.Sequenced,
+          )
           .futureValue
           .mapping
           .threshold
@@ -226,7 +231,11 @@ class SvInitializationIntegrationTest extends SvIntegrationTestBase {
       eventually() {
         val participantAdminConnection = sv1Backend.appState.participantAdminConnection
         val dsoHostingParticipants = participantAdminConnection
-          .getPartyToParticipant(decentralizedSynchronizerId, dsoParty)
+          .getPartyToParticipant(
+            decentralizedSynchronizerId,
+            dsoParty,
+            topologySnapshot = TopologySnapshot.Sequenced,
+          )
           .futureValue
           .mapping
           .participants

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOffboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOffboardingIntegrationTest.scala
@@ -20,6 +20,7 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   IsTheCantonSequencerBFTEnabled,
   updateAutomationConfig,
 }
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
 import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.ExecuteConfirmedActionTrigger
@@ -222,6 +223,7 @@ class SvOffboardingIntegrationTest
                 .getPartyToParticipant(
                   decentralizedSynchronizerId,
                   sv3Backend.getDsoInfo().dsoParty,
+                  topologySnapshot = TopologySnapshot.Sequenced,
                 )
                 .futureValue
                 .mapping

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
@@ -15,6 +15,7 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   bumpUrl,
   updateAutomationConfig,
 }
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
   IntegrationTestWithIsolatedEnvironment,
@@ -330,7 +331,11 @@ class SvReonboardingIntegrationTest
               sv3Party,
             ).map(_.toProtoPrimitive)
             val mapping = sv1Backend.appState.participantAdminConnection
-              .getPartyToParticipant(decentralizedSynchronizerId, sv1Backend.getDsoInfo().dsoParty)
+              .getPartyToParticipant(
+                decentralizedSynchronizerId,
+                sv1Backend.getDsoInfo().dsoParty,
+                topologySnapshot = TopologySnapshot.Sequenced,
+              )
               .futureValue
               .mapping
             mapping.participants.map(_.participantId) should contain theSameElementsAs Seq(
@@ -430,7 +435,11 @@ class SvReonboardingIntegrationTest
           .name shouldBe sv4Name
 
         val mapping = sv1Backend.appState.participantAdminConnection
-          .getPartyToParticipant(decentralizedSynchronizerId, sv1Backend.getDsoInfo().dsoParty)
+          .getPartyToParticipant(
+            decentralizedSynchronizerId,
+            sv1Backend.getDsoInfo().dsoParty,
+            topologySnapshot = TopologySnapshot.Sequenced,
+          )
           .futureValue
           .mapping
         mapping.participants.map(_.participantId) should contain theSameElementsAs Seq(
@@ -505,6 +514,7 @@ class SvReonboardingIntegrationTest
             .getPartyToParticipant(
               decentralizedSynchronizerId,
               sv4Party,
+              topologySnapshot = TopologySnapshot.Sequenced,
             )
             .futureValue
             .mapping

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorReonboardingIntegrationTest.scala
@@ -11,6 +11,7 @@ import org.apache.pekko.http.scaladsl.model.Uri
 import org.lfdecentralizedtrust.splice.config.*
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms.bumpUrl
 import org.lfdecentralizedtrust.splice.environment.RetryFor
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.identities.NodeIdentitiesDump
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
@@ -221,6 +222,7 @@ trait ValidatorReonboardingIntegrationTestBase
       .getPartyToParticipant(
         decentralizedSynchronizerId,
         partyId,
+        topologySnapshot = TopologySnapshot.Sequenced,
       )
       .futureValue
       .mapping

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
@@ -5,6 +5,7 @@ import com.digitalasset.canton.BaseTest
 import com.digitalasset.canton.config.RequireTypes.{NonNegativeInt, Port}
 import com.digitalasset.canton.config.{ApiLoggingConfig, FullClientConfig}
 import com.digitalasset.canton.discard.Implicits.DiscardOps
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import com.digitalasset.canton.time.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
@@ -46,6 +47,7 @@ trait DomainMigrationUtil extends BaseTest with TestCommon {
           synchronizerId,
           dsoParty,
           None,
+          topologySnapshot = TopologySnapshot.Sequenced,
         )
     } {
       _.mapping.participantIds.size shouldBe 4

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
@@ -696,7 +696,7 @@ class ParticipantAdminConnection(
       description,
       queryType =>
         EitherT(
-          getPartyToParticipant(synchronizerId, party, None, queryType)
+          getPartyToParticipant(synchronizerId, party, None, queryType, TopologySnapshot.Sequenced)
             .map { result =>
               val newHostingParticipants = participantChange(result.mapping.participants)
               Either.cond(
@@ -748,6 +748,7 @@ class ParticipantAdminConnection(
             synchronizerId,
             party,
             topologyTransactionType = topologyTransactionType,
+            topologySnapshot = TopologySnapshot.Sequenced,
           ).map(result => {
             Either.cond(
               result.mapping.participants

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/TopologyAdminConnection.scala
@@ -240,7 +240,7 @@ abstract class TopologyAdminConnection(
       // get only active (non-removed) mappings by default; this matches the Canton console defaults
       operation: Option[TopologyChangeOp] = Some(TopologyChangeOp.Replace),
       topologyTransactionType: TopologyTransactionType = AuthorizedState,
-      topologySnapshot: TopologySnapshot = TopologySnapshot.Effective,
+      topologySnapshot: TopologySnapshot,
   )(implicit traceContext: TraceContext): Future[TopologyResult[PartyToParticipant]] =
     findPartyToParticipant(
       synchronizerId,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -30,6 +30,7 @@ import org.lfdecentralizedtrust.splice.environment.{
   ParticipantAdminConnection,
   SequencerAdminConnection,
 }
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.http.v0.definitions.{
   AcsRequest,
   BatchListVotesByVoteRequestsRequest,
@@ -2205,6 +2206,8 @@ class HttpScanHandler(
           domain,
           party,
           topologyTransactionType = AuthorizedState,
+          topologySnapshot =
+            TopologySnapshot.Effective, // Follow the usual Canton APIs to return effective and not sequenced state.
         )
         participantId <- response.mapping.participantIds match {
           case Seq() =>

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
@@ -27,6 +27,7 @@ import org.lfdecentralizedtrust.splice.http.v0.{definitions, sv_operator as v0}
 import org.lfdecentralizedtrust.splice.http.v0.sv_operator.SvOperatorResource as r0
 import org.lfdecentralizedtrust.splice.config.{NetworkAppClientConfig, UpgradesConfig}
 import org.lfdecentralizedtrust.splice.environment.*
+import TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.http.{
   HttpClient,
   HttpFeatureSupportHandler,
@@ -431,6 +432,8 @@ class HttpSvOperatorHandler(
             .getPartyToParticipant(
               dsoRules.domain,
               party,
+              topologySnapshot =
+                TopologySnapshot.Effective, // Follow the usual Canton APIs to return effective and not sequenced state.
             )
           _ <- {
             if (partyToParticipant.mapping.partyId == party) {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/offboarding/SvOffboardingPartyToParticipantTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/offboarding/SvOffboardingPartyToParticipantTrigger.scala
@@ -15,6 +15,7 @@ import org.lfdecentralizedtrust.splice.automation.{
   TriggerContext,
 }
 import org.lfdecentralizedtrust.splice.environment.ParticipantAdminConnection
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,6 +52,7 @@ class SvOffboardingPartyToParticipantProposalTrigger(
         .getPartyToParticipant(
           dsoRules.domain,
           dsoParty,
+          topologySnapshot = TopologySnapshot.Sequenced,
         )
         .map(_.mapping.participantIds)
     } yield currentHostingParticipantIds.filter(e => offboardedParticipants.contains(e))
@@ -84,6 +86,7 @@ class SvOffboardingPartyToParticipantProposalTrigger(
         .getPartyToParticipant(
           dsoRules.domain,
           dsoParty,
+          topologySnapshot = TopologySnapshot.Sequenced,
         )
     } yield {
       !currentHostingParticipants.mapping.participantIds.contains(task)

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/onboarding/SvOnboardingPartyToParticipantProposalTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/onboarding/SvOnboardingPartyToParticipantProposalTrigger.scala
@@ -14,7 +14,8 @@ import org.lfdecentralizedtrust.splice.environment.{
   ParticipantAdminConnection,
   TopologyAdminConnection,
 }
-import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AllProposals
+import TopologyAdminConnection.TopologySnapshot
+import TopologyAdminConnection.TopologyTransactionType.AllProposals
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
@@ -63,6 +64,7 @@ class SvOnboardingPartyToParticipantProposalTrigger(
             currentlyHostingParticipants <- participantAdminConnection.getPartyToParticipant(
               dsoRules.domain,
               dsoParty,
+              topologySnapshot = TopologySnapshot.Sequenced,
             )
             dsoPartyHostingProposals <- participantAdminConnection.listPartyToParticipant(
               store = TopologyStoreId.Synchronizer(dsoRules.domain).some,
@@ -140,6 +142,7 @@ class SvOnboardingPartyToParticipantProposalTrigger(
     partyToParticipant <- participantAdminConnection.getPartyToParticipant(
       dsoRules.domain,
       dsoParty,
+      topologySnapshot = TopologySnapshot.Sequenced,
     )
   } yield {
     partyToParticipant.base.serial != task.serial

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/onboarding/SvOnboardingPromoteParticipantToSubmitterTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/onboarding/SvOnboardingPromoteParticipantToSubmitterTrigger.scala
@@ -7,6 +7,7 @@ import cats.implicits.catsSyntaxParallelTraverse1
 import cats.syntax.option.*
 import org.lfdecentralizedtrust.splice.automation.*
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AuthorizedState
 import org.lfdecentralizedtrust.splice.environment.{ParticipantAdminConnection, RetryFor}
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
@@ -60,7 +61,11 @@ class SvOnboardingPromoteParticipantToSubmitterTrigger(
     for {
       dsoRules <- dsoStore.getDsoRules()
       dsoHostingParticipants <- participantAdminConnection
-        .getPartyToParticipant(dsoRules.domain, dsoParty)
+        .getPartyToParticipant(
+          dsoRules.domain,
+          dsoParty,
+          topologySnapshot = TopologySnapshot.Sequenced,
+        )
         .map(_.mapping.participants)
       res <-
         if (dsoHostingParticipants.forall(_.permission == ParticipantPermission.Submission)) {
@@ -165,7 +170,11 @@ class SvOnboardingPromoteParticipantToSubmitterTrigger(
     svs
       .parTraverse { svParty =>
         participantAdminConnection
-          .getPartyToParticipant(dsoRules.domain, svParty)
+          .getPartyToParticipant(
+            dsoRules.domain,
+            svParty,
+            topologySnapshot = TopologySnapshot.Sequenced,
+          )
       }
       .map(_.flatMap(_.mapping.participants))
   }
@@ -196,7 +205,11 @@ class SvOnboardingPromoteParticipantToSubmitterTrigger(
     for {
       dsoRules <- dsoStore.getDsoRules()
       dsoHostingParticipants <- participantAdminConnection
-        .getPartyToParticipant(dsoRules.domain, dsoParty)
+        .getPartyToParticipant(
+          dsoRules.domain,
+          dsoParty,
+          topologySnapshot = TopologySnapshot.Sequenced,
+        )
         .map(_.mapping.participants)
     } yield {
       dsoHostingParticipants

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeDsoPartyHosting.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeDsoPartyHosting.scala
@@ -9,6 +9,7 @@ import org.lfdecentralizedtrust.splice.environment.{
   RetryFor,
   RetryProvider,
 }
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.sv.admin.api.client.SvConnection
 import org.lfdecentralizedtrust.splice.sv.admin.api.client.commands.HttpSvPublicAppClient.OnboardSvPartyMigrationAuthorizeProposalNotFound
@@ -119,6 +120,7 @@ class JoiningNodeDsoPartyHosting(
                             .getPartyToParticipant(
                               synchronizerId,
                               dsoParty,
+                              topologySnapshot = TopologySnapshot.Sequenced,
                             )
                             .map(result =>
                               if (

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -37,7 +37,10 @@ import org.lfdecentralizedtrust.splice.config.{
   UpgradesConfig,
 }
 import org.lfdecentralizedtrust.splice.environment.*
-import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
+  TopologySnapshot,
+  TopologyTransactionType,
+}
 import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.migration.DomainMigrationInfo
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
@@ -558,8 +561,13 @@ class JoiningNodeInitializer(
       "submission_rights",
       description,
       for {
+        // We do actually want to be able to submit after this so wait until the effective time.
         dsoPartyHosting <- participantAdminConnection
-          .getPartyToParticipant(synchronizerId, dsoParty)
+          .getPartyToParticipant(
+            synchronizerId,
+            dsoParty,
+            topologySnapshot = TopologySnapshot.Effective,
+          )
       } yield {
         dsoPartyHosting.mapping.participants.find(_.participantId == participantId) match {
           case None =>

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sponsor/SponsorDsoPartyHosting.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sponsor/SponsorDsoPartyHosting.scala
@@ -9,6 +9,7 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.Topol
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
   AuthorizedStateChanged,
   TopologyResult,
+  TopologySnapshot,
 }
 import org.lfdecentralizedtrust.splice.environment.{ParticipantAdminConnection, RetryFor}
 import org.lfdecentralizedtrust.splice.sv.onboarding.DsoPartyHosting
@@ -98,7 +99,11 @@ class SponsorDsoPartyHosting(
     SponsorDsoPartyHosting.ValidProposalOrAcceptedState,
   ] = {
     val partyToParticipantAcceptedState =
-      participantAdminConnection.getPartyToParticipant(synchronizerId, dsoParty)
+      participantAdminConnection.getPartyToParticipant(
+        synchronizerId,
+        dsoParty,
+        topologySnapshot = TopologySnapshot.Sequenced,
+      )
     OptionT(
       participantAdminConnection
         .listPartyToParticipant(

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/migration/ParticipantPartyMigrator.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/migration/ParticipantPartyMigrator.scala
@@ -20,6 +20,7 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MonadUtil
 import com.google.protobuf.ByteString
 import io.grpc.Status
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AuthorizedState
 import org.lfdecentralizedtrust.splice.environment.{
   BaseLedgerConnection,
@@ -175,8 +176,17 @@ class ParticipantPartyMigrator(
   ): Future[Set[PartyId]] =
     for {
       mappings <- Future.traverse(parties) { partyId =>
+        // Party migration is generally based on effective state so we use that here although
+        // in practice the code here doesn't pay enough attention to timestamps
+        // that if you really fall in the interval between sequencing and effective time things likely fall over either way.
         participantAdminConnection
-          .getPartyToParticipant(synchronizerId, partyId, None, AuthorizedState)
+          .getPartyToParticipant(
+            synchronizerId,
+            partyId,
+            None,
+            AuthorizedState,
+            topologySnapshot = TopologySnapshot.Effective,
+          )
           .map(_.mapping)
       }
     } yield {
@@ -303,8 +313,17 @@ class ParticipantPartyMigrator(
             s"Party $partyId is hosted on participant $participantId",
             topologyTransactionType =>
               EitherT {
+                // Party migration is generally based on effective state so we use that here although
+                // in practice the code here doesn't pay enough attention to timestamps
+                // that if you really fall in the interval between sequencing and effective time things likely fall over either way.
                 participantAdminConnection
-                  .getPartyToParticipant(synchronizerId, partyId, None, topologyTransactionType)
+                  .getPartyToParticipant(
+                    synchronizerId,
+                    partyId,
+                    None,
+                    topologyTransactionType,
+                    topologySnapshot = TopologySnapshot.Effective,
+                  )
                   .flatMap { result =>
                     result.mapping.participants match {
                       case Seq() => Future.successful(Left(result))

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpExternalWalletHandler.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpExternalWalletHandler.scala
@@ -11,6 +11,7 @@ import org.lfdecentralizedtrust.splice.environment.{
   ParticipantAdminConnection,
   RetryProvider,
 }
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.environment.ledger.api.DedupOffset
 import org.lfdecentralizedtrust.splice.http.v0.external.wallet.WalletResource as r0
 import org.lfdecentralizedtrust.splice.http.v0.{external, definitions as d0}
@@ -164,6 +165,8 @@ class HttpExternalWalletHandler(
           .getPartyToParticipant(
             synchronizerId,
             receivingValidator,
+            topologySnapshot = TopologySnapshot.Effective,
+            // Follow the usual Canton APIs to use the effective state although for the currently short delay we have it doesn't really matter.
           )
           .transform(
             _.mapping.participantIds,


### PR DESCRIPTION
except for the one or two cases where it didn't seem to make sense.

Ended up making it explicit everywhere as it seems like the only way to ensure you're forced to think about all call sites and can hopefully make the correct call.

part of #4271

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
