### PR TITLE
ignore gcpQuotas.excludedMetrics for quota alerts (0.5.18 port)

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -128,6 +128,22 @@ monitoring:
         # Multiplier applied to a wallet sweep's configured maxBalance to set the alert threshold.
         # 1.5 means the alert fires if the balance is 50% higher than expected.
         tolerance: 1.5
+      gcpQuotas:
+        # Quota metric names to exclude from all GCP quota alerts.
+        # Each entry is matched exactly for quota exceeded.
+        # Prefer `excludedApproachingMetrics` to ignore only the >90% alerts.
+        excludedMetrics:
+          - cloudkms.googleapis.com/read_requests
+          - cloudkms.googleapis.com/write_requests
+          - cloudkms.googleapis.com/crypto_requests
+          - cloudkms.googleapis.com/hsm_symmetric_requests
+          - cloudkms.googleapis.com/hsm_asymmetric_requests
+          - cloudkms.googleapis.com/hsm_generate_random_requests
+          - cloudkms.googleapis.com/external_kms_requests
+        # Quota metric names to exclude only from the "approaching limit" (>90%) alerts.
+        # These metrics will still trigger the "quota exceeded" alert.
+        # GCP is more forgiving of larger sets in this value.
+        excludedApproachingMetrics: []
     # Alert on secrets appearing in logs (JWTs, Bearer tokens, passwords, etc.)
     # Key=value secrets (excluding masked values)
     # JWTs identified by base64 header prefix "eyJhbGc" (decodes to '{"alg')

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -52,6 +52,16 @@ monitoring:
         thresholdPerNamespace: 0.05
       deployment:
         pendingPeriodMinutes: 5
+      gcpQuotas:
+        excludedApproachingMetrics: []
+        excludedMetrics:
+          - 'cloudkms.googleapis.com/read_requests'
+          - 'cloudkms.googleapis.com/write_requests'
+          - 'cloudkms.googleapis.com/crypto_requests'
+          - 'cloudkms.googleapis.com/hsm_symmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_asymmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_generate_random_requests'
+          - 'cloudkms.googleapis.com/external_kms_requests'
       ingestion:
         thresholdEntriesPerBatch: 80
       loadTester:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -52,6 +52,16 @@ monitoring:
         thresholdPerNamespace: 0.05
       deployment:
         pendingPeriodMinutes: 5
+      gcpQuotas:
+        excludedApproachingMetrics: []
+        excludedMetrics:
+          - 'cloudkms.googleapis.com/read_requests'
+          - 'cloudkms.googleapis.com/write_requests'
+          - 'cloudkms.googleapis.com/crypto_requests'
+          - 'cloudkms.googleapis.com/hsm_symmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_asymmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_generate_random_requests'
+          - 'cloudkms.googleapis.com/external_kms_requests'
       ingestion:
         thresholdEntriesPerBatch: 80
       loadTester:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -52,6 +52,16 @@ monitoring:
         thresholdPerNamespace: 0.05
       deployment:
         pendingPeriodMinutes: 5
+      gcpQuotas:
+        excludedApproachingMetrics: []
+        excludedMetrics:
+          - 'cloudkms.googleapis.com/read_requests'
+          - 'cloudkms.googleapis.com/write_requests'
+          - 'cloudkms.googleapis.com/crypto_requests'
+          - 'cloudkms.googleapis.com/hsm_symmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_asymmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_generate_random_requests'
+          - 'cloudkms.googleapis.com/external_kms_requests'
       ingestion:
         thresholdEntriesPerBatch: 80
       loadTester:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -52,6 +52,16 @@ monitoring:
         thresholdPerNamespace: 0.05
       deployment:
         pendingPeriodMinutes: 5
+      gcpQuotas:
+        excludedApproachingMetrics: []
+        excludedMetrics:
+          - 'cloudkms.googleapis.com/read_requests'
+          - 'cloudkms.googleapis.com/write_requests'
+          - 'cloudkms.googleapis.com/crypto_requests'
+          - 'cloudkms.googleapis.com/hsm_symmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_asymmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_generate_random_requests'
+          - 'cloudkms.googleapis.com/external_kms_requests'
       ingestion:
         thresholdEntriesPerBatch: 80
       loadTester:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -52,6 +52,16 @@ monitoring:
         thresholdPerNamespace: 0.05
       deployment:
         pendingPeriodMinutes: 5
