### PR TITLE
Upgrade operator to 2.6.0

### DIFF
--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -645,7 +645,7 @@
           }
         ]
       },
-      "version": "2.4.1"
+      "version": "2.6.0"
     },
     "name": "pulumi-kubernetes-operator",
     "provider": "",
@@ -769,9 +769,9 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "create": "bash SPLICE_ROOT/cluster/pulumi/operator/pulumi-operator-crd-update.sh 2.4.1"
+      "create": "bash SPLICE_ROOT/cluster/pulumi/operator/pulumi-operator-crd-update.sh 2.6.0"
     },
-    "name": "update-pulumi-operator-crd-2.4.1",
+    "name": "update-pulumi-operator-crd-2.6.0",
     "provider": "",
     "type": "command:local:Command"
   }

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -23,8 +23,8 @@ const secretName = (
 ).metadata.name;
 
 // If the operator version is updated the crd version might need to be upgraded as well, check the release notes https://github.com/pulumi/pulumi-kubernetes-operator/releases
-const operatorVersion = '2.4.1';
-const operatorCrdVersion = '2.4.1';
+const operatorVersion = '2.6.0';
+const operatorCrdVersion = '2.6.0';
 
 export const operator = new k8s.helm.v3.Release(
   'pulumi-kubernetes-operator',


### PR DESCRIPTION
Includes
https://github.com/pulumi/pulumi-kubernetes-operator/pull/1155 which hopefully fixes some of our issues.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
