### PR TITLE
Fix WalletMetricsTest failing to retry on CommandFailure

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMetricsTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMetricsTest.scala
@@ -26,7 +26,8 @@ class WalletMetricsTest
     "update when tapping coin" in { implicit env =>
       val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
 
-      eventually() {
+      // metrics.get can throw non-test-failure exceptions
+      eventually(retryOnTestFailuresOnly = false) {
         aliceValidatorBackend.metrics
           .get(
             s"$MetricsPrefix.wallet.unlocked-amulet-balance",
@@ -89,7 +90,8 @@ class WalletMetricsTest
       aliceWalletClient.tap(100.0)
       p2pTransfer(aliceWalletClient, bobWalletClient, bobUserParty, 50.0)
 
-      eventually() {
+      // metrics.get can throw non-test-failure exceptions
+      eventually(retryOnTestFailuresOnly = false) {
         // Polling triggers
         // Not exhaustive, only triggers configured to run (e.g., no WalletSweepTrigger)
         Seq(


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/8170

This assumes that the fix in https://github.com/hyperledger-labs/splice/pull/4764 was correct, which I'm not entirely sold on given that the error is "Found 2 matching metrics".
In any case, if it happens again, we [now have a better error log there](https://github.com/hyperledger-labs/splice/blame/fffff2979c83a89b9ca570d53391a0e48dcc9d3d/canton/community/app-base/src/main/scala/com/digitalasset/canton/console/InstanceReference.scala#L236), so it'll make debugging this easier.