+      gcpQuotas:
+        excludedApproachingMetrics: []
+        excludedMetrics:
+          - 'cloudkms.googleapis.com/read_requests'
+          - 'cloudkms.googleapis.com/write_requests'
+          - 'cloudkms.googleapis.com/crypto_requests'
+          - 'cloudkms.googleapis.com/hsm_symmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_asymmetric_requests'
+          - 'cloudkms.googleapis.com/hsm_generate_random_requests'
+          - 'cloudkms.googleapis.com/external_kms_requests'
       ingestion:
         thresholdEntriesPerBatch: 80
       loadTester:

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -3443,12 +3443,17 @@
         {
           "conditionPrometheusQueryLanguage": {
             "duration": "300s",
-            "query": "\n            serviceruntime_googleapis_com:quota_allocation_usage{monitored_resource=\"consumer_quota\"}\n            / ignoring(limit_name) group_right()\n            (serviceruntime_googleapis_com:quota_limit{monitored_resource=\"consumer_quota\"} > 0)\n            > 0.9\n          "
+            "query": "\n            serviceruntime_googleapis_com:quota_allocation_usage{monitored_resource=\"consumer_quota\", quota_metric!~\"cloudkms.googleapis.com/read_requests|cloudkms.googleapis.com/write_requests|cloudkms.googleapis.com/crypto_requests|cloudkms.googleapis.com/hsm_symmetric_requests|cloudkms.googleapis.com/hsm_asymmetric_requests|cloudkms.googleapis.com/hsm_generate_random_requests|cloudkms.googleapis.com/external_kms_requests\"}\n            / ignoring(limit_name) group_right()\n            (serviceruntime_googleapis_com:quota_limit{monitored_resource=\"consumer_quota\", quota_metric!~\"cloudkms.googleapis.com/read_requests|cloudkms.googleapis.com/write_requests|cloudkms.googleapis.com/crypto_requests|cloudkms.googleapis.com/hsm_symmetric_requests|cloudkms.googleapis.com/hsm_asymmetric_requests|cloudkms.googleapis.com/hsm_generate_random_requests|cloudkms.googleapis.com/external_kms_requests\"} > 0)\n            > 0.9\n          "
           },
           "displayName": "Allocation Quota approaching limit (>90%) in mock"
         }
       ],
       "displayName": "Allocation Quota approaching limit (>90%) in mock",
+      "documentation": {
+        "content": "An allocation quota (CPUs, Static IPs, Disk Space, etc.) is >90% utilized in **mock**.\n\nCheck the incident details, chart under \"Alert Metrics\", for the specific quota.",
+        "mimeType": "text/markdown",
+        "subject": "Allocation quota approaching limit (>90%) in mock"
+      },
       "notificationChannels": [
         null
       ],
@@ -3491,7 +3496,7 @@
             ],
             "comparison": "COMPARISON_GT",
             "duration": "60s",
-            "filter": "resource.type=\"consumer_quota\" AND metric.type=\"serviceruntime.googleapis.com/quota/exceeded\"",
+            "filter": "resource.type=\"consumer_quota\" AND metric.type=\"serviceruntime.googleapis.com/quota/exceeded\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/read_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/write_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/crypto_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/hsm_symmetric_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/hsm_asymmetric_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/hsm_generate_random_requests\" AND metric.label.quota_metric != \"cloudkms.googleapis.com/external_kms_requests\"",
             "trigger": {
               "count": 1
             }
@@ -3500,6 +3505,11 @@
         }
       ],
       "displayName": "Quota Exceeded in mock",
+      "documentation": {
+        "content": "The quota \"${metric.display_name}\" (${metric.label.quota_metric}) has been exceeded in cluster mock.",
+        "mimeType": "text/markdown",
+        "subject": "Quota ${metric.label.quota_metric} exceeded in mock"
+      },
       "notificationChannels": [
         null
       ],
@@ -3531,12 +3541,17 @@
         {
           "conditionPrometheusQueryLanguage": {
             "duration": "300s",
-            "query": "\n            serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource=\"consumer_quota\"}\n            / ignoring(limit_name) group_right()\n            (serviceruntime_googleapis_com:quota_limit{monitored_resource=\"consumer_quota\"} > 0)\n            > 0.9\n          "
+            "query": "\n            serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource=\"consumer_quota\", quota_metric!~\"cloudkms.googleapis.com/read_requests|cloudkms.googleapis.com/write_requests|cloudkms.googleapis.com/crypto_requests|cloudkms.googleapis.com/hsm_symmetric_requests|cloudkms.googleapis.com/hsm_asymmetric_requests|cloudkms.googleapis.com/hsm_generate_random_requests|cloudkms.googleapis.com/external_kms_requests\"}\n            / ignoring(limit_name) group_right()\n            (serviceruntime_googleapis_com:quota_limit{monitored_resource=\"consumer_quota\", quota_metric!~\"cloudkms.googleapis.com/read_requests|cloudkms.googleapis.com/write_requests|cloudkms.googleapis.com/crypto_requests|cloudkms.googleapis.com/hsm_symmetric_requests|cloudkms.googleapis.com/hsm_asymmetric_requests|cloudkms.googleapis.com/hsm_generate_random_requests|cloudkms.googleapis.com/external_kms_requests\"} > 0)\n            > 0.9\n          "
           },
           "displayName": "Rate Quota approaching limit (>90%) in mock"
         }
       ],
       "displayName": "Rate Quota approaching limit (>90%) in mock",
