### PR TITLE
sv app - change sync reconnection to start lsu triggers

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -350,17 +350,17 @@ class LogicalSynchronizerUpgradeIntegrationTest
       logSuffix = "global-synchronizer-upgrade",
     )() {
 
-      clue(s"wait for lsu announcement") {
-        waitForLsuAnnouncement()
-      }
-
       clue(
-        "Pause traffic transfer trigger on sv2 to simulate a participant that is conencted to a non initialized sequencer past upgrade tiem"
+        "Pause traffic transfer trigger on sv2 to simulate a participant that is connected to a non initialized sequencer past upgrade tiem"
       ) {
         sv2Backend.dsoAutomation
           .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
           .pause()
           .futureValue
+      }
+
+      clue(s"wait for lsu announcement") {
+        waitForLsuAnnouncement()
       }
 
       clue("new nodes are initialized") {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -354,7 +354,9 @@ class LogicalSynchronizerUpgradeIntegrationTest
         waitForLsuAnnouncement()
       }
 
-      clue("Pause traffic transfer trigger on sv2") {
+      clue(
+        "Pause traffic transfer trigger on sv2 to simulate a participant that is conencted to a non initialized sequencer past upgrade tiem"
+      ) {
         sv2Backend.dsoAutomation
           .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
           .pause()
@@ -366,7 +368,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
           val upgradeSequencerClient = backend.sequencerClientFor(_.successor.value)
           val upgradeMediatorClient = backend.mediatorClientFor(_.successor.value)
           clue(s"check ${backend.name} initialized sequencer from synchronizer predecessor") {
-            eventuallySucceeds(2.minutes) {
+            eventuallySucceeds(3.minutes) {
               upgradeSequencerClient.physical_synchronizer_id shouldBe successorPsid
             }
           }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LogicalSynchronizerUpgradeIntegrationTest.scala
@@ -33,7 +33,10 @@ import org.lfdecentralizedtrust.splice.sv.config.{
   SvSynchronizerNodeConfig,
   SvSynchronizerNodesConfig,
 }
-import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSynchronizerUpgradeTrigger
+import org.lfdecentralizedtrust.splice.sv.lsu.{
+  LogicalSyncUpgradeTransferTrafficTrigger,
+  LogicalSynchronizerUpgradeTrigger,
+}
 import org.lfdecentralizedtrust.splice.util.*
 import org.lfdecentralizedtrust.splice.wallet.config.WalletAppClientConfig
 import org.lfdecentralizedtrust.splice.wallet.store.TxLogEntry.Http.BuyTrafficRequestStatus
@@ -351,6 +354,13 @@ class LogicalSynchronizerUpgradeIntegrationTest
         waitForLsuAnnouncement()
       }
 
+      clue("Pause traffic transfer trigger on sv2") {
+        sv2Backend.dsoAutomation
+          .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
+          .pause()
+          .futureValue
+      }
+
       clue("new nodes are initialized") {
         initialSvNodesDoingTheLsu.map { backend =>
           val upgradeSequencerClient = backend.sequencerClientFor(_.successor.value)
@@ -371,6 +381,14 @@ class LogicalSynchronizerUpgradeIntegrationTest
 
       clue(s"wait for upgrade time $upgradeTime") {
         Threading.sleep(Duration.between(Instant.now(), upgradeTime.toInstant).toMillis.abs)
+      }
+
+      clue("Restart sv2 and resume traffic transfer trigger") {
+        sv2Backend.stop()
+        sv2Backend.startSync()
+        sv2Backend.dsoAutomation
+          .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
+          .resume()
       }
 
       def participantIsConnectedToNewSynchronizer(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/ProcessTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/ProcessTestUtil.scala
@@ -114,7 +114,7 @@ trait ProcessTestUtil { this: BaseTest =>
       extraEnv*
     )
   }
-  val defaultJavaToolOptions = "-Xms4g -Xmx6g"
+  val defaultJavaToolOptions = "-Xms4g -Xmx8g"
   private def startCantonInternal(
       args: Seq[String],
       logSuffix: String,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
@@ -34,11 +34,12 @@ import com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionCo
 import com.digitalasset.canton.sequencing.{
   GrpcSequencerConnection,
   SequencerConnection,
-  SequencerConnectionValidation,
   SequencerConnections,
+  SequencerConnectionValidation,
 }
 import com.digitalasset.canton.sequencing.protocol.TrafficState
 import com.digitalasset.canton.topology.{
+  ConfiguredPhysicalSynchronizerId,
   KnownPhysicalSynchronizerId,
   NodeIdentity,
   ParticipantId,
@@ -150,9 +151,7 @@ class ParticipantAdminConnection(
       traceContext: TraceContext
   ): Future[Option[PhysicalSynchronizerId]] =
     OptionT(for {
-      configuredDomains <- runCmd(
-        ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
-      )
+      configuredDomains <- listRegisteredSynchronizers()
     } yield configuredDomains.collectFirst {
       case (configuredSynchronizer, psid, _)
           if configuredSynchronizer.synchronizerAlias == synchronizerAlias =>
@@ -167,11 +166,17 @@ class ParticipantAdminConnection(
       )
       .value
 
+  def listRegisteredSynchronizers()(implicit
+      tc: TraceContext
+  ): Future[Seq[(SynchronizerConnectionConfig, ConfiguredPhysicalSynchronizerId, Boolean)]] = {
+    runCmd(
+      ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
+    )
+  }
+
   def getPhysicalSynchronizerId(synchronizerId: SynchronizerId)(implicit
       traceContext: TraceContext
-  ): Future[PhysicalSynchronizerId] = runCmd(
-    ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
-  ).map(
+  ): Future[PhysicalSynchronizerId] = listRegisteredSynchronizers().map(
     _.collectFirst {
       case (_, KnownPhysicalSynchronizerId(psid), _) if psid.logical == synchronizerId => psid
     }.getOrElse(
@@ -508,9 +513,7 @@ class ParticipantAdminConnection(
       domain: SynchronizerAlias
   )(implicit traceContext: TraceContext): Future[Option[SynchronizerConnectionConfig]] =
     for {
-      configuredDomains <- runCmd(
-        ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
-      )
+      configuredDomains <- listRegisteredSynchronizers()
     } yield configuredDomains
       .collectFirst {
         case (configuredDomain, _, _) if configuredDomain.synchronizerAlias == domain =>

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -185,7 +185,7 @@ class BaseLedgerConnection(
 
   def ensureUserPrimaryPartyIsAllocated(
       userId: String,
-      hint: String,
+      hint: => String,
       participantAdminConnection: ParticipantAdminConnection,
   )(implicit traceContext: TraceContext): Future[PartyId] =
     retryProvider.ensureThatO(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SynchronizerNodeService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SynchronizerNodeService.scala
@@ -49,25 +49,28 @@ class SynchronizerNodeService[T <: SynchronizerNode](
       case None => Future.successful(false)
       case Some(successor) =>
         for {
-          connections <- participantAdminConnection.listConnectedDomains()
+          synchronizers <- participantAdminConnection.listRegisteredSynchronizers()
           succesorInitialized <- successor.sequencerAdminConnection
             .isNodeInitialized()
             .attemptT
             .getOrElse(false)
-          global = connections
+          global = synchronizers
             .find(
-              _.synchronizerAlias == globalSynchronizerAlias
+              _._1.synchronizerAlias == globalSynchronizerAlias
             )
+            .flatMap(_._2.toOption)
             .getOrElse(
               throw Status.NOT_FOUND
-                .withDescription(s"No connected synchronizer with alias $globalSynchronizerAlias")
+                .withDescription(
+                  s"No registered synchronizer with alias $globalSynchronizerAlias that has a physical synchronizer id"
+                )
                 .asRuntimeException
             )
           successorPSId <-
             if (succesorInitialized)
               successor.sequencerAdminConnection.getPhysicalSynchronizerId().map(Some(_))
             else Future.successful(None)
-        } yield successorPSId.map(_.serial).contains(global.physicalSynchronizerId.serial)
+        } yield successorPSId.map(_.serial).contains(global.serial)
     }
 
   def activeSynchronizerNode()(implicit tc: TraceContext): Future[T] =

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -227,40 +227,6 @@ class SvDsoAutomationService(
       )
     )
 
-    synchronizerNodeService.nodes.successor match {
-      case Some(successorSynchronizerNode) =>
-        registerTrigger(
-          new LogicalSynchronizerUpgradeTrigger(
-            triggerContext,
-            synchronizerNodeReconciler,
-            synchronizerNodeService.nodes,
-            successorSynchronizerNode,
-            participantAdminConnection,
-            store,
-            config.domainMigrationDumpPath.getOrElse(
-              throw new IllegalArgumentException("Domain migration dump path must be set for LSU")
-            ),
-            config.bftSequencerConnection,
-          )
-        )
-        registerTrigger(
-          new LogicalSyncUpgradeTransferTrafficTrigger(
-            triggerContext,
-            synchronizerNodeService.nodes.current,
-            successorSynchronizerNode,
-          )
-        )
-        registerTrigger(
-          new LogicalSynchronizerUpgradeSequencingTestTrigger(
-            config,
-            triggerContext,
-            synchronizerNodeService.nodes.current,
-            successorSynchronizerNode,
-          )
-        )
-      case _ => ()
-    }
-
     registerTrigger(
       new ReconcileDynamicSynchronizerParametersTrigger(
         triggerContext,
@@ -311,6 +277,42 @@ class SvDsoAutomationService(
 
     registerTriggersForSynchronizers(synchronizerNodeService.nodes.current)
     synchronizerNodeService.nodes.successor.foreach(registerTriggersForSynchronizers)
+  }
+
+  def registerLsuTriggers() = {
+    synchronizerNodeService.nodes.successor match {
+      case Some(successorSynchronizerNode) =>
+        registerTrigger(
+          new LogicalSynchronizerUpgradeTrigger(
+            triggerContext,
+            synchronizerNodeReconciler,
+            synchronizerNodeService.nodes,
+            successorSynchronizerNode,
+            participantAdminConnection,
+            store,
+            config.domainMigrationDumpPath.getOrElse(
+              throw new IllegalArgumentException("Domain migration dump path must be set for LSU")
+            ),
+            config.bftSequencerConnection,
+          )
+        )
+        registerTrigger(
+          new LogicalSyncUpgradeTransferTrafficTrigger(
+            triggerContext,
+            synchronizerNodeService.nodes.current,
+            successorSynchronizerNode,
+          )
+        )
+        registerTrigger(
+          new LogicalSynchronizerUpgradeSequencingTestTrigger(
+            config,
+            triggerContext,
+            synchronizerNodeService.nodes.current,
+            successorSynchronizerNode,
+          )
+        )
+      case _ => ()
+    }
   }
 
   def registerTrafficReconciliationTriggers(): Unit = {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SetupUtil.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SetupUtil.scala
@@ -24,16 +24,15 @@ private[onboarding] object SetupUtil {
   )(implicit
       traceContext: TraceContext
   ): Future[PartyId] = {
-    val partyHint = config.svPartyHint.getOrElse(
-      config.onboarding
-        .getOrElse(
-          sys.error("Cannot setup SV party without either party hint or an onboarding config")
-        )
-        .name
-    )
     connection.ensureUserPrimaryPartyIsAllocated(
       config.ledgerApiUser,
-      partyHint,
+      config.svPartyHint.getOrElse(
+        config.onboarding
+          .getOrElse(
+            sys.error("Cannot setup SV party without either party hint or an onboarding config")
+          )
+          .name
+      ),
       participantAdminConnection,
     )
   }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -180,10 +180,21 @@ class JoiningNodeInitializer(
           )
         ),
       ).tupled
-      // It is possible that the participant left disconnected to domains due to a failure in the last SV startup.
-      // Reconnect all domains at the beginning of SV initialization in case, but
-      // only if we already host the dso party or if we don't see a proposal to host it.
-      decentralizedSynchronizerId <- proceedWithReconnectAllDomains(dsoPartyId)
+      decentralizedSynchronizerId <- participantAdminConnection
+        .getSynchronizerId(config.domains.global.alias)
+      dsoPartyHosting = newDsoPartyHosting(dsoPartyId)
+      dsoPartyIsAuthorized <- dsoPartyHosting.isDsoPartyAuthorizedOn(
+        decentralizedSynchronizerId,
+        participantId,
+      )
+      _ <-
+        // do not reconnect if we host the party, as we can be in some LSU stage and the participant cannot reconnect if the new sync is not functional
+        if (!dsoPartyIsAuthorized) {
+          reconnectSynchronizersIfDsoPartyMigrationSafe(
+            decentralizedSynchronizerId,
+            dsoPartyId,
+          )
+        } else Future.unit
       svParty <- SetupUtil.setupSvParty(
         initConnection,
         config,
@@ -227,16 +238,11 @@ class JoiningNodeInitializer(
         connection,
         loggerFactory,
       )
-      dsoPartyHosting = newDsoPartyHosting(storeKey.dsoParty)
       currentNode <- synchronizerNodeService.activeSynchronizerNode()
       // We need to first wait to ensure the CometBFT node is caught up
       // If the CometBFT node is not caught up and we start the CometBFT triggers, if the network doesn't have any
       // fault tolerance then it might be blocked until the CometBFT node is caught up.
       _ <- waitUntilCometBftNodeHasCaughtUp(currentNode)
-      dsoPartyIsAuthorized <- dsoPartyHosting.isDsoPartyAuthorizedOn(
-        decentralizedSynchronizerId,
-        participantId,
-      )
       withSvStore = new WithSvStore(
         svAutomation,
         new JoiningNodeDsoPartyHosting(
@@ -281,6 +287,12 @@ class JoiningNodeInitializer(
                 config.parameters.enabledFeatures,
                 synchronizerNodeReconciler,
               )
+            // register before maybe reconnecting to proceed with the LSU if the participant is in a broken state
+            _ = dsoAutomation.registerLsuTriggers()
+            _ <- reconnectSynchronizersIfDsoPartyMigrationSafe(
+              decentralizedSynchronizerId,
+              dsoPartyId,
+            )
             _ <- svStore.domains.waitForDomainConnection(config.domains.global.alias)
             _ <- dsoStore.domains.waitForDomainConnection(config.domains.global.alias)
             _ <- retryProvider
@@ -317,6 +329,7 @@ class JoiningNodeInitializer(
                 packageVersionSupport,
                 decentralizedSynchronizerId,
               )
+            _ = dsoAutomation.registerLsuTriggers()
           } yield dsoAutomation
         }
       // We set the initial round to the one from the sponsor if no initial round is store in the user metadata yet
@@ -503,18 +516,15 @@ class JoiningNodeInitializer(
   // - already hosts the dsoParty or
   // - is not in the process to host it
   // if not we risk reconnecting while the party was authorized but the acs was not imported yet thus breaking the participant
-  private def proceedWithReconnectAllDomains(
-      dsoParty: PartyId
-  )(implicit tc: TraceContext, ec: ExecutionContext): Future[SynchronizerId] = {
+  private def reconnectSynchronizersIfDsoPartyMigrationSafe(
+      decentralizedSynchronizerId: SynchronizerId,
+      dsoParty: PartyId,
+  )(implicit tc: TraceContext, ec: ExecutionContext): Future[Unit] = {
     retryProvider.retry(
       RetryFor.ClientCalls,
       "reconnect_all_domains",
       "Reconnecting to all domains if participant hosts or is not in the process to host the dsoParty.",
       for {
-        decentralizedSynchronizerId <- participantAdminConnection
-          .getPhysicalSynchronizerId(
-            config.domains.global.alias
-          )
         participantId <- participantAdminConnection.getParticipantId()
         // Check if the participant hosts the DSO party. If so,
         // the dsoParty is hosted on the participant we can proceed to all domains reconnect
@@ -546,7 +556,6 @@ class JoiningNodeInitializer(
         logger.info(
           s"Participant hosts dsoParty: ${dsoPartyToParticipantMapping.nonEmpty} and has proposals to host dsoParty ${activeDsoPartyToParticipantProposals.nonEmpty}"
         )
-        decentralizedSynchronizerId.logical
       },
       logger,
     )

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -353,6 +353,7 @@ class SV1Initializer(
           config.scan,
         ),
       )
+      _ = dsoAutomation.registerLsuTriggers()
       _ <- dsoStore.domains.waitForDomainConnection(config.domains.global.alias)
       withDsoStore = new WithDsoStore(
         dsoAutomation,


### PR DESCRIPTION
avoid the need to reconnect before starting lsu triggers

this fixes the edge case where the traffic was not transferred, the upgrade time was reached and the sv apps were restarted 

https://github.com/DACH-NY/canton-network-internal/issues/4758

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
