### PR TITLE
Enable sig trap for GHA runners

### DIFF
--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -116,6 +116,11 @@ function installDockerRunnerScaleSet(
                     name: 'RUNNER_WAIT_FOR_DOCKER_IN_SECONDS',
                     value: '120',
                   },
+                  // May help shutting down runners https://github.com/actions/runner/pull/2233
+                  {
+                    name: 'RUNNER_MANUALLY_TRAP_SIG',
+                    value: 'true',
+                  },
                 ],
                 resources: resourcesSpecFromConfig(resources),
                 // required to mount the nix store inside the container from the NFS


### PR DESCRIPTION
I'm not all that optimistic this does anything. But in https://github.com/actions/runner/pull/2233 it sounds like it may be a good idea and I don't see a lot of harm in it.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
