### PR TITLE
remove svs.default

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -223,8 +223,6 @@ sv:
         maxTokens: 2147483647
         tokensPerFill: 2147483647
         fillInterval: 60s
-svs:
-  default: !include(base-sv.yaml) {}
 validators:
   validator-runbook:
     namespace: validator

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -358,41 +358,6 @@ sv:
           name: 'version'
           type: 'unlimited'
 svs:
-  default:
-    logging:
-      apiRequestLogLevel: 'DEBUG'
-      appsAsync: false
-      appsLogLevel: 'DEBUG'
-      cantonAsync: false
-      cantonLogLevel: 'DEBUG'
-      cometbftLogLevel: 'debug'
-    participant:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_PARTICIPANT_PRUNING'
-          value: "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
-      bftSequencerConnection: true
-      resources:
-        limits:
-          memory: '18Gi'
-        requests:
-          memory: '12Gi'
-    pruning:
-      participant:
-        cron: '0 /10 * * * ?'
-        enabled: true
-        maxDuration: '5m'
-        retentionPeriod: '30d'
-      sequencer:
-        enabled: false
-    validatorApp:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT'
-          value: "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
-      resources:
-        limits:
-          memory: '4Gi'
-        requests:
-          memory: '2Gi'
   sv:
     cometbft:
       resources:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -358,41 +358,6 @@ sv:
           name: 'version'
           type: 'unlimited'
 svs:
-  default:
-    logging:
-      apiRequestLogLevel: 'DEBUG'
-      appsAsync: false
-      appsLogLevel: 'DEBUG'
-      cantonAsync: false
-      cantonLogLevel: 'DEBUG'
-      cometbftLogLevel: 'debug'
-    participant:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_PARTICIPANT_PRUNING'
-          value: "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
-      bftSequencerConnection: true
-      resources:
-        limits:
-          memory: '18Gi'
-        requests:
-          memory: '12Gi'
-    pruning:
-      participant:
-        cron: '0 /10 * * * ?'
-        enabled: true
-        maxDuration: '5m'
-        retentionPeriod: '30d'
-      sequencer:
-        enabled: false
-    validatorApp:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT'
-          value: "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
-      resources:
-        limits:
-          memory: '4Gi'
-        requests:
-          memory: '2Gi'
   sv:
     cometbft:
       resources:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -358,41 +358,6 @@ sv:
           name: 'version'
           type: 'unlimited'
 svs:
-  default:
-    logging:
-      apiRequestLogLevel: 'DEBUG'
-      appsAsync: false
-      appsLogLevel: 'DEBUG'
-      cantonAsync: false
-      cantonLogLevel: 'DEBUG'
-      cometbftLogLevel: 'debug'
-    participant:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_PARTICIPANT_PRUNING'
-          value: "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
-      bftSequencerConnection: true
-      resources:
-        limits:
-          memory: '18Gi'
-        requests:
-          memory: '12Gi'
-    pruning:
-      participant:
-        cron: '0 /10 * * * ?'
-        enabled: true
-        maxDuration: '5m'
-        retentionPeriod: '30d'
-      sequencer:
-        enabled: false
-    validatorApp:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT'
-          value: "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
-      resources:
-        limits:
-          memory: '4Gi'
-        requests:
-          memory: '2Gi'
   sv:
     cometbft:
       resources:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -358,41 +358,6 @@ sv:
           name: 'version'
           type: 'unlimited'
 svs:
