### PR TITLE
Bump canton to 3.5.1-snapshot.20260429.18795.0.v9fec8f12

### DIFF
--- a/nix/canton-sources.json
+++ b/nix/canton-sources.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.5.1-snapshot.20260429.18789.0.v6872eaeb",
-  "oss_sha256": "sha256:1v1vb2w4m23br0k6xziblhwh8nsgpsnh49mwhlpvy3f9ckgw5af8",
-  "canton_base_image_sha256": "sha256:8e5b5dd8bc3fab0b50a87fd648c99f1ee96b4a4e224a1abe28910776187576fe",
-  "canton_participant_image_sha256": "sha256:a668cb093a710e079a026402c276c77f81b0fb6b112418c9d7e9bbfc273ecf3c",
-  "canton_mediator_image_sha256": "sha256:a6ccd715d13a0eab9adc35604fbcfbeee71a03bbb7b0845882b8a081d8873651",
-  "canton_sequencer_image_sha256": "sha256:3886aef9054f852db181a8a92ff6714bd6d290b7c31518a77a1ce51c66cdc7e2"
+  "version": "3.5.1-snapshot.20260429.18795.0.v9fec8f12",
+  "oss_sha256": "sha256:1ky0mmnh5r4x43kay6ljfcava5s1acn6y97crsx86pglalzd02f6",
+  "canton_base_image_sha256": "sha256:b1fd73080abe59469a5dbf573ab842f00b35abaf903a2586b58604f9ecd902a7",
+  "canton_participant_image_sha256": "sha256:7beda39f1a852e5eec149b9eba3ee590901bee1676519274a7c24653128fa918",
+  "canton_mediator_image_sha256": "sha256:392e03f4735b300e506cc3a3e005b092f8536c94f84f4cf8a41b02cdfca1635e",
+  "canton_sequencer_image_sha256": "sha256:2903de26b0af68b284e02332da3b1bff4c5879d3090bac4179df2f5c6869fd54"
 }


### PR DESCRIPTION
edit:
Does not fix https://github.com/DACH-NY/cn-test-failures/issues/8183 but https://github.com/DACH-NY/cn-test-failures/issues/8132