### PR TITLE
Rename "Validator faucet cap" UI label to "Validator liveness reward cap"

### DIFF
--- a/apps/sv/frontend/src/utils/buildAmuletConfigChanges.ts
+++ b/apps/sv/frontend/src/utils/buildAmuletConfigChanges.ts
@@ -231,7 +231,7 @@ function buildIssuanceCurveChanges(
     },
     {
       fieldName: 'issuanceCurveInitialValueOptValidatorFaucetCap',
-      label: 'Minting curve: Initial value: Validator faucet cap',
+      label: 'Minting curve: Initial value: Validator liveness reward cap',
       currentValue: before?.initialValue?.optValidatorFaucetCap || '',
       newValue: after?.initialValue?.optValidatorFaucetCap || '',
     },
@@ -291,7 +291,7 @@ function buildIssuanceCurveChanges(
           },
           {
             fieldName: `issuanceCurveFutureValues${idx}OptValidatorFaucetCap`,
-            label: `Minting curve: Step ${idx}: Validator faucet cap`,
+            label: `Minting curve: Step ${idx}: Validator liveness reward cap`,
             currentValue: fv._2.optValidatorFaucetCap || '',
             newValue: after?.futureValues[idx]._2.optValidatorFaucetCap || '',
           },


### PR DESCRIPTION
## Summary

Aligns user-facing terminology with the Canton Coin whitepaper, which uses "liveness rewards" rather than "faucet" for the per-round validator rewards. Fixes #958.

- `apps/sv/frontend`: relabel the two `optValidatorFaucetCap` rows in the SV governance minting curve diff view ("Validator faucet cap" -> "Validator liveness reward cap").

## Scope

Per the original issue author guidance ("No changes to Daml code; just UI for now"), this is intentionally minimal:

- **No Daml changes.** The final diff leaves `splice-amulet` untouched to avoid triggering a Daml package/version change.
- **No on-chain ABI changes.** The `ValidatorLivenessActivityRecord` template already exists alongside the deprecated `ValidatorFaucetCoupon`; the wallet OpenAPI already exposes both endpoint sets. Renaming `FaucetState`, `optValidatorFaucetCap`, `optIssuancePerValidatorFaucetCoupon`, etc. would break on-chain contract compatibility for fields still in active templates and is out of scope.
- **No public API renames.** The Scan OpenAPI endpoints (`/v0/validators/validator-faucets`, `/v0/top-validators-by-validator-faucets`) are unchanged here. Adding a parallel "liveness" set (mirroring what was done for the wallet API) would be a reasonable follow-up but is a separate concern from a label rename.
- **No internal Scala/test renames.** Many internal classes (e.g. `ReceiveFaucetCouponTrigger`, `listValidatorFaucetCouponsOnDomain`) still process the deprecated `ValidatorFaucetCoupon` template; their names accurately describe what they do. They can be revisited if/when the deprecated template is removed.

## Test plan

- [x] `git diff --check upstream/main HEAD`
- [x] `npm run format:check -- src/utils/buildAmuletConfigChanges.ts` from `apps/sv/frontend`
- [x] `npm run lint:check -- src/utils/buildAmuletConfigChanges.ts` from `apps/sv/frontend`
- [x] Reviewed the final PR diff: it is limited to the two user-facing SV frontend label strings.