### PR TITLE
Bump the size of the persistent heap dump pvc for participants

### DIFF
--- a/cluster/pulumi/common-sv/src/synchronizer/participant.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/participant.ts
@@ -149,7 +149,7 @@ function installParticipantChart(
     resources: participant?.resources,
     pvc: spliceConfig.configuration.persistentHeapDumps
       ? {
-          size: '10Gi',
+          size: '35Gi',
           volumeStorageClass: standardStorageClassName,
         }
       : undefined,


### PR DESCRIPTION
I think that this was the actual intention in https://github.com/hyperledger-labs/splice/pull/5307

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
