### PR TITLE
add placeholder backport workflows to enable testing from a branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,45 @@
+name: Backport a commit or PR across branches
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'A commit SHA to backport (either commit_sha or pr_number must be provided)'
+        required: false
+        type: string
+      pr_number:
+        description: 'A merged PR to backport (either commit_sha or pr_number must be provided)'
+        required: false
+        type: number
+      base_branch:
+        description: 'The branch to backport to'
+        required: true
+        type: string
+      reviewer:
+        description: 'The GitHub username of a reviewer to request a review from (currently supports only one reviewer)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: 'A commit SHA to backport (either commit_sha or pr_number must be provided)'
+        required: false
+        type: string
+      pr_number:
+        description: 'A merged PR to backport (either commit_sha or pr_number must be provided)'
+        required: false
+        type: number
+      base_branch:
+        description: 'The branch to backport to'
+        required: true
+        type: string
+      reviewer:
+        description: 'The GitHub username of a reviewer to request a review from (currently supports only one reviewer)'
+        required: false
+        type: string
+
+jobs:
+  dummy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dummy step
+        run: echo 'Hello, world!'

--- a/.github/workflows/backport_reminder.yml
+++ b/.github/workflows/backport_reminder.yml
@@ -1,0 +1,20 @@
+name: Remind to backport PRs to release branches
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+  # pull_request:
+  #   types: [opened, reopened]
+  #   paths:
+  #     - cluster/deployment/**
+  #     - cluster/configs/**
+  #     - '**/expected.json'
+
+jobs:
+  dummy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dummy step
+        run: echo 'Hello, world!'

--- a/.github/workflows/do_backports.yml
+++ b/.github/workflows/do_backports.yml
@@ -1,0 +1,19 @@
+
+# On merging a PR, automatically backport it to other branches as requested in a comment on that PR
+
+name: Auto-backport PRs to release branches
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+  # pull_request:
+  #   types: [closed]
+
+jobs:
+  dummy:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dummy step
+        run: echo 'Hello, world!'


### PR DESCRIPTION
GHA allows running a workflow from a branch only if it's properly defined on main.