### PR TITLE
Revert "Disable reconnectOnSynchronizerConfigurationChange in DR IT test"

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisasterRecoveryIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DisasterRecoveryIntegrationTest.scala
@@ -13,7 +13,6 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
 }
 import org.lfdecentralizedtrust.splice.config.{
   ConfigTransforms,
-  EnabledFeaturesConfig,
   NetworkAppClientConfig,
   ParticipantClientConfig,
 }
@@ -96,25 +95,6 @@ class DisasterRecoveryIntegrationTest
       .withPreSetup(_ => ())
       .unsafeWithSequencerAvailabilityDelay(NonNegativeFiniteDuration.ofSeconds(5))
       .addConfigTransformsToFront((_, conf) => ConfigTransforms.bumpCantonPortsBy(22_000)(conf))
-      .addConfigTransforms((_, conf) =>
-        // TODO(DACH-NY/cn-test-failures#7486): this shouldn't be required once we have a Canton fix
-        conf.copy(
-          validatorApps = conf.validatorApps.map { case (k, config) =>
-            k -> config.copy(parameters =
-              config.parameters.copy(enabledFeatures =
-                EnabledFeaturesConfig(reconnectOnSynchronizerConfigurationChange = false)
-              )
-            )
-          },
-          svApps = conf.svApps.map { case (k, config) =>
-            k -> config.copy(parameters =
-              config.parameters.copy(enabledFeatures =
-                EnabledFeaturesConfig(reconnectOnSynchronizerConfigurationChange = false)
-              )
-            )
-          },
-        )
-      )
       .addConfigTransforms(
         (_, conf) =>
           updateAutomationConfig(ConfigurableApp.Sv)(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/7486

Reverts hyperledger-labs/splice#4374

This should be fixed as of https://github.com/DACH-NY/canton/commit/d24b790de9da060060b188e94da35f4cad0e6871, CI seems to agree: https://github.com/hyperledger-labs/splice/actions/runs/24453205735/job/71447373980?pr=5043