### PR TITLE
strip trailing # from update IDs in ACS snapshots

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
@@ -238,7 +238,8 @@ sealed trait ScanHttpEncodings {
              across SVs (and also not useful for users). */
           None
         } else {
-          Some(eventId.split(":")(0))
+          // We strip the `#` prefix if it exists, because it does not consistently exist across SVs.
+          Some(eventId.split(":")(0).stripPrefix("#"))
         },
         createdEvent.getContractId,
         templateIdString(createdEvent.getTemplateId),

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
@@ -141,13 +141,13 @@ class AcsSnapshotBulkStorageTest
           .getChecksums(objectKeys.toSeq)
           .futureValue
           .map(_.checksum) should contain theSameElementsInOrderAs Seq(
-          "ViKwAawccbUGu7VOF9K+w1fwXOJL82x8KtlPR8fE5QQ=",
-          "0JsYpCrjL3Iesxvba4mq6JazsAq3iIAKWPjViQhQDd0=",
-          "uGbENvaUVHMbZ5aVwR0iezkR1tpO0plZPXs79Rg2Kx0=",
-          "ecGsxj9T8BgMPgaguPcKJK9tomTEPuSv216vqvGrtVE=",
-          "CVECMUsWmg4hN0gdI2mOhXPZabJjxYNft/J0e3Yo/JU=",
-          "EGexqBExmi9b6H+kjsD+4aizbR6pBP3qQ6LXmMfiXMY=",
-          "ciCi6myO535U0y+eeZS90agy4QwBueeWGAZnnbr2zvM=",
+          "n6CV6dF9zpleq66YiXmCG96hw1BBakp1I8JjC5lf5n0=",
+          "bJDalSmiVKCk9QSc6sAWdahJNZQqVn51WmkFbQI6wkA=",
+          "noZU+He8HnCM38MujtpEle4NNGwnE7wN8z96V+HTdK0=",
+          "rwak+Y4JcInTiEa2yUKf8rjO3RD7ay/D2hmQG4BAa54=",
+          "YM7SNxHrU3xYyNOjgEqowitAvgsiX1f7tq0pCaD/OhQ=",
+          "Mb3D2ZOVQclMwuYEqLuTKhGqnUHCio6K61FBTXgt5Vs=",
+          "+5iW2M9Vz5y9sCtEWyrS3m+EUqnD50dXRVIMQAMSgBY=",
         )
       }
     }


### PR DESCRIPTION
Seems like with https://github.com/hyperledger-labs/splice/blob/main/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala#L662-L671 + backfilling somehow ended up with event IDs in DBs sometimes having the trailing # and sometimes not :( 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