-  default:
-    logging:
-      apiRequestLogLevel: 'DEBUG'
-      appsAsync: false
-      appsLogLevel: 'DEBUG'
-      cantonAsync: false
-      cantonLogLevel: 'DEBUG'
-      cometbftLogLevel: 'debug'
-    participant:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_PARTICIPANT_PRUNING'
-          value: "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
-      bftSequencerConnection: true
-      resources:
-        limits:
-          memory: '18Gi'
-        requests:
-          memory: '12Gi'
-    pruning:
-      participant:
-        cron: '0 /10 * * * ?'
-        enabled: true
-        maxDuration: '5m'
-        retentionPeriod: '30d'
-      sequencer:
-        enabled: false
-    validatorApp:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT'
-          value: "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
-      resources:
-        limits:
-          memory: '4Gi'
-        requests:
-          memory: '2Gi'
   sv:
     cometbft:
       resources:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -358,41 +358,6 @@ sv:
           name: 'version'
           type: 'unlimited'
 svs:
-  default:
-    logging:
-      apiRequestLogLevel: 'DEBUG'
-      appsAsync: false
-      appsLogLevel: 'DEBUG'
-      cantonAsync: false
-      cantonLogLevel: 'DEBUG'
-      cometbftLogLevel: 'debug'
-    participant:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_PARTICIPANT_PRUNING'
-          value: "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
-      bftSequencerConnection: true
-      resources:
-        limits:
-          memory: '18Gi'
-        requests:
-          memory: '12Gi'
-    pruning:
-      participant:
-        cron: '0 /10 * * * ?'
-        enabled: true
-        maxDuration: '5m'
-        retentionPeriod: '30d'
-      sequencer:
-        enabled: false
-    validatorApp:
-      additionalEnvVars:
-        - name: 'ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT'
-          value: "canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m\n"
-      resources:
-        limits:
-          memory: '4Gi'
-        requests:
-          memory: '2Gi'
   sv:
     cometbft:
       resources:

--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -137,6 +137,8 @@ const SvValidatorAppConfigSchema = z
 // https://docs.cometbft.com/main/explanation/core/running-in-production
 const CometbftLogLevelSchema = z.enum(['info', 'error', 'debug', 'none']);
 // things here are declared optional even when they aren't, to allow partial overrides of defaults
+// TODO(DACH-NY/canton-network-internal#4859) the above is no longer true since defaults were removed.
+//   We should remove .optional() from required fields.
 const SingleSvConfigSchema = z
   .object({
     publicName: z.string().optional(),
@@ -183,11 +185,7 @@ const SingleSvConfigSchema = z
     versionOverride: CnChartVersionSchema.optional(),
   })
   .strict();
-const AllSvsConfigurationSchema = z.record(z.string(), SingleSvConfigSchema).and(
-  z.object({
-    default: SingleSvConfigSchema.default({}),
-  })
-);
+const AllSvsConfigurationSchema = z.record(z.string(), SingleSvConfigSchema);
 const SvsConfigurationSchema = z.object({
   svs: AllSvsConfigurationSchema,
 });
@@ -197,15 +195,13 @@ export type SingleSvConfiguration = z.infer<typeof SingleSvConfigSchema>;
 
 const clusterSvsConfiguration: SingleSvConfig = SvsConfigurationSchema.parse(clusterYamlConfig).svs;
 
-export const allConfiguredSvs: string[] = Object.keys(clusterSvsConfiguration).filter(
-  k => k !== 'default'
-);
+export const allConfiguredSvs: string[] = Object.keys(clusterSvsConfiguration);
 
 // SVs that don't match the standard sv-X pattern; we deploy those always, independently of DSO_SIZE
 export const configuredExtraSvs: string[] = allConfiguredSvs.filter(k => !k.match(/^sv(-\d+)?$/));
 
 export const configForSv = (svName: string): SingleSvConfiguration => {
-  return merge({}, clusterSvsConfiguration.default, clusterSvsConfiguration[svName]);
+  return clusterSvsConfiguration[svName];
 };
 
 export const allSvsConfiguration: SingleSvConfiguration[] = allConfiguredSvs.map(sv => {


### PR DESCRIPTION
After https://github.com/hyperledger-labs/splice/pull/5225 and https://github.com/DACH-NY/canton-network-internal/pull/4761 got merged we can finally get rid of the dedicated `svs.default` merging logic.