### PR TITLE
[static] skip canton_concistency_check for pr_static_checks (before approved)

### DIFF
--- a/.github/workflows/build.static_tests.yml
+++ b/.github/workflows/build.static_tests.yml
@@ -13,9 +13,15 @@ on:
         type: boolean
         required: false
         default: false
+      oss_only:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   check_canton_consistency:
+    # Skipped for external contributors (fork PRs) due to container registry auth constraints
+    if: ${{ !inputs.oss_only }}
     runs-on: ${{ inputs.self_hosted && 'self-hosted-k8s-x-small' || 'ubuntu-24.04' }}
     timeout-minutes: 15
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
     with:
       commit_sha: ${{ inputs.commit_sha }}
       self_hosted: true
+      oss_only: ${{ inputs.oss_only }}
 
   deployment_test:
     uses: ./.github/workflows/build.deployment_test.yml

--- a/.github/workflows/pr_static_checks.yml
+++ b/.github/workflows/pr_static_checks.yml
@@ -21,3 +21,4 @@ jobs:
       self_hosted: false
       commit_sha: ${{ github.event.pull_request.head.sha }}
       skip_todo_check: true # runs from forks with on: pull_request run in context of the fork, so issue references will be broken
+      oss_only: true


### PR DESCRIPTION
Skipping canton consistency check for non contributor pr
See https://github.com/hyperledger-labs/splice/actions/runs/23448295695/job/68357233067?pr=4569 for a failure

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
