### PR TITLE
ValidatorPreflightIntegrationTest: wait longer for SV runbook connection

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/ValidatorPreflightIntegrationTest.scala
@@ -614,7 +614,7 @@ class RunbookValidatorPreflightIntegrationTest extends ValidatorPreflightIntegra
   override def checkValidatorIsConnectedToSvRunbook() = "Validator is connected to SV runbook" in {
     implicit env =>
       val sv = sv_client("sv")
-      eventually() {
+      eventually(2.minutes) {
         val dsoInfo = sv.getDsoInfo()
         val nodeState = dsoInfo.svNodeStates.get(dsoInfo.svParty).value.payload
         val domainConfig = nodeState.state.synchronizerNodes.asScala.values.headOption.value


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7711

We actually were waiting for the runbook to be up; but it sometimes also needs a bit longer for its sequencer to become usable.

[static]

(Static checks only because the other thing doesn't run preflights anyway)

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
