### PR TITLE
Fix Helm builds because YAML is fun

### DIFF
--- a/cluster/helm/splice-cometbft/values-template.yaml
+++ b/cluster/helm/splice-cometbft/values-template.yaml
@@ -109,3 +109,4 @@ mempool:
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-domain/values-template.yaml
+++ b/cluster/helm/splice-domain/values-template.yaml
@@ -37,3 +37,4 @@ sequencer:
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-global-domain/values-template.yaml
+++ b/cluster/helm/splice-global-domain/values-template.yaml
@@ -56,3 +56,4 @@ enableAntiAffinity: true
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-load-tester/values-template.yaml
+++ b/cluster/helm/splice-load-tester/values-template.yaml
@@ -22,3 +22,4 @@ resources:
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-participant/values-template.yaml
+++ b/cluster/helm/splice-participant/values-template.yaml
@@ -50,3 +50,4 @@ disableAuth: false
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-party-allocator/values-template.yaml
+++ b/cluster/helm/splice-party-allocator/values-template.yaml
@@ -23,3 +23,4 @@ metrics:
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-scan/values-template.yaml
+++ b/cluster/helm/splice-scan/values-template.yaml
@@ -77,3 +77,4 @@ logLevel: DEBUG
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-splitwell-app/values-template.yaml
+++ b/cluster/helm/splice-splitwell-app/values-template.yaml
@@ -42,3 +42,4 @@ failOnAppVersionMismatch: true
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-splitwell-web-ui/values-template.yaml
+++ b/cluster/helm/splice-splitwell-web-ui/values-template.yaml
@@ -27,3 +27,4 @@ spliceInstanceNames:
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-sv-node/values-template.yaml
+++ b/cluster/helm/splice-sv-node/values-template.yaml
@@ -72,3 +72,4 @@ logLevel: DEBUG
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+

--- a/cluster/helm/splice-validator/values-template.yaml
+++ b/cluster/helm/splice-validator/values-template.yaml
@@ -89,3 +89,4 @@ logLevel: DEBUG
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true
+


### PR DESCRIPTION
[force]

https://github.com/hyperledger-labs/splice/pull/4063/ broke main because

- no trailing newline
- but we rely on that here when we extend the `values.yaml`: https://github.com/hyperledger-labs/splice/blob/7848fb3108c7988de64989070a6ed932fe1dd90b/cluster/helm/local.mk#L63

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
