### PR TITLE
Increase timeout to succeed for first submission after the LSU

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -456,7 +456,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
             0L,
             Some("transfer-command-description"),
           )
-        actAndCheck()(
+        actAndCheck(timeUntilSuccess = 1.minute)(
           "Submit signed TransferCommand creation",
           aliceValidatorBackend.submitTransferPreapprovalSend(
             externalPartyOnboarding.party,


### PR DESCRIPTION
Until traffic is transferred on the new sync and everything's back online it might take a few seconds and the 20s timeout for the triggers to run seems to sometimes be hit.

[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/7792

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
