### PR TITLE
UnsupportedPackageVettingIntegrationTest: bump vetDars timeout

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnsupportedPackageVettingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnsupportedPackageVettingIntegrationTest.scala
@@ -4,6 +4,11 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.topology.SynchronizerId
+import org.lfdecentralizedtrust.splice.automation.PackageVettingTrigger
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
+  ConfigurableApp,
+  updateAutomationConfig,
+}
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AuthorizedState
 import org.lfdecentralizedtrust.splice.environment.{
   DarResource,
@@ -13,13 +18,28 @@ import org.lfdecentralizedtrust.splice.environment.{
 }
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
+import org.lfdecentralizedtrust.splice.sv.automation.singlesv.SvPackageVettingTrigger
 import org.lfdecentralizedtrust.splice.util.UploadablePackage
+import org.lfdecentralizedtrust.splice.validator.automation.ValidatorPackageVettingTrigger
+import org.scalatest.concurrent.PatienceConfiguration
+
+import scala.concurrent.duration.FiniteDuration
 
 class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology1Sv(this.getClass.getSimpleName)
+      .addConfigTransforms((_, config) =>
+        updateAutomationConfig(ConfigurableApp.Sv)(
+          _.withPausedTrigger[SvPackageVettingTrigger]
+        )(config)
+      )
+      .addConfigTransforms((_, config) =>
+        updateAutomationConfig(ConfigurableApp.Validator)(
+          _.withPausedTrigger[ValidatorPackageVettingTrigger]
+        )(config)
+      )
 
   "Unsupported vetted packages are automatically removed by the package vetting trigger for SV and validator" in {
     implicit env =>
@@ -36,12 +56,14 @@ class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
         synchronizerId,
         unsupportedDarsToVet,
         unsupportedDarsToVet,
+        sv1Backend.dsoAutomation.trigger[SvPackageVettingTrigger],
       )
       test(
         sv1ValidatorBackend.appState.participantAdminConnection,
         synchronizerId,
         unsupportedDarsToVet,
         unsupportedDarsToVet,
+        sv1ValidatorBackend.validatorAutomation.trigger[ValidatorPackageVettingTrigger],
       )
       // See https://github.com/DACH-NY/canton/issues/29834: set darsUnvettedByAutomation when unvetting works on non-sv validators
       test(
@@ -49,6 +71,7 @@ class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
         synchronizerId,
         unsupportedDarsToVet,
         Seq.empty,
+        aliceValidatorBackend.validatorAutomation.trigger[ValidatorPackageVettingTrigger],
       )
   }
 
@@ -57,6 +80,7 @@ class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
       synchronizerId: SynchronizerId,
       unsupportedDarsToVet: Seq[DarResource],
       darsUnvettedByAutomation: Seq[DarResource],
+      vettingTrigger: PackageVettingTrigger,
   ) = {
     val participantId = participantAdminConnection.getParticipantId().futureValue
     val name = participantId.uid.identifier
@@ -70,7 +94,7 @@ class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
           .futureValue
         participantAdminConnection
           .vetDars(synchronizerId, unsupportedDarsToVet, None, None)
-          .futureValue
+          .futureValue(timeout = PatienceConfiguration.Timeout(FiniteDuration(40, "seconds")))
       },
     )(
       s"the unsupported packages are vetted on $name",
@@ -82,6 +106,7 @@ class UnsupportedPackageVettingIntegrationTest extends IntegrationTest {
           .map(_.packageId) should contain allElementsOf unsupportedDarsToVet.map(_.packageId),
     )
     clue(s"the unsupported packages are then removed by the package vetting trigger from $name") {
+      vettingTrigger.resume()
       eventually() {
         participantAdminConnection
           .listVettedPackages(participantId, synchronizerId, AuthorizedState)


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7793

and addresses Martin's comment on manually starting the vetting triggers.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
