### PR TITLE
Transfer traffic in LSU roll forward test

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -624,7 +624,7 @@ class JoiningNodeInitializer(
         if (mediatorTrafficState.extraTrafficLimit != unlimitedTraffic)
           throw Status.FAILED_PRECONDITION
             .withDescription(
-              show"SV mediator $participantId does not have unlimited traffic on synchronizer $synchronizerId"
+              show"SV mediator $mediatorId does not have unlimited traffic on synchronizer $synchronizerId"
             )
             .asRuntimeException()
         ()

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/lsu/RollForwardLsuInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/lsu/RollForwardLsuInitializer.scala
@@ -135,6 +135,8 @@ class RollForwardLsuInitializer(
               // Upgrade time is used to publish the sequencer sucessor which we don't care about for roll-forward LSUs.
               upgradeTime = None,
             )
+            trafficState <- legacyNode.sequencerAdminConnection.getLsuTrafficControlState()
+            _ <- currentNode.sequencerAdminConnection.setLsuTrafficControlState(trafficState)
           } yield ()
         }
       sequencerId <- currentNode.sequencerAdminConnection.getSequencerId


### PR DESCRIPTION
This is still the "happy path" LSU where you don't need to specify any
timestamp.

Will do the manual timestamps next.

Also this still doesn't work due to Canton bugs but it fails later now so don't really see a reason to not merge it.

[ci]

Signed-off-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org>

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
