### PR TITLE
Add support for injectiong DABFT latency

### DIFF
--- a/cluster/pulumi/canton-network/src/chaosMesh.ts
+++ b/cluster/pulumi/canton-network/src/chaosMesh.ts
@@ -2,12 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
+  appsAffinityAndTolerations,
+  clusterYamlConfig,
   DecentralizedSynchronizerUpgradeConfig,
   GCP_PROJECT,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 import { Resource } from '@pulumi/pulumi';
+import { z } from 'zod';
+
+const chaosMeshSchema = z.object({
+  chaosMesh: z
+    .object({
+      dabftLatency: z.string().optional(),
+    })
+    .optional(),
+});
+
+const config = chaosMeshSchema.parse(clusterYamlConfig);
 
 export type ChaosMeshArguments = {
   dependsOn: Resource[];
@@ -44,6 +57,50 @@ export const podKillSchedule = (
             namespaces: [appNs],
           },
         },
+      },
+    },
+    { dependsOn }
+  );
+
+// Injecting latency between the DABFT nodes is a bit convoluted.
+// Chaos Mesh does support specifying a target pod so naturally we would apply it to all traffic between two sequencers.
+// However, this only works if you talk to the pod directly. In our case, we use the external URL of the other sequencer which then gets routed through the istio loopback
+// and bypasses that.
+// Istio also has an option to add latency but it is not supported on https virtualservices which we have for the DABFT traffic.
+// Therefore we instead inject the latency from requests to the ingress pod to the sequencer. However,
+// we only want it to apply to DABFT traffic not the full sequencer ingress. You cannot specify a port when specifying targets https://github.com/chaos-mesh/chaos-mesh/issues/2295
+// so we have to use externalTargets which does support pods. However, using a name like global-domain-0-sequencer.sv-3 will resolve to the service IP not the pod IP so it also won't apply.
+// Therefore we just apply a wildcard to all IPs for port 5010 and hope nothing else runs on port 5010. ipset does not like a full 0.0.0.0/0 wildcard so we
+// instead use 10.0.0.0/8.
+export const dabftLatency = (
+  chaosMeshNs: k8s.core.v1.Namespace,
+  latency: string,
+  dependsOn: Resource[]
+): k8s.apiextensions.CustomResource =>
+  new k8s.apiextensions.CustomResource(
+    `dabft-latency`,
+    {
+      apiVersion: 'chaos-mesh.org/v1alpha1',
+      kind: 'NetworkChaos',
+      metadata: {
+        name: 'dabft-latency',
+        namespace: chaosMeshNs.metadata.name,
+      },
+      spec: {
+        action: 'delay',
+        // run on all pods that match the selector
+        mode: 'all',
+        selector: {
+          namespaces: ['cluster-ingress'],
+          labelSelectors: {
+            app: 'istio-ingress',
+          },
+        },
+        delay: {
+          latency,
+        },
+        direction: 'to',
+        externalTargets: ['10.0.0.0/8:5010'],
       },
     },
     { dependsOn }
@@ -157,6 +214,25 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
         },
         chaosDaemon: {
           ...infraAffinityAndTolerations,
+          // the chaos-daemon needs to run on the apps nodes to be able to inject latency
+          tolerations: [
+            ...infraAffinityAndTolerations.tolerations,
+            ...appsAffinityAndTolerations.tolerations,
+          ],
+          affinity: {
+            nodeAffinity: {
+              requiredDuringSchedulingIgnoredDuringExecution: {
+                nodeSelectorTerms: [
+                  ...infraAffinityAndTolerations.affinity.nodeAffinity
+                    .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
+                  ...appsAffinityAndTolerations.affinity.nodeAffinity
+                    .requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms,
+                ],
+              },
+            },
+          },
+          runtime: 'containerd',
+          socketPath: '/run/containerd/containerd.sock',
         },
         dashboard: {
           ...infraAffinityAndTolerations,
@@ -180,5 +256,8 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
     'sv-app',
     'validator-app',
   ].forEach(name => podKillSchedule(ns, name, 'sv-4', [roleBinding, ...dependsOn]));
+  if (config.chaosMesh?.dabftLatency) {
+    dabftLatency(ns, config.chaosMesh.dabftLatency, [roleBinding, ...dependsOn]);
+  }
   return chaosMesh;
 };


### PR DESCRIPTION
[static]

I never want to do any network changes again but it does seem to work properly now.

I think we may want support for injecting arbitrary chaos-mesh stuff in the config but this seems convoluted enough that it deserves a special case even if we add that later imho.

fixes #5002



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
