### PR TITLE
Pin faucet cap=0 test to Splice 0.5.11 Daml versions

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorFaucetCapZeroTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorFaucetCapZeroTimeBasedIntegrationTest.scala
@@ -11,20 +11,42 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.environment.BuildInfo
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
+import org.lfdecentralizedtrust.splice.sv.config.SvOnboardingConfig.InitialPackageConfig
 import org.lfdecentralizedtrust.splice.util.{DisclosedContracts, TimeTestUtil, WalletTestUtil}
 
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
+// TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+@org.lfdecentralizedtrust.splice.util.scalatesttags.NoDamlCompatibilityCheck
 class ValidatorFaucetCapZeroTimeBasedIntegrationTest
     extends IntegrationTestWithIsolatedEnvironment
     with WalletTestUtil
     with TimeTestUtil {
 
+  // Package versions from Splice 0.5.11 — the Daml versions currently deployed on MainNet,
+  // which do not include the Daml-side fix for the division-by-zero bug on cap=0 rounds.
+  // TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+  private val initialPackageConfig = InitialPackageConfig(
+    amuletVersion = "0.1.16",
+    amuletNameServiceVersion = "0.1.17",
+    dsoGovernanceVersion = "0.1.22",
+    validatorLifecycleVersion = "0.1.6",
+    walletVersion = "0.1.17",
+    walletPaymentsVersion = "0.1.16",
+  )
+
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology1SvWithSimTime(this.getClass.getSimpleName)
+      // TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+      .withNoVettedPackages(implicit env => env.validators.local.map(_.participantClient))
       .addConfigTransform((_, config) => ConfigTransforms.withValidatorFaucetCap(0)(config))
+      .addConfigTransform((_, config) =>
+        ConfigTransforms.updateAllSvAppFoundDsoConfigs_(
+          _.copy(initialPackageConfig = initialPackageConfig)
+        )(config)
+      )
 
   "system works with optValidatorFaucetCap=0 and handles stale liveness records" in {
     implicit env =>


### PR DESCRIPTION
[ci]

Part of #3461

Pin ValidatorFaucetCapZeroTimeBasedIntegrationTest to the Daml package versions from Splice 0.5.11 (the versions currently deployed on MainNet) to verify that the Scala-side workaround for the division-by-zero bug works even without the Daml-side fix from #4377.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
