### PR TITLE
Fix query for external party config state

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
@@ -127,7 +127,7 @@ trait TimeTestUtil extends TestCommon {
       .map(_.data.targetArchiveAfter)
       .min
     val advanceWith = Duration.between(now, nextTargetArchive.plusSeconds(10))
-    advanceTimeAndWaitForExternalPartyConfigStateAutomation(advanceWith)
+    advanceTimeAndWaitForExternalPartyConfigStateAutomation(configStates, advanceWith)
   }
 
   def waitForUpdateExternalPartyConfigStatesAutomation(implicit
@@ -239,11 +239,9 @@ trait TimeTestUtil extends TestCommon {
   }
 
   def advanceTimeAndWaitForExternalPartyConfigStateAutomation(
-      duration: Duration
+      configStates: Seq[ExternalPartyConfigState.Contract],
+      duration: Duration,
   )(implicit env: SpliceTestConsoleEnvironment) = {
-    val configStates = sv1Backend.participantClientWithAdminToken.ledger_api_extensions.acs
-      .filterJava(ExternalPartyConfigState.COMPANION)(dsoParty, _ => true)
-
     actAndCheck("advancing time", advanceTime(duration))(
       s"waiting for automation to update ExternalPartyConfigState",
       _ => {


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/8081

[ci]

What seems to be happening is:

1. We query for the config states and decide how far we need to advance.
2. We can be in a situation where the answer is not at all.
3. So then concurrently automation can update the external party config states.
4. We then query again before advancing time and fetch the updated state.
5. We then advance time by 0.
6. Then we query again and obviously nothing changed.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
