### PR TITLE
Error out if dabft is enabled but lsu is not

### DIFF
--- a/cluster/pulumi/common/src/domainMigration.ts
+++ b/cluster/pulumi/common/src/domainMigration.ts
@@ -36,6 +36,14 @@ export class DecentralizedSynchronizerMigrationConfig {
     if (this.lsuEnabled && this.frozenMigrationId == undefined) {
       throw new Error('frozen migration must be defined when LSU is enabled');
     }
+    if (
+      (this.legacy?.sequencer.enableBftSequencer ||
+        this.active.sequencer.enableBftSequencer ||
+        this.upgrade?.sequencer.enableBftSequencer) &&
+      !this.lsuEnabled
+    ) {
+      throw new Error('LSU must be enabled when using DABFT');
+    }
   }
 
   runningMigrations(): MigrationInfo[] {


### PR DESCRIPTION
We broke the scan config which is very confusing because the SV app will still enable it.

Don't see it worst the investment to fix dabft without LSU.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
