### PR TITLE
[ci] Use sequencer ID as connection alias instead of SV name

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorSequencerConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorSequencerConnectionIntegrationTest.scala
@@ -127,6 +127,14 @@ class ValidatorSequencerConnectionIntegrationTest
         }
       }
 
+      withClue("Connection aliases should be sequencer IDs, not SV names") {
+        val aliases = getSequencerAliases(
+          aliceValidatorBackend.participantClientWithAdminToken,
+          globalSyncAlias,
+        )
+        all(aliases) should startWith("SEQ::")
+      }
+
       withClue("Alice's validator should remain functional after the URL change") {
         eventuallySucceeds() {
           aliceValidatorBackend.onboardUser(aliceWalletClient.config.ledgerApiUser)
@@ -164,6 +172,20 @@ class ValidatorSequencerConnectionIntegrationTest
     sequencerConnections.connections.forgetNE.collect {
       case GrpcSequencerConnection(endpoints, _, _, _, _) => endpoints.head1.toString
     }.toSet
+  }
+
+  private def getSequencerAliases(
+      participantConnection: ParticipantClientReference,
+      synchronizerAlias: SynchronizerAlias,
+  ): Seq[String] = {
+    val sequencerConnections = participantConnection.synchronizers
+      .config(synchronizerAlias)
+      .value
+      .sequencerConnections
+
+    sequencerConnections.connections.forgetNE.collect {
+      case GrpcSequencerConnection(_, _, _, alias, _) => alias.unwrap
+    }
   }
 
   private def setSequencerUrl(

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -245,11 +245,11 @@ class DomainConnector(
     // sequencer connections will be ignore if they are with a invalid Alias, empty url or not yet available (`before availableAfter`)
     val validConnections = sequencers
       .collect {
-        case DsoSequencer(sequencerMigrationId, _, url, svName, availableAfter)
+        case DsoSequencer(sequencerMigrationId, id, url, _, availableAfter)
             if migrationId == sequencerMigrationId && url.nonEmpty && !domainTime.toInstant
               .isBefore(availableAfter) =>
           for {
-            sequencerAlias <- SequencerAlias.create(svName)
+            sequencerAlias <- SequencerAlias.create(id.toProtoPrimitive)
             grpcSequencerConnection <- GrpcSequencerConnection.create(
               url,
               None,


### PR DESCRIPTION
When a sequencer's identity changes (e.g. after SV node reset), the old
connection alias matched the new one (both used the SV name), causing Canton
to compare the new sequencer ID against the stale expected ID — resulting in
a fatal validation failure that never retries.

Fix: use the sequencer ID (SEQ::name::fingerprint) as the SequencerAlias.
A changed sequencer ID now creates a new connection instead of failing
validation on the old one.

Closes hyperledger-labs/splice#4171

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
