### PR TITLE
start-frontend.sh: wait for direnv to load after 'cd'

### DIFF
--- a/start-frontends.sh
+++ b/start-frontends.sh
@@ -15,7 +15,9 @@ function tmux_cmd() {
   else
     tmux new-window -t "$t" -n "$title"
   fi
-  tmux send-keys -t "$t" "cd $wd" C-m
+  local direnv_ready_event="${tmux_session}-cd-done-${tmux_window}"
+  tmux send-keys -t "$t" "cd $wd && tmux wait-for -S $direnv_ready_event" C-m
+  tmux wait-for "$direnv_ready_event"
   tmux send-keys -t "$t" "$cmd" C-m
   tmux_window=$((tmux_window + 1))
 }
@@ -75,11 +77,9 @@ function start_frontend() {
   local log_file="${LOG_DIR}/npm-${app}-${user}.out"
 
   tmux_cmd "${app}-${user}" "${frontend_dir}" \
-    "trap \"rm -f ${config_file}\" EXIT"
-
-  tmux send-keys -t "${tmux_session}:$((tmux_window - 1))" \
-    "BROWSER=none PORT=$port JSON_API_URL=$JSON_API_URL VITE_SPLICE_CONFIG=\"\$(cat $config_file)\" \
-    npm start 2>&1 | tee -a $log_file" C-m
+    "trap \"rm -f ${config_file}\" EXIT && \
+    BROWSER=none PORT=$port JSON_API_URL=$JSON_API_URL VITE_SPLICE_CONFIG=\"\$(cat $config_file)\" \
+    npm start 2>&1 | tee -a $log_file"
 }
 
 function start_test() {


### PR DESCRIPTION
And combine the trap cms with npm start, such that it waits and doesn't race

start-frontend.sh was failing quite consistently for me as the direnv loading was slow, even adding sleep would not help in making it work properly. 

So hopefully this would make it robust.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
