### PR TITLE
0.5.16 backport: Allow per-SV cloudSql configuration for apps-pg databases (#4578)

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -87,6 +87,9 @@ pulumiProjectConfig:
     hasPublicInfo: true
     cloudSql:
       enabled: true
+  sv-runbook:
+    cloudSql:
+      enabled: true
 monitoring:
   alerting:
     enableNoDataAlerts: true
@@ -129,6 +132,10 @@ loadTester:
     windowDurationMinutes: 150
 svs:
   default:
+    appsPg:
+      cloudSql:
+        enabled: true
+        tier: "apps-pg-override-tier"
     pruning:
       cometbft:
         retainBlocks: 5040000
@@ -205,6 +212,9 @@ svs:
     participant:
       bftSequencerConnection: false
   sv-1:
+    appsPg:
+      cloudSql:
+        tier: "apps-pg-override-tier-sv-1"
     periodicSnapshots:
       topology:
         projectId: 'da-cn-test'

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2514,7 +2514,7 @@
           "day": 2,
           "hour": 8
         },
-        "tier": "db-custom-2-7680",
+        "tier": "apps-pg-override-tier-sv-1",
         "userLabels": {
           "cluster": "mock"
         }
@@ -3455,7 +3455,7 @@
           "day": 2,
           "hour": 8
         },
-        "tier": "db-custom-2-7680",
+        "tier": "apps-pg-override-tier",
         "userLabels": {
           "cluster": "mock"
         }

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -580,7 +580,6 @@
         },
         "participantAddress": "participant-3",
         "persistence": {
-          "host": "apps-pg.sv.svc.cluster.local",
           "postgresName": "apps-pg",
           "secretName": "apps-pg-secret"
         },
@@ -1358,70 +1357,57 @@
     "inputs": {},
     "name": "sv-apps-pg",
     "provider": "",
-    "type": "canton:network:postgres"
+    "type": "canton:cloud:postgres"
   },
   {
     "custom": true,
     "id": "",
     "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "apps-pg",
-      "namespace": "sv",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
+      "databaseVersion": "POSTGRES_14",
+      "deletionProtection": false,
+      "region": "europe-west6",
+      "settings": {
+        "activationPolicy": "ALWAYS",
+        "backupConfiguration": {
+          "enabled": true,
+          "pointInTimeRecoveryEnabled": true
         },
-        "cluster": {
-          "dnsName": "mock.global.canton.network.digitalasset.com",
-          "fixedTokens": false,
-          "hostname": "mock.global.canton.network.digitalasset.com",
-          "name": "cn-mocknet"
-        },
-        "db": {
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "48Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "apps-pg-secret"
-        },
-        "tolerations": [
+        "databaseFlags": [
           {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
+            "name": "random_page_cost",
+            "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
           }
-        ]
-      },
-      "version": "0.3.20"
+        ],
+        "deletionProtectionEnabled": false,
+        "edition": "ENTERPRISE",
+        "insightsConfig": {
+          "queryInsightsEnabled": true
+        },
+        "ipConfiguration": {
+          "enablePrivatePathForGoogleCloudServices": true,
+          "ipv4Enabled": false,
+          "privateNetwork": "projects/test-project/global/networks/default"
+        },
+        "locationPreference": {
+          "zone": "europe-west6-a"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "tier": "apps-pg-override-tier",
+        "userLabels": {
+          "cluster": "mock"
+        }
+      }
     },
     "name": "sv-apps-pg",
     "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
+    "type": "gcp:sql/databaseInstance:DatabaseInstance"
   },
   {
     "custom": true,
@@ -1561,7 +1547,6 @@
         "participantAddress": "participant-3",
         "permissionedSynchronizer": false,
         "persistence": {
-          "host": "apps-pg.sv.svc.cluster.local",
           "postgresName": "apps-pg",
           "secretName": "apps-pg-secret"
         },
@@ -1603,6 +1588,16 @@
     "name": "sv-app",
     "provider": "",
     "type": "kubernetes:helm.sh/v3:Release"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cantonnet"
+    },
+    "name": "sv-db-apps-pg-cantonnet",
+    "provider": "",
+    "type": "gcp:sql/database:Database"
   },
   {
     "custom": true,
@@ -1820,6 +1815,20 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "name": "cnadmin",
+      "password": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": null
+      }
+    },
+    "name": "user-sv-apps-pg",
+    "provider": "",
+    "type": "gcp:sql/user:User"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
       "maxHistory": 10,
