### PR TITLE
set zstd compression level for bulk storage

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -41,9 +41,6 @@ final case class BulkStorageConfig(
     updatesPollingInterval: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofSeconds(30),
     // The maximum parallelization for uploading multiple parts of the same object
     maxParallelPartUploads: Int = 4,
-    // zstd compression level
-    // TODO(#3429): remove from here, and move to ScanStorageConfig, this must not be configured per-SV. We put it here for now to experiment with the impact of different compression levels.
-    zstdCompressionLevel: Int = 3,
     s3: Option[S3Config] = None,
 )
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -25,6 +25,7 @@ case class ScanStorageConfig(
     bulkDbReadChunkSize: Int, // Chunk size to read from the DB for copying to bulk storage
     bulkZstdFrameSize: Long, // Size of each zstd frame. In prod, must be >= 5 MB as each frame is written as a part in multi-part upload, which are enforced by most s3 implementations to be >= 5MB each
     bulkMaxFileSize: Long, // Max file size (estimated, may end up being slightly bigger) for bulk storage objects
+    zstdCompressionLevel: Int,
 ) {
   require(
     dbAcsSnapshotPeriodHours > 0 && 24 % dbAcsSnapshotPeriodHours == 0,
@@ -133,5 +134,6 @@ object ScanStorageConfigs {
     bulkDbReadChunkSize = 1000,
     bulkZstdFrameSize = 12L * 1024 * 1024,
     bulkMaxFileSize = 128L * 1024 * 1024,
+    zstdCompressionLevel = 3,
   )
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3ZstdObjects.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/S3ZstdObjects.scala
@@ -38,7 +38,7 @@ class S3ZstdObjects(
       getObjectKey: Int => String
   ): Flow[ByteString, String, NotUsed] =
     Flow[ByteString]
-      .via(ZstdGroupedWeight(appConfig.zstdCompressionLevel, storageConfig.bulkZstdFrameSize))
+      .via(ZstdGroupedWeight(storageConfig.zstdCompressionLevel, storageConfig.bulkZstdFrameSize))
       .via(
         GroupedWeightS3ObjectFlow(
           s3Connection,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerTest.scala
@@ -697,6 +697,7 @@ class AcsSnapshotTriggerTest
     bulkDbReadChunkSize = 1, // ignored in this test
     bulkZstdFrameSize = 0L, // ignored in this test
     bulkMaxFileSize = 0L, // ignored in this test
+    zstdCompressionLevel = 0, // ignored in this test
   )
 
   private def unused0[T]: () => Future[T] = () => fail("This argument should not be used")

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfigTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfigTest.scala
@@ -19,6 +19,7 @@ class ScanStorageConfigTest
           bulkDbReadChunkSize = 1,
           bulkZstdFrameSize = 0L,
           bulkMaxFileSize = 0L,
+          zstdCompressionLevel = 0,
         )
         val prev = cantonTimestamp("2007-12-03T11:30:00.00Z")
         val next = cantonTimestamp("2007-12-03T12:00:00.00Z")
@@ -31,6 +32,7 @@ class ScanStorageConfigTest
           bulkDbReadChunkSize = 1,
           bulkZstdFrameSize = 0L,
           bulkMaxFileSize = 0L,
+          zstdCompressionLevel = 0,
         )
         val prev = cantonTimestamp("2007-12-03T12:00:00.00Z")
         val next = cantonTimestamp("2007-12-03T14:00:00.00Z")
@@ -43,6 +45,7 @@ class ScanStorageConfigTest
           bulkDbReadChunkSize = 1,
           bulkZstdFrameSize = 0L,
           bulkMaxFileSize = 0L,
+          zstdCompressionLevel = 0,
         )
         val prev = cantonTimestamp("2007-12-03T21:00:00.00Z")
         val next = cantonTimestamp("2007-12-04T00:00:00.00Z")

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
@@ -69,6 +69,7 @@ class AcsSnapshotBulkStorageTest
     bulkDbReadChunkSize = 1000,
     bulkZstdFrameSize = 10000L,
     bulkMaxFileSize = 50000L,
+    zstdCompressionLevel = 3,
   )
   val appConfig = BulkStorageConfig(
     snapshotPollingInterval = NonNegativeFiniteDuration.ofSeconds(5)

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -50,6 +50,7 @@ class UpdateHistoryBulkStorageTest
     bulkDbReadChunkSize = 500,
     bulkZstdFrameSize = 10000L,
     maxFileSize,
+    zstdCompressionLevel = 3,
   )
   val appConfig = BulkStorageConfig(
     updatesPollingInterval = NonNegativeFiniteDuration.ofSeconds(5)


### PR DESCRIPTION
experiments on cilr show ~0.5% difference in size between zstd compression level 3 & 9, so going with the standard default of 3.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
