### PR TITLE
fix lnav download on mac

### DIFF
--- a/nix/lnav.nix
+++ b/nix/lnav.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
   src =
     if stdenv.isDarwin then
       fetchzip {
-        url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-x86_64-macos.zip";
-        sha256 = "sha256:f282d567e1bdb2c3e54d9502671b8011c0d4e3700b2616cf72778602f8ee0371";
+        url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-aarch64-macos.zip";
+        sha256 = "sha256:eXdiy0v15e/MUW2M9NE4QujDqvwH96Od0Lkqeo39pzU=";
       } else fetchzip {
         url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-linux-musl-x86_64.zip";
         sha256 = "sha256-k8x83y64GIpGMnNyYLGpo5bRFvaxENhwbKSdWw4UCuU=";


### PR DESCRIPTION
Broke in #5253, x86_64 is no longer built by lnav for macos.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
