### PR TITLE
pulumi: add dependency on bulk storage resources

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -180,6 +180,8 @@ svs:
           memory: '1536Mi'
         limits:
           memory: '2048Mi'
+      bulkStorage:
+        enabled: true
     svApp:
       additionalPackagesToUnvet:
         splice-wallet-payments: [ "0.1.15", "0.1.16" ]

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1553,6 +1553,90 @@
   {
     "custom": true,
     "id": "",
+    "inputs": {},
+    "name": "mock-sv-1-bulk-hmac",
+    "provider": "",
+    "type": "gcp:storage/hmacKey:HmacKey"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "bucket": "mock-sv-1-bulk",
+      "member": "serviceAccount:undefined",
+      "role": "roles/storage.objectUser"
+    },
+    "name": "mock-sv-1-bulk-sa-role",
+    "provider": "",
+    "type": "gcp:storage/bucketIAMMember:BucketIAMMember"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "accountId": "mock-sv-1-bulk-sa",
+      "displayName": "Service Account for Bulk-Storage Bucket Read/Write Access"
+    },
+    "name": "mock-sv-1-bulk-sa",
+    "provider": "",
+    "type": "gcp:serviceaccount/account:Account"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "location": "europe-west6",
+      "name": "mock-sv-1-bulk"
+    },
+    "name": "mock-sv-1-bulk",
+    "provider": "",
+    "type": "gcp:storage/bucket:Bucket"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {},
+    "name": "mock-sv-da-1-bulk-hmac",
+    "provider": "",
+    "type": "gcp:storage/hmacKey:HmacKey"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "bucket": "mock-sv-da-1-bulk",
+      "member": "serviceAccount:undefined",
+      "role": "roles/storage.objectUser"
+    },
+    "name": "mock-sv-da-1-bulk-sa-role",
+    "provider": "",
+    "type": "gcp:storage/bucketIAMMember:BucketIAMMember"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "accountId": "mock-sv-da-1-bulk-sa",
+      "displayName": "Service Account for Bulk-Storage Bucket Read/Write Access"
+    },
+    "name": "mock-sv-da-1-bulk-sa",
+    "provider": "",
+    "type": "gcp:serviceaccount/account:Account"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "location": "europe-west6",
+      "name": "mock-sv-da-1-bulk"
+    },
+    "name": "mock-sv-da-1-bulk",
+    "provider": "",
+    "type": "gcp:storage/bucket:Bucket"
+  },
+  {
+    "custom": true,
+    "id": "",
     "inputs": {
       "datasetId": "mock_da2_scan",
       "deleteContentsOnDestroy": true,
@@ -2642,6 +2726,29 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "apiVersion": "v1",
+      "data": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {
+          "accessKey": "",
+          "secretAccessKey": ""
+        }
+      },
+      "kind": "Secret",
+      "metadata": {
+        "name": "splice-app-bulk-storage-credentials",
+        "namespace": "sv-1"
+      },
+      "type": "Opaque"
+    },
+    "name": "sv-1-bulk-storage-credentials",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "length": 16,
       "overrideSpecial": "_%@",
       "special": true
@@ -3334,6 +3441,14 @@
           }
         },
         "apiRequestLogLevel": "DEBUG",
+        "bulkStorage": {
+          "s3": {
+            "bucketName": "mock-sv-1-bulk",
+            "endpoint": "https://storage.googleapis.com",
+            "region": "europe-west6",
+            "secretName": "splice-app-bulk-storage-credentials"
+          }
+        },
         "cluster": {
           "dnsName": "mock.global.canton.network.digitalasset.com",
           "fixedTokens": false,
@@ -3841,6 +3956,29 @@
     "name": "sv-1",
     "provider": "",
     "type": "kubernetes:core/v1:Namespace"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "v1",
+      "data": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {
+          "accessKey": "",
+          "secretAccessKey": ""
+        }
+      },
+      "kind": "Secret",
+      "metadata": {
+        "name": "splice-app-bulk-storage-credentials",
+        "namespace": "sv-da-1"
+      },
+      "type": "Opaque"
+    },
+    "name": "sv-da-1-bulk-storage-credentials",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
   },
   {
     "custom": true,
@@ -4367,6 +4505,14 @@
           }
         },
         "apiRequestLogLevel": "DEBUG",
