### PR TITLE
override participantAddress in sv-runbook for a logical synchronizer deployment

### DIFF
--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -275,9 +275,7 @@ async function installSvAndValidator(
   const svValues: ChartValues = {
     ...valuesFromYamlFile,
     ...commonSvAppValues,
-    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
-      ? { participantAddress: 'participant' }
-      : {}),
+    participantAddress: canton.participant.internalClusterAddress,
     participantIdentitiesDumpImport: participantBootstrapDumpSecret
       ? { secretName: participantBootstrapDumpSecretName }
       : undefined,
@@ -373,9 +371,7 @@ async function installSvAndValidator(
     ...defaultScanValues,
     ...persistenceForPostgres(appsPg, defaultScanValues),
     ...spliceInstanceNames,
-    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
-      ? { participantAddress: 'participant' }
-      : {}),
+    participantAddress: canton.participant.internalClusterAddress,
     metrics: {
       enable: true,
     },
@@ -435,9 +431,7 @@ async function installSvAndValidator(
         TRUSTED_SCAN_URL: `http://scan-app.${xns.logicalName}:5012`,
       }
     ),
-    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
-      ? { participantAddress: 'participant' }
-      : {}),
+    participantAddress: canton.participant.internalClusterAddress,
     metrics: {
       enable: true,
     },


### PR DESCRIPTION
This failed during the initial deployment in the LSU workflow.