### PR TITLE
Add scan http encodings encode() to read perf test

### DIFF
--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -15,7 +15,6 @@ permissions:
 
 jobs:
   ingestion_performance_tests:
-
     # note that we're loading the entirety of mainnet updates (and in the future, the ACS) so as to make sure that that's not the bottleneck.
     # as of 03.03.2026 that seems to be enough, but we might have to increase it as the activity in mainnet does too.
     runs-on: self-hosted-k8s-medium

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   ingestion_performance_tests:
+    needs: read_performance_tests
     # note that we're loading the entirety of mainnet updates (and in the future, the ACS) so as to make sure that that's not the bottleneck.
     # as of 03.03.2026 that seems to be enough, but we might have to increase it as the activity in mainnet does too.
     runs-on: self-hosted-k8s-medium
@@ -96,7 +97,7 @@ jobs:
           slack_channel: '${{ secrets.FAILURE_NOTIFICATIONS_SLACK_CHANNEL }}'
 
   read_performance_tests:
-    needs: ingestion_performance_tests
+    #needs: ingestion_performance_tests
     runs-on: self-hosted-k8s-medium
     container:
       image: us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/splice-test-ci:0.3.12

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -15,7 +15,6 @@ permissions:
 
 jobs:
   ingestion_performance_tests:
-    needs: read_performance_tests
     # note that we're loading the entirety of mainnet updates (and in the future, the ACS) so as to make sure that that's not the bottleneck.
     # as of 03.03.2026 that seems to be enough, but we might have to increase it as the activity in mainnet does too.
     runs-on: self-hosted-k8s-medium
@@ -97,7 +96,7 @@ jobs:
           slack_channel: '${{ secrets.FAILURE_NOTIFICATIONS_SLACK_CHANNEL }}'
 
   read_performance_tests:
