### PR TITLE
Avoid overwriting timeout handler for custom time-out routes

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -480,7 +480,6 @@ class ScanApp(
                           customTimeout.duration,
                           httpErrorHandler.timeoutHandler(customTimeout.duration, _),
                         ).tflatMap { _ =>
-
                           // only apply exceptions directive for custom timeout routes
                           httpErrorHandler.exceptionsDirective(traceContext).tflatMap { _ =>
                             provide(traceContext)


### PR DESCRIPTION
@OriolMunoz-da @moritzkiefer-da We don't need to set the the timeout-handler again for custom-timeout routes. WDYT?
