### PR TITLE
Nuke gitrepository finalizers in cncluster reset

### DIFF
--- a/build-tools/lib/pulumi-helpers
+++ b/build-tools/lib/pulumi-helpers
@@ -86,7 +86,7 @@ function _infra_up() {
 }
 
 function _remove_pulumi_finalizers() {
-    for resource in stack update; do
+    for resource in stack update gitrepository; do
       if ! kubectl get "$resource" --all-namespaces 2>/dev/null; then
         _info "Resource type $resource not found or no resources, skipping"
       else
@@ -96,7 +96,7 @@ function _remove_pulumi_finalizers() {
             _info "$resource $name in namespace $namespace has no finalizers, skipping"
           else
             _info "$resource $name in namespace $namespace has finalizers $finalizers"
-            new_finalizers=$(jq 'del(.[] | select(. == "finalizer.stack.pulumi.com"))' <<< "$finalizers")
+            new_finalizers=$(jq 'del(.[] | select(. | IN("finalizers.stack.pulumi.com", "finalizers.fluxcd.io")))' <<< "$finalizers")
             patch_payload="{\"metadata\":{\"finalizers\": $new_finalizers}}"
             _info "Patch payload for $resource $name in namespace $namespace: $patch_payload"
             kubectl patch -n "$namespace" "$resource" "$name" -p "$patch_payload" --type=merge


### PR DESCRIPTION
Tested through a cncluster reset on scratche which seems to have done the right thing with this.

fixes https://github.com/DACH-NY/cn-test-failures/issues/7609

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