-    #needs: ingestion_performance_tests
+    needs: ingestion_performance_tests
     runs-on: self-hosted-k8s-medium
     container:
       image: us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/splice-test-ci:0.3.12

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   ingestion_performance_tests:
+
     # note that we're loading the entirety of mainnet updates (and in the future, the ACS) so as to make sure that that's not the bottleneck.
     # as of 03.03.2026 that seems to be enough, but we might have to increase it as the activity in mainnet does too.
     runs-on: self-hosted-k8s-medium

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/BaseStorePerformanceTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/BaseStorePerformanceTest.scala
@@ -195,20 +195,23 @@ abstract class BaseStorePerformanceTest(
       metricsJson: Json,
       metricsDir: String,
       pertTestType: String,
+      opName: Option[String] = None,
   ): Unit = {
-    val json = Json
-      .obj(
-        "test_name" -> Json.fromString(testName),
-        "metrics" -> metricsJson,
-      )
-      .spaces2
+    val effectiveName = opName.fold(testName)(s => s"$testName-$s")
+    val baseFields = Seq(
+      "test_name" -> Json.fromString(effectiveName),
+      "metrics" -> metricsJson,
+    )
+    val fields =
+      opName.fold(baseFields)(op => baseFields :+ ("operation" -> Json.fromString(op)))
+    val json = Json.obj(fields*).spaces2
 
-    println(s"$pertTestType metrics for $testName:\n$json")
+    println(s"$pertTestType metrics for $effectiveName:\n$json")
 
     try {
       val dir = Paths.get(s"/tmp/$metricsDir")
       Files.createDirectories(dir)
-      val metricsFile = dir.resolve(s"$testName.json")
+      val metricsFile = dir.resolve(s"$effectiveName.json")
       Files.writeString(
         metricsFile,
         json,
@@ -218,7 +221,7 @@ abstract class BaseStorePerformanceTest(
       println(s"Wrote metrics to $metricsFile")
     } catch {
       case e: Exception =>
-        println(s"Failed to write metrics file for $testName: ${e.getMessage}")
+        println(s"Failed to write metrics file for $effectiveName: ${e.getMessage}")
     }
   }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/StoreReadPerformanceTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/StoreReadPerformanceTest.scala
@@ -44,7 +44,10 @@ abstract class StoreReadPerformanceTest(
       ingestionConfig,
     ) {
 
-  protected def readOperation(store: Store, txs: Seq[TreeUpdateWithMigrationId]): ReadOperation
+  protected def readOperations(
+      store: Store,
+      txs: Seq[TreeUpdateWithMigrationId],
+  ): Seq[ReadOperation]
 
   /** Verify that the data read back from the store matches the original ingested data. */
   protected def verifyReadResults(
@@ -67,15 +70,15 @@ abstract class StoreReadPerformanceTest(
             * we just write and read immediately, which is not what we have in production.
             *  Need to flush the caches(db etc)
             */
-          metrics <- runReadBenchmarks(store, txs)
+          metricsByOp <- runReadBenchmarks(store, txs)
           _ <- verifyReadResults(store, txs)
-          _ = writeReadMetrics(metrics)
+          _ = metricsByOp.foreach { case (opName, m) => writeReadMetrics(opName, m) }
         } yield ()
       }
   }
 
   @SuppressWarnings(Array("org.lfdecentralizedtrust.splice.wart.Println"))
-  private def writeReadMetrics(metrics: StoreReadPerfMetrics): Unit = {
+  private def writeReadMetrics(opName: String, metrics: StoreReadPerfMetrics): Unit = {
     val completionEpochSec = java.time.Instant.now().getEpochSecond
     val jobName = "splice_perf_read"
 
@@ -114,38 +117,43 @@ abstract class StoreReadPerformanceTest(
       ),
     )
 
-    writeMetricsFile(metricsJson, "store-read-perf-metrics", "Read")
+    writeMetricsFile(metricsJson, "store-read-perf-metrics", "Read", opName = Some(opName))
   }
 
   @SuppressWarnings(Array("org.lfdecentralizedtrust.splice.wart.Println"))
   private def runReadBenchmarks(store: Store, txs: Seq[TreeUpdateWithMigrationId])(implicit
       tc: TraceContext
-  ): Future[StoreReadPerfMetrics] = {
-    val op = readOperation(store, txs)
+  ): Future[Seq[(String, StoreReadPerfMetrics)]] = {
+    val ops = readOperations(store, txs)
     val updateSizeBytes = Files.size(updateHistoryDumpPath)
-    val wallBefore = System.nanoTime()
-    val cpuBefore = getProcessCpuTimeNs
-    op.execute(tc).map { _ =>
-      val wallAfter = System.nanoTime()
-      val cpuAfter = getProcessCpuTimeNs
-      val duration = wallAfter - wallBefore
-      val cpuDeltaNs = math.max(cpuAfter - cpuBefore, 0L)
-      val heapUsed = getHeapUsedBytes
-      val cpuToWallClockRatio =
-        if (duration > 0) BigDecimal(cpuDeltaNs) / BigDecimal(duration) else BigDecimal(0)
+    ops.foldLeft(Future.successful(Vector.empty[(String, StoreReadPerfMetrics)])) { (accF, op) =>
+      accF.flatMap { acc =>
+        val wallBefore = System.nanoTime()
+        val cpuBefore = getProcessCpuTimeNs
+        op.execute(tc).map { _ =>
+          val wallAfter = System.nanoTime()
+          val cpuAfter = getProcessCpuTimeNs
+          val duration = wallAfter - wallBefore
+          val cpuDeltaNs = math.max(cpuAfter - cpuBefore, 0L)
+          val heapUsed = getHeapUsedBytes
+          val cpuToWallClockRatio =
+            if (duration > 0) BigDecimal(cpuDeltaNs) / BigDecimal(duration) else BigDecimal(0)
 
-      val msg =
-        f"Read '${op.name}': time=${BigDecimal(duration) / 1e6}%.2f ms, updateSize=$updateSizeBytes bytes, numUpdates=${txs.size}"
-      logger.info(msg)
-      println(s"${this.getClass.getName}: $msg")
+          val msg =
+            f"Read '${op.name}': time=${BigDecimal(duration) / 1e6}%.2f ms, updateSize=$updateSizeBytes bytes, numUpdates=${txs.size}"
+          logger.info(msg)
+          println(s"${this.getClass.getName}: $msg")
 
-      StoreReadPerfMetrics(
-        totalTimeNs = BigDecimal(duration),
-        peakHeapBytes = heapUsed,
-        cpuToWallClockRatio = cpuToWallClockRatio,
-        updateSizeBytes = updateSizeBytes,
-        numUpdates = txs.size.toLong,
-      )
+          val m = StoreReadPerfMetrics(
+            totalTimeNs = BigDecimal(duration),
+            peakHeapBytes = heapUsed,
+            cpuToWallClockRatio = cpuToWallClockRatio,
+            updateSizeBytes = updateSizeBytes,
+            numUpdates = txs.size.toLong,
+          )
+          acc :+ (op.name -> m)
+        }
+      }
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/UpdateHistoryReadPerformanceTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/UpdateHistoryReadPerformanceTest.scala
@@ -73,7 +73,7 @@ class UpdateHistoryReadPerformanceTest(
   ): Seq[ReadOperation] =
     Seq(
       getUpdateByIdOperation(store, txs),
-      encodeUpdateOperation(store, txs),
+      encodeUpdateOperation(txs),
     )
 
   /** Fetches the update from the store and decode. */
@@ -83,7 +83,7 @@ class UpdateHistoryReadPerformanceTest(
   ): ReadOperation = {
     val updateIds = txs.map(_.update.update.updateId)
     ReadOperation(
-      name = "getUpdateById",
+      name = "getUpdate",
       execute = { implicit tc: TraceContext =>
         updateIds.foldLeft(Future.successful(())) { (accF, updateId) =>
           accF.flatMap { _ =>
@@ -94,14 +94,12 @@ class UpdateHistoryReadPerformanceTest(
     )
   }
 
-  /** Runs ScanHttpEncodings.encodeUpdate to isolate the
+  /** Runs ScanHttpEncodings.encodeUpdate. This isolates the
     * cost of the encoding step from the cost of the DB read.
     */
   private def encodeUpdateOperation(
-      store: UpdateHistory,
-      txs: Seq[TreeUpdateWithMigrationId],
+      txs: Seq[TreeUpdateWithMigrationId]
   ): ReadOperation = {
-    val _ = store
     ReadOperation(
       name = "encodeUpdate",
       execute = { implicit tc: TraceContext =>

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/UpdateHistoryReadPerformanceTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/performance/tests/UpdateHistoryReadPerformanceTest.scala
@@ -3,14 +3,20 @@ package org.lfdecentralizedtrust.splice.performance.tests
 import com.daml.metrics.api.noop.NoOpMetricsFactory
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
 import com.digitalasset.canton.config.{ProcessingTimeout, StorageConfig}
-import com.digitalasset.canton.logging.NamedLoggerFactory
+import com.digitalasset.canton.logging.{ErrorLoggingContext, NamedLoggerFactory}
 import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
 import com.typesafe.config.Config
 import org.apache.pekko.actor.ActorSystem
 import org.lfdecentralizedtrust.splice.config.{IngestionConfig, SpliceConfig}
+import org.lfdecentralizedtrust.splice.http.v0.definitions.DamlValueEncoding
 import org.lfdecentralizedtrust.splice.migration.DomainMigrationInfo
+import org.lfdecentralizedtrust.splice.scan.admin.http.{
+  ExternalHashInclusionPolicy,
+  ScanHttpEncodings,
+}
+import org.lfdecentralizedtrust.splice.scan.config.ScanAppBackendConfig
 import org.lfdecentralizedtrust.splice.store.{
   HistoryMetrics,
   TreeUpdateWithMigrationId,
@@ -61,7 +67,17 @@ class UpdateHistoryReadPerformanceTest(
     )
   }
 
-  override protected def readOperation(
+  override protected def readOperations(
+      store: UpdateHistory,
+      txs: Seq[TreeUpdateWithMigrationId],
+  ): Seq[ReadOperation] =
+    Seq(
+      getUpdateByIdOperation(store, txs),
+      encodeUpdateOperation(store, txs),
+    )
+
+  /** Fetches the update from the store and decode. */
+  private def getUpdateByIdOperation(
       store: UpdateHistory,
       txs: Seq[TreeUpdateWithMigrationId],
   ): ReadOperation = {
@@ -71,9 +87,36 @@ class UpdateHistoryReadPerformanceTest(
       execute = { implicit tc: TraceContext =>
         updateIds.foldLeft(Future.successful(())) { (accF, updateId) =>
           accF.flatMap { _ =>
-            /** TODO(#4790): Add application level processing (e.g. normalization for SVs using makeConsistentAcrossSvs())
-              */
             store.getUpdate(updateId).map(_ => ())
+          }
+        }
+      },
+    )
+  }
+
+  /** Runs ScanHttpEncodings.encodeUpdate to isolate the
+    * cost of the encoding step from the cost of the DB read.
+    */
+  private def encodeUpdateOperation(
+      store: UpdateHistory,
+      txs: Seq[TreeUpdateWithMigrationId],
+  ): ReadOperation = {
+    val _ = store
+    ReadOperation(
+      name = "encodeUpdate",
+      execute = { implicit tc: TraceContext =>
+        implicit val elc: ErrorLoggingContext =
+          ErrorLoggingContext.fromTracedLogger(logger)(tc)
+        Future {
+          txs.foreach { tx =>
+            val _ = ScanHttpEncodings.encodeUpdate(
+              tx,
+              encoding = DamlValueEncoding.members.CompactJson,
+              version = ScanHttpEncodings.V1,
+              hashInclusionPolicy = ExternalHashInclusionPolicy.ApplyThreshold,
+              externalTransactionHashThresholdTime =
+                ScanAppBackendConfig.DefaultExternalTransactionHashThresholdTime,
+            )
           }
         }
       },


### PR DESCRIPTION
- We already have the read performance test for UpdateHistory.getUpdate()
- This adds ScanHttpEncodigns.encode() test
- With both UpdateHistory.getUpdate() and ScanHttpEncodigns.encode(), we get a good understanding of the latency of /v2/updates/{update_id}

Grafana:

<img width="1987" height="1901" alt="Screenshot 2026-04-28 at 16 37 33" src="https://github.com/user-attachments/assets/331b99fb-40e3-479f-bac9-dbed2c46cbb8" />
