### PR TITLE
Ignore scan UI in SV preflight checks

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/RunbookSvPreflightIntegrationTestBase.scala
@@ -195,7 +195,7 @@ abstract class RunbookSvPreflightIntegrationTestBase
   "The Scan UI is working" in { _ =>
     withFrontEnd("sv") { implicit webDriver =>
       go to scanUrl
-      // TODO(tech-debt): Consider checking something here or just remove that check
+    // TODO(tech-debt): Consider checking something here or just remove that check
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvNonDevNetPreflightintegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/SvNonDevNetPreflightintegrationTest.scala
@@ -88,7 +88,7 @@ abstract class SvNonDevNetPreflightIntegrationTestBase
 
     withFrontEnd("sv") { implicit webDriver =>
       go to scanUrl
-      // TODO(tech-debt): Consider checking something here or just remove that check
+    // TODO(tech-debt): Consider checking something here or just remove that check
     }
   }
 


### PR DESCRIPTION
They are hard broken after https://github.com/hyperledger-labs/splice/pull/4721

Fixes https://github.com/DACH-NY/cn-test-failures/issues/7810

Goal is to fix main quickly; leaving the "what to test instead?" question for later

[static] because the other thing doesn't run preflights

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
