### PR TITLE
reonboarding integration test - Fix triggers being paused

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvReonboardingIntegrationTest.scala
@@ -336,15 +336,13 @@ class SvReonboardingIntegrationTest
             }
           }
 
-          val triggers =
-            Seq(sv1ValidatorBackend, sv3ValidatorBackend, sv3ValidatorBackend).map(sv =>
-              // prevent changing sync connetion configs while offboarding to prevent having to re-submit topology transactions that get lost from the queue during reconnets
-              sv.validatorAutomation.trigger[ReconcileSequencerConnectionsTrigger]
-            )
           TriggerTestUtil
             .setTriggersWithin(
-              triggersToPauseAtStart = triggers,
-              triggersToResumeAtStart = triggers,
+              triggersToPauseAtStart =
+                Seq(sv1ValidatorBackend, sv2ValidatorBackend, sv3ValidatorBackend).map(sv =>
+                  // prevent changing sync connection configs while offboarding to prevent having to re-submit topology transactions that get lost from the queue during reconnets
+                  sv.validatorAutomation.trigger[ReconcileSequencerConnectionsTrigger]
+                )
             ) {
               eventually(90.seconds) {
                 sv1Backend.getDsoInfo().dsoRules.payload.svs.keySet.asScala shouldBe Set(


### PR DESCRIPTION
triggers to start should not be set as the paused triggers are automatically resumed after the block

also fix the double sv3 instead of sv2 validator

[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/7935

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
