### PR TITLE
Avoid storing LSU state in memory

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DecentralizedSynchronizerMigrationIntegrationTest.scala
@@ -53,7 +53,6 @@ import org.lfdecentralizedtrust.splice.environment.{ParticipantAdminConnection, 
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
-import org.lfdecentralizedtrust.splice.integration.tests.DecentralizedSynchronizerMigrationIntegrationTest.migrationDumpDir
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.BracketSynchronous.bracket
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
   IntegrationTestWithIsolatedEnvironment,
@@ -74,7 +73,7 @@ import org.lfdecentralizedtrust.splice.sv.automation.singlesv.{
 }
 import org.lfdecentralizedtrust.splice.sv.config.SvOnboardingConfig.DomainMigration
 import org.lfdecentralizedtrust.splice.sv.util.SvUtil
-import org.lfdecentralizedtrust.splice.util.DomainMigrationUtil.testDumpDir
+import org.lfdecentralizedtrust.splice.util.DomainMigrationUtil.{migrationTestDumpDir, testDumpDir}
 import org.lfdecentralizedtrust.splice.util.{
   DomainMigrationUtil,
   PackageQualifiedName,
@@ -87,7 +86,6 @@ import org.lfdecentralizedtrust.splice.util.{
   WalletTestUtil,
 }
 import org.lfdecentralizedtrust.splice.wallet.automation.ExpireTransferOfferTrigger
-import org.scalatest.OptionValues
 import org.scalatest.time.{Minute, Span}
 import org.slf4j.event.Level
 
@@ -202,7 +200,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                   scanClient =
                     TrustSingle(url = s"http://127.0.0.1:${sv1ScanConfig.adminApi.port}"),
                   restoreFromMigrationDump = Some(
-                    (migrationDumpDir("aliceValidator") / "domain_migration_dump.json").path
+                    (migrationTestDumpDir("aliceValidator") / "domain_migration_dump.json").path
                   ),
                   domainMigrationId = 1L,
                 )
@@ -220,7 +218,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                   scanClient =
                     TrustSingle(url = s"http://127.0.0.1:${sv1ScanConfig.adminApi.port}"),
                   restoreFromMigrationDump = Some(
-                    (migrationDumpDir("splitwellValidator") / "domain_migration_dump.json").path
+                    (migrationTestDumpDir("splitwellValidator") / "domain_migration_dump.json").path
                   ),
                   onboarding = splitwellValidatorConfig.onboarding.map(onboarding =>
                     onboarding.copy(
@@ -275,7 +273,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
             if (name == "aliceValidator" || name == "splitwellValidator")
               validatorConfig.copy(
                 domainMigrationDumpPath =
-                  Some((migrationDumpDir(name) / "domain_migration_dump.json").path)
+                  Some((migrationTestDumpDir(name) / "domain_migration_dump.json").path)
               )
             else validatorConfig
           )(conf)
@@ -288,7 +286,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                 onboarding = Some(
                   DomainMigration(
                     c.onboarding.value.name,
-                    (migrationDumpDir(
+                    (migrationTestDumpDir(
                       name.stripSuffix("Local")
                     ) / "domain_migration_dump.json").path,
                   )
@@ -297,7 +295,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
             } else
               c.copy(
                 domainMigrationDumpPath =
-                  Some((migrationDumpDir(name) / "domain_migration_dump.json").path)
+                  Some((migrationTestDumpDir(name) / "domain_migration_dump.json").path)
               )
           )(conf),
         // TODO(DACH-NY/canton-network-node#9014) Consider keeping this running and instead
@@ -616,14 +614,14 @@ class DecentralizedSynchronizerMigrationIntegrationTest
                   allNodes.map(_.oldParticipantConnection)
                 )
               }
-              deleteDirectoryRecursively(migrationDumpDir.toFile)
+              deleteDirectoryRecursively(testDumpDir.toFile)
             },
           ) {
 
             withClueAndLog("dump has been written in the configured location for the sv.") {
               eventually(timeUntilSuccess = 2.minute, maxPollInterval = 2.second) {
                 allNodes.foreach { node =>
-                  (migrationDumpDir(
+                  (migrationTestDumpDir(
                     node.oldBackend.name
                   ) / "domain_migration_dump.json").path.exists shouldBe true
                 }
@@ -633,7 +631,7 @@ class DecentralizedSynchronizerMigrationIntegrationTest
             withClueAndLog("dump has been written in the configured location for the validator.") {
               eventually(timeUntilSuccess = 2.minute, maxPollInterval = 2.second) {
                 Seq(aliceValidatorBackend, splitwellValidatorBackend).foreach { validator =>
-                  (migrationDumpDir(
+                  (migrationTestDumpDir(
                     validator.name
                   ) / "domain_migration_dump.json").path.exists shouldBe true
                 }
@@ -1479,17 +1477,5 @@ class DecentralizedSynchronizerMigrationIntegrationTest
       users,
       rights,
     )
-  }
-}
-
-object DecentralizedSynchronizerMigrationIntegrationTest extends OptionValues {
-  val migrationDumpDir: Path = testDumpDir.resolve(s"domain-migration-dump")
-  // Not using temp-files so test-generated outputs are easy to inspect.
-  def migrationDumpDir(node: String): Path = {
-    val dumpDir = migrationDumpDir.resolve(s"$node")
-    if (!dumpDir.toFile.exists()) {
-      dumpDir.toFile.mkdirs()
-    }
-    dumpDir
   }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -1,5 +1,6 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
+import better.files.File.apply
 import cats.implicits.catsSyntaxOptionId
 import com.digitalasset.canton.{HasExecutionContext, SynchronizerAlias}
 import com.digitalasset.canton.admin.api.client.data
@@ -31,6 +32,7 @@ import org.lfdecentralizedtrust.splice.sv.config.{
   SvSynchronizerNodeConfig,
   SvSynchronizerNodesConfig,
 }
+import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSynchronizerUpgradeSequencingTestTrigger
 import org.lfdecentralizedtrust.splice.util.*
 import org.lfdecentralizedtrust.splice.wallet.store.TxLogEntry.Http.BuyTrafficRequestStatus
 import org.scalatest.time.{Minutes, Span}
@@ -72,10 +74,13 @@ class LogicalSynchronizerUpgradeIntegrationTest
       .unsafeWithSequencerAvailabilityDelay(NonNegativeFiniteDuration.ofSeconds(5))
       .addConfigTransforms((_, config) => {
         ConfigTransforms
-          .updateAllSvAppConfigs { (_, config) =>
+          .updateAllSvAppConfigs { (name, config) =>
             config.copy(
               localSynchronizerNodes = config.localSynchronizerNodes
                 .copy(successor = config.localSynchronizerNodes.current.some),
+              domainMigrationDumpPath = Some(
+                (DomainMigrationUtil.migrationTestDumpDir(name) / "domain_migration_dump.json").path
+              ),
               parameters = config.parameters.copy(
                 spliceCachingConfigs = config.parameters.spliceCachingConfigs.copy(
                   physicalSynchronizerExpiration = NonNegativeFiniteDuration.ofSeconds(1)
@@ -95,7 +100,13 @@ class LogicalSynchronizerUpgradeIntegrationTest
               ),
             )
           })
-          .andThen(ConfigTransforms.bumpCantonSyncSuccessorPortsBy(22_000))(config)
+          .andThen(ConfigTransforms.bumpCantonSyncSuccessorPortsBy(22_000))
+          .andThen(
+            ConfigTransforms.updateAutomationConfig(ConfigTransforms.ConfigurableApp.Sv)(
+              // TODO(DACH-NY/canton-network-internal#4254) Reenable once this is fixed in Canton
+              _.withPausedTrigger[LogicalSynchronizerUpgradeSequencingTestTrigger]
+            )
+          )(config)
       })
       .addConfigTransform((_, config) =>
         ConfigTransforms.useDecentralizedSynchronizerSplitwell()(config)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMigrationApiIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMigrationApiIntegrationTest.scala
@@ -6,11 +6,11 @@ import cats.implicits.catsSyntaxOptionId
 import com.digitalasset.canton.console.CommandFailure
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
-import org.lfdecentralizedtrust.splice.integration.tests.DecentralizedSynchronizerMigrationIntegrationTest.migrationDumpDir
 import org.lfdecentralizedtrust.splice.integration.tests.SvMigrationApiIntegrationTest.{
   directoryForDump,
   migrationDumpPathForSv,
 }
+import org.lfdecentralizedtrust.splice.util.DomainMigrationUtil.migrationTestDumpDir
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -62,7 +62,7 @@ object SvMigrationApiIntegrationTest {
   }
 
   def migrationDumpPathForSv(name: String): File = {
-    migrationDumpDir(name) / "domain_migration_dump.json"
+    migrationTestDumpDir(name) / "domain_migration_dump.json"
   }
 
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/DomainMigrationUtil.scala
@@ -173,4 +173,13 @@ object DomainMigrationUtil {
 
   val testDumpDir: Path = Paths.get("apps/app/src/test/resources/dumps")
 
+  def migrationTestDumpDir(node: String) = {
+    val migrationDumpDir = testDumpDir.resolve(s"domain-migration-dump")
+    val dumpDir = migrationDumpDir.resolve(s"$node")
+    if (!dumpDir.toFile.exists()) {
+      dumpDir.toFile.mkdirs()
+    }
+    dumpDir
+  }
+
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.environment
 
+import better.files.File
 import cats.implicits.*
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.grpc.adapter.client.pekko.ClientAdapter
@@ -15,7 +16,7 @@ import com.digitalasset.canton.admin.api.client.data.{NodeStatus, SequencerStatu
 import com.digitalasset.canton.config.{ApiLoggingConfig, ClientConfig, NonNegativeFiniteDuration}
 import com.digitalasset.canton.config.RequireTypes.{NonNegativeLong, PositiveInt}
 import com.digitalasset.canton.data.CantonTimestamp
-import com.digitalasset.canton.grpc.ByteStringStreamObserver
+import com.digitalasset.canton.grpc.{ByteStringStreamObserver, OutputFileStreamObserver}
 import com.digitalasset.canton.lifecycle.LifeCycle.CloseableChannel
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
@@ -59,6 +60,7 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.Topol
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AuthorizedState
 
+import java.nio.file.{Files, Path}
 import java.util.{Base64, Collections}
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.jdk.CollectionConverters.*
@@ -107,31 +109,35 @@ class SequencerAdminConnection(
     ).flatMap(_ => responseObserver.resultFuture.map(_.map(_.chunk)))
   }
 
-  def getLsuState()(implicit
+  def getLsuState(file: File)(implicit
       traceContext: TraceContext
-  ): Future[ByteString] = {
-    val responseObserver = new ByteStringStreamObserver[SequencerLsuStateResponse](_.chunk)
+  ): Future[Unit] = {
+    val responseObserver = new OutputFileStreamObserver[SequencerLsuStateResponse](
+      file,
+      _.chunk,
+    )
     runCmd(
       TopologyAdminCommands.Read
         .SequencerLsuState(
           store = None,
           observer = responseObserver,
         )
-    ).flatMap(_ => responseObserver.resultBytes)
+    ).map(_ => ())
   }
 
   def initializeFromPredecessor(
-      topologySnapshot: ByteString,
+      topologySnapshot: Path,
       staticSynchronizerParameters: StaticSynchronizerParameters,
   )(implicit
       traceContext: TraceContext
   ): Future[Unit] = {
+    val inputStream = Files.newInputStream(topologySnapshot)
     runCmd(
       SequencerAdminCommands.InitializeFromLsuPredecessor(
-        topologySnapshot,
+        inputStream,
         staticSynchronizerParameters,
       )
-    )
+    ).andThen(_ => inputStream.close())
   }
 
   def getPhysicalSynchronizerId()(implicit

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -256,6 +256,9 @@ class SvDsoAutomationService(
             synchronizerNodeService.nodes,
             successorSynchronizerNode,
             store,
+            config.domainMigrationDumpPath.getOrElse(
+              throw new IllegalArgumentException("Domain migration dump path must be set for LSU")
+            ),
           )
         )
         registerTrigger(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LogicalSynchronizerUpgradeTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LogicalSynchronizerUpgradeTrigger.scala
@@ -33,6 +33,7 @@ import org.lfdecentralizedtrust.splice.sv.onboarding.SynchronizerNodeReconciler.
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
 
 import java.net.URI
+import java.nio.file.Path
 import scala.concurrent.{ExecutionContext, Future}
 
 class LogicalSynchronizerUpgradeTrigger(
@@ -41,6 +42,7 @@ class LogicalSynchronizerUpgradeTrigger(
     localSynchronizerNodes: LocalSynchronizerNodes[LocalSynchronizerNode],
     successorSynchronizerNode: LocalSynchronizerNode,
     store: SvDsoStore,
+    dumpPath: Path,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -51,6 +53,7 @@ class LogicalSynchronizerUpgradeTrigger(
 
   private val exporter =
     new LsuStateExporter(
+      dumpPath,
       currentSynchronizerNode.sequencerAdminConnection,
       currentSynchronizerNode.mediatorAdminConnection,
       loggerFactory,
@@ -174,7 +177,7 @@ class LogicalSynchronizerUpgradeTrigger(
             show"Initializing sequencer from predecessor with $parameters"
           )
           successorSynchronizerNode.sequencerAdminConnection.initializeFromPredecessor(
-            state.synchronizerState,
+            state.synchronizerStatePath,
             parameters.copy(
               protocolVersion = task.work.announcement.successorSynchronizerId.protocolVersion
             ),

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuState.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuState.scala
@@ -5,14 +5,13 @@ package org.lfdecentralizedtrust.splice.sv.lsu
 
 import cats.implicits.toBifunctorOps
 import com.digitalasset.canton.topology.{MediatorId, SequencerId}
-import com.google.protobuf.ByteString
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import org.lfdecentralizedtrust.splice.http.v0.definitions
 import org.lfdecentralizedtrust.splice.identities.NodeIdentitiesDump
 
+import java.nio.file.{Path, Paths}
 import java.time.Instant
-import java.util.Base64
 import scala.util.Try
 
 case class SynchronizerNodeIdentities(
@@ -62,7 +61,7 @@ object SynchronizerNodeIdentities {
 case class LsuState(
     upgradesAt: Instant,
     nodeIdentities: SynchronizerNodeIdentities,
-    synchronizerState: ByteString,
+    synchronizerStatePath: Path,
 )
 
 object LsuState {
@@ -73,15 +72,11 @@ object LsuState {
   implicit val decodeInstant: Decoder[Instant] =
     Decoder.decodeString.emapTry(str => Try(Instant.parse(str)))
 
-  implicit val encodeByteString: Encoder[ByteString] =
-    Encoder.instance(bs => Json.fromString(Base64.getEncoder.encodeToString(bs.toByteArray)))
+  implicit val encodePath: Encoder[Path] =
+    Encoder.instance(p => Json.fromString(p.toString))
 
-  implicit val decodeByteString: Decoder[ByteString] =
-    Decoder.decodeString.emap { str =>
-      Try(ByteString.copyFrom(Base64.getDecoder.decode(str))).toEither.leftMap(t =>
-        s"Failed to decode Base64 ByteString: ${t.getMessage}"
-      )
-    }
+  implicit val decodePath: Decoder[Path] =
+    Decoder.decodeString.emap { str => Right(Paths.get(str)) }
 
   implicit val encoder: Encoder[LsuState] = deriveEncoder[LsuState]
   implicit val decoder: Decoder[LsuState] = deriveDecoder[LsuState]

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuStateExporter.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuStateExporter.scala
@@ -12,9 +12,11 @@ import org.lfdecentralizedtrust.splice.environment.{
 }
 import org.lfdecentralizedtrust.splice.identities.NodeIdentitiesStore
 
+import java.nio.file.Path
 import scala.concurrent.{ExecutionContext, Future}
 
 class LsuStateExporter(
+    lsuStatePath: Path,
     sequencerAdminConnection: SequencerAdminConnection,
     mediatorAdminConnection: MediatorAdminConnection,
     val loggerFactory: NamedLoggerFactory,
@@ -29,7 +31,7 @@ class LsuStateExporter(
   def exportLSUState(upgradesAt: CantonTimestamp)(implicit tc: TraceContext): Future[LsuState] = {
     logger.info(s"Exporting LSU state for upgrade at $upgradesAt")
     for {
-      lsuState <- sequencerAdminConnection.getLsuState()
+      _ <- sequencerAdminConnection.getLsuState(lsuStatePath)
       sequencerIdentityDump <- sequencerIdentityStore.getNodeIdentitiesDump()
       mediatorIdentityDump <- mediatorIdentityStore.getNodeIdentitiesDump()
     } yield {
@@ -39,7 +41,7 @@ class LsuStateExporter(
           sequencerIdentityDump,
           mediatorIdentityDump,
         ),
-        lsuState,
+        lsuStatePath,
       )
     }
 

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/admin/api/client/commands/SequencerAdminCommands.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/admin/api/client/commands/SequencerAdminCommands.scala
@@ -33,6 +33,7 @@ import io.grpc.Context.CancellableContext
 import io.grpc.stub.StreamObserver
 import io.grpc.{Context, ManagedChannel}
 
+import java.io.InputStream
 import scala.concurrent.Future
 
 object SequencerAdminCommands {
@@ -251,7 +252,7 @@ object SequencerAdminCommands {
   }
 
   final case class InitializeFromLsuPredecessor(
-      topologySnapshot: ByteString,
+      topologySnapshotStream: InputStream,
       synchronizerParameters: com.digitalasset.canton.protocol.StaticSynchronizerParameters,
   ) extends GrpcAdminCommand[
         proto.InitializeSequencerFromLsuPredecessorRequest,
@@ -272,20 +273,26 @@ object SequencerAdminCommands {
     ): Future[proto.InitializeSequencerFromLsuPredecessorResponse] =
       GrpcStreamingUtils.streamToServer(
         service.initializeSequencerFromLsuPredecessor,
-        (topologySnapshot: Array[Byte]) =>
-          proto.InitializeSequencerFromLsuPredecessorRequest(
-            topologySnapshot = ByteString.copyFrom(topologySnapshot),
-            synchronizerParameters = Some(synchronizerParameters.toProtoV30),
-          ),
-        request.topologySnapshot,
+        _ => {
+          GrpcStreamingUtils.readChunkBytes(topologySnapshotStream) match {
+            case Array() => None
+            case bytes =>
+              val request = proto.InitializeSequencerFromLsuPredecessorRequest(
+                topologySnapshot = ByteString.copyFrom(bytes),
+                synchronizerParameters = Some(synchronizerParameters.toProtoV30),
+              )
+              Some(Right(request))
+          }
+        },
       )
 
     override protected def createRequest()
         : Either[String, proto.InitializeSequencerFromLsuPredecessorRequest] =
       Right(
+        // Unused, since we construct requests when streaming
         proto.InitializeSequencerFromLsuPredecessorRequest(
-          topologySnapshot = topologySnapshot,
-          synchronizerParameters = Some(synchronizerParameters.toProtoV30),
+          topologySnapshot = ByteString.EMPTY,
+          synchronizerParameters = None,
         )
       )
 

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/HealthAdministration.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/HealthAdministration.scala
@@ -30,7 +30,7 @@ import com.digitalasset.canton.console.{
   Help,
   Helpful,
 }
-import com.digitalasset.canton.grpc.FileStreamObserver
+import com.digitalasset.canton.grpc.OutputFileStreamObserver
 import com.digitalasset.canton.logging.NamedLogging
 import com.digitalasset.canton.tracing.TraceContext
 import io.grpc.Context
@@ -87,7 +87,7 @@ abstract class HealthAdministration[S <: NodeStatus.Status](
   ): String = consoleEnvironment.run {
     val file = File(outputFile)
     val responseObserver =
-      new FileStreamObserver[v30.HealthDumpResponse](file, _.chunk)
+      new OutputFileStreamObserver[v30.HealthDumpResponse](file, _.chunk)
 
     def call: ConsoleCommandResult[Context.CancellableContext] =
       adminCommand(new StatusAdminCommands.GetHealthDump(responseObserver, chunkSize))

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/ParticipantRepairAdministration.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/ParticipantRepairAdministration.scala
@@ -23,7 +23,7 @@ import com.digitalasset.canton.console.{
   Helpful,
 }
 import com.digitalasset.canton.data.CantonTimestamp
-import com.digitalasset.canton.grpc.FileStreamObserver
+import com.digitalasset.canton.grpc.OutputFileStreamObserver
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.participant.admin.data.{
   ActiveContractOld,
@@ -218,7 +218,7 @@ class ParticipantRepairAdministration(
     check(FeatureFlag.Repair) {
       consoleEnvironment.run {
         val file = File(outputFile)
-        val responseObserver = new FileStreamObserver[ExportAcsOldResponse](file, _.chunk)
+        val responseObserver = new OutputFileStreamObserver[ExportAcsOldResponse](file, _.chunk)
 
         def call: ConsoleCommandResult[Context.CancellableContext] =
           runner.adminCommand(
@@ -307,7 +307,7 @@ class ParticipantRepairAdministration(
   ): Unit =
     consoleEnvironment.run {
       val file = File(exportFilePath)
-      val responseObserver = new FileStreamObserver[ExportAcsResponse](file, _.chunk)
+      val responseObserver = new OutputFileStreamObserver[ExportAcsResponse](file, _.chunk)
 
       def call: ConsoleCommandResult[Context.CancellableContext] =
         runner.adminCommand(

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/PartiesAdministration.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/PartiesAdministration.scala
@@ -31,7 +31,7 @@ import com.digitalasset.canton.console.{
   ParticipantReference,
 }
 import com.digitalasset.canton.discard.Implicits.DiscardOps
-import com.digitalasset.canton.grpc.FileStreamObserver
+import com.digitalasset.canton.grpc.OutputFileStreamObserver
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.participant.admin.data.{
   ContractImportMode,
@@ -747,7 +747,7 @@ class ParticipantPartiesAdministrationGroup(
   ): Unit =
     consoleEnvironment.run {
       val file = File(exportFilePath)
-      val responseObserver = new FileStreamObserver[ExportPartyAcsResponse](file, _.chunk)
+      val responseObserver = new OutputFileStreamObserver[ExportPartyAcsResponse](file, _.chunk)
 
       def call: ConsoleCommandResult[Context.CancellableContext] =
         reference.adminCommand(

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/SequencerAdministration.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/SequencerAdministration.scala
@@ -36,6 +36,7 @@ import com.digitalasset.canton.synchronizer.sequencer.admin.grpc.InitializeSeque
 import com.digitalasset.canton.topology.SequencerId
 import com.google.protobuf.ByteString
 
+import java.io.BufferedInputStream
 import scala.concurrent.ExecutionContext
 
 class SequencerAdministration(node: SequencerReference) extends ConsoleCommandGroup.Impl(node) {
@@ -172,10 +173,10 @@ class SequencerAdministration(node: SequencerReference) extends ConsoleCommandGr
   }
 
   @Help.Summary(
-    "Initialize a sequencer for the logical upgrade from the state of its predecessor"
+    "Initialize a sequencer for the logical upgrade from the state of its predecessor, streaming the state from a file"
   )
   def initialize_from_lsu_predecessor(
-      predecessorState: ByteString,
+      inputFile: String,
       synchronizerParameters: StaticSynchronizerParameters,
       waitForReady: Boolean = true,
   ): Unit = {
@@ -184,7 +185,9 @@ class SequencerAdministration(node: SequencerReference) extends ConsoleCommandGr
     consoleEnvironment.run {
       runner.adminCommand(
         InitializeFromLsuPredecessor(
-          predecessorState,
+          new BufferedInputStream(
+            new java.io.FileInputStream(inputFile)
+          ),
           synchronizerParameters.toInternal,
         )
       )

--- a/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/TopologyAdministrationGroup.scala
+++ b/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/commands/TopologyAdministrationGroup.scala
@@ -39,7 +39,7 @@ import com.digitalasset.canton.crypto.*
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.error.CantonError
-import com.digitalasset.canton.grpc.ByteStringStreamObserver
+import com.digitalasset.canton.grpc.{ByteStringStreamObserver, OutputFileStreamObserver}
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.topology.*
 import com.digitalasset.canton.topology.admin.grpc.{BaseQuery, TopologyStoreId}
@@ -767,7 +767,7 @@ class TopologyAdministrationGroup(
       }
 
     @Help.Summary(
-      "Download the topology upgrade state for a sequencer (intended for logical synchronizer upgrade)"
+      "Stream the topology upgrade state for a sequencer (intended for logical synchronizer upgrade) to a file"
     )
     @Help.Description(
       """Download the topology snapshot which includes the entire history of topology transactions
@@ -782,22 +782,26 @@ class TopologyAdministrationGroup(
         """
     )
     def sequencer_lsu_state(
+        outputFile: String,
         topologyStore: Option[TopologyStoreId.Synchronizer] = None,
         timeout: NonNegativeDuration = timeouts.unbounded,
-    ): ByteString =
+    ): Unit =
       consoleEnvironment.run {
-        val responseObserver = new ByteStringStreamObserver[SequencerLsuStateResponse](_.chunk)
+        val fileStreamObserver = new OutputFileStreamObserver[SequencerLsuStateResponse](
+          better.files.File(outputFile),
+          _.chunk,
+        )
 
         def call: ConsoleCommandResult[Context.CancellableContext] =
           adminCommand(
-            TopologyAdminCommands.Read.SequencerLsuState(topologyStore, responseObserver)
+            TopologyAdminCommands.Read.SequencerLsuState(topologyStore, fileStreamObserver)
           )
 
         processResult(
           call,
-          responseObserver.resultBytes,
+          fileStreamObserver.result,
           timeout,
-          "Downloading the genesis state for logical upgrade",
+          "Downloading the genesis state for logical upgrade to a file",
         )
       }
 

--- a/canton/community/app/src/test/scala/com/digitalasset/canton/integration/tests/upgrade/lsu/LsuTopologyExportImportIntegrationTest.scala
+++ b/canton/community/app/src/test/scala/com/digitalasset/canton/integration/tests/upgrade/lsu/LsuTopologyExportImportIntegrationTest.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.canton.integration.tests.upgrade.lsu
 
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
-import com.digitalasset.canton.console.{CommandFailure, InstanceReference}
+import com.digitalasset.canton.console.{CommandFailure, InstanceReference, LocalInstanceReference}
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.integration.*
 import com.digitalasset.canton.integration.EnvironmentDefinition.S1M1

--- a/canton/community/base/src/main/scala/com/digitalasset/canton/grpc/OutputFileStreamObserver.scala
+++ b/canton/community/base/src/main/scala/com/digitalasset/canton/grpc/OutputFileStreamObserver.scala
@@ -12,11 +12,14 @@ import io.grpc.stub.StreamObserver
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
-class FileStreamObserver[T](
-    inputFile: File,
+/** A StreamObserver that writes incoming elements to a file, using a provided converter to convert
+  * the elements to bytes.
+  */
+class OutputFileStreamObserver[T](
+    outputFile: File,
     converter: T => ByteString,
 ) extends StreamObserver[T] {
-  private val os = inputFile.newFileOutputStream(append = false)
+  private val os = outputFile.newFileOutputStream(append = false)
   private val requestComplete: Promise[Unit] = Promise[Unit]()
 
   def result: Future[Unit] = requestComplete.future

--- a/canton/community/common/src/main/scala/com/digitalasset/canton/util/GrpcStreamingUtils.scala
+++ b/canton/community/common/src/main/scala/com/digitalasset/canton/util/GrpcStreamingUtils.scala
@@ -46,6 +46,15 @@ object GrpcStreamingUtils {
   private final val defaultChunkSize: Int =
     1024 * 1024 * 2 // 2MB - This is half of the default max message size of gRPC
 
+  /** A blocking method that waits for a chunk of bytes from the input stream, or the end of the
+    * stream.
+    * @return
+    *   an array of bytes read from the input stream (with at most `chunkSize` bytes), or an empty
+    *   array if the end of the stream has been reached.
+    */
+  def readChunkBytes(inputStream: InputStream, chunkSize: Int = defaultChunkSize): Array[Byte] =
+    inputStream.readNBytes(chunkSize)
+
   def streamFromClient[Req, Resp, C](
       extractChunkBytes: Req => ByteString,
       extractContext: Req => C,


### PR DESCRIPTION
[ci]

fixes #4302

Ended up going for using a file as an intermediate. Seems less of a hassle with no huge downside.

I repurposed the HDM field as we already have that set anyway and setting another one doesn't seem very helpful.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
