### PR TITLE
Stop ignoring damlc warnings

### DIFF
--- a/project/ignore-patterns/sbt-output.ignore.txt
+++ b/project/ignore-patterns/sbt-output.ignore.txt
@@ -132,13 +132,3 @@ WARN: InvalidDefaultArgInFrom
 
 # the script does not try to be secure
 .*api_jwt\.py:153: InsecureKeyLengthWarning:.*
-
-# Produced by 'daml test' due to divulgence: https://github.com/digital-asset/daml/issues/22737
-Use of divulged contracts is deprecated and incompatible with pruning. To remedy, add one of the readers
-
-# Sadly our log checker triggers on the standalone DsWarning message, which is on a separate line
-# and can thus not pattern match on the real problem above. We thus ignore all Daml compiler warnings in
-# the build until we improve the log checker to match on warning messages, see #4708 for details.
-# TODO(#4708): make sbt fail again on all damlc warnings
-stderr: Severity: DsWarning
-


### PR DESCRIPTION
Seems like the offending warning is gone with the damlc upgrade.

Fixes #4708 [ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
