### PR TITLE
Fix usage of runSupervised

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ServiceWithGuaranteedShutdown.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ServiceWithGuaranteedShutdown.scala
@@ -14,7 +14,7 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.PekkoUtil
 import io.grpc.StatusRuntimeException
 import org.apache.pekko.{Done, NotUsed}
-import org.apache.pekko.stream.{KillSwitches, Materializer}
+import org.apache.pekko.stream.{KillSwitches, Materializer, UniqueKillSwitch}
 import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
 import org.lfdecentralizedtrust.splice.automation.ServiceWithShutdown
 
@@ -72,11 +72,8 @@ class ServiceWithGuaranteedShutdown[S](
       // If we didn't, we'd get situations where e.g. two ingestions are running simultaneously (and break a lot).
       // For more information, see https://github.com/DACH-NY/canton-network-node/issues/10126.
       .toMat(Sink.ignore)(Keep.both),
-    errorLogMessagePrefix = if (retryProvider.isClosing) {
-      "Ignoring failure to handle transaction, as we are shutting down"
-    } else {
-      "Fatally failed to handle element"
-    },
+    errorLogMessagePrefix = "Fatally failed to handle element",
+    isDone = (_: (UniqueKillSwitch, Future[Done])) => retryProvider.isClosing,
   )
 
   def completed: Future[Done] =


### PR DESCRIPTION
The previous implementation looks broken:

1. The `errorLogMessagePrefix` parameter is passed by value, so the `if (retryProvider.isClosing)` condition is evaluated only once, when the service starts.
2. The code for `PekkoUtil.runSupervised` contains a section to "avoid errors on shutdown", but that relies on the `isDone` parameter which we never set and it defaults to `_ => false`

It does mean that instead of printing "Ignoring failure to handle transaction, as we are shutting down" on shutdown, we will print the more confusing "Fatally failed to handle element (encountered after the graph is completed)". I don't see a way around that without changing PekkoUtil from the Canton fork.

Relevant change: https://github.com/DACH-NY/canton-network-node/pull/16890

Concrete example where the current code fails:

1. Verdict ingestion is running
2. RetryProvider initiates shutdown
3. Verdict ingestion stream processing (the async map call presumably started before shutdown was initiated) fails, because it uses `DbMultiDomainAcsStore.waitUntilRecordTimeReached` which throws an exception when the RetryProvider is shutting down.
4. We get a spurious log error