### PR TITLE
fix the task completion marker

### DIFF
--- a/cluster/images/splice-test-runner-hook/local.mk
+++ b/cluster/images/splice-test-runner-hook/local.mk
@@ -12,10 +12,10 @@ $(dir)/target/LICENSE: ${SPLICE_ROOT}/cluster/images/LICENSE | $(dir)/target
 	cp $< $@
 
 $(dir)/target/.npm_installed: $(package_files) | $(dir)/target
-	touch $@
 	npm ci --prefix $(src_dir)
     # we run ci here and not the bootstrap script because it modifies the package.json file
 	npm ci --prefix $(src_dir)/packages/hooklib && npm ci --prefix $(src_dir)/packages/k8s && npm ci --prefix $(src_dir)/packages/docker
+	touch $@
 
 $(dir)/target/index.js: $(source_files) $(dir)/target/.npm_installed | $(dir)/target
 	npm run build-all --prefix $(src_dir)


### PR DESCRIPTION
This fixes https://github.com/DACH-NY/cn-test-failures/issues/8078

We've had the task completion marker `touch $@` before finishing the task, which created the issue in the first place.