### PR TITLE
support configuring ephemeral storage for gke nodes

### DIFF
--- a/cluster/pulumi/cluster/src/config.ts
+++ b/cluster/pulumi/cluster/src/config.ts
@@ -7,6 +7,7 @@ const GkeNodePoolConfigSchema = z.object({
   minNodes: z.number(),
   maxNodes: z.number(),
   nodeType: z.string(),
+  bootDiskSizeGb: z.number().optional(),
 });
 const GkeClusterConfigSchema = z.object({
   nodePools: z.object({

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -87,7 +87,7 @@ function hyperdiskNodePool(cluster: string, config: GkeNodePoolConfig, location?
       machineType: config.nodeType,
       bootDisk: {
         diskType: 'hyperdisk-balanced',
-        sizeGb: 100,
+        sizeGb: config.bootDiskSizeGb || 100,
       },
       taints: [
         {


### PR DESCRIPTION
@nicu-da nudged me to check how many runners fit in the current ephemeral storage we have for splice. The answer is 4-5, which seems too low. I'll bump that to 200GB, to fit 8-10.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
