### PR TITLE
[ci] Fix flaky DevelopmentFundCouponIntegrationTest history assertions

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DevelopmentFundCouponIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DevelopmentFundCouponIntegrationTest.scala
@@ -399,19 +399,21 @@ class DevelopmentFundCouponIntegrationTest
     }
 
     clue("Collected coupon is listed in listDevelopmentFundCouponHistory as claimed") {
-      val expectedStatus = httpDef.ArchivedDevelopmentFundCoupon.Status.Claimed -> None
-      // As the fund manager, Alice can view the claimed coupon
-      assertListDevelopmentFundCouponHistoryStatuses(
-        aliceValidatorWalletClient,
-        beneficiary,
-        Seq(expectedStatus),
-      )
-      // As the beneficiary, Bob can view the claimed coupon
-      assertListDevelopmentFundCouponHistoryStatuses(
-        bobWalletClient,
-        beneficiary,
-        Seq(expectedStatus),
-      )
+      eventually() {
+        val expectedStatus = httpDef.ArchivedDevelopmentFundCoupon.Status.Claimed -> None
+        // As the fund manager, Alice can view the claimed coupon
+        assertListDevelopmentFundCouponHistoryStatuses(
+          aliceValidatorWalletClient,
+          beneficiary,
+          Seq(expectedStatus),
+        )
+        // As the beneficiary, Bob can view the claimed coupon
+        assertListDevelopmentFundCouponHistoryStatuses(
+          bobWalletClient,
+          beneficiary,
+          Seq(expectedStatus),
+        )
+      }
     }
 
     clue("Claimed development fund coupon is included in the transaction history") {
@@ -520,19 +522,21 @@ class DevelopmentFundCouponIntegrationTest
       }
 
       clue("The expired coupon is listed in listDevelopmentFundCouponHistory as expired") {
-        val expectedStatus = httpDef.ArchivedDevelopmentFundCoupon.Status.Expired -> None
-        // As the fund manager, Alice can view the expired coupon
-        assertListDevelopmentFundCouponHistoryStatuses(
-          aliceValidatorWalletClient,
-          beneficiary,
-          Seq(expectedStatus),
-        )
-        // As the beneficiary, Bob can view the expired coupon
-        assertListDevelopmentFundCouponHistoryStatuses(
-          bobWalletClient,
-          beneficiary,
-          Seq(expectedStatus),
-        )
+        eventually() {
+          val expectedStatus = httpDef.ArchivedDevelopmentFundCoupon.Status.Expired -> None
+          // As the fund manager, Alice can view the expired coupon
+          assertListDevelopmentFundCouponHistoryStatuses(
+            aliceValidatorWalletClient,
+            beneficiary,
+            Seq(expectedStatus),
+          )
+          // As the beneficiary, Bob can view the expired coupon
+          assertListDevelopmentFundCouponHistoryStatuses(
+            bobWalletClient,
+            beneficiary,
+            Seq(expectedStatus),
+          )
+        }
       }
     }
   }
@@ -614,32 +618,31 @@ class DevelopmentFundCouponIntegrationTest
           )
         },
       )(
-        "The coupon is archived and the total unclaimed development fund coupon amount increases",
+        "The coupon is archived, the total unclaimed development fund coupon amount increases, " +
+          "and the archived coupon is listed in listDevelopmentFundCouponHistory as rejected",
         _ => {
           aliceValidatorWalletClient
             .listActiveDevelopmentFundCoupons() shouldBe empty withClue "alice coupons"
           getUnclaimedDevelopmentFundCouponTotal(
             sv1ValidatorBackend
           ) shouldBe (unclaimedDevelopmentFundCouponTotalBeforeRejection + developmentFundCouponAmount)
+
+          val expectedStatus =
+            httpDef.ArchivedDevelopmentFundCoupon.Status.Rejected -> Some(rejectionReason)
+          // As the fund manager, Alice can view the rejected coupon
+          assertListDevelopmentFundCouponHistoryStatuses(
+            aliceValidatorWalletClient,
+            beneficiary,
+            Seq(expectedStatus),
+          )
+          // As the beneficiary, Bob can view the rejected coupon
+          assertListDevelopmentFundCouponHistoryStatuses(
+            bobWalletClient,
+            beneficiary,
+            Seq(expectedStatus),
+          )
         },
       )
-
-      clue("The rejected coupon is listed in listDevelopmentFundCouponHistory as rejected") {
-        val expectedStatus =
-          httpDef.ArchivedDevelopmentFundCoupon.Status.Rejected -> Some(rejectionReason)
-        // As the fund manager, Alice can view the rejected coupon
-        assertListDevelopmentFundCouponHistoryStatuses(
-          aliceValidatorWalletClient,
-          beneficiary,
-          Seq(expectedStatus),
-        )
-        // As the beneficiary, Bob can view the rejected coupon
-        assertListDevelopmentFundCouponHistoryStatuses(
-          bobWalletClient,
-          beneficiary,
-          Seq(expectedStatus),
-        )
-      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7729

Three test cases in DevelopmentFundCouponIntegrationTest assert on
listDevelopmentFundCouponHistory in bare `clue` blocks without retry
logic, but the history data comes from the async tx log ingestion
pipeline. Different wallet stores process ledger events at different
speeds, so Bob's wallet tx log may not have finished ingesting the
rejection/claim/expiry event by the time the assertion runs.

The "Withdrawing" test already had the correct pattern: it places its
history assertions inside the `actAndCheck` check function, which
retries via `eventually()`. The other three tests did not.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
