### PR TITLE
Update Token Standard Devnet version to 0.6.1-snapshot.20260427.2678.0.v86ff9ad5

### DIFF
--- a/token-standard/TOKEN_STANDARD_V2_DEVNET.md
+++ b/token-standard/TOKEN_STANDARD_V2_DEVNET.md
@@ -1,6 +1,6 @@
 # Token Standard V2 DevNet
 
-Splice version: `0.6.0-snapshot.20260422.2626.0.v5aaef00e`
+Splice version: `0.6.1-snapshot.20260427.2678.0.v86ff9ad5`
 
 Container image repository (compose `IMAGE_REPO`/ helm `imageRepo`): `ghcr.io/digital-asset/decentralized-canton-sync-dev/docker`
 So the docker pull command should look like `docker pull ghcr.io/digital-asset/decentralized-canton-sync-dev/docker/SOME_IMAGE:THE_VERSION_ABOVE`


### PR DESCRIPTION
https://token-std-v2-dev.global.canton.network.digitalasset.com/version

[static]

I'm uploading the release bundle now, the link doesn't need to change.