### PR TITLE
deflake: filter metric by sync_id

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMetricsTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMetricsTest.scala
@@ -60,10 +60,15 @@ class WalletMetricsTest
           tx.subtype.value shouldBe TxLogEntry.BalanceChangeTransactionSubtype.Tap.toProto
           tx.date.value
       }
+      val synchronizerId =
+        sv1Backend.participantClient.synchronizers.list_connected().loneElement.synchronizerId
       val metrics = aliceValidatorBackend.metrics
         .get(
           s"$MetricsPrefix.store.last-ingested-record-time-ms",
-          Map("store_party" -> aliceUserParty.toString),
+          Map(
+            "store_party" -> aliceUserParty.toString,
+            "synchronizer_id" -> synchronizerId.logical.toString,
+          ),
         )
         .select[MetricValue.LongPoint]
         .value
@@ -73,8 +78,6 @@ class WalletMetricsTest
         BigDecimal(time.toEpochMilli) - recordTimeLedgerTimeTolerance,
         BigDecimal(time.toEpochMilli) + recordTimeLedgerTimeTolerance,
       )
-      val synchronizerId =
-        sv1Backend.participantClient.synchronizers.list_connected().loneElement.synchronizerId
       metrics.attributes("synchronizer_id") shouldBe synchronizerId.logical.toString
     }
   }


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7879

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