+        "bulkStorage": {
+          "s3": {
+            "bucketName": "mock-sv-da-1-bulk",
+            "endpoint": "https://storage.googleapis.com",
+            "region": "europe-west6",
+            "secretName": "splice-app-bulk-storage-credentials"
+          }
+        },
         "cluster": {
           "dnsName": "mock.global.canton.network.digitalasset.com",
           "fixedTokens": false,

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -219,6 +219,7 @@ export async function installSvNode(
         ? svCometBftGovernanceKeySecret(xns, config.cometBftGovernanceKey)
         : []
     )
+    .concat(bulkStorageBucket ? [bulkStorageBucket.secret, bulkStorageBucket.bucket] : [])
     .concat(extraDependsOn);
 
   const defaultPostgres = config.splitPostgresInstances

--- a/cluster/pulumi/canton-network/src/sv.ts
+++ b/cluster/pulumi/canton-network/src/sv.ts
@@ -615,9 +615,9 @@ function installScan(
           bulkStorage: {
             s3: {
               region: config.bulkStorageBucket.region,
-              bucketName: config.bulkStorageBucket.bucketName,
+              bucketName: config.bulkStorageBucket.bucket.name,
               endpoint: 'https://storage.googleapis.com', // gcs endpoint for s3
-              secretName: config.bulkStorageBucket.secretName,
+              secretName: config.bulkStorageBucket.secret.metadata.name,
             },
           },
         }

--- a/cluster/pulumi/common-sv/src/bulkStorage.ts
+++ b/cluster/pulumi/common-sv/src/bulkStorage.ts
@@ -74,6 +74,6 @@ export function installScanBulkStorage(
   return {
     region: GcpRegion,
     bucket,
-    secret
+    secret,
   } as BulkStorageBucket;
 }

--- a/cluster/pulumi/common-sv/src/bulkStorage.ts
+++ b/cluster/pulumi/common-sv/src/bulkStorage.ts
@@ -15,6 +15,8 @@ export type BulkStorageBucket = {
   bucketName: string;
   region: string;
   secretName: string;
+  bucket: gcp.storage.Bucket;
+  secret: k8s.core.v1.Secret;
 };
 
 export function installScanBulkStorage(
@@ -53,7 +55,7 @@ export function installScanBulkStorage(
   const secretAccessKey = hmacKey.secret;
 
   const secretName = 'splice-app-bulk-storage-credentials';
-  new k8s.core.v1.Secret(
+  const secret = new k8s.core.v1.Secret(
     `${xns.logicalName}-bulk-storage-credentials`,
     {
       metadata: {
@@ -75,5 +77,7 @@ export function installScanBulkStorage(
     bucketName,
     region: GcpRegion,
     secretName,
+    bucket,
+    secret
   } as BulkStorageBucket;
 }

--- a/cluster/pulumi/common-sv/src/bulkStorage.ts
+++ b/cluster/pulumi/common-sv/src/bulkStorage.ts
@@ -12,10 +12,8 @@ import {
 import { BulkStorageConfig } from './singleSvConfig';
 
 export type BulkStorageBucket = {
-  bucketName: string;
-  region: string;
-  secretName: string;
   bucket: gcp.storage.Bucket;
+  region: string;
   secret: k8s.core.v1.Secret;
 };
 
@@ -74,9 +72,7 @@ export function installScanBulkStorage(
   );
 
   return {
-    bucketName,
     region: GcpRegion,
-    secretName,
     bucket,
     secret
   } as BulkStorageBucket;


### PR DESCRIPTION
When trying to enable on DevNet, it failed to create the hmac key, but still configured scan, which caused downtime in scan until resolved. This should prevent that.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
