### PR TITLE
Use 24h time format everywhere in the new Governance

### DIFF
--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -75,6 +75,7 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
               <DesktopDateTimePicker
                 value={dayjs(field.state.value.effectiveDate)}
                 format={dateTimeFormatISO}
+                ampm={false}
                 onChange={newDate => {
                   field.handleChange({
                     type: 'custom',


### PR DESCRIPTION
Fixes #4556

<img width="520" height="579" alt="image" src="https://github.com/user-attachments/assets/43d1366f-9400-435b-b830-394c9b495ed3" />

All other date time pickers and values are using 24h format

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
