### PR TITLE
Traffic Based App Rewards: Expand GetRewardAccountingActivityTotalsResponse

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanAppRewardsComputationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanAppRewardsComputationTimeBasedIntegrationTest.scala
@@ -81,7 +81,7 @@ class ScanAppRewardsComputationTimeBasedIntegrationTest
       clue("Verify activity totals for the aggregated round") {
         val totals = sv1ScanBackend.getRewardAccountingActivityTotals(earliest)
         totals.value.roundNumber shouldBe earliest
-        totals.value.numActivityRecordsInRound should be > 0L
+        totals.value.activityRecordsCount should be > 0L
       }
 
       clue("Verify 404 for non-existent round") {

--- a/apps/common/src/main/resources/db/migration/canton-network/postgres/stable/V064__app_reward_accounting_tables.sql
+++ b/apps/common/src/main/resources/db/migration/canton-network/postgres/stable/V064__app_reward_accounting_tables.sql
@@ -39,7 +39,7 @@ create table app_activity_round_totals
     -- Used for debugging purposes.
     active_app_provider_parties_count     bigint not null,
     -- Total number of activity records in this round across all parties.
-    num_activity_records_in_round         bigint not null,
+    activity_records_count                bigint not null,
 
     constraint app_activity_round_totals_pkey primary key (history_id, round_number)
 );

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -4047,7 +4047,7 @@ components:
         - round_number
         - total_app_activity_weight
         - active_parties_count
-        - num_activity_records_in_round
+        - activity_records_count
       properties:
         round_number:
           type: integer
@@ -4058,6 +4058,6 @@ components:
         active_parties_count:
           type: integer
           format: int64
-        num_activity_records_in_round:
+        activity_records_count:
           type: integer
           format: int64

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2429,7 +2429,7 @@ class HttpScanHandler(
                   roundNumber = roundTotal.roundNumber,
                   totalAppActivityWeight = roundTotal.totalRoundAppActivityWeight,
                   activePartiesCount = roundTotal.activeAppProviderPartiesCount,
-                  numActivityRecordsInRound = roundTotal.numActivityRecordsInRound,
+                  activityRecordsCount = roundTotal.activityRecordsCount,
                 )
               )
           }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
@@ -46,7 +46,7 @@ object DbScanAppRewardsStore {
       roundNumber: Long,
       totalRoundAppActivityWeight: Long,
       activeAppProviderPartiesCount: Long,
-      numActivityRecordsInRound: Long,
+      activityRecordsCount: Long,
   )
 
   final case class AppRewardPartyTotalT(
@@ -130,7 +130,7 @@ class DbScanAppRewardsStore(
       roundNumber = prs.<<[Long],
       totalRoundAppActivityWeight = prs.<<[Long],
       activeAppProviderPartiesCount = prs.<<[Long],
-      numActivityRecordsInRound = prs.<<[Long],
+      activityRecordsCount = prs.<<[Long],
     )
   }
 