+      "documentation": {
+        "content": "A rate quota (API requests per minute, HSM operations, etc.) is >90% utilized in **mock**.\n\nCheck the incident details, chart under \"Alert Metrics\", for the specific quota.",
+        "mimeType": "text/markdown",
+        "subject": "Rate quota approaching limit (>90%) in mock"
+      },
       "notificationChannels": [
         null
       ],

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -18,6 +18,17 @@ export const clusterBaseDomain = clusterHostname.split('.')[0];
 
 export const gcpDnsProject = config.requireEnv('GCP_DNS_PROJECT');
 
+const quotaMetricNameSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9.-]+\.[a-zA-Z0-9-]+\/[a-zA-Z0-9_./-]+$/, 'full GCP quota metric name');
+
+const GcpQuotasConfigSchema = z.object({
+  // so existing overrides don't break
+  enabled: z.literal(true).optional(),
+  excludedMetrics: z.array(quotaMetricNameSchema),
+  excludedApproachingMetrics: z.array(quotaMetricNameSchema),
+});
+
 const MonitoringConfigSchema = z
   .object({
     alerting: z.object({
@@ -79,8 +90,7 @@ const MonitoringConfigSchema = z
         walletSweep: z.object({
           tolerance: z.number(),
         }),
-        // so existing overrides don't break
-        gcpQuotas: z.object({ enabled: z.literal(true) }).optional(),
+        gcpQuotas: GcpQuotasConfigSchema,
       }),
       logAlerts: z.object({}).catchall(z.string()).default({}),
       loggedSecretsFilter: z.string().optional(),
@@ -138,6 +148,8 @@ export const InfraConfigSchema = z.object({
 });
 
 export type CloudArmorConfig = z.infer<typeof CloudArmorConfigSchema>;
+
+export type GcpQuotaAlertsConfig = z.infer<typeof GcpQuotasConfigSchema>;
 
 export type Config = z.infer<typeof InfraConfigSchema>;
 

--- a/cluster/pulumi/infra/src/gcpAlerts.ts
+++ b/cluster/pulumi/infra/src/gcpAlerts.ts
@@ -10,12 +10,22 @@ import {
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 
 import { slackAlertNotificationChannel, slackToken } from './alertings';
-import { monitoringConfig } from './config';
+import { type GcpQuotaAlertsConfig, monitoringConfig } from './config';
 
 const enableChaosMesh = config.envFlag('ENABLE_CHAOS_MESH');
 
 function ensureTrailingNewline(s: string): string {
   return s.endsWith('\n') ? s : `${s}\n`;
+}
+
+// Monitoring filter limited to 2048 chars: https://cloud.google.com/monitoring/api/v3/filters
+function assertFilterLength(filter: string): string {
+  if (filter.length > 2048) {
+    throw new Error(
+      `${CLUSTER_BASENAME} monitoring filter is ${filter.length} chars; >2048 char limit`
+    );
+  }
+  return filter;
 }
 
 export function getNotificationChannel(
@@ -291,10 +301,25 @@ resource.type="cloudsql_database"
 }
 
 export function installGcpQuotaAlerts(
-  notificationChannel: gcp.monitoring.NotificationChannel
+  notificationChannel: gcp.monitoring.NotificationChannel,
+  gcpQuotasConfig: GcpQuotaAlertsConfig
 ): void {
   const quotaUsageThreshold = 0.9;
   const quotaUsageThresholdPercent = quotaUsageThreshold * 100;
+  const excludedMetrics = gcpQuotasConfig.excludedMetrics;
+
+  // Build exclusion fragments for threshold filters and PromQL queries.
+  // excludedMetrics applies to all alerts; excludedApproachingMetrics only to the >90% alerts.
+  // Cloud Monitoring filters only support = and != (no regex), so we use one != per metric.
+  const thresholdExclusion = excludedMetrics
+    .map(m => ` AND metric.label.quota_metric != "${m}"`)
+    .join('');
+
+  const approachingExcluded = [...excludedMetrics, ...gcpQuotasConfig.excludedApproachingMetrics];
+  const approachingExclusionRegex =
+    approachingExcluded.length > 0 ? approachingExcluded.join('|') : null;
+  const promqlExclusion =
+    approachingExclusionRegex !== null ? `, quota_metric!~"${approachingExclusionRegex}"` : '';
 
   const baseArgs: Pick<
     gcp.monitoring.AlertPolicyArgs,
@@ -309,6 +334,11 @@ export function installGcpQuotaAlerts(
   new gcp.monitoring.AlertPolicy('quotaExceededAlert', {
     ...baseArgs,
     displayName: `Quota Exceeded in ${CLUSTER_BASENAME}`,
+    documentation: {
+      subject: `Quota \${metric.label.quota_metric} exceeded in ${CLUSTER_BASENAME}`,
+      content: `The quota "\${metric.display_name}" (\${metric.label.quota_metric}) has been exceeded in cluster ${CLUSTER_BASENAME}.`,
+      mimeType: 'text/markdown',
+    },
     conditions: [
       {
         // "Quota Full" (Exceeded right now)
@@ -324,8 +354,9 @@ export function installGcpQuotaAlerts(
           ],
           comparison: 'COMPARISON_GT',
           duration: '60s',
-          filter:
-            'resource.type="consumer_quota" AND metric.type="serviceruntime.googleapis.com/quota/exceeded"',
+          filter: assertFilterLength(
+            `resource.type="consumer_quota" AND metric.type="serviceruntime.googleapis.com/quota/exceeded"${thresholdExclusion}`
+          ),
           trigger: {
             count: 1,
           },
@@ -342,15 +373,23 @@ export function installGcpQuotaAlerts(
   new gcp.monitoring.AlertPolicy('quotaAllocationAlert', {
     ...baseArgs,
     displayName: `Allocation Quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
+    documentation: {
+      subject: `Allocation quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
+      content: [
+        `An allocation quota (CPUs, Static IPs, Disk Space, etc.) is >${quotaUsageThresholdPercent}% utilized in **${CLUSTER_BASENAME}**.`,
+        'Check the incident details, chart under "Alert Metrics", for the specific quota.',
+      ].join('\n\n'),
+      mimeType: 'text/markdown',
+    },
     conditions: [
       {
         // Tracks resources like CPUs, Static IPs, Disk Space
         displayName: `Allocation Quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
           query: `
-            serviceruntime_googleapis_com:quota_allocation_usage{monitored_resource="consumer_quota"}
+            serviceruntime_googleapis_com:quota_allocation_usage{monitored_resource="consumer_quota"${promqlExclusion}}
             / ignoring(limit_name) group_right()
-            (serviceruntime_googleapis_com:quota_limit{monitored_resource="consumer_quota"} > 0)
+            (serviceruntime_googleapis_com:quota_limit{monitored_resource="consumer_quota"${promqlExclusion}} > 0)
             > ${quotaUsageThreshold}
           `,
           duration: '300s',
@@ -362,15 +401,23 @@ export function installGcpQuotaAlerts(
   new gcp.monitoring.AlertPolicy('quotaRateAlert', {
     ...baseArgs,
     displayName: `Rate Quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
+    documentation: {
+      subject: `Rate quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
+      content: [
+        `A rate quota (API requests per minute, HSM operations, etc.) is >${quotaUsageThresholdPercent}% utilized in **${CLUSTER_BASENAME}**.`,
+        'Check the incident details, chart under "Alert Metrics", for the specific quota.',
+      ].join('\n\n'),
+      mimeType: 'text/markdown',
+    },
     conditions: [
       {
         // Tracks API requests, HSM operations per minute, etc.
         displayName: `Rate Quota approaching limit (>${quotaUsageThresholdPercent}%) in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
           query: `
-            serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource="consumer_quota"}
+            serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource="consumer_quota"${promqlExclusion}}
             / ignoring(limit_name) group_right()
-            (serviceruntime_googleapis_com:quota_limit{monitored_resource="consumer_quota"} > 0)
+            (serviceruntime_googleapis_com:quota_limit{monitored_resource="consumer_quota"${promqlExclusion}} > 0)
             > ${quotaUsageThreshold}
           `,
           duration: '300s',

--- a/cluster/pulumi/infra/src/index.ts
+++ b/cluster/pulumi/infra/src/index.ts
@@ -85,7 +85,7 @@ if (enableAlerts && !clusterIsResetPeriodically) {
     if (monitoringConfig.alerting.loggedSecretsFilter) {
       installLoggedSecretsAlerts(notificationChannel);
     }
-    installGcpQuotaAlerts(notificationChannel);
+    installGcpQuotaAlerts(notificationChannel, monitoringConfig.alerting.alerts.gcpQuotas);
     installCloudSqlTxIdUtilizationAlert(notificationChannel);
   }
 }


### PR DESCRIPTION
Backports #4858.