### PR TITLE
fix(charts): restore Stakater Reloader annotation rendering

### DIFF
--- a/cluster/helm/cn-docs/templates/docs.yaml
+++ b/cluster/helm/cn-docs/templates/docs.yaml
@@ -7,10 +7,10 @@ kind: Deployment
 metadata:
   name: docs
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" "docs") | nindent 4 }}

--- a/cluster/helm/splice-domain/templates/domain.yaml
+++ b/cluster/helm/splice-domain/templates/domain.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -6,10 +6,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $mediatorLabel) | nindent 4 }}

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -6,10 +6,10 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1

--- a/cluster/helm/splice-load-tester/templates/load-tester.yaml
+++ b/cluster/helm/splice-load-tester/templates/load-tester.yaml
@@ -6,10 +6,10 @@ kind: Deployment
 metadata:
   name: load-tester
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}

--- a/cluster/helm/splice-participant/templates/participant.yaml
+++ b/cluster/helm/splice-participant/templates/participant.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}

--- a/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
+++ b/cluster/helm/splice-party-allocator/templates/party-allocator.yaml
@@ -6,10 +6,10 @@ kind: Deployment
 metadata:
   name: party-allocator
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" .Release.Name) | nindent 4 }}

--- a/cluster/helm/splice-scan/templates/scan.yaml
+++ b/cluster/helm/splice-scan/templates/scan.yaml
@@ -8,10 +8,10 @@ kind: Deployment
 metadata:
   name: {{ $scanAppLabel }}
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $scanAppLabel) | nindent 4 }}
@@ -294,10 +294,10 @@ kind: Deployment
 metadata:
   name: {{ $scanWebUiAppLabel }}
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $scanWebUiAppLabel) | nindent 4 }}

--- a/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
+++ b/cluster/helm/splice-splitwell-app/templates/splitwell.yaml
@@ -6,10 +6,10 @@ kind: Deployment
 metadata:
   name: splitwell-app
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" "splitwell-app") | nindent 4 }}

--- a/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv-web-ui.yaml
@@ -5,10 +5,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $appIdentifier) | nindent 4 }}

--- a/cluster/helm/splice-sv-node/templates/sv.yaml
+++ b/cluster/helm/splice-sv-node/templates/sv.yaml
@@ -8,10 +8,10 @@ kind: Deployment
 metadata:
   name: {{ $appIdentifier }}
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $appIdentifier) | nindent 4 }}

--- a/cluster/helm/splice-validator/templates/ans-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/ans-web-ui.yaml
@@ -6,10 +6,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $ansWebUiLabel) | nindent 4 }}

--- a/cluster/helm/splice-validator/templates/validator.yaml
+++ b/cluster/helm/splice-validator/templates/validator.yaml
@@ -6,10 +6,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   name: {{ $validatorAppLabel }}
   namespace: {{ .Release.Namespace }}

--- a/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
+++ b/cluster/helm/splice-validator/templates/wallet-web-ui.yaml
@@ -6,10 +6,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- $annotations := include "splice-util-lib.default-annotations" . }}
+  {{- $annotations := include "splice-util-lib.default-annotations" .Values }}
   {{- if $annotations }}
   annotations:
-    {{- $annotations .Values | nindent 4 }}
+    {{- $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "splice-util-lib.default-labels" (set . "app" $walletWebUiLabel) | nindent 4 }}

--- a/cluster/helm/splice-validator/tests/validator_test.yaml
+++ b/cluster/helm/splice-validator/tests/validator_test.yaml
@@ -82,6 +82,25 @@ tests:
           value:
             mock-annotation: still-an-annotation
 
+  - it: "renders Stakater Reloader annotation by default"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
+  - it: "omits Stakater Reloader annotation when enableReloader is false"
+    set:
+      enableReloader: false
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
   - it: "always populates enable-wallet"
     set:
       enableWallet: false


### PR DESCRIPTION
## Summary

PR #5082 (shipped in **Splice 0.6.1**) wrapped the annotations block in an `if` check to fix the cosmetic issue reported in #5079 (empty `annotations:` block when `enableReloader: false`). The fix passed the wrong context to the helper and used invalid Go template syntax to emit the captured value, with the result that the `reloader.stakater.com/auto: "true"` annotation is **silently dropped from every affected Deployment**, regardless of the `enableReloader` value. This breaks the Stakater Reloader integration introduced as a default in #4063 for all 0.6.1 users.

Detailed root-cause analysis is in the linked issue: #5282.

The two bugs in the prior form:

1. `include "splice-util-lib.default-annotations" .` passes the full chart context. The helper reads `.enableReloader` directly, but that key lives at `.Values.enableReloader`, so the helper always returns empty and the `if $annotations` guard always fails.
2. `{{- $annotations .Values | nindent 4 }}` treats the captured string as a callable. Strings are not callable in Go templates; the `.Values` argument is silently discarded.

This PR:
- Restores the `.Values` context to the helper call (matches 0.5.18 behaviour and the helper's expectation).
- Emits the captured string directly (`{{- $annotations | nindent N }}`).
- Preserves the `if $annotations` wrap so the empty-block fix from #5079 still holds when `enableReloader: false`.

The change is applied identically across the 14 chart templates that PR #5082 touched.

## Test plan

- [x] Adds a `helm-unittest` case in `splice-validator/tests/validator_test.yaml` covering both branches:
  - default settings (`enableReloader: true`) → `metadata.annotations["reloader.stakater.com/auto"]` equals `"true"`
  - `enableReloader: false` → `metadata.annotations` does not exist (no empty block)
- [x] Verified locally on a real cluster: applying this fix to a 0.6.1 deployment of `splice-validator` causes the reloader annotation to reappear on `validator-app`, `ans-web-ui`, `wallet-web-ui`, and `participant` Deployments.

Closes #5282.
Refs #5079, #5082, #4063.