### PR TITLE
lsu - retry tap in test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -257,7 +257,9 @@ class LogicalSynchronizerUpgradeIntegrationTest
         expectedAmulets: Range = 50 to 50,
     ) = {
       val walletUserParty = onboardWalletUser(walletClient, validatorBackend)
-      walletClient.tap(tapAmount)
+      eventuallySucceeds() {
+        walletClient.tap(tapAmount)
+      }
       clue(s"${validatorBackend.name} has tapped a amulet") {
         checkWallet(
           walletUserParty,


### PR DESCRIPTION
avoids stupid things like not enough traffic

[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/8053

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
