### PR TITLE
Add  errorCodeIdIgnores in SpliceCircuitBreaker to ignore locked contracts errors

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceCircuitBreaker.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/SpliceCircuitBreaker.scala
@@ -114,7 +114,7 @@ class SpliceCircuitBreaker(
       case ex: StatusRuntimeException =>
         ErrorDetails
           .from(ex)
-          .exists {
+          .collect {
             case ErrorDetails.ErrorInfoDetail(errorCodeId, metadata)
                 if metadata.contains("category") =>
               val categoryIgnored = metadata
@@ -125,6 +125,7 @@ class SpliceCircuitBreaker(
               val codeIgnored = errorCodesToIgnore.exists(_.id == errorCodeId)
               categoryIgnored || codeIgnored
           }
+          .exists(identity)
       case _ => false
     }
   }


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/7809

we don't want it to trip for contention errors such as the locked contracts contentions we get from ExpireRewardCouponsTrigger:
`failed with ABORTED/LOCAL_VERDICT_LOCKED_CONTRACTS(2,77b77d8b): Rejected transaction is referring to locked contracts `

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
