### PR TITLE
[ci] Fix race condition in Auth0 cache secret per project.

### DIFF
--- a/cluster/pulumi/common/src/auth0/auth0.ts
+++ b/cluster/pulumi/common/src/auth0/auth0.ts
@@ -107,6 +107,12 @@ export class Auth0Fetch implements Auth0Client {
     return kc.makeApiClient(CoreV1Api);
   }
 
+  // Each Pulumi stack gets its own cache secret to avoid concurrent write races
+  // when multiple stacks (e.g., validator1, splitwell) run in parallel.
+  private get cacheSecretName(): string {
+    return `${this.cfg.fixedTokenCacheName}-${pulumi.getProject()}-${pulumi.getStack()}`;
+  }
+
   public async loadAuth0Cache(): Promise<void> {
     if (!fixedTokens()) {
       await pulumi.log.debug('Fixed tokens not enabled, skipping Auth0 cache load');
@@ -120,7 +126,7 @@ export class Auth0Fetch implements Auth0Client {
     try {
       const k8sApi = this.getK8sClient();
       const cacheSecret = await k8sApi.readNamespacedSecret({
-        name: this.cfg.fixedTokenCacheName,
+        name: this.cacheSecretName,
         namespace: 'default',
       });
 
@@ -158,40 +164,35 @@ export class Auth0Fetch implements Auth0Client {
       data[clientId] = Buffer.from(JSON.stringify(cachedToken)).toString('base64');
     }
 
+    const secretBody = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: this.cacheSecretName,
+      },
+      data,
+    };
+
     try {
       await pulumi.log.info('Attempting to create secret');
       const k8sApi = this.getK8sClient();
       await k8sApi.createNamespacedSecret({
         namespace: 'default',
-        body: {
-          apiVersion: 'v1',
-          kind: 'Secret',
-          metadata: {
-            name: this.cfg.fixedTokenCacheName,
-          },
-          data,
-        },
+        body: secretBody,
       });
     } catch (_) {
       try {
         await pulumi.log.info('Deleting existing secret');
         const k8sApi = this.getK8sClient();
         await k8sApi.deleteNamespacedSecret({
-          name: this.cfg.fixedTokenCacheName,
+          name: this.cacheSecretName,
           namespace: 'default',
         });
 
         await pulumi.log.info('Creating new secret');
         await k8sApi.createNamespacedSecret({
           namespace: 'default',
-          body: {
-            apiVersion: 'v1',
-            kind: 'Secret',
-            metadata: {
-              name: this.cfg.fixedTokenCacheName,
-            },
-            data,
-          },
+          body: secretBody,
         });
       } catch (e) {
         await pulumi.log.error(`Auth0 cache update failed: ${JSON.stringify(e)}`);


### PR DESCRIPTION
Creating / deleting auth0 cache secret, per pulumi project. 
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