@@ -237,11 +237,11 @@ class DbScanAppRewardsStore(
     else {
       val values = sqlCommaSeparated(items.map { row =>
         sql"""(${row.historyId}, ${row.roundNumber}, ${row.totalRoundAppActivityWeight},
-              ${row.activeAppProviderPartiesCount}, ${row.numActivityRecordsInRound})"""
+              ${row.activeAppProviderPartiesCount}, ${row.activityRecordsCount})"""
       })
       (sql"""insert into #${Tables.appActivityRoundTotals}(
               history_id, round_number, total_round_app_activity_weight,
-              active_app_provider_parties_count, num_activity_records_in_round
+              active_app_provider_parties_count, activity_records_count
             ) values """ ++ values).asUpdate
     }
   }
@@ -267,7 +267,7 @@ class DbScanAppRewardsStore(
 
     runQuerySingle(
       sql"""select history_id, round_number, total_round_app_activity_weight,
-                   active_app_provider_parties_count, num_activity_records_in_round
+                   active_app_provider_parties_count, activity_records_count
             from #${Tables.appActivityRoundTotals}
             where history_id = $historyId and round_number = $roundNumber
             limit 1
@@ -534,13 +534,6 @@ class DbScanAppRewardsStore(
             where a.round_number = $roundNumber
               and v.history_id = $historyId
           ),
-          record_count as (
-            select count(*) as num_records_in_round
-            from app_activity_record_store a
-            join scan_verdict_store v on a.verdict_row_id = v.row_id
-            where a.round_number = $roundNumber
-              and v.history_id = $historyId
-          ),
           aggregated as (
             select party, sum(weight) as total_weight,
                    count(*) as num_activity_records
@@ -566,7 +559,7 @@ class DbScanAppRewardsStore(
             select $historyId, $roundNumber, total_weight, seq_num, party,
                    num_activity_records
             from numbered
-            returning total_app_activity_weight
+            returning total_app_activity_weight, num_activity_records
           )"""
 
   /** Insert the round-level totals from the RETURNING output of insertPartyTotals. */
@@ -576,12 +569,12 @@ class DbScanAppRewardsStore(
              round_number,
              total_round_app_activity_weight,
              active_app_provider_parties_count,
-             num_activity_records_in_round)
+             activity_records_count)
           select $historyId,
                  $roundNumber,
                  coalesce(sum(total_app_activity_weight), 0),
                  count(*),
-                 (select num_records_in_round from record_count)
+                 coalesce(sum(num_activity_records), 0)
           from inserted_parties"""
 
   // -- Reward computation -----------------------------------------------------

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -61,7 +61,7 @@ class DbScanAppRewardsStoreTest
           roundNumber = roundNumber,
           totalRoundAppActivityWeight = 999999L,
           activeAppProviderPartiesCount = 5L,
-          numActivityRecordsInRound = 42L,
+          activityRecordsCount = 42L,
         )
         _ <- store.insertAppActivityRoundTotals(Seq(row))
         loaded <- store.getAppActivityRoundTotalByRound(roundNumber)
@@ -275,7 +275,7 @@ class DbScanAppRewardsStoreTest
           roundNumber = roundNumber,
           totalRoundAppActivityWeight = 1000L,
           activeAppProviderPartiesCount = 2L,
-          numActivityRecordsInRound = 10L,
+          activityRecordsCount = 10L,
         )
         _ <- store.insertAppActivityRoundTotals(Seq(row))
         duplicate = row.copy(totalRoundAppActivityWeight = 2000L)
@@ -324,7 +324,7 @@ class DbScanAppRewardsStoreTest
 
         roundTotal.value.totalRoundAppActivityWeight shouldBe 500L
         roundTotal.value.activeAppProviderPartiesCount shouldBe 1L
-        roundTotal.value.numActivityRecordsInRound shouldBe 1L
+        roundTotal.value.activityRecordsCount shouldBe 1L
       }
     }
 
@@ -368,7 +368,7 @@ class DbScanAppRewardsStoreTest
 
         roundTotal.value.totalRoundAppActivityWeight shouldBe 1000L // 300+300+400
         roundTotal.value.activeAppProviderPartiesCount shouldBe 3L
-        roundTotal.value.numActivityRecordsInRound shouldBe 2L // 2 activity records total
+        roundTotal.value.activityRecordsCount shouldBe 4L // sum of per-party counts: alice=2 + bob=1 + charlie=1
       }
     }
 
@@ -384,7 +384,7 @@ class DbScanAppRewardsStoreTest
         partyTotals shouldBe empty
         roundTotal.value.totalRoundAppActivityWeight shouldBe 0L
         roundTotal.value.activeAppProviderPartiesCount shouldBe 0L
-        roundTotal.value.numActivityRecordsInRound shouldBe 0L
+        roundTotal.value.activityRecordsCount shouldBe 0L
       }
     }
 
@@ -406,7 +406,7 @@ class DbScanAppRewardsStoreTest
         partyTotals.head.totalAppActivityWeight shouldBe 100L
         partyTotals.head.numActivityRecords shouldBe 1L
         roundTotal.value.totalRoundAppActivityWeight shouldBe 100L
-        roundTotal.value.numActivityRecordsInRound shouldBe 1L
+        roundTotal.value.activityRecordsCount shouldBe 1L
       }
     }
 


### PR DESCRIPTION
Fixes #4645 
Follow-up to [this comment](https://github.com/hyperledger-labs/splice/pull/4420#discussion_r2976340145)
Tracked in #4384

- Adds num_activity_records_in_round
- Added on a feature branch, to updates the existing migration
- Also adds num_activity_records per party to the migration, though this is not exposed as there is no pre-existing route

Both columns and the new route will be useful for debugging

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
