### PR TITLE
Avoid useless proto conversion

### DIFF
--- a/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/Transaction.java
+++ b/canton/community/bindings-java/src/main/java/com/daml/ledger/javaapi/data/Transaction.java
@@ -120,9 +120,8 @@ public final class Transaction {
                 event ->
                     new Node(
                         event.getNodeId(),
-                        event.toProtoEvent().hasExercised()
-                            ? event.toProtoEvent().getExercised().getLastDescendantNodeId()
-                            : event.getNodeId()))
+                        (event instanceof ExercisedEvent)
+                            ? ((ExercisedEvent) event).getLastDescendantNodeId() : event.getNodeId()))
             .collect(Collectors.toCollection(LinkedList::new));
 
     this.nodesById =


### PR DESCRIPTION
Upstreamed in https://github.com/DACH-NY/canton/pull/31773/changes but on 3.4 we use the version in our fork.

[ci]

Not sure how much it matters but it did show up in a scan stack trace when the node was overloaded.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
