### PR TITLE
Wait for stores in verdict ingestion

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/DbTcsStore.scala
@@ -148,20 +148,22 @@ class DbTcsStore(
     earliestArchivedAtCache.get() match {
       case some @ Some(_) => Future.successful(some)
       case None =>
-        val storeId = acsStore.acsStoreId
-        val migrationId = acsStore.domainMigrationId
-        storage
-          .query(
-            sql"""SELECT MIN(archived_at) FROM #$archiveTableName
+        acsStore.waitUntilAcsIngested {
+          val storeId = acsStore.acsStoreId
+          val migrationId = acsStore.domainMigrationId
+          storage
+            .query(
+              sql"""SELECT MIN(archived_at) FROM #$archiveTableName
                   WHERE store_id = $storeId
                     AND migration_id = $migrationId
                """.as[Option[CantonTimestamp]].head,
-            "getEarliestArchivedAt",
-          )
-          .map { tsO =>
-            tsO.foreach(ts => earliestArchivedAtCache.compareAndSet(None, Some(ts)))
-            tsO
-          }
+              "getEarliestArchivedAt",
+            )
+            .map { tsO =>
+              tsO.foreach(ts => earliestArchivedAtCache.compareAndSet(None, Some(ts)))
+              tsO
+            }
+        }
     }
   }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictStoreIngestion.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictStoreIngestion.scala
@@ -72,17 +72,25 @@ class ScanVerdictStoreIngestion(
 
   override protected def source(implicit tc: TraceContext): Source[Seq[v30.Verdict], NotUsed] = {
 
+    // Completes when all stores are ready to serve data.
+    def waitForStores(): Future[Unit] =
+      for {
+        _ <- store.waitUntilInitialized
+        _ <- appActivityComputationO match {
+          case Some(appActivityComputation) => appActivityComputation.waitUntilInitialized
+          case None => Future.unit
+        }
+      } yield ()
+
     def mediatorClientSource
         : Source[Seq[v30.Verdict], (KillSwitch, scala.concurrent.Future[Done])] = {
       val base: Source[Seq[v30.Verdict], NotUsed] =
         Source
-          .future(
-            store.waitUntilInitialized.flatMap(_ =>
-              store
-                .maxVerdictRecordTime(migrationId)
-                .map(_.getOrElse(CantonTimestamp.MinValue))
-            )
-          )
+          .future(waitForStores().flatMap { _ =>
+            store
+              .maxVerdictRecordTime(migrationId)
+              .map(_.getOrElse(CantonTimestamp.MinValue))
+          })
           .map { ts =>
             logger.info(s"Streaming verdicts starting from $ts")
             Some(ts)

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -25,6 +25,8 @@ class AppActivityComputation(
 )(implicit ec: ExecutionContext)
     extends NamedLogging {
 
+  def waitUntilInitialized: Future[Unit] = rewardsReferenceStore.waitUntilInitialized
+
   /** Compute app activity records for a batch of verdicts.
     *
     * Records are returned with verdictRowId = DUMMY_VERDICT_ROW_ID as a placeholder.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -38,6 +38,8 @@ class CachingScanRewardsReferenceStore private[splice] (
 
   override def key: ScanRewardsReferenceStore.Key = store.key
 
+  override def waitUntilInitialized: Future[Unit] = store.waitUntilInitialized
+
   override def lookupActiveOpenMiningRounds(
       recordTimes: Seq[CantonTimestamp]
   )(implicit tc: TraceContext): Future[Map[CantonTimestamp, (Long, CantonTimestamp)]] =

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -31,6 +31,14 @@ trait ScanRewardsReferenceStore extends AppStore {
 
   def key: ScanRewardsReferenceStore.Key
 
+  /** Waits for this store to be initialized.
+    * All other methods on this store will independently wait for initialization
+    * to complete before returning results, this method is useful for cases where
+    * the caller wants to wait for initialization to complete before starting
+    * to use this store.
+    */
+  def waitUntilInitialized: Future[Unit]
+
   /** For a batch of record times, resolve the oldest open mining round at each time.
     * Returns map from record_time to (roundNumber, roundOpensAt).
     * This will wait till the round info could be obtained for record_times

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -64,6 +64,8 @@ class DbScanRewardsReferenceStore(
     )
     with ScanRewardsReferenceStore {
 
+  override def waitUntilInitialized: Future[Unit] = multiDomainAcsStore.waitUntilAcsIngested()
+
   private val tcsStore = new DbTcsStore(
     multiDomainAcsStore,
     descriptor => SynchronizerId.tryFromString(descriptor.key("synchronizerId")),


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7821.

Otherwise we get 
```
java.lang.RuntimeException: Using acsStoreId before it was assigned
```