### PR TITLE
Ensure BulkStorageTests work with newer amulet versions

### DIFF
--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
@@ -20,7 +20,7 @@ import com.digitalasset.canton.{HasActorSystem, HasExecutionContext}
 import io.grpc.StatusRuntimeException
 import org.apache.pekko.stream.scaladsl.Sink
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
-import org.lfdecentralizedtrust.splice.environment.{RetryProvider, SpliceMetrics}
+import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider, SpliceMetrics}
 import org.lfdecentralizedtrust.splice.http.v0.definitions as httpApi
 import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
 import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
@@ -327,6 +327,7 @@ class AcsSnapshotBulkStorageTest
                       0L,
                       BigDecimal(0.1),
                       contractId = LfContractId.assertFromString("00" + f"$idx%064x").coid,
+                      version = DarResources.amulet_0_1_17, // ensure packageid determinism
                     )
                     SpliceCreatedEvent(s"#event_id_$idx:1", toCreatedEvent(amt))
                   }),

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -612,7 +612,7 @@ class UpdateHistoryBulkStorageTest
         0L,
         BigDecimal(0.1),
         contractId = LfContractId.assertFromString("00" + f"$idx%064x").coid,
-        version = DarResources.amulet_0_1_17
+        version = DarResources.amulet_0_1_17,
       )
       val tx = mkCreateTx(
         1, // not used in updates v2

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -21,7 +21,7 @@ import io.grpc.StatusRuntimeException
 import org.apache.pekko.stream.scaladsl.Keep
 import org.apache.pekko.stream.testkit.scaladsl.TestSink
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
-import org.lfdecentralizedtrust.splice.environment.{RetryProvider, SpliceMetrics}
+import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider, SpliceMetrics}
 import org.lfdecentralizedtrust.splice.environment.ledger.api.TransactionTreeUpdate
 import org.lfdecentralizedtrust.splice.http.v0.definitions.UpdateHistoryItemV2
 import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
@@ -612,6 +612,7 @@ class UpdateHistoryBulkStorageTest
         0L,
         BigDecimal(0.1),
         contractId = LfContractId.assertFromString("00" + f"$idx%064x").coid,
+        version = DarResources.amulet_0_1_17
       )
       val tx = mkCreateTx(
         1, // not used in updates v2


### PR DESCRIPTION
Stumbled upon this in the token standard branch after merging. The default is 'current' , which means the package_id changes everytime amulet gets bumped.