### PR TITLE
Bump the size of the persistent heap dump pvc

### DIFF
--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -172,7 +172,7 @@ abstract class InStackDecentralizedSynchronizerNode
           additionalJvmOptions: getAdditionalJvmOptions(svConfig.sequencer?.additionalJvmOptions),
           pvc: spliceConfig.configuration.persistentHeapDumps
             ? {
-                size: '10Gi',
+                size: '35Gi',
                 volumeStorageClass: standardStorageClassName,
               }
             : undefined,


### PR DESCRIPTION
32Gi reserved for heap dumps (participant requests 32Gi of memory)
3Gi reserved for continuous flight recording