### PR TITLE
[backport] override participantAddress in sv-runbook for a logical synchronizer deployment (canton-3.5)

### DIFF
--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -295,6 +295,9 @@ async function installSvAndValidator(
   const svValues: ChartValues = {
     ...valuesFromYamlFile,
     ...commonSvAppValues,
+    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
+      ? { participantAddress: 'participant' }
+      : {}),
     participantIdentitiesDumpImport: participantBootstrapDumpSecret
       ? { secretName: participantBootstrapDumpSecretName }
       : undefined,
@@ -435,6 +438,9 @@ async function installSvAndValidator(
     ...defaultScanValues,
     ...persistenceForPostgres(appsPg, defaultScanValues),
     ...spliceInstanceNames,
+    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
+      ? { participantAddress: 'participant' }
+      : {}),
     metrics: {
       enable: true,
     },
@@ -492,6 +498,9 @@ async function installSvAndValidator(
         TRUSTED_SCAN_URL: `http://scan-app.${xns.logicalName}:5012`,
       }
     ),
+    ...(decentralizedSynchronizerMigrationConfig.active.enableLogicalSynchronizerDeploymentMode
+      ? { participantAddress: 'participant' }
+      : {}),
     metrics: {
       enable: true,
     },


### PR DESCRIPTION
Backport of https://github.com/hyperledger-labs/splice/pull/4543