### PR TITLE
Improve perf of makeConsistentAcrossSVs

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
@@ -1591,6 +1591,10 @@ class UpdateHistory(
           .map(EventId.nodeIdFromEventId)
       )
       .toMap
+    val lastDescendantNodes = EventId.lastDescendantNodesFromChildNodeIds(
+      exerciseRows.map(r => EventId.nodeIdFromEventId(r.eventId)),
+      nodesWithChildren,
+    )
     val exerciseEvents = exerciseRows.map { row =>
       val nodeId = EventId.nodeIdFromEventId(row.eventId)
       new ExercisedEvent(
@@ -1614,7 +1618,10 @@ class UpdateHistory(
         /*actingParties = */ row.actingParties.getOrElse(missingStringSeq).asJava,
         /*consuming = */ row.consuming,
         /*lastDescendedNodeId = */ Integer.valueOf(
-          EventId.lastDescendedNodeFromChildNodeIds(nodeId, nodesWithChildren)
+          lastDescendantNodes.getOrElse(
+            nodeId,
+            throw new IllegalStateException(s"Node $nodeId was not in lastDescendantNodes"),
+          )
         ),
         /*exerciseResult = */ ProtobufCodec.deserializeValue(row.result),
         /*implementedInterfaces = */ java.util.Collections.emptyList(),

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/EventId.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/EventId.scala
@@ -3,6 +3,8 @@
 
 package org.lfdecentralizedtrust.splice.util
 
+import scala.collection.mutable
+
 object EventId {
 
   /*
@@ -38,14 +40,31 @@ object EventId {
   }
 
   // TODO(#640) - remove this conversion as it's costly
-  def lastDescendedNodeFromChildNodeIds(
-      nodeId: Int,
+  def lastDescendantNodesFromChildNodeIds(
+      nodeIds: Seq[Int],
       nodesWithChildren: Map[Int, Seq[Int]],
-  ): Int =
-    nodesWithChildren
-      .getOrElse(nodeId, Seq.empty)
-      .maxOption
-      .map(lastChildId => lastDescendedNodeFromChildNodeIds(lastChildId, nodesWithChildren))
-      .getOrElse(nodeId)
+  ): Map[Int, Int] = {
+    // Local cache to store results for any node encountered during traversal
+    val cache = mutable.Map.empty[Int, Int]
+
+    def getOrCompute(id: Int): Int = {
+      // If we've seen this node before, return the cached result
+      cache.getOrElseUpdate(
+        id, {
+          nodesWithChildren.get(id).flatMap(_.maxOption) match {
+            case Some(lastChildId) =>
+              // Recurse to find the descendant of the rightmost child
+              getOrCompute(lastChildId)
+            case None =>
+              // Leaf node: the last descended node is itself
+              id
+          }
+        },
+      )
+    }
+
+    // Process the input list and map each original ID to its last descendant
+    nodeIds.map(id => id -> getOrCompute(id)).toMap
+  }
 
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTestBase.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/UpdateHistoryTestBase.scala
@@ -354,6 +354,12 @@ object UpdateHistoryTestBase {
         nodeId.intValue() -> tree.getChildNodeIds(event).asScala.toSeq.map(_.intValue())
       case (nodeId, _) => nodeId.intValue() -> Seq.empty
     }.toMap
+    val lastDescendantNodes = EventId.lastDescendantNodesFromChildNodeIds(
+      tree.getEventsById.asScala.collect { case (nodeId, _: ExercisedEvent) =>
+        nodeId.intValue()
+      }.toSeq,
+      nodesWithChildren,
+    )
     new Transaction(
       /*updateId = */ tree.getUpdateId,
       /*commandId = */ if (mode == LostInScanApi) { "" }
@@ -363,7 +369,7 @@ object UpdateHistoryTestBase {
       /*workflowId = */ tree.getWorkflowId,
       /*effectiveAt = */ tree.getEffectiveAt,
       /*events = */ tree.getEvents.asScala
-        .map(withoutLostData(nodesWithChildren, _))
+        .map(withoutLostData(lastDescendantNodes, _))
         .asJava,
       /*offset = */ tree.getOffset,
       /*synchronizerId = */ tree.getSynchronizerId,
@@ -377,14 +383,14 @@ object UpdateHistoryTestBase {
   }
 
   private def withoutLostData(
-      nodesWithChildren: Map[Int, Seq[Int]],
+      lastDescendantNodes: Map[Int, Int],
       event: Event,
   ): Event = {
     event match {
       case created: CreatedEvent =>
         withoutLostData(created)
       case exercised: ExercisedEvent =>
-        withoutLostData(nodesWithChildren, exercised)
+        withoutLostData(lastDescendantNodes, exercised)
       case _ => throw new RuntimeException("Invalid event type")
     }
   }
@@ -423,7 +429,7 @@ object UpdateHistoryTestBase {
   }
 
   private def withoutLostData(
-      nodesWithChildren: Map[Int, Seq[Int]],
+      lastDescendantNodes: Map[Int, Int],
       exercised: ExercisedEvent,
   ): ExercisedEvent = {
     new ExercisedEvent(
@@ -442,9 +448,11 @@ object UpdateHistoryTestBase {
       /*choiceArgument = */ exercised.getChoiceArgument,
       /*actingParties = */ exercised.getActingParties,
       /*consuming = */ exercised.isConsuming,
-      /*lastDescendedNodeid = */ EventId.lastDescendedNodeFromChildNodeIds(
+      /*lastDescendedNodeid = */ lastDescendantNodes.getOrElse(
         exercised.getNodeId.intValue(),
-        nodesWithChildren,
+        throw new IllegalStateException(
+          s"Node ${exercised.getNodeId.intValue()} was not in lastDescendantNodes"
+        ),
       ),
       /*exerciseResult = */ exercised.getExerciseResult,
       /*implementedInterfaces = */ exercised.getImplementedInterfaces,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
@@ -258,6 +258,12 @@ sealed trait ScanHttpEncodings {
           EventId.nodeIdFromEventId
         )
     }
+    val lastDescendantNodes = EventId.lastDescendantNodesFromChildNodeIds(
+      http.eventsById.collect { case (eventId, _: httpApi.TreeEvent.members.ExercisedEvent) =>
+        EventId.nodeIdFromEventId(eventId)
+      }.toSeq,
+      nodesWithChildren,
+    )
     TreeUpdateWithMigrationId(
       UpdateHistoryResponse(
         update = ledgerApi.TransactionTreeUpdate(
@@ -269,7 +275,7 @@ sealed trait ScanHttpEncodings {
             http.eventsById
               .map { case (eventId, treeEventHttp) =>
                 Integer.valueOf(EventId.nodeIdFromEventId(eventId)) -> httpToJavaEvent(
-                  nodesWithChildren,
+                  lastDescendantNodes,
                   treeEventHttp,
                 )
               }
@@ -342,12 +348,12 @@ sealed trait ScanHttpEncodings {
     }
 
   private def httpToJavaEvent(
-      nodesWithChildren: Map[Int, Seq[Int]],
+      lastDescendantNodes: Map[Int, Int],
       http: httpApi.TreeEvent,
   ): javaApi.Event = http match {
     case httpApi.TreeEvent.members.CreatedEvent(createdHttp) => httpToJavaCreatedEvent(createdHttp)
     case httpApi.TreeEvent.members.ExercisedEvent(exercisedHttp) =>
-      httpToJavaExercisedEvent(nodesWithChildren, exercisedHttp)
+      httpToJavaExercisedEvent(lastDescendantNodes, exercisedHttp)
   }
 
   def httpToJavaCreatedEvent(http: httpApi.CreatedEvent): javaApi.CreatedEvent = {
@@ -373,7 +379,7 @@ sealed trait ScanHttpEncodings {
   }
 
   private def httpToJavaExercisedEvent(
-      nodesWithChildren: Map[Int, Seq[Int]],
+      lastDescendantNodes: Map[Int, Int],
       http: httpApi.ExercisedEvent,
   ): javaApi.ExercisedEvent = {
     val templateId = parseTemplateId(http.templateId)
@@ -391,9 +397,9 @@ sealed trait ScanHttpEncodings {
       decodeChoiceArgument(templateId, interfaceId, http.choice, http.choiceArgument),
       http.actingParties.asJava,
       http.consuming,
-      EventId.lastDescendedNodeFromChildNodeIds(
+      lastDescendantNodes.getOrElse(
         nodeId,
-        nodesWithChildren,
+        throw new IllegalStateException(s"Node $nodeId was not in lastDescendantNodes"),
       ),
       decodeExerciseResult(templateId, interfaceId, http.choice, http.exerciseResult),
       /*implementedInterfaces = */ java.util.Collections.emptyList(),
@@ -743,7 +749,13 @@ object ScanHttpEncodings {
           .map(_.intValue())
           .map(mapping)
       case (nodeId, _) => mapping(nodeId.intValue()) -> Seq.empty
-    }
+    }.toMap
+    val lastDescendantNodes = EventId.lastDescendantNodesFromChildNodeIds(
+      tree.getEventsById.asScala.collect { case (_, exercised: javaApi.ExercisedEvent) =>
+        mapping(exercised.getNodeId)
+      }.toSeq,
+      nodesWithChildren,
+    )
     val eventsById: Iterable[(Int, javaApi.Event)] = tree.getEventsById.asScala.map {
       case (nodeId, created: javaApi.CreatedEvent) =>
         mapping(nodeId) -> new javaApi.CreatedEvent(
@@ -778,9 +790,9 @@ object ScanHttpEncodings {
           exercised.getChoiceArgument,
           exercised.getActingParties,
           exercised.isConsuming,
-          EventId.lastDescendedNodeFromChildNodeIds(
+          lastDescendantNodes.getOrElse(
             newNodeId,
-            nodesWithChildren.toMap,
+            throw new IllegalStateException(s"Node $nodeId was not in lastDescendantNodes"),
           ),
           exercised.getExerciseResult,
           exercised.getImplementedInterfaces,

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -33,3 +33,6 @@
       - Validators
          - Completely removed
 
+   - Scan
+
+        - Improve CPU usage of update and event history.


### PR DESCRIPTION
Two very low-hanging fruits both of which are quadratic in the worst case and are now linear:

1. The repeated `toMap` calls are replaced by a single one. This showed up in profiles and obviously is kinda bad.
2. `lastDescendantNodes` is now computed with linear complexity once for the full transaction instead of separately for each nodes which can end up being quadratic.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
