### PR TITLE
Fix lsu roll forward test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuIntegrationTest.scala
@@ -198,12 +198,19 @@ class RollForwardLsuIntegrationTest
       }
     }
 
+    // This is what is announced but then fails
+    val announcementNewSynchronizerSerial =
+      decentralizedSynchronizerPSId.serial + NonNegativeInt.one
+    // This is the synchronizer we roll forward two
     val newSynchronizerSerial = decentralizedSynchronizerPSId.serial + NonNegativeInt.two
-    val successorPsid = decentralizedSynchronizerPSId.copy(serial = newSynchronizerSerial)
+    val successorPsid = decentralizedSynchronizerPSId.copy(
+      serial = newSynchronizerSerial,
+      protocolVersion = ProtocolVersion.v34,
+    )
     val topologyFreezeTime = CantonTimestamp.now()
     val upgradeTime = CantonTimestamp.now().plusSeconds(60)
     clue("Schedule logical synchronizer upgrade") {
-      scheduleLsu(topologyFreezeTime, upgradeTime, newSynchronizerSerial.value.toLong)
+      scheduleLsu(topologyFreezeTime, upgradeTime, announcementNewSynchronizerSerial.value.toLong)
     }
     clue("Topology state contains LSU announcement") {
       eventually(3.minutes) {
@@ -229,6 +236,10 @@ class RollForwardLsuIntegrationTest
       participants = false,
       enableBftSequencer = true,
       logSuffix = "roll-forward-lsu",
+      extraSequencerConfig = Seq(
+        s"parameters.lsu-repair.lsu-sequencing-bounds-override.lower-bound-sequencing-time-exclusive=${upgradeTime}",
+        s"parameters.lsu-repair.lsu-sequencing-bounds-override.upgrade-time=${upgradeTime}",
+      ),
     )() {
       // Wait first so that the participant has observed the timestamp and will happily migrate.
       clue(s"wait for upgrade time $upgradeTime") {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
@@ -156,7 +156,7 @@ class SequencerAdminConnection(
   def initializeFromPredecessor(
       topologySnapshot: Path,
       staticSynchronizerParameters: StaticSynchronizerParameters,
-      ignorePsidCheck: Boolean = false,
+      ignorePsidCheck: Boolean,
   )(implicit
       traceContext: TraceContext
   ): Future[Unit] = {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LogicalSynchronizerUpgradeTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LogicalSynchronizerUpgradeTrigger.scala
@@ -134,6 +134,7 @@ class LogicalSynchronizerUpgradeTrigger(
         task.work.announcement.successorSynchronizerId,
         task.readyAt,
         Some(task.work.announcement.upgradeTime),
+        ignorePsidCheck = false,
       )
       currentPsid <- currentSynchronizerNode.sequencerAdminConnection
         .getPhysicalSynchronizerId()

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuNodeInitializer.scala
@@ -74,6 +74,7 @@ class LsuNodeInitializer(
       successorSynchronizerId: PhysicalSynchronizerId,
       now: CantonTimestamp,
       upgradeTime: Option[CantonTimestamp],
+      ignorePsidCheck: Boolean,
   )(implicit tc: TraceContext): Future[StaticSynchronizerParameters] = {
     logger.info("Initializing sequencer and mediators from the data of the old nodes")
     for {
@@ -102,6 +103,7 @@ class LsuNodeInitializer(
             parameters.copy(
               protocolVersion = successorSynchronizerId.protocolVersion
             ),
+            ignorePsidCheck,
           )
         },
         logger,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/lsu/RollForwardLsuInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/lsu/RollForwardLsuInitializer.scala
@@ -165,6 +165,7 @@ class RollForwardLsuInitializer(
               now = clock.now,
               // Upgrade time is used to publish the sequencer sucessor which we don't care about for roll-forward LSUs.
               upgradeTime = None,
+              ignorePsidCheck = true,
             )
             trafficState <- legacyNode.sequencerAdminConnection.getLsuTrafficControlState(ts =
               rollForwardConfig.exportTimes.map(_.trafficExportTime.getTimestamp())


### PR DESCRIPTION
The previous test made no sense. We announced serial 2 and then roll-forward'ded to serial 2. Now we announce 1 and roll forward to
2. This does require disabling the psid check and manually specifying the lower bound.

Note that in the test against PV 35 this actually tests a protocol downgrade now. That works though and seems actually like a useful scenario to test.

fixes https://github.com/DACH-NY/cn-test-failures/issues/8159

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