@@ -1900,7 +1909,6 @@
           "retention": "30d"
         },
         "persistence": {
-          "host": "apps-pg.sv.svc.cluster.local",
           "postgresName": "apps-pg",
           "secretName": "apps-pg-secret"
         },

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -245,7 +245,7 @@ export async function installSvNode(
       `cn-apps-pg`,
       `cn-apps-pg`,
       config.version,
-      spliceConfig.pulumiProjectConfig.cloudSql,
+      svConfig.appsPg?.cloudSql ?? spliceConfig.pulumiProjectConfig.cloudSql,
       true,
       {
         logicalDecoding: !!baseConfig.scanBigQuery,

--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -80,6 +80,11 @@ const Auth0ConfigSchema = z
     clientId: z.string().optional(),
   })
   .strict();
+const AppsPgConfigSchema = z
+  .object({
+    cloudSql: CloudSqlWithOverrideConfigSchema,
+  })
+  .strict();
 const SvAppConfigSchema = z
   .object({
     additionalEnvVars: z.array(EnvVarConfigSchema).default([]),
@@ -135,6 +140,7 @@ const SingleSvConfigSchema = z
     participant: SvParticipantConfigSchema.optional(),
     sequencer: SvSequencerConfigSchema.optional(),
     mediator: SvMediatorConfigSchema.optional(),
+    appsPg: AppsPgConfigSchema.optional(),
     svApp: SvAppConfigSchema.optional(),
     scanApp: ScanAppConfigSchema.optional(),
     validatorApp: SvValidatorAppConfigSchema.optional(),

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -244,7 +244,14 @@ async function installSvAndValidator(
 
   const canton = installCanton(onboardingName, decentralizedSynchronizerMigrationConfig);
 
-  const appsPg = installPostgres(xns, 'apps-pg', 'apps-pg-secret', 'postgres-values-apps.yaml');
+  const appsPg = installPostgres(
+    xns,
+    'apps-pg',
+    'apps-pg-secret',
+    'postgres-values-apps.yaml',
+    true,
+    svConfig.appsPg?.cloudSql
+  );
 
   const valuesFromYamlFile = loadYamlFromFile(
     `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/sv-values.yaml`,

--- a/cluster/pulumi/sv-runbook/src/postgres.ts
+++ b/cluster/pulumi/sv-runbook/src/postgres.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as _ from 'lodash';
 import {
+  CloudSqlConfig,
   clusterSmallDisk,
   ExactNamespace,
   loadYamlFromFile,
@@ -19,20 +20,14 @@ export function installPostgres(
   name: string,
   secretName: string,
   selfHostedValuesFile: string,
-  isActive: boolean = true
+  isActive: boolean = true,
+  cloudSqlConfigOverride?: CloudSqlConfig
 ): SplicePostgres | CloudPostgres {
-  if (spliceConfig.pulumiProjectConfig.cloudSql.enabled) {
-    return new CloudPostgres(
-      xns,
-      name,
-      name,
-      secretName,
-      spliceConfig.pulumiProjectConfig.cloudSql,
-      isActive,
-      {
-        disableProtection: supportsSvRunbookReset,
-      }
-    );
+  const cloudSqlConfig = cloudSqlConfigOverride ?? spliceConfig.pulumiProjectConfig.cloudSql;
+  if (cloudSqlConfig.enabled) {
+    return new CloudPostgres(xns, name, name, secretName, cloudSqlConfig, isActive, {
+      disableProtection: supportsSvRunbookReset,
+    });
   } else {
     const valuesFromFile = loadYamlFromFile(
       `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/${selfHostedValuesFile}`


### PR DESCRIPTION
Backports https://github.com/hyperledger-labs/splice/pull/4578

See https://github.com/hyperledger-labs/splice/issues/4558

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
