### PR TITLE
Increase wait to check that sv did the LSU

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -423,7 +423,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
 
       initialSvNodesDoingTheLsu.par.map { backend =>
         clue(s"SV ${backend.name} connects to the new sequencers and syncs topology") {
-          eventually() {
+          eventually(60.seconds) {
             participantIsConnectedToNewSynchronizer(
               backend.participantClientWithAdminToken,
               isSv4Connected = false,


### PR DESCRIPTION
an SV can be a bit slower than a validator because it only has it's sequencer, and it needs to have the traffic migrated as well before it's fully connected

[ci]

fix for https://github.com/hyperledger-labs/splice/actions/runs/24332292404/job/71040827904?pr=4995

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
