### PR TITLE
Bump Canton to `3.4.12-snapshot.20260317.17625.0.v93e6c2fc`

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,11 +1,11 @@
 {
-  "version": "3.4.12-snapshot.20260313.17621.0.v5c5d13d2",
+  "version": "3.4.12-snapshot.20260317.17625.0.v93e6c2fc",
   "tooling_sdk_version": "3.3.0-snapshot.20250415.13756.0.vafc5c867",
   "daml_release": "v3.3.0-snapshot.20250417.0",
-  "enterprise_sha256": "sha256:1l9fzd143nfw5f8kpzw9a4bixwr1wimzk1sfm27sin8qfv53hfal",
-  "oss_sha256": "sha256:02y5m7r57fhrc8m8vzhv1bf3xwlvksb6l15fgk2xlq668ycvv2zm",
-  "canton_base_image_sha256": "sha256:0cd2b9565195e3b2f6e75d9a7a1cd81f23ce9e2c853cb4d8df8f3ff02fa32055",
-  "canton_participant_image_sha256": "sha256:b14d015f01cdebe95ef2935428a110d7ac2440e63c9ac290c629571759ab762a",
-  "canton_mediator_image_sha256": "sha256:200ee6a88efbb0ae2a510de22af6878a58e0b908ab754e81c0fdf42174e56edc",
-  "canton_sequencer_image_sha256": "sha256:64a93dc0bab2b7126729622d1a6c9a09abe5f73ed5745940bbca2f705c9eb2f3"
+  "enterprise_sha256": "sha256:0xi9klgr5cjjsblaz9lj0xbgbz7j30i1k1qin1jyy5kd1wl2kzrn",
+  "oss_sha256": "sha256:00h96h939xq9gv05ixxygp327mpmbw6y1p4pr7r3jl5gjscwfmbb",
+  "canton_base_image_sha256": "sha256:e5b375a540f38fdbd3f5139f4b59a846a800c38b073f3bbd1a3a6b97b41c1117",
+  "canton_participant_image_sha256": "sha256:d32483804c980c401f241cab5e623300e4f35142424883e06d45d96b008b7159",
+  "canton_mediator_image_sha256": "sha256:f7cecc73431a76616fdc1c969b626624fcae68aaac3da7841c39d34c92b2e83f",
+  "canton_sequencer_image_sha256": "sha256:f0f3d9711b35413a6dbee204d1f149b066b191382a67af9327828acee4b97257"
 }


### PR DESCRIPTION
No concrete reason, https://github.com/DACH-NY/canton-network-internal/issues/4167 told me to do this regularly.

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
