### PR TITLE
Handle old daml versions in wallet tx log test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTxLogWithSynchronizerFeesIntegrationTest.scala
@@ -1,6 +1,9 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
+import com.digitalasset.daml.lf.data.Ref.PackageVersion
+import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.install.amuletoperationoutcome.COO_Error
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms
+import org.lfdecentralizedtrust.splice.environment.DarResources
 import org.lfdecentralizedtrust.splice.util.{SynchronizerFeesTestUtil, WalletTestUtil}
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
@@ -40,12 +43,32 @@ class WalletTxLogWithSynchronizerFeesIntegrationTest
 
       actAndCheck(
         "Fail to purchase extra traffic for SV1", {
-          loggerFactory.assertThrowsAndLogs[CommandFailure](
-            buyMemberTraffic(sv1ValidatorBackend, domainFeesConfig.minTopupAmount - 1, now),
-            _.errorMessage should include(
-              "splice.lfdecentralizedtrust.org/insufficient-topup-amount"
-            ),
-          )
+          if (
+            PackageVersion.assertFromString(
+              sv1ScanBackend
+                .getAmuletRules()
+                .payload
+                .configSchedule
+                .initialValue
+                .packageConfig
+                .amulet
+            ) >= DarResources.amulet_0_1_18.metadata.version
+          ) {
+            loggerFactory.assertThrowsAndLogs[CommandFailure](
+              buyMemberTraffic(sv1ValidatorBackend, domainFeesConfig.minTopupAmount - 1, now),
+              _.errorMessage should include(
+                "splice.lfdecentralizedtrust.org/insufficient-topup-amount"
+              ),
+            )
+          } else {
+            inside(
+              buyMemberTraffic(sv1ValidatorBackend, domainFeesConfig.minTopupAmount - 1, now)
+            ) { case coo: COO_Error =>
+              coo.invalidTransferReasonValue.toString should startWith(
+                "ITR_InsufficientTopupAmount"
+              )
+            }
+          }
         },
       )(
         "The failure was ignored by the tx log parser",


### PR DESCRIPTION
This failed the daily compat tests against old Daml versions.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
