### PR TITLE
add better error logging to dump-config.ts files so that the original error is not obfuscated

### DIFF
--- a/cluster/pulumi/canton-network/dump-config.ts
+++ b/cluster/pulumi/canton-network/dump-config.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Need to import this by path and not through the module, so the module is not
 // initialized when we don't want it to (to avoid pulumi configs trying to being read here)
-import { Auth0Config } from '@lfdecentralizedtrust/splice-pulumi-common/src/auth0/auth0types';
-
 import {
   SecretsFixtureMap,
   initDumpConfig,
@@ -11,12 +9,12 @@ import {
 } from '../common/src/dump-config-common';
 
 async function main() {
-  initDumpConfig();
+  await initDumpConfig();
   const installCluster = await import('./src/installCluster');
 
   const secrets = new SecretsFixtureMap();
 
-  installCluster.installCluster({
+  await installCluster.installCluster({
     getSecrets: () => Promise.resolve(secrets),
     /* eslint-disable @typescript-eslint/no-unused-vars */
     getClientAccessToken: (clientId: string, clientSecret: string, audience: string) =>
@@ -26,4 +24,7 @@ async function main() {
   });
 }
 
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/cluster/dump-config.ts
+++ b/cluster/pulumi/cluster/dump-config.ts
@@ -11,4 +11,7 @@ async function main() {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/cluster/tsconfig.json
+++ b/cluster/pulumi/cluster/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "*.ts"
   ]
 }

--- a/cluster/pulumi/deployment/dump-config.ts
+++ b/cluster/pulumi/deployment/dump-config.ts
@@ -18,6 +18,6 @@ async function main() {
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 main().catch(e => {
-  console.error(e);
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/gcp/dump-config.ts
+++ b/cluster/pulumi/gcp/dump-config.ts
@@ -12,4 +12,7 @@ async function main() {
   });
 }
 
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/infra/dump-config.ts
+++ b/cluster/pulumi/infra/dump-config.ts
@@ -7,10 +7,14 @@ import { initDumpConfig } from '../common/src/dump-config-common';
 async function main() {
   await initDumpConfig();
 
+  /* eslint-disable no-process-env */
   process.env.SLACK_ACCESS_TOKEN = 's3cr3t';
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const infra: typeof import('./src/index') = await import('./src/index');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/multi-validator/dump-config.ts
+++ b/cluster/pulumi/multi-validator/dump-config.ts
@@ -7,7 +7,10 @@ import { initDumpConfig } from '../common/src/dump-config-common';
 async function main() {
   await initDumpConfig();
   const installNode = await import('./src/installNode');
-  installNode.installNode();
+  await installNode.installNode();
 }
 
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/operator/dump-config.ts
+++ b/cluster/pulumi/operator/dump-config.ts
@@ -18,6 +18,6 @@ async function main() {
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 main().catch(e => {
-  console.error(e);
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/splitwell/dump-config.ts
+++ b/cluster/pulumi/splitwell/dump-config.ts
@@ -25,6 +25,6 @@ async function main() {
 }
 
 main().catch(e => {
-  console.error(e);
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/sv-canton/dump-config.ts
+++ b/cluster/pulumi/sv-canton/dump-config.ts
@@ -49,7 +49,7 @@ async function writeMigration(migrationId: DomainMigrationIndex, svs: StaticSvCo
   }
 }
 
-main().catch(err => {
-  console.error(err);
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/sv-runbook/dump-config.ts
+++ b/cluster/pulumi/sv-runbook/dump-config.ts
@@ -9,7 +9,9 @@ import {
 async function main() {
   await initDumpConfig();
 
+  /* eslint-disable no-process-env */
   process.env.ARTIFACTORY_USER = 'artie';
+  /* eslint-disable no-process-env */
   process.env.ARTIFACTORY_PASSWORD = 's3cr3t';
 
   const installNode = await import('./src/installNode');
@@ -32,7 +34,7 @@ async function main() {
     walletUserName: svRunbookConfig.validatorWalletUser!,
   };
 
-  installNode.installNode(
+  await installNode.installNode(
     authOClient,
     svRunbookConfig.nodeName,
     svAppConfig,
@@ -41,4 +43,7 @@ async function main() {
   );
 }
 
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});

--- a/cluster/pulumi/sv/dump-config.ts
+++ b/cluster/pulumi/sv/dump-config.ts
@@ -25,7 +25,7 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error(err);
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/validator-runbook/dump-config.ts
+++ b/cluster/pulumi/validator-runbook/dump-config.ts
@@ -50,6 +50,6 @@ async function main() {
 }
 
 main().catch(e => {
-  console.error(e);
+  console.error(e.stack ?? e.message ?? e);
   process.exit(1);
 });

--- a/cluster/pulumi/validator1/dump-config.ts
+++ b/cluster/pulumi/validator1/dump-config.ts
@@ -9,12 +9,12 @@ import {
 } from '../common/src/dump-config-common';
 
 async function main() {
-  initDumpConfig();
+  await initDumpConfig();
   const installNode = await import('./src/installNode');
 
   const secrets = new SecretsFixtureMap();
 
-  installNode.installNode({
+  await installNode.installNode({
     getSecrets: () => Promise.resolve(secrets),
     /* eslint-disable @typescript-eslint/no-unused-vars */
     getClientAccessToken: (clientId: string, clientSecret: string, audience: string) =>
@@ -24,4 +24,7 @@ async function main() {
   });
 }
 
-main();
+main().catch(e => {
+  console.error(e.stack ?? e.message ?? e);
+  process.exit(1);
+});


### PR DESCRIPTION
Improves error reporting in issues like https://github.com/DACH-NY/cn-test-failures/issues/7627

The seemingly unrelated changes were forced by the linter.