### PR TITLE
try deflaking SvMergeSvRewardStateIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeSvRewardStateIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvMergeSvRewardStateIntegrationTest.scala
@@ -66,7 +66,7 @@ class SvMergeSvRewardStateIntegrationTest extends SvIntegrationTestBase with Tri
           newRewardStates should have size 2 withClue "SvRewardStates"
         },
       )
-      loggerFactory.assertLogs(
+      loggerFactory.assertLoggedWarningsAndErrorsSeq(
         {
           resumeAllDsoDelegateTriggers[MergeSvRewardStateContractsTrigger]
           clue("Trigger merges SvRewardState contracts") {
@@ -76,9 +76,12 @@ class SvMergeSvRewardStateIntegrationTest extends SvIntegrationTestBase with Tri
             }
           }
         },
-        _.warningMessage should include(
-          "SV Digital-Asset-2 has 2 SvRewardState contracts, this likely indicates a bug"
-        ),
+        lines =>
+          forAll(lines)(
+            _.warningMessage should include(
+              "SV Digital-Asset-2 has 2 SvRewardState contracts, this likely indicates a bug"
+            )
+          ),
       )
     }
   // Not testing reward state contracts for different sv names, this is covered through every test with multiple SVs anyway.


### PR DESCRIPTION
Not sure about this at all, but my best theory is that somehow the trigger runs twice before the contracts are actually merged, thus printing the warning twice, and I think this change would allow that.

(maybe) fixes https://github.com/DACH-NY/cn-test-failures/issues/7881

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
