### PR TITLE
Remove redundant post-LSU `approximate topology snapshot` log ignore

### DIFF
--- a/project/ignore-patterns/canton-standalone-global-synchronizer-upgrade.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-global-synchronizer-upgrade.ignore.txt
@@ -3,9 +3,6 @@ SEQUENCER_OVERLOADED.*it is behind on processing events.*sv4StandaloneSequencer
 sv4StandaloneSequencer.*Sequencer can't take requests because it is behind on processing events
 request current time.*Sequencer can't take requests because it is behind on processing events
 
-# TODO(DACH-NY/cn-test-failures#7875) revisit this ignore
-Using approximate topology snapshot at .* for desired timestamp
-
 # TODO(DACH-NY/cn-test-failures#7888) revisit this ignore
 GrpcClientGaveUp: DEADLINE_EXCEEDED
 GrpcClientGaveUp: CANCELLED/RST_STREAM


### PR DESCRIPTION
[ci]

Should be fixed now: https://github.com/DACH-NY/canton/pull/31922

Would close https://github.com/DACH-NY/cn-test-failures/issues/7875 if it wasn't closed already

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
