### PR TITLE
Add a cluster config that controls the creation of the grafana SA

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -2102,6 +2102,9 @@ function subcmd_silence_grafana_alerts() {
     until=$(date -u -d "+${duration}" '+%FT%TZ')
 
     _info "Fetching token"
+    if ! kubectl get secret -n observability grafana-service-account-token-secret &>/dev/null; then
+        _error "Grafana service account token secret not found. Set monitoring.enableGrafanaServiceAccountToken to true in the cluster config and redeploy the observability stack."
+    fi
     token=$(kubectl get secret -n observability grafana-service-account-token-secret --template="{{.data.token}}" | base64 --decode)
 
     shift 1

--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -87,6 +87,7 @@ initialRound: 0
 #  canton-network:
 #    installDataOnly: true
 monitoring:
+  enableGrafanaServiceAccountToken: false
   alerting:
     enableNoDataAlerts: false
     alerts:

--- a/cluster/configs/shared/enable-grafana-sa.yaml
+++ b/cluster/configs/shared/enable-grafana-sa.yaml
@@ -1,0 +1,2 @@
+monitoring:
+  enableGrafanaServiceAccountToken: true

--- a/cluster/configs/shared/scratchnet.yaml
+++ b/cluster/configs/shared/scratchnet.yaml
@@ -1,4 +1,4 @@
-!include(base.yaml;scratch-default-operator.yaml;scratch-default-synchronizer-migration.yaml)
+!include(base.yaml;scratch-default-operator.yaml;scratch-default-synchronizer-migration.yaml;enable-grafana-sa.yaml)
 infra:
   prometheus:
     retentionDuration: "30d"

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -90,6 +90,7 @@ monitoring:
         tolerance: 1.5
     enableNoDataAlerts: false
     loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+  enableGrafanaServiceAccountToken: true
 multiValidator:
   postgresPvcSize: '100Gi'
   resources:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -90,6 +90,7 @@ monitoring:
         tolerance: 1.5
     enableNoDataAlerts: false
     loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+  enableGrafanaServiceAccountToken: true
 multiValidator:
   postgresPvcSize: '100Gi'
   resources:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -90,6 +90,7 @@ monitoring:
         tolerance: 1.5
     enableNoDataAlerts: false
     loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+  enableGrafanaServiceAccountToken: true
 multiValidator:
   postgresPvcSize: '100Gi'
   resources:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -90,6 +90,7 @@ monitoring:
         tolerance: 1.5
     enableNoDataAlerts: false
     loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+  enableGrafanaServiceAccountToken: true
 multiValidator:
   postgresPvcSize: '100Gi'
   resources:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -90,6 +90,7 @@ monitoring:
         tolerance: 1.5
     enableNoDataAlerts: false
     loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+  enableGrafanaServiceAccountToken: true
 multiValidator:
   postgresPvcSize: '100Gi'
   resources:

--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -442,25 +442,6 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "apiVersion": "v1",
-      "kind": "Secret",
-      "metadata": {
-        "name": "grafana-service-account-token-secret",
-        "namespace": "observability"
-      },
-      "stringData": {
-        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
-        "value": {}
-      }
-    },
-    "name": "grafana-service-account-token-secret",
-    "provider": "",
-    "type": "kubernetes:core/v1:Secret"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
       "apiVersion": "networking.istio.io/v1alpha3",
       "kind": "VirtualService",
       "metadata": {
@@ -501,41 +482,6 @@
     "name": "grafana-virtual-service",
     "provider": "",
     "type": "kubernetes:networking.istio.io/v1alpha3:VirtualService"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "name": "grafana-sa-token",
-      "serviceAccountId": "undefined_id"
-    },
-    "name": "grafanaSAToken",
-    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
-    "type": "grafana:index/serviceAccountToken:ServiceAccountToken"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "role": "Editor"
-    },
-    "name": "grafanaSA",
-    "provider": "urn:pulumi:test-stack::test-project::pulumi:providers:grafana::grafana::undefined_id",
-    "type": "grafana:index/serviceAccount:ServiceAccount"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "auth": {
-        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
-        "value": "cn-admin:grafana-keys-admin-password"
-      },
-      "url": "https://grafana.mock.global.canton.network.digitalasset.com"
-    },
-    "name": "grafana",
-    "provider": "",
-    "type": "pulumi:providers:grafana"
   },
   {
     "custom": true,

--- a/cluster/pulumi/observability/src/config.ts
+++ b/cluster/pulumi/observability/src/config.ts
@@ -16,6 +16,7 @@ const GcpQuotasConfigSchema = z.object({
 
 const MonitoringConfigSchema = z
   .object({
+    enableGrafanaServiceAccountToken: z.boolean(),
     alerting: z.object({
       enableNoDataAlerts: z.boolean(),
       alerts: z.object({

--- a/cluster/pulumi/observability/src/observability.ts
+++ b/cluster/pulumi/observability/src/observability.ts
@@ -19,7 +19,6 @@ import {
   infraAffinityAndTolerations,
   infraPremiumStorageClassName,
   infraStandardStorageClassName,
-  isMainNet,
   loadTesterConfig,
   ObservabilityReleaseName,
   SPLICE_ROOT,
@@ -555,7 +554,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
     supportTeamEmailAddress
   );
   createGrafanaAlerting(namespaceName);
-  if (!isMainNet) {
+  if (monitoringConfig.enableGrafanaServiceAccountToken) {
     createGrafanaServiceAccount(namespaceName, adminPassword, [prometheusStack, postgres.pg]);
   }
   createGrafanaEnvoyFilter(namespaceName, [prometheusStack]);


### PR DESCRIPTION
disabled by default, enabled in scratches and will also enable it in cimain/ciperiodic

[static]

part of https://github.com/hyperledger-labs/splice/issues/677


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
