### PR TITLE
[ci] drop null values in bulk storage updates

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -124,7 +124,11 @@ class UpdateHistorySegmentBulkStorage(
         ScanHttpEncodings.V1,
       )
     )
-    val updatesStr = encoded.map(_.asJson.noSpacesSortKeys).mkString("\n") + "\n"
+    /* When we add new fields, we make them optional, and they will be None until a coordinated switching point.
+     * We therefore want to drop null values from the JSON, to avoid emitting a lot of "fieldX: null" in the dumps until the switching point,
+     * otherwise we'll break BFT guarantees when SVs adopt a version with the optional field asynchronously.
+     */
+    val updatesStr = encoded.map(_.asJson.dropNullValues.noSpacesSortKeys).mkString("\n") + "\n"
     val updatesBytes = ByteString(updatesStr.getBytes(StandardCharsets.UTF_8))
     logger.debug(
       s"Read and encoded ${encoded.length} updates from DB, to a bytestring of size ${updatesBytes.length} bytes. Timestamps are ${updates.headOption


### PR DESCRIPTION
Part of #4744 (the bulk storage bullet)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
