### PR TITLE
[backport] remove implicit base config loading from loadClusterYamlConfig (release-line-0.5.13)

### DIFF
--- a/cluster/deployment/config.yaml
+++ b/cluster/deployment/config.yaml
@@ -1,3 +1,0 @@
-# This config is part of a legacy config loader feature which will soon be removed.
-# Please refrain from editing it. Instead edit cluster/configs/shared/base.yaml
-!include($SPLICE_ROOT/cluster/configs/shared/base.yaml) {}

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -1,3 +1,4 @@
+!include(../../configs/shared/base.yaml)
 validator1:
   kms:
     type: gcp

--- a/cluster/pulumi/common/src/config/configLoader.ts
+++ b/cluster/pulumi/common/src/config/configLoader.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as Yaml from 'js-yaml';
-import { existsSync, readFileSync, realpathSync } from 'fs';
-import { merge, mergeWith } from 'lodash';
+import { readFileSync } from 'fs';
+import { mergeWith } from 'lodash';
 import { dirname, join, resolve, sep as pathSeparator } from 'path';
 import { env } from 'process';
 
@@ -150,21 +150,9 @@ class ConfigError extends Error {
 }
 
 export function loadClusterYamlConfig(): unknown {
-  const baseConfig = readAndParseYaml(
-    `${spliceEnvConfig.context.splicePath}/cluster/deployment/config.yaml`
-  );
-  // Load an additional common overrides config if it exists;
-  // if the file is identical to the base config for some reason, loading it will not change anything.
-  // It is resolved against the cluster path with expanded symlinks to ensure that additional
-  // overrides from the internal repository are not applied to clusters defined in splice.
-  const commonOverridesConfigPath = `${realpathSync(spliceEnvConfig.context.clusterPath())}/../config.yaml`;
-  const commonOverridesConfig = existsSync(commonOverridesConfigPath)
-    ? readAndParseYaml(commonOverridesConfigPath)
-    : {};
-  const clusterOverridesConfig = readAndParseYaml(getMainConfigPath());
-  return merge({}, baseConfig, commonOverridesConfig, clusterOverridesConfig);
+  return readAndParseYaml(getClusterConfigPath());
 }
 
-export function getMainConfigPath(): string {
+export function getClusterConfigPath(): string {
   return join(spliceEnvConfig.context.clusterPath(), 'config.yaml');
 }

--- a/cluster/pulumi/resolvedConfigEmitter.ts
+++ b/cluster/pulumi/resolvedConfigEmitter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { loadClusterYamlConfig, getMainConfigPath } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/configLoader';
+import { loadClusterYamlConfig, getClusterConfigPath } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/configLoader';
 import { writeFileSync } from 'fs';
 import { dump } from 'js-yaml';
 import { dirname, resolve } from 'path';
@@ -13,5 +13,5 @@ const resolvedConfigYaml = dump(config, {
   noRefs: true,
   forceQuotes: true,
 });
-const resolvedConfigPath = resolve(dirname(getMainConfigPath()), 'config.resolved.yaml');
+const resolvedConfigPath = resolve(dirname(getClusterConfigPath()), 'config.resolved.yaml');
 writeFileSync(resolvedConfigPath, `${header}${resolvedConfigYaml}`);


### PR DESCRIPTION
[backport] remove implicit base config loading from loadClusterYamlConfig (release-line-0.5.13)

Backport of https://github.com/hyperledger-labs/splice/pull/4484