### PR TITLE
Split svConfigs.ts to isolate infra dependencies to common-sv

### DIFF
--- a/cluster/pulumi/common-sv/src/config.ts
+++ b/cluster/pulumi/common-sv/src/config.ts
@@ -45,16 +45,19 @@ export interface ScanBigQueryConfig {
   prefix: string;
 }
 
-export interface StaticSvConfig {
+export interface StaticSvConfigBasic {
   nodeName: string;
   ingressName: string;
   onboardingName: string;
+  sweep?: SweepConfig;
+}
+
+export interface StaticSvConfig extends StaticSvConfigBasic {
   validatorWalletUser?: string;
   auth0ValidatorAppName: string;
   auth0SvAppName: string;
   cometBft: StaticCometBftConfig;
   onboardingPollingInterval?: string;
-  sweep?: SweepConfig;
   scanBigQuery?: ScanBigQueryConfig;
   svIdKeySecretName?: string;
   cometBftGovernanceKeySecretName?: string;

--- a/cluster/pulumi/common-sv/src/index.ts
+++ b/cluster/pulumi/common-sv/src/index.ts
@@ -14,3 +14,4 @@ export * from './approvedIdentities';
 export * from './svApp';
 export * from './validatorApp';
 export * from './bulkStorage';
+export * from './svConfigsBasic';

--- a/cluster/pulumi/common-sv/src/svConfigs.ts
+++ b/cluster/pulumi/common-sv/src/svConfigs.ts
@@ -14,6 +14,11 @@ import { spliceEnvConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/
 import { StaticSvConfig } from './config';
 import { dsoSize, skipExtraSvs } from './dsoConfig';
 import { configForSv, configuredExtraSvs } from './singleSvConfig';
+import {
+  fromSingleSvConfigBasic,
+  standardSvConfigsBasic,
+  svRunbookConfigBasic,
+} from './svConfigsBasic';
 
 const sv1ScanBigQuery = spliceEnvConfig.envFlag('SV1_SCAN_BIGQUERY', false);
 
@@ -48,9 +53,7 @@ const fromSingleSvConfig = (nodeName: string, cometBftNodeIndex: number): Static
   const svCometBftSecrets = svCometBftKeysFromSecret(svCometBftSecretName);
 
   return {
-    nodeName,
-    ingressName: config.subdomain!,
-    onboardingName: config.publicName!,
+    ...fromSingleSvConfigBasic(nodeName),
     auth0ValidatorAppName: config.validatorApp?.auth0?.name
       ? config.validatorApp.auth0.name
       : `${nodeName}_validator`,
@@ -68,9 +71,6 @@ const fromSingleSvConfig = (nodeName: string, cometBftNodeIndex: number): Static
     },
     svIdKeySecretName: config.svApp?.svIdKeyGcpSecret,
     cometBftGovernanceKeySecretName: config.svApp?.cometBftGovernanceKeyGcpSecret,
-    ...(config.validatorApp?.sweep
-      ? { sweep: sweepConfigFromEnv(config.validatorApp.sweep.fromEnv) }
-      : {}),
     ...(config.scanApp?.bigQuery
       ? { scanBigQuery: { dataset: 'devnet_da2_scan', prefix: 'da2' } }
       : {}),
@@ -79,327 +79,275 @@ const fromSingleSvConfig = (nodeName: string, cometBftNodeIndex: number): Static
 
 // to generate new keys: https://cimain.network.canton.global/sv_operator/sv_helm.html#generating-your-cometbft-node-keys
 // TODO(DACH-NY/canton-network-internal#435): rotate the non-mainNet keys as they have been exposed in github (once mechanism is in place)
-export const standardSvConfigs: StaticSvConfig[] = isMainNet
-  ? [
-      {
-        // TODO(DACH-NY/canton-network-node#12169): consider making nodeName and ingressName the same (also for all other SVs)
-        nodeName: 'sv-1',
-        ingressName: 'sv-2', // fun, right?
-        onboardingName: 'Digital-Asset-2',
-        auth0ValidatorAppName: 'validator',
-        auth0SvAppName: 'sv',
-        cometBft: {
-          nodeIndex: 1,
-          id: '4c7c99516fb3309b89b7f8ed94690994c8ec0ab0',
-          privateKey: svCometBftSecrets[0].nodePrivateKey,
-          validator: {
-            keyAddress: '9473617BBC80C12F68CC25B5A754D1ED9035886C',
-            privateKey: svCometBftSecrets[0].validatorPrivateKey,
-            publicKey: 'H2bcJU2zbzbLmP78YWiwMgtB0QG1MNTSozGl1tP11hI=',
+export const standardSvConfigs: StaticSvConfig[] = (
+  isMainNet
+    ? [
+        {
+          auth0ValidatorAppName: 'validator',
+          auth0SvAppName: 'sv',
+          cometBft: {
+            nodeIndex: 1,
+            id: '4c7c99516fb3309b89b7f8ed94690994c8ec0ab0',
+            privateKey: svCometBftSecrets[0].nodePrivateKey,
+            validator: {
+              keyAddress: '9473617BBC80C12F68CC25B5A754D1ED9035886C',
+              privateKey: svCometBftSecrets[0].validatorPrivateKey,
+              publicKey: 'H2bcJU2zbzbLmP78YWiwMgtB0QG1MNTSozGl1tP11hI=',
+            },
+          },
+          ...(sv1ScanBigQuery
+            ? { scanBigQuery: { dataset: 'mainnet_da2_scan', prefix: 'da2' } }
+            : {}),
+        },
+      ]
+    : [
+        {
+          auth0ValidatorAppName: 'sv1_validator',
+          auth0SvAppName: 'sv-1',
+          validatorWalletUser: isDevNet
+            ? 'auth0|64afbc0956a97fe9577249d7'
+            : 'auth0|64529b128448ded6aa68048f',
+          cometBft: {
+            nodeIndex: 1,
+            id: '5af57aa83abcec085c949323ed8538108757be9c',
+            privateKey: svCometBftSecrets[0].nodePrivateKey,
+            validator: {
+              keyAddress: '8A931AB5F957B8331BDEF3A0A081BD9F017A777F',
+              privateKey: svCometBftSecrets[0].validatorPrivateKey,
+              publicKey: 'gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw=',
+            },
+          },
+          ...(sv1ScanBigQuery
+            ? { scanBigQuery: { dataset: 'devnet_da2_scan', prefix: 'da2' } }
+            : {}),
+        },
+        {
+          auth0ValidatorAppName: 'sv2_validator',
+          auth0SvAppName: 'sv-2',
+          validatorWalletUser: 'auth0|64afbc353bbc7ca776e27bf4',
+          cometBft: {
+            nodeIndex: 2,
+            id: 'c36b3bbd969d993ba0b4809d1f587a3a341f22c1',
+            privateKey: svCometBftSecrets[1].nodePrivateKey,
+            validator: {
+              keyAddress: '04A57312179F1E0C93B868779EE4C7FAC41666F0',
+              privateKey: svCometBftSecrets[1].validatorPrivateKey,
+              publicKey: 'BVSM9/uPGLU7lJj72SUw1a261z2L6Yy2XKLhpUvbxqE=',
+            },
           },
         },
-        sweep: sweepConfigFromEnv('SV1'),
-        ...(sv1ScanBigQuery
-          ? { scanBigQuery: { dataset: 'mainnet_da2_scan', prefix: 'da2' } }
-          : {}),
-      },
-    ]
-  : [
-      {
-        // TODO(DACH-NY/canton-network-node#12169): consider making nodeName and ingressName the same (also for all other SVs)
-        nodeName: 'sv-1',
-        ingressName: 'sv-2', // fun, right?
-        onboardingName: 'Digital-Asset-2',
-        auth0ValidatorAppName: 'sv1_validator',
-        auth0SvAppName: 'sv-1',
-        validatorWalletUser: isDevNet
-          ? 'auth0|64afbc0956a97fe9577249d7'
-          : 'auth0|64529b128448ded6aa68048f',
-        cometBft: {
-          nodeIndex: 1,
-          id: '5af57aa83abcec085c949323ed8538108757be9c',
-          privateKey: svCometBftSecrets[0].nodePrivateKey,
-          validator: {
-            keyAddress: '8A931AB5F957B8331BDEF3A0A081BD9F017A777F',
-            privateKey: svCometBftSecrets[0].validatorPrivateKey,
-            publicKey: 'gpkwc1WCttL8ZATBIPWIBRCrb0eV4JwMCnjRa56REPw=',
+        {
+          auth0ValidatorAppName: 'sv3_validator',
+          auth0SvAppName: 'sv-3',
+          validatorWalletUser: 'auth0|64afbc4431b562edb8995da6',
+          cometBft: {
+            nodeIndex: 3,
+            id: '0d8e87c54d199e85548ccec123c9d92966ec458c',
+            privateKey: svCometBftSecrets[2].nodePrivateKey,
+            validator: {
+              keyAddress: 'FFF137F42421B0257CDC8B2E41F777B81A081E80',
+              privateKey: svCometBftSecrets[2].validatorPrivateKey,
+              publicKey: 'dxm4n1MRP/GuSEkJIwbdB4zVcGAeacohFKNtbKK8oRA=',
+            },
           },
         },
-        sweep: sweepConfigFromEnv('SV1'),
-        ...(sv1ScanBigQuery ? { scanBigQuery: { dataset: 'devnet_da2_scan', prefix: 'da2' } } : {}),
-      },
-      {
-        // TODO(DACH-NY/canton-network-node#12169): consider making nodeName and ingressName the same (also for all other SVs)
-        nodeName: 'sv-2',
-        ingressName: 'sv-2-eng',
-        onboardingName: 'Digital-Asset-Eng-2',
-        auth0ValidatorAppName: 'sv2_validator',
-        auth0SvAppName: 'sv-2',
-        validatorWalletUser: 'auth0|64afbc353bbc7ca776e27bf4',
-        cometBft: {
-          nodeIndex: 2,
-          id: 'c36b3bbd969d993ba0b4809d1f587a3a341f22c1',
-          privateKey: svCometBftSecrets[1].nodePrivateKey,
-          validator: {
-            keyAddress: '04A57312179F1E0C93B868779EE4C7FAC41666F0',
-            privateKey: svCometBftSecrets[1].validatorPrivateKey,
-            publicKey: 'BVSM9/uPGLU7lJj72SUw1a261z2L6Yy2XKLhpUvbxqE=',
+        {
+          auth0ValidatorAppName: 'sv4_validator',
+          auth0SvAppName: 'sv-4',
+          validatorWalletUser: 'auth0|64afbc720e20777e46fff490',
+          cometBft: {
+            nodeIndex: 4,
+            id: 'ee738517c030b42c3ff626d9f80b41dfc4b1a3b8',
+            privateKey: svCometBftSecrets[3].nodePrivateKey,
+            validator: {
+              keyAddress: 'DE36D23DE022948A11200ABB9EE07F049D17D903',
+              privateKey: svCometBftSecrets[3].validatorPrivateKey,
+              publicKey: '2umZdUS97a6VUXMGsgKJ/VbQbanxWaFUxK1QimhlEjo=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-3',
-        ingressName: 'sv-3-eng',
-        onboardingName: 'Digital-Asset-Eng-3',
-        auth0ValidatorAppName: 'sv3_validator',
-        auth0SvAppName: 'sv-3',
-        validatorWalletUser: 'auth0|64afbc4431b562edb8995da6',
-        cometBft: {
-          nodeIndex: 3,
-          id: '0d8e87c54d199e85548ccec123c9d92966ec458c',
-          privateKey: svCometBftSecrets[2].nodePrivateKey,
-          validator: {
-            keyAddress: 'FFF137F42421B0257CDC8B2E41F777B81A081E80',
-            privateKey: svCometBftSecrets[2].validatorPrivateKey,
-            publicKey: 'dxm4n1MRP/GuSEkJIwbdB4zVcGAeacohFKNtbKK8oRA=',
+        {
+          auth0ValidatorAppName: 'sv5_validator',
+          auth0SvAppName: 'sv-5',
+          validatorWalletUser: 'auth0|65c15c482a18b1ef030ba290',
+          cometBft: {
+            nodeIndex: 5,
+            id: '205437468610305149d131bbf9bf1f47658d861b',
+            privateKey: svCometBftSecrets[4].nodePrivateKey,
+            validator: {
+              keyAddress: '1A6C9E60AFD830682CBEF5496F6E5515B20B0F2D',
+              privateKey: svCometBftSecrets[4].validatorPrivateKey,
+              publicKey: 'ykypzmTJei5w+DiNM67nCfb06FMpHliYU7FXpxDYJgY=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-4',
-        ingressName: 'sv-4-eng',
-        onboardingName: 'Digital-Asset-Eng-4',
-        auth0ValidatorAppName: 'sv4_validator',
-        auth0SvAppName: 'sv-4',
-        validatorWalletUser: 'auth0|64afbc720e20777e46fff490',
-        cometBft: {
-          nodeIndex: 4,
-          id: 'ee738517c030b42c3ff626d9f80b41dfc4b1a3b8',
-          privateKey: svCometBftSecrets[3].nodePrivateKey,
-          validator: {
-            keyAddress: 'DE36D23DE022948A11200ABB9EE07F049D17D903',
-            privateKey: svCometBftSecrets[3].validatorPrivateKey,
-            publicKey: '2umZdUS97a6VUXMGsgKJ/VbQbanxWaFUxK1QimhlEjo=',
+        {
+          auth0ValidatorAppName: 'sv6_validator',
+          auth0SvAppName: 'sv-6',
+          validatorWalletUser: 'auth0|65c26e959666d60d24fe523a',
+          cometBft: {
+            nodeIndex: 6,
+            id: '60c21490e82d6a1fb0c35b9a04e4f64ae00ce5c0',
+            privateKey: svCometBftSecrets[5].nodePrivateKey,
+            validator: {
+              keyAddress: 'DC41F08916D8C41B931F9037E6F2571C58D0E01A',
+              privateKey: svCometBftSecrets[5].validatorPrivateKey,
+              publicKey: 'wAFEjO8X4qaD6dRM1TSvWjX+SMXoLEqIIjqqWUi1ETI=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-5',
-        ingressName: 'sv-5-eng',
-        onboardingName: 'Digital-Asset-Eng-5',
-        auth0ValidatorAppName: 'sv5_validator',
-        auth0SvAppName: 'sv-5',
-        validatorWalletUser: 'auth0|65c15c482a18b1ef030ba290',
-        cometBft: {
-          nodeIndex: 5,
-          id: '205437468610305149d131bbf9bf1f47658d861b',
-          privateKey: svCometBftSecrets[4].nodePrivateKey,
-          validator: {
-            keyAddress: '1A6C9E60AFD830682CBEF5496F6E5515B20B0F2D',
-            privateKey: svCometBftSecrets[4].validatorPrivateKey,
-            publicKey: 'ykypzmTJei5w+DiNM67nCfb06FMpHliYU7FXpxDYJgY=',
+        {
+          auth0ValidatorAppName: 'sv7_validator',
+          auth0SvAppName: 'sv-7',
+          validatorWalletUser: 'auth0|65c26e9d45eaef5c191a167e',
+          cometBft: {
+            nodeIndex: 7,
+            id: '81f3b7d26ae796d369fbf42481a65c6265b41e8c',
+            privateKey: svCometBftSecrets[6].nodePrivateKey,
+            validator: {
+              keyAddress: '66FA9399FF2E7AF2517E7CE2EDCA11F51C573F61',
+              privateKey: svCometBftSecrets[6].validatorPrivateKey,
+              publicKey: 'aWWSRgIAJSc3pPaz89zu2yEyqRuKY5SY8Evpt/klt74=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-6',
-        ingressName: 'sv-6-eng',
-        onboardingName: 'Digital-Asset-Eng-6',
-        auth0ValidatorAppName: 'sv6_validator',
-        auth0SvAppName: 'sv-6',
-        validatorWalletUser: 'auth0|65c26e959666d60d24fe523a',
-        cometBft: {
-          nodeIndex: 6,
-          id: '60c21490e82d6a1fb0c35b9a04e4f64ae00ce5c0',
-          privateKey: svCometBftSecrets[5].nodePrivateKey,
-          validator: {
-            keyAddress: 'DC41F08916D8C41B931F9037E6F2571C58D0E01A',
-            privateKey: svCometBftSecrets[5].validatorPrivateKey,
-            publicKey: 'wAFEjO8X4qaD6dRM1TSvWjX+SMXoLEqIIjqqWUi1ETI=',
+        {
+          auth0ValidatorAppName: 'sv8_validator',
+          auth0SvAppName: 'sv-8',
+          validatorWalletUser: 'auth0|65c26ea449ef8564a0ec9297',
+          cometBft: {
+            nodeIndex: 8,
+            id: '404371a5f62773ca07925555c9fbb6287861947c',
+            privateKey: svCometBftSecrets[7].nodePrivateKey,
+            validator: {
+              keyAddress: '5E35AE8D464FA92525BCC408C7827A943BDF4900',
+              privateKey: svCometBftSecrets[7].validatorPrivateKey,
+              publicKey: '/W/bfGC9S0VeKtx5ID9HFJ4JO8dSbnY/wE8J+yESOxY=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-7',
-        ingressName: 'sv-7-eng',
-        onboardingName: 'Digital-Asset-Eng-7',
-        auth0ValidatorAppName: 'sv7_validator',
-        auth0SvAppName: 'sv-7',
-        validatorWalletUser: 'auth0|65c26e9d45eaef5c191a167e',
-        cometBft: {
-          nodeIndex: 7,
-          id: '81f3b7d26ae796d369fbf42481a65c6265b41e8c',
-          privateKey: svCometBftSecrets[6].nodePrivateKey,
-          validator: {
-            keyAddress: '66FA9399FF2E7AF2517E7CE2EDCA11F51C573F61',
-            privateKey: svCometBftSecrets[6].validatorPrivateKey,
-            publicKey: 'aWWSRgIAJSc3pPaz89zu2yEyqRuKY5SY8Evpt/klt74=',
+        {
+          auth0ValidatorAppName: 'sv9_validator',
+          auth0SvAppName: 'sv-9',
+          validatorWalletUser: 'auth0|65c26eac58f141b4ca1dc5da',
+          cometBft: {
+            nodeIndex: 9,
+            id: 'aeee969d0efb0784ea36b9ad743a2e5964828325',
+            privateKey: svCometBftSecrets[8].nodePrivateKey,
+            validator: {
+              keyAddress: '06070D2FD47073BE1635C3DEB862A88669906847',
+              privateKey: svCometBftSecrets[8].validatorPrivateKey,
+              publicKey: 'rkd3pJH+kwrDt9i8b3I9c1RqznnsFe5PueE3gB5nZg8=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-8',
-        ingressName: 'sv-8-eng',
-        onboardingName: 'Digital-Asset-Eng-8',
-        auth0ValidatorAppName: 'sv8_validator',
-        auth0SvAppName: 'sv-8',
-        validatorWalletUser: 'auth0|65c26ea449ef8564a0ec9297',
-        cometBft: {
-          nodeIndex: 8,
-          id: '404371a5f62773ca07925555c9fbb6287861947c',
-          privateKey: svCometBftSecrets[7].nodePrivateKey,
-          validator: {
-            keyAddress: '5E35AE8D464FA92525BCC408C7827A943BDF4900',
-            privateKey: svCometBftSecrets[7].validatorPrivateKey,
-            publicKey: '/W/bfGC9S0VeKtx5ID9HFJ4JO8dSbnY/wE8J+yESOxY=',
+        {
+          auth0ValidatorAppName: 'sv10_validator',
+          auth0SvAppName: 'sv-10',
+          validatorWalletUser: 'auth0|65e0a7854c76b74b28b8477f',
+          cometBft: {
+            nodeIndex: 10,
+            id: 'cc8e74ca2c3c66820266dc6cca759f5368dd9924',
+            privateKey: svCometBftSecrets[9].nodePrivateKey,
+            validator: {
+              keyAddress: 'E71220096CC607150D56914B9175A5D4B70B00E6',
+              privateKey: svCometBftSecrets[9].validatorPrivateKey,
+              publicKey: '9aJvIAkmKWiKGzLY354fA3nWPL62X2Ye5b52bmGEtMI=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-9',
-        ingressName: 'sv-9-eng',
-        onboardingName: 'Digital-Asset-Eng-9',
-        auth0ValidatorAppName: 'sv9_validator',
-        auth0SvAppName: 'sv-9',
-        validatorWalletUser: 'auth0|65c26eac58f141b4ca1dc5da',
-        cometBft: {
-          nodeIndex: 9,
-          id: 'aeee969d0efb0784ea36b9ad743a2e5964828325',
-          privateKey: svCometBftSecrets[8].nodePrivateKey,
-          validator: {
-            keyAddress: '06070D2FD47073BE1635C3DEB862A88669906847',
-            privateKey: svCometBftSecrets[8].validatorPrivateKey,
-            publicKey: 'rkd3pJH+kwrDt9i8b3I9c1RqznnsFe5PueE3gB5nZg8=',
+        {
+          auth0ValidatorAppName: 'sv11_validator',
+          auth0SvAppName: 'sv-11',
+          validatorWalletUser: 'auth0|65e0a78976d9757e3f14846b',
+          cometBft: {
+            nodeIndex: 11,
+            id: '21f60b2667972ff943fbd46ea9ca82ddf0905948',
+            privateKey: svCometBftSecrets[10].nodePrivateKey,
+            validator: {
+              keyAddress: '14474E591E9C75E5FCA4520B36CD4963E2FBAA2C',
+              privateKey: svCometBftSecrets[10].validatorPrivateKey,
+              publicKey: 'cSNIpvKpUVdnpDh7m0zhZXRhX4MTRlZeYDnwl47mLrM=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-10',
-        ingressName: 'sv-10-eng',
-        onboardingName: 'Digital-Asset-Eng-10',
-        auth0ValidatorAppName: 'sv10_validator',
-        auth0SvAppName: 'sv-10',
-        validatorWalletUser: 'auth0|65e0a7854c76b74b28b8477f',
-        cometBft: {
-          nodeIndex: 10,
-          id: 'cc8e74ca2c3c66820266dc6cca759f5368dd9924',
-          privateKey: svCometBftSecrets[9].nodePrivateKey,
-          validator: {
-            keyAddress: 'E71220096CC607150D56914B9175A5D4B70B00E6',
-            privateKey: svCometBftSecrets[9].validatorPrivateKey,
-            publicKey: '9aJvIAkmKWiKGzLY354fA3nWPL62X2Ye5b52bmGEtMI=',
+        {
+          auth0ValidatorAppName: 'sv12_validator',
+          auth0SvAppName: 'sv-12',
+          validatorWalletUser: 'auth0|65e0a78d68c39e5cc0351ed2',
+          cometBft: {
+            nodeIndex: 12,
+            id: '817bb28c471d7a8631e701c914fc7e9a65e74be2',
+            privateKey: svCometBftSecrets[11].nodePrivateKey,
+            validator: {
+              keyAddress: '1E5F191A4E2C4DD5026A3B26F1F66A809D5D4E8C',
+              privateKey: svCometBftSecrets[11].validatorPrivateKey,
+              publicKey: 'F0cuaIrJU4NfTmtpqVP6y6oReJh2WSuB9YWDKtSR2wU=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-11',
-        ingressName: 'sv-11-eng',
-        onboardingName: 'Digital-Asset-Eng-11',
-        auth0ValidatorAppName: 'sv11_validator',
-        auth0SvAppName: 'sv-11',
-        validatorWalletUser: 'auth0|65e0a78976d9757e3f14846b',
-        cometBft: {
-          nodeIndex: 11,
-          id: '21f60b2667972ff943fbd46ea9ca82ddf0905948',
-          privateKey: svCometBftSecrets[10].nodePrivateKey,
-          validator: {
-            keyAddress: '14474E591E9C75E5FCA4520B36CD4963E2FBAA2C',
-            privateKey: svCometBftSecrets[10].validatorPrivateKey,
-            publicKey: 'cSNIpvKpUVdnpDh7m0zhZXRhX4MTRlZeYDnwl47mLrM=',
+        {
+          auth0ValidatorAppName: 'sv13_validator',
+          auth0SvAppName: 'sv-13',
+          validatorWalletUser: 'auth0|65e0a7914c76b74b28b84793',
+          cometBft: {
+            nodeIndex: 13,
+            id: '254dd73eb4cee23d439c2f2e706ccdbeac52f06c',
+            privateKey: svCometBftSecrets[12].nodePrivateKey,
+            validator: {
+              keyAddress: 'CFF50F6EFD5DFDD8DAD7A468D5FB5DA2D43CF281',
+              privateKey: svCometBftSecrets[12].validatorPrivateKey,
+              publicKey: '6ltWNxHRrwPj9qPYB3HQWL4hpeFTCjHSW2m+7rCYWAw=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-12',
-        ingressName: 'sv-12-eng',
-        onboardingName: 'Digital-Asset-Eng-12',
-        auth0ValidatorAppName: 'sv12_validator',
-        auth0SvAppName: 'sv-12',
-        validatorWalletUser: 'auth0|65e0a78d68c39e5cc0351ed2',
-        cometBft: {
-          nodeIndex: 12,
-          id: '817bb28c471d7a8631e701c914fc7e9a65e74be2',
-          privateKey: svCometBftSecrets[11].nodePrivateKey,
-          validator: {
-            keyAddress: '1E5F191A4E2C4DD5026A3B26F1F66A809D5D4E8C',
-            privateKey: svCometBftSecrets[11].validatorPrivateKey,
-            publicKey: 'F0cuaIrJU4NfTmtpqVP6y6oReJh2WSuB9YWDKtSR2wU=',
+        {
+          auth0ValidatorAppName: 'sv14_validator',
+          auth0SvAppName: 'sv-14',
+          validatorWalletUser: 'auth0|65e0a795aa7a40df0cc65ace',
+          cometBft: {
+            nodeIndex: 14,
+            id: '9de44f8ddac42901c094371e867bb0db60ab03b8',
+            privateKey: svCometBftSecrets[13].nodePrivateKey,
+            validator: {
+              keyAddress: 'F691F4CA91B972A6B291C09BADA9970AAAC86C84',
+              privateKey: svCometBftSecrets[13].validatorPrivateKey,
+              publicKey: 'rP4eWO4WZctUrQE5ZDFHkXxCWfZa6tc8B8qLmrzV7gE=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-13',
-        ingressName: 'sv-13-eng',
-        onboardingName: 'Digital-Asset-Eng-13',
-        auth0ValidatorAppName: 'sv13_validator',
-        auth0SvAppName: 'sv-13',
-        validatorWalletUser: 'auth0|65e0a7914c76b74b28b84793',
-        cometBft: {
-          nodeIndex: 13,
-          id: '254dd73eb4cee23d439c2f2e706ccdbeac52f06c',
-          privateKey: svCometBftSecrets[12].nodePrivateKey,
-          validator: {
-            keyAddress: 'CFF50F6EFD5DFDD8DAD7A468D5FB5DA2D43CF281',
-            privateKey: svCometBftSecrets[12].validatorPrivateKey,
-            publicKey: '6ltWNxHRrwPj9qPYB3HQWL4hpeFTCjHSW2m+7rCYWAw=',
+        {
+          auth0ValidatorAppName: 'sv15_validator',
+          auth0SvAppName: 'sv-15',
+          validatorWalletUser: 'auth0|65e0a7994c76b74b28b8479c',
+          cometBft: {
+            nodeIndex: 15,
+            id: '7a5f4f9ee97ec24bb4a1a6ed22ec3676805fa494',
+            privateKey: svCometBftSecrets[14].nodePrivateKey,
+            validator: {
+              keyAddress: 'AAE830BF1289910D20E646D9B69561D9E0F965EA',
+              privateKey: svCometBftSecrets[14].validatorPrivateKey,
+              publicKey: 'iAxMTvCLe/YO4cP9+RocTxw7+lEsGxsiiPc2hMq6oLs=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-14',
-        ingressName: 'sv-14-eng',
-        onboardingName: 'Digital-Asset-Eng-14',
-        auth0ValidatorAppName: 'sv14_validator',
-        auth0SvAppName: 'sv-14',
-        validatorWalletUser: 'auth0|65e0a795aa7a40df0cc65ace',
-        cometBft: {
-          nodeIndex: 14,
-          id: '9de44f8ddac42901c094371e867bb0db60ab03b8',
-          privateKey: svCometBftSecrets[13].nodePrivateKey,
-          validator: {
-            keyAddress: 'F691F4CA91B972A6B291C09BADA9970AAAC86C84',
-            privateKey: svCometBftSecrets[13].validatorPrivateKey,
-            publicKey: 'rP4eWO4WZctUrQE5ZDFHkXxCWfZa6tc8B8qLmrzV7gE=',
+        {
+          auth0ValidatorAppName: 'sv16_validator',
+          auth0SvAppName: 'sv-16',
+          validatorWalletUser: 'auth0|65e0a79de124e5c43dcb6a19',
+          cometBft: {
+            nodeIndex: 16,
+            id: '9831eeb365f221034e70f27c5073ee0857bdc945',
+            privateKey: svCometBftSecrets[15].nodePrivateKey,
+            validator: {
+              keyAddress: '0C77119A80F4B4305729D49EC76FC7D4C0576229',
+              privateKey: svCometBftSecrets[15].validatorPrivateKey,
+              publicKey: '+cNplFRLm7gBS/hIsJrWVcDtfGoCQ2Yb4HCzvBqYdZ0=',
+            },
           },
         },
-      },
-      {
-        nodeName: 'sv-15',
-        ingressName: 'sv-15-eng',
-        onboardingName: 'Digital-Asset-Eng-15',
-        auth0ValidatorAppName: 'sv15_validator',
-        auth0SvAppName: 'sv-15',
-        validatorWalletUser: 'auth0|65e0a7994c76b74b28b8479c',
-        cometBft: {
-          nodeIndex: 15,
-          id: '7a5f4f9ee97ec24bb4a1a6ed22ec3676805fa494',
-          privateKey: svCometBftSecrets[14].nodePrivateKey,
-          validator: {
-            keyAddress: 'AAE830BF1289910D20E646D9B69561D9E0F965EA',
-            privateKey: svCometBftSecrets[14].validatorPrivateKey,
-            publicKey: 'iAxMTvCLe/YO4cP9+RocTxw7+lEsGxsiiPc2hMq6oLs=',
-          },
-        },
-      },
-      {
-        nodeName: 'sv-16',
-        ingressName: 'sv-16-eng',
-        onboardingName: 'Digital-Asset-Eng-16',
-        auth0ValidatorAppName: 'sv16_validator',
-        auth0SvAppName: 'sv-16',
-        validatorWalletUser: 'auth0|65e0a79de124e5c43dcb6a19',
-        cometBft: {
-          nodeIndex: 16,
-          id: '9831eeb365f221034e70f27c5073ee0857bdc945',
-          privateKey: svCometBftSecrets[15].nodePrivateKey,
-          validator: {
-            keyAddress: '0C77119A80F4B4305729D49EC76FC7D4C0576229',
-            privateKey: svCometBftSecrets[15].validatorPrivateKey,
-            publicKey: '+cNplFRLm7gBS/hIsJrWVcDtfGoCQ2Yb4HCzvBqYdZ0=',
-          },
-        },
-      },
-    ];
+      ]
+).map((e, i) => ({ ...e, ...standardSvConfigsBasic[i] }));
 
 // TODO(#1892): consider supporting overrides of hardcoded svs (in case we're keeping hardcoded svs at all)
 export const extraSvConfigs: StaticSvConfig[] = configuredExtraSvs.map((k, index) =>
@@ -412,9 +360,7 @@ export const svConfigs = standardSvConfigs.concat(extraSvConfigs);
 export const sv1Config: StaticSvConfig = standardSvConfigs[0];
 
 export const svRunbookConfig: StaticSvConfig = {
-  onboardingName: 'DA-Helm-Test-Node',
-  nodeName: 'sv',
-  ingressName: 'sv',
+  ...svRunbookConfigBasic,
   auth0SvAppName: 'sv',
   auth0ValidatorAppName: 'validator',
   // Default to admin@sv-dev.com (devnet) or admin@sv.com (non devnet) at the sv-test tenant by default

--- a/cluster/pulumi/common-sv/src/svConfigsBasic.ts
+++ b/cluster/pulumi/common-sv/src/svConfigsBasic.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DeploySvRunbook, isMainNet } from '@lfdecentralizedtrust/splice-pulumi-common';
+import { SweepConfig } from '@lfdecentralizedtrust/splice-pulumi-common-validator';
+import { spliceEnvConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/envConfig';
+
+import { StaticSvConfigBasic } from './config';
+import { dsoSize, skipExtraSvs } from './dsoConfig';
+import { configForSv, configuredExtraSvs } from './singleSvConfig';
+
+function sweepConfigFromEnv(nodeName: string): SweepConfig | undefined {
+  const asJson = spliceEnvConfig.optionalEnv(`${nodeName}_SWEEP`);
+  return asJson ? JSON.parse(asJson) : undefined;
+}
+
+export function fromSingleSvConfigBasic(nodeName: string): StaticSvConfigBasic {
+  const config = configForSv(nodeName);
+  return {
+    nodeName,
+    ingressName: config.subdomain!,
+    onboardingName: config.publicName!,
+    ...(config.validatorApp?.sweep
+      ? { sweep: sweepConfigFromEnv(config.validatorApp.sweep.fromEnv) }
+      : {}),
+  };
+}
+
+// TODO(DACH-NY/canton-network-node#12169): consider making nodeName and ingressName the same (also for all other SVs)
+export const standardSvConfigsBasic: StaticSvConfigBasic[] = isMainNet
+  ? [
+      {
+        nodeName: 'sv-1',
+        ingressName: 'sv-2',
+        onboardingName: 'Digital-Asset-2',
+        sweep: sweepConfigFromEnv('SV1'),
+      },
+    ]
+  : [
+      {
+        nodeName: 'sv-1',
+        ingressName: 'sv-2',
+        onboardingName: 'Digital-Asset-2',
+        sweep: sweepConfigFromEnv('SV1'),
+      },
+      { nodeName: 'sv-2', ingressName: 'sv-2-eng', onboardingName: 'Digital-Asset-Eng-2' },
+      ...Array.from({ length: 14 }, (_, i) => ({
+        nodeName: `sv-${i + 3}`,
+        ingressName: `sv-${i + 3}-eng`,
+        onboardingName: `Digital-Asset-Eng-${i + 3}`,
+      })),
+    ];
+
+export const extraSvConfigsBasic: StaticSvConfigBasic[] = configuredExtraSvs.map(name =>
+  fromSingleSvConfigBasic(name)
+);
+
+export const svRunbookConfigBasic: StaticSvConfigBasic = {
+  onboardingName: 'DA-Helm-Test-Node',
+  nodeName: 'sv',
+  ingressName: 'sv',
+};
+
+export const svConfigsBasic = standardSvConfigsBasic.concat(extraSvConfigsBasic);
+
+// "core SVs" are deployed as part of the `infra` stack;
+// if config.yaml contains any SVs that don't match the standard sv-X pattern, we deploy them independently of DSO_SIZE
+export const coreSvsToDeployBasic = standardSvConfigsBasic
+  .slice(0, dsoSize)
+  .concat(skipExtraSvs ? [] : extraSvConfigsBasic);
+
+export const allSvsToDeployBasic = coreSvsToDeployBasic.concat(
+  DeploySvRunbook ? [svRunbookConfigBasic] : []
+);

--- a/cluster/pulumi/infra/src/auth0.ts
+++ b/cluster/pulumi/infra/src/auth0.ts
@@ -14,11 +14,11 @@ import {
   NamespacedAuth0Configs,
   fixedTokens,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
+import { dsoSize } from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/dsoConfig';
 import {
-  standardSvConfigs,
-  extraSvConfigs,
-  dsoSize,
-} from '@lfdecentralizedtrust/splice-pulumi-common-sv';
+  standardSvConfigsBasic,
+  extraSvConfigsBasic,
+} from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/svConfigsBasic';
 
 function tokenLifetime(): number {
   return fixedTokens() ? 2592000 : 86400; // TODO(DACH-NY/canton-network-internal#2114): Move this to the cluster config? We want it to be long for fixed token clusters
@@ -382,7 +382,7 @@ function mainNetAuth0(clusterBasename: string, dnsNames: string[]): pulumi.Outpu
     ingressName: 'sv-2', // Ingress name of sv-1 is sv-2!
   };
 
-  const extraSvs: svAuth0Params[] = extraSvConfigs.map(sv => ({
+  const extraSvs: svAuth0Params[] = extraSvConfigsBasic.map(sv => ({
     namespace: sv.nodeName,
     description: sv.onboardingName,
     ingressName: sv.ingressName,
@@ -410,14 +410,14 @@ function nonMainNetAuth0(clusterBasename: string, dnsNames: string[]): pulumi.Ou
     clientSecret: auth0MgtClientSecret,
   });
 
-  const standardSvs: svAuth0Params[] = standardSvConfigs
+  const standardSvs: svAuth0Params[] = standardSvConfigsBasic
     .map(sv => ({
       namespace: sv.nodeName,
       description: sv.nodeName.replace(/-/g, '').toUpperCase(),
       ingressName: sv.ingressName,
     }))
     .slice(0, dsoSize);
-  const extraSvs: svAuth0Params[] = extraSvConfigs.map(sv => ({
+  const extraSvs: svAuth0Params[] = extraSvConfigsBasic.map(sv => ({
     namespace: sv.nodeName,
     description: sv.onboardingName,
     ingressName: sv.ingressName,

--- a/cluster/pulumi/infra/src/index.ts
+++ b/cluster/pulumi/infra/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // ensure the config is loaded and the ENV is overriden
 import { config } from '@lfdecentralizedtrust/splice-pulumi-common';
-import { svsConfig } from '@lfdecentralizedtrust/splice-pulumi-common-sv';
+import { svsConfig } from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/config';
 
 import { clusterIsResetPeriodically, enableAlerts } from './alertings';
 import { configureAuth0 } from './auth0';

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -4,9 +4,9 @@ import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import {
-  allSvsToDeploy,
-  coreSvsToDeploy,
-} from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/svConfigs';
+  allSvsToDeployBasic,
+  coreSvsToDeployBasic,
+} from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/svConfigsBasic';
 import { cometBFTExternalPort } from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/synchronizer/cometbftConfig';
 import { spliceConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/config/config';
 import { PodMonitor, ServiceMonitor } from '@lfdecentralizedtrust/splice-pulumi-common/src/metrics';
@@ -43,7 +43,7 @@ export const istioVersion = {
 };
 
 // dsoSize + number of extra SVs added via config.yaml
-const numCoreSvsToDeploy = coreSvsToDeploy.length;
+const numCoreSvsToDeploy = coreSvsToDeployBasic.length;
 
 function configureIstioBase(
   ns: k8s.core.v1.Namespace,
@@ -686,7 +686,7 @@ function configurePublicInfo(ingressNs: k8s.core.v1.Namespace): k8s.apiextension
                       hosts: [
                         // We could also have done `info.sv*.whatever` here but enumerating what we expect seems slightly more secure
                         ...new Set(
-                          allSvsToDeploy
+                          allSvsToDeployBasic
                             .map(sv => [
                               `info.${sv.ingressName}.${getDnsNames().cantonDnsName}`,
                               `info.${sv.ingressName}.${getDnsNames().daDnsName}`,
@@ -711,7 +711,7 @@ function configureSequencerHighPerformanceGrpcDestinationRules(
   return [
     ...(function* () {
       for (const migration of DecentralizedSynchronizerUpgradeConfig.runningMigrations()) {
-        for (const sv of allSvsToDeploy) {
+        for (const sv of allSvsToDeployBasic) {
           yield configureSequencerHighPerformanceGrpcDestinationRule(
             ingressNs,
             sv.nodeName,

--- a/cluster/pulumi/infra/src/network.ts
+++ b/cluster/pulumi/infra/src/network.ts
@@ -14,7 +14,7 @@ import {
   isDevNet,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 import { infraAffinityAndTolerations } from '@lfdecentralizedtrust/splice-pulumi-common';
-import { svConfigs } from '@lfdecentralizedtrust/splice-pulumi-common-sv';
+import { svConfigsBasic } from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/svConfigsBasic';
 
 import { gcpDnsProject } from './config';
 
@@ -189,7 +189,7 @@ function clusterCertificate(
         `*.validator1.${dnsName}`,
         `*.splitwell.${dnsName}`,
         `*.sv.${dnsName}`,
-      ].concat(svConfigs.map(sv => `*.${sv.ingressName}.${dnsName}`))
+      ].concat(svConfigsBasic.map(sv => `*.${sv.ingressName}.${dnsName}`))
     )
     .flat();
 

--- a/cluster/pulumi/infra/src/observability.ts
+++ b/cluster/pulumi/infra/src/observability.ts
@@ -24,11 +24,11 @@ import {
   ObservabilityReleaseName,
   SPLICE_ROOT,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
+import { allSvsConfiguration } from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/singleSvConfig';
 import {
-  allSvsConfiguration,
-  extraSvConfigs,
-  standardSvConfigs,
-} from '@lfdecentralizedtrust/splice-pulumi-common-sv';
+  extraSvConfigsBasic,
+  standardSvConfigsBasic,
+} from '@lfdecentralizedtrust/splice-pulumi-common-sv/src/svConfigsBasic';
 import { SweepConfig } from '@lfdecentralizedtrust/splice-pulumi-common-validator';
 import { SplicePostgres } from '@lfdecentralizedtrust/splice-pulumi-common/src/postgres';
 import { local } from '@pulumi/command';
@@ -762,8 +762,8 @@ function partyIdTransform(partyId: string) {
 }
 
 function createGrafanaAlerting(namespace: Input<string>) {
-  const sweepConfigs: SweepConfig[] = extraSvConfigs
-    .concat(standardSvConfigs)
+  const sweepConfigs: SweepConfig[] = extraSvConfigsBasic
+    .concat(standardSvConfigsBasic)
     .map(sv => sv.sweep!)
     .filter(e => e != undefined);
   const cometbftPruningHighestBlockRetain = allSvsConfiguration


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/3520

Before:
The infrastructure stacks were calling allSvsToDeploy, which in turn called svCometBftSecrets. This resulted in a 404 error if the secret did not exist.

With the change:
This PR extracts the constants from common-sv used by the infra stack into a new file, newIdentities.ts. This allows us to bypass allSvsToDeploy and avoid the 404 error.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
