### PR TITLE
[static] Fix race condition in Auth0 cache secret by using replace in…

### DIFF
--- a/cluster/pulumi/common/src/auth0/auth0.ts
+++ b/cluster/pulumi/common/src/auth0/auth0.ts
@@ -158,44 +158,45 @@ export class Auth0Fetch implements Auth0Client {
       data[clientId] = Buffer.from(JSON.stringify(cachedToken)).toString('base64');
     }
 
+    const secretBody = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: this.cfg.fixedTokenCacheName,
+      },
+      data,
+    };
+
     try {
       await pulumi.log.info('Attempting to create secret');
       const k8sApi = this.getK8sClient();
       await k8sApi.createNamespacedSecret({
         namespace: 'default',
-        body: {
-          apiVersion: 'v1',
-          kind: 'Secret',
-          metadata: {
-            name: this.cfg.fixedTokenCacheName,
-          },
-          data,
-        },
+        body: secretBody,
       });
-    } catch (_) {
+    } catch (createErr) {
       try {
-        await pulumi.log.info('Deleting existing secret');
+        // Create failed (e.g., secret already exists), attempt to replace it atomically.
+        await pulumi.log.info('Create failed, attempting to replace existing secret');
         const k8sApi = this.getK8sClient();
-        await k8sApi.deleteNamespacedSecret({
+        await k8sApi.replaceNamespacedSecret({
           name: this.cfg.fixedTokenCacheName,
           namespace: 'default',
+          body: secretBody,
         });
-
-        await pulumi.log.info('Creating new secret');
-        await k8sApi.createNamespacedSecret({
-          namespace: 'default',
-          body: {
-            apiVersion: 'v1',
-            kind: 'Secret',
-            metadata: {
-              name: this.cfg.fixedTokenCacheName,
-            },
-            data,
-          },
-        });
-      } catch (e) {
-        await pulumi.log.error(`Auth0 cache update failed: ${JSON.stringify(e)}`);
-        process.exit(1);
+      } catch (replaceErr) {
+        try {
+          // Replace also failed (e.g., secret was deleted concurrently), try create again.
+          await pulumi.log.info('Replace failed, attempting to create secret again');
+          const k8sApi = this.getK8sClient();
+          await k8sApi.createNamespacedSecret({
+            namespace: 'default',
+            body: secretBody,
+          });
+        } catch (e) {
+          await pulumi.log.error(`Auth0 cache update failed: ${JSON.stringify(e)}`);
+          process.exit(1);
+        }
       }
     }
 


### PR DESCRIPTION
…stead of delete+create

Maybe this fixes https://github.com/DACH-NY/cn-test-failures/issues/7726

From 'robotic input' so please check.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
