### PR TITLE
Fix flake ExternalPartySetupProposalIntegrationTest createExternalPartyProposalViaLedgerApi due to Ledger time is at or past deadline

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternalPartySetupProposalIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ExternalPartySetupProposalIntegrationTest.scala
@@ -641,7 +641,7 @@ class ExternalPartySetupProposalIntegrationTest
     ) {
       val (proposalCid, _) = actAndCheck(
         s"Create a proposal to setup an external party with a soon-to-expire transfer preapproval",
-        createExternalPartyProposalViaLedgerApi(externalParty, Instant.now().plusSeconds(2)),
+        createExternalPartyProposalViaLedgerApi(externalParty, Instant.now().plusSeconds(5)),
       )(
         s"External party setup proposal for $externalParty was created",
         { proposalCid =>


### PR DESCRIPTION
Fix https://github.com/DACH-NY/cn-test-failures/issues/8080