### PR TITLE
[codex] Fix external-party balance round selection

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternallySignedTxsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternallySignedTxsTimeBasedIntegrationTest.scala
@@ -71,10 +71,22 @@ class ExternallySignedTxsTimeBasedIntegrationTest
         aliceValidatorWalletClient.transferPreapprovalSend(onboarding1.party, 100.0, ""),
       )(
         "External party 1 sees the transfer",
-        _ =>
-          aliceValidatorBackend
-            .getExternalPartyBalance(onboarding1.party)
-            .totalUnlockedCoin shouldBe "100.0000000000",
+        _ => {
+          // Reproduce the bug condition: multiple rounds are open while the endpoint summarizes
+          // current ACS holdings. The response must use the latest open round, otherwise fees can
+          // be computed against a round that predates the amulet creation.
+          val activeOpenRounds = sv1ScanBackend
+            .getOpenAndIssuingMiningRounds()
+            ._1
+            .filter(openRound => !openRound.payload.opensAt.isAfter(env.environment.clock.now.toInstant))
+          activeOpenRounds.size should be > 1
+          val latestOpenRound =
+            sv1ScanBackend.getLatestOpenMiningRound(env.environment.clock.now).contract.payload.round.number
+          val balance = aliceValidatorBackend.getExternalPartyBalance(onboarding1.party)
+          balance.totalUnlockedCoin shouldBe "100.0000000000"
+          balance.computedAsOfRound shouldBe latestOpenRound
+          BigDecimal(balance.accumulatedHoldingFeesTotal) should be >= BigDecimal(0)
+        },
       )
 
       // Onboard external party 2

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
@@ -908,34 +908,60 @@ class HttpValidatorAdminHandler(
           openRounds <- scanConnection.getOpenAndIssuingMiningRounds().map(_._1)
           contracts <- getExternalPartyAmulets(partyId)
         } yield {
-          val earliestOpenRound = openRounds
-            .minByOption(_.payload.round.number)
-            .fold(
-              throw Status.NOT_FOUND
-                .withDescription("No open mining round found")
-                .asRuntimeException()
-            )(_.payload.round.number)
-          val amuletsSummary = contracts._1.foldLeft(HoldingsSummary.Empty) { case (acc, amulet) =>
-            acc.addAmulet(amulet.payload, earliestOpenRound)
-          }
-          val summary = contracts._2.foldLeft(amuletsSummary) { case (acc, amulet) =>
-            acc.addLockedAmulet(amulet.payload, earliestOpenRound)
-          }
           v0.ValidatorAdminResource.GetExternalPartyBalanceResponse.OK(
-            definitions.ExternalPartyBalanceResponse(
-              partyId = partyIdStr,
-              totalUnlockedCoin = Codec.encode(summary.totalUnlockedCoin),
-              totalLockedCoin = Codec.encode(summary.totalLockedCoin),
-              totalCoinHoldings = Codec.encode(summary.totalCoinHoldings),
-              accumulatedHoldingFeesUnlocked = Codec.encode(summary.accumulatedHoldingFeesUnlocked),
-              accumulatedHoldingFeesLocked = Codec.encode(summary.accumulatedHoldingFeesLocked),
-              accumulatedHoldingFeesTotal = Codec.encode(summary.accumulatedHoldingFeesTotal),
-              totalAvailableCoin = Codec.encode(summary.totalAvailableCoin),
-              computedAsOfRound = earliestOpenRound,
+            HttpValidatorAdminHandler.buildExternalPartyBalanceResponse(
+              partyIdStr,
+              HttpValidatorAdminHandler.latestExternalPartyBalanceRound(
+                clock.now.toInstant,
+                openRounds.map(_.payload),
+              ),
+              contracts._1.map(_.payload),
+              contracts._2.map(_.payload),
             )
           )
         }
       }
     }
