### PR TITLE
1000 istio policies does not work; use larger chunks to avoid

### DIFF
--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -3,6 +3,7 @@
 import * as gcp from '@pulumi/gcp';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
+import * as assert from 'assert/strict';
 import {
   allSvsToDeployBasic,
   coreSvsToDeployBasic,
@@ -273,6 +274,32 @@ function configureCometBFTGatewayService(
   );
 }
 
+/**
+ * There doesn't seem to be an istio-level limit on number of IP lists but at
+ * some point we probably hit some k8s limits on the size of a definition so we
+ * split it into 100-500 IP ranges per policy.
+ *
+ * For 100k IPs, the difference between a chunk size of 100 vs 500 from scratch
+ * is 20min in pulumi vs 130min in pulumi. But we're still concerned about k8s
+ * limits on definition size. So if we break 10000 we'll gradually increase
+ * the chunk size, 20 IPs at a time, until reaching 500 chunk size for 50k IPs,
+ * which at least is tested for up to 100k IPs.
+ *
+ * Why 20? Too small jumps makes much noisier Pulumi previews. Too large, and we
+ * might jump right into a limit only revealed after extensive testing without
+ * really knowing where that limit is. 20 is a compromise: only jumps every 200
+ * IPs so realignment updates are rare.
+ */
+function istioAccessPolicyChunkSize(ipRangesLength: number) {
+  assert.ok(ipRangesLength >= 0, 'nonsense');
+  assert.ok(
+    ipRangesLength < 250000,
+    `${ipRangesLength} IPs untested, consider testing & increasing maximum chunk size`
+  );
+  const stepSize = 20;
+  return Math.max(100, Math.min(500, Math.ceil(ipRangesLength / (stepSize * 100)) * stepSize));
+}
+
 const istioApiVersion = 'security.istio.io/v1beta1';
 
 function istioAccessPolicies(
@@ -299,8 +326,7 @@ function istioAccessPolicies(
     }
   );
   return externalIPRanges.apply(ipRanges => {
-    // There doesn't seem to be an istio-level limit on number of IP lists but at some point we probably hit some k8s limits on the size of a definition so we split it into 100 IP ranges per policy.
-    const chunkSize = 100;
+    const chunkSize = istioAccessPolicyChunkSize(ipRanges.length);
     const chunks = Array.from({ length: Math.ceil(ipRanges.length / chunkSize) }, (_, i) =>
       ipRanges.slice(i * chunkSize, i * chunkSize + chunkSize)
     );


### PR DESCRIPTION
Found while testing #3817 with 100k IPs, 100 chunk-size; 500 chunk-size works great. More explained in included comment.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
