### PR TITLE
Remove now-upstreamed encryption key caching overrides

### DIFF
--- a/cluster/images/canton-participant/additional-config.conf
+++ b/cluster/images/canton-participant/additional-config.conf
@@ -5,19 +5,6 @@
 canton.participants.participant {
     parameters {
       commitment-asynchronous-initialization = true
-      caching {
-        # TODO(#3882) upstream and then remove here
-        session-encryption-key-cache {
-          sender-cache {
-            maximum-size = 100000 # default is 10000
-            expire-after-timeout = 3600s # default is 10s
-          }
-          receiver-cache {
-            maximum-size = 100000 # default is 10000
-            expire-after-timeout = 3600s # default is 10s
-          }
-        }
-      }
     }
     topology {
         enable-topology-state-cache-consistency-checks = false


### PR DESCRIPTION
See https://github.com/DACH-NY/canton/pull/31798

Fixes https://github.com/hyperledger-labs/splice/issues/3882 (last PR of many)

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