+  }
+}
+
+object HttpValidatorAdminHandler {
+
+  private[http] def latestExternalPartyBalanceRound(
+      now: Instant,
+      openRounds: Seq[org.lfdecentralizedtrust.splice.codegen.java.splice.round.OpenMiningRound],
+  ): Long =
+    openRounds.view
+      .filter(round => !round.opensAt.isAfter(now))
+      .maxByOption(_.round.number)
+      .fold(
+        throw Status.NOT_FOUND
+          .withDescription("No open mining round found")
+          .asRuntimeException()
+      )(_.round.number)
+
+  private[http] def buildExternalPartyBalanceResponse(
+      partyIdStr: String,
+      asOfRound: Long,
+      amulets: Seq[Amulet],
+      lockedAmulets: Seq[LockedAmulet],
+  ): definitions.ExternalPartyBalanceResponse = {
+    val amuletsSummary = amulets.foldLeft(HoldingsSummary.Empty) { case (acc, amulet) =>
+      acc.addAmulet(amulet, asOfRound)
+    }
+    val summary = lockedAmulets.foldLeft(amuletsSummary) { case (acc, amulet) =>
+      acc.addLockedAmulet(amulet, asOfRound)
+    }
+    definitions.ExternalPartyBalanceResponse(
+      partyId = partyIdStr,
+      totalUnlockedCoin = Codec.encode(summary.totalUnlockedCoin),
+      totalLockedCoin = Codec.encode(summary.totalLockedCoin),
+      totalCoinHoldings = Codec.encode(summary.totalCoinHoldings),
+      accumulatedHoldingFeesUnlocked = Codec.encode(summary.accumulatedHoldingFeesUnlocked),
+      accumulatedHoldingFeesLocked = Codec.encode(summary.accumulatedHoldingFeesLocked),
+      accumulatedHoldingFeesTotal = Codec.encode(summary.accumulatedHoldingFeesTotal),
+      totalAvailableCoin = Codec.encode(summary.totalAvailableCoin),
+      computedAsOfRound = asOfRound,
+    )
   }
 }

--- a/apps/validator/src/test/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandlerTest.scala
+++ b/apps/validator/src/test/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandlerTest.scala
@@ -1,0 +1,36 @@
+package org.lfdecentralizedtrust.splice.validator.admin.http
+
+import org.lfdecentralizedtrust.splice.store.StoreTestBase
+import org.lfdecentralizedtrust.splice.util.HoldingsSummary
+
+import java.time.Instant
+
+class HttpValidatorAdminHandlerTest extends StoreTestBase {
+
+  "HttpValidatorAdminHandler" should {
+
+    "summarize external-party balances as of the latest open round" in {
+      val now = Instant.parse("2026-01-01T00:10:00Z")
+      val openRounds = Seq(
+        openMiningRound(dsoParty, 1L, 1.0, opensAt = now.minusSeconds(600)),
+        openMiningRound(dsoParty, 2L, 1.0, opensAt = now.minusSeconds(60)),
+      )
+      val user = userParty(1)
+      val amulet = this.amulet(user, BigDecimal(100), createdAtRound = 2L, ratePerRound = 0.5)
+
+      val negativeSummary = HoldingsSummary.Empty.addAmulet(amulet.payload, 1L)
+      negativeSummary.accumulatedHoldingFeesTotal.signum shouldBe -1
+
+      val balance = HttpValidatorAdminHandler.buildExternalPartyBalanceResponse(
+        user.toProtoPrimitive,
+        HttpValidatorAdminHandler.latestExternalPartyBalanceRound(now, openRounds.map(_.payload)),
+        Seq(amulet.payload),
+        Seq.empty,
+      )
+
+      balance.totalUnlockedCoin shouldBe "100.0000000000"
+      balance.computedAsOfRound shouldBe 2L
+      BigDecimal(balance.accumulatedHoldingFeesTotal) shouldBe BigDecimal(0)
+    }
+  }
+}


### PR DESCRIPTION
## What changed

This fixes `/v0/admin/external-party/balance` to compute balances using the latest active open mining round instead of the earliest open round.

The handler now:
- selects the latest open round that is already active
- builds the response through a small helper that summarizes current amulets and locked amulets at that round
- keeps the change scoped to the validator external-party balance path

The PR also adds:
- a focused validator regression for the round-selection root cause
- an end-to-end integration regression that reproduces the multi-round timing condition and checks the endpoint response

## Root cause

The endpoint was mixing two different time views:
- current ACS holdings for the external party
- the earliest open mining round as `computedAsOfRound`

When more than one round was open, that could evaluate a current amulet against a round that predated its creation. That produced the negative holding-fee symptom reported in #2069.

## User impact

External-party balance responses now report:
- the correct `computedAsOfRound` for current holdings
- non-negative accumulated holding fees under the reproduced multi-round condition
- unchanged unlocked balance semantics

## Validation

Before the fix:
- `sbt 'apps-app/testOnly org.lfdecentralizedtrust.splice.integration.tests.ExternallySignedTxsTimeBasedIntegrationTest'`
- failed at `ExternallySignedTxsTimeBasedIntegrationTest.scala:87` because `computedAsOfRound` was `1` instead of `2`

After the fix:
- `sbt 'apps-app/testOnly org.lfdecentralizedtrust.splice.integration.tests.ExternallySignedTxsTimeBasedIntegrationTest'`
- passed: 1 test, 0 failed

Focused regression:
- `sbt 'apps-validator/testOnly org.lfdecentralizedtrust.splice.validator.admin.http.HttpValidatorAdminHandlerTest'`
- passed: 1 test, 0 failed
