### PR TITLE
Disable cloudsql postgres terraform deletion protection

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2706,7 +2706,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -3910,7 +3910,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -691,7 +691,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -876,7 +876,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -989,7 +989,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1756,7 +1756,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -1871,7 +1871,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -1986,7 +1986,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -2101,7 +2101,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -2216,7 +2216,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -2331,7 +2331,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -2446,7 +2446,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -2665,7 +2665,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -2780,7 +2780,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -2895,7 +2895,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -3010,7 +3010,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -4137,7 +4137,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -4252,7 +4252,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -4367,7 +4367,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -4482,7 +4482,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -4597,7 +4597,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -4712,7 +4712,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -4827,7 +4827,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -5071,7 +5071,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -5186,7 +5186,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "NEVER",
@@ -5301,7 +5301,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -5416,7 +5416,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -317,7 +317,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -601,7 +601,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -755,7 +755,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",
@@ -935,7 +935,7 @@
     "id": "",
     "inputs": {
       "databaseVersion": "POSTGRES_14",
-      "deletionProtection": true,
+      "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
         "activationPolicy": "ALWAYS",

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -120,7 +120,9 @@ export class CloudPostgres
       name,
       {
         databaseVersion: 'POSTGRES_14',
-        deletionProtection: deletionProtection,
+        // keep always false as this is the terraform provider and cannot be manually removed
+        // https://github.com/pulumi/pulumi-gcp/issues/1209
+        deletionProtection: false,
         region: config.requireEnv('CLOUDSDK_COMPUTE_REGION'),
         settings: {
           deletionProtectionEnabled: deletionProtection,


### PR DESCRIPTION
This is always a pain as it's the third layer of protection, the gcp one and the pulumi ones can be manually disabled but this layer requires a pulumi up to disable, if not you need to manually delete and then refresh.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
