### PR TITLE
Wrap annotation field in a check for empty annotations

### DIFF
--- a/cluster/helm/cn-docs/templates/docs.yaml
+++ b/cluster/helm/cn-docs/templates/docs.yaml
@@ -7,8 +7,11 @@ kind: Deployment
 metadata:
   name: docs
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" "docs") | nindent 4 }}
 spec:

--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -4,8 +4,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}
   name: {{ .Release.Name }}

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -6,8 +6,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $mediatorLabel) | nindent 4 }}
     splice-component: mediator

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -6,8 +6,11 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/cluster/helm/splice-load-tester/templates/load-tester.yaml
+++ b/cluster/helm/splice-load-tester/templates/load-tester.yaml
@@ -6,8 +6,11 @@ kind: Deployment
 metadata:
   name: load-tester
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}
 spec:

--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -4,8 +4,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}
     {{- with $.Values.metrics.migration }}

--- a/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
+++ b/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
@@ -6,8 +6,11 @@ kind: Deployment
 metadata:
   name: party-allocator
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}
 spec:

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -8,8 +8,11 @@ kind: Deployment
 metadata:
   name: {{ $scanAppLabel }}
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $scanAppLabel) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}
@@ -291,8 +294,11 @@ kind: Deployment
 metadata:
   name: {{ $scanWebUiAppLabel }}
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $scanWebUiAppLabel) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}

--- a/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
+++ b/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
@@ -6,8 +6,11 @@ kind: Deployment
 metadata:
   name: splitwell-app
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" "splitwell-app") | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}

--- a/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
@@ -5,8 +5,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $appIdentifier) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -8,8 +8,11 @@ kind: Deployment
 metadata:
   name: {{ $appIdentifier }}
   namespace: {{ .Release.Namespace }}
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $appIdentifier) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}

--- a/cluster/helm/splice-validator/templates/ans-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/ans-web-ui.yaml
@@ -6,8 +6,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $ansWebUiLabel) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -6,8 +6,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   name: {{ $validatorAppLabel }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
@@ -6,8 +6,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- if $annotations }}
   annotations:
-    {{- include "splice-util-lib.default-annotations" .Values | nindent 4 }}
+    {{- $annotations .Values | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $walletWebUiLabel) | nindent 4 }}
     migration: {{ .Values.migration.id | quote }}


### PR DESCRIPTION

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).

Fixes #5079 by checking if default-annotations is empty before templating the annotations field

Current state
<img width="1492" height="312" alt="Screenshot 2026-04-16 at 2 34 25 PM" src="https://github.com/user-attachments/assets/7b26b98e-8f23-4dfc-aed8-fa2da44b6c5c" />

After changes
<img width="1492" height="312" alt="Screenshot 2026-04-16 at 2 34 41 PM" src="https://github.com/user-attachments/assets/3ba9dd33-83d4-43b6-b0c3-b0260ac76176" />
