### PR TITLE
Disable lsu sequencing test trigger again

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -33,7 +33,10 @@ import org.lfdecentralizedtrust.splice.sv.config.{
   SvSynchronizerNodeConfig,
   SvSynchronizerNodesConfig,
 }
-import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSynchronizerUpgradeTrigger
+import org.lfdecentralizedtrust.splice.sv.lsu.{
+  LogicalSynchronizerUpgradeTrigger,
+  LogicalSynchronizerUpgradeSequencingTestTrigger,
+}
 import org.lfdecentralizedtrust.splice.util.*
 import org.lfdecentralizedtrust.splice.wallet.config.WalletAppClientConfig
 import org.lfdecentralizedtrust.splice.wallet.store.TxLogEntry.Http.BuyTrafficRequestStatus
@@ -115,7 +118,14 @@ class LogicalSynchronizerUpgradeIntegrationTest
         ConfigTransforms.useDecentralizedSynchronizerSplitwell()(config)
       )
       .addConfigTransform((_, config) =>
-        ConfigTransforms.bumpCantonSyncSuccessorPortsBy(22_000)(config)
+        ConfigTransforms
+          .bumpCantonSyncSuccessorPortsBy(22_000)
+          .andThen(
+            ConfigTransforms.updateAutomationConfig(ConfigTransforms.ConfigurableApp.Sv)(
+              // TODO(DACH-NY/cn-test-failures#7890) Reenable once this is fixed in Canton
+              _.withPausedTrigger[LogicalSynchronizerUpgradeSequencingTestTrigger]
+            )
+          )(config)
       )
       // use the standalone participant
       .addConfigTransforms((_, config) => {


### PR DESCRIPTION
[ci]

Too flaky and Canton seems confident this is the culprit.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
