### PR TITLE
Tweak autovacuum settings for participant pruning

### DIFF
--- a/cluster/images/canton-participant/R__repeatable-migration.sql
+++ b/cluster/images/canton-participant/R__repeatable-migration.sql
@@ -10,3 +10,80 @@ alter table common_sequenced_events
         autovacuum_analyze_scale_factor = 0.0,
         autovacuum_analyze_threshold = 1000000
         );
+alter table lapi_filter_activate_stakeholder
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table lapi_filter_deactivate_stakeholder
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table lapi_filter_various_witness
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table lapi_filter_activate_witness
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table lapi_filter_deactivate_witness
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table lapi_events_various_witnessed
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );
+alter table par_contracts
+    set (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 10000,
+        autovacuum_vacuum_cost_limit = 2000,
+        autovacuum_vacuum_cost_delay = 5,
+        autovacuum_vacuum_insert_scale_factor = 0.0,
+        autovacuum_vacuum_insert_threshold = 100000,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 1000000
+        );


### PR DESCRIPTION
All of these seem slow to prune on mainnet and in some cases we explicitly see seq scans.

[ci]

fixes https://github.com/hyperledger-labs/splice/issues/4606



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
