### PR TITLE
[static] Update of release notes for 0.5.17

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -29,27 +29,34 @@
 
     - SV and Validator app
 
-    - Going forward unusable splice DARs will be automatically unvetted by the super validators.
-      This will be used for DARs that can already not be used,
-      e.g., because a downgrade of AmuletRules to that version is not possible so it does not force more aggressive upgrades for validators or app devs.
+        - Going forward unusable splice DARs will be automatically unvetted by the super validators.
+          This will be used for DARs that can already not be used,
+          e.g., because a downgrade of AmuletRules to that version is not possible so it does not force more aggressive upgrades for validators or app devs.
 
-      The minimum supported versions are:
+          The minimum supported versions are:
 
-         ================== =======
-         name               version
-         ================== =======
-         amulet             0.1.14
-         amuletNameService  0.1.14
-         dsoGovernance      0.1.19
-         validatorLifecycle 0.1.5
-         wallet             0.1.14
-         walletPayments     0.1.14
-         ================== =======
+             ================== =======
+             name               version
+             ================== =======
+             amulet             0.1.14
+             amuletNameService  0.1.14
+             dsoGovernance      0.1.19
+             validatorLifecycle 0.1.5
+             wallet             0.1.14
+             walletPayments     0.1.14
+             ================== =======
 
     - Scan
 
        - Added a new ``/v1/domains/{domain_id}/parties/{party_id}/participant-id`` endpoint that returns all participant IDs hosting a given party,
          supporting parties hosted on multiple participants. The previous ``/v0`` endpoint only supported single-participant hosting.
+
+       - Added an optional ``external_transaction_hash`` field to the response of ``GET /v1/updates/{update-id}``, ``GET /v2/updates/{update-id}``,  GET ``/v1/updates``, and GET ``/v2/updates`` endpoints. While currently not set, this field will eventually include the transaction hashes signed by external parties.
+
+       - **Experimental**: Added an optional ``app_activity_records`` field to the response of ``GET /v0/events/{update-id}`` and ``POST /v0/events`` endpoints. This is currently never set but will eventually include traffic summaries and app activity records are included alongside verdicts in event history items.
+         This is part of the CIP-104 preview and is subject to change.
+         App activity record computation will be enabled step-by-step on Dev/Test/MainNet,
+         once the SVs have successfully concluded their performance testing.
 
     - SV UI
 
@@ -61,14 +68,6 @@
          synchronizer is active. To enable the second synchronizer called ``app-synchronizer``, start LocalNet with the ``multi-sync`` Docker
          Compose profile (``--profile multi-sync``). The ``app-provider`` and ``app-user`` participant nodes are cross-connected to both
          synchronizers. See :ref:`multi-sync-localnet` for details.
-
-     - Scan
-
-       - **Experimental**: Add an optional ``app_activity_records`` field to the response of ``GET /v0/events/{update-id}`` and ``POST /v0/events`` endpoints. This is currently never set but will eventually include traffic summaries and app activity records are included alongside verdicts in event history items.
-         This is part of the CIP-104 preview and is subject to change.
-
-         App activity record computation will be enabled step-by-step on Dev/Test/MainNet,
-         once the SVs have successfully concluded their performance testing.
 
 .. release-notes:: 0.5.16
 


### PR DESCRIPTION
Also changed indentation for Going forward... since it looked weird, otherwise you get a single bullet with just SV and Validator app above it:
Fix:
<img width="717" height="655" alt="image" src="https://github.com/user-attachments/assets/73be933b-228c-4caa-b4e0-8370b5c0f6ed" />

Before fix:
<img width="761" height="459" alt="image" src="https://github.com/user-attachments/assets/7f2b7a6f-5212-44c7-a36f-d7b3366e6e99" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
