### PR TITLE
exclude sv runbook from offboard sv runbook script

### DIFF
--- a/cluster/scripts/vote-for-offboard-sv-runbook.sh
+++ b/cluster/scripts/vote-for-offboard-sv-runbook.sh
@@ -79,7 +79,7 @@ for ((i=2; i<=DSO_SIZE; i++)); do
 done
 
 # extra SVs from all the config.yaml files
-extra_svs=$(get_resolved_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+)$") | not)')
+extra_svs=$(get_resolved_config | yq '.svs | keys | .[] | select(test("^(default|sv-[0-9]+|sv)$") | not)')
 for sv in $extra_svs; do
   other_svs+=("$sv")
 done


### PR DESCRIPTION
With config.yaml restructuring, list of voting svs now includes the runbook itself; this results in bad hostname, but it shouldn't try to vote at all.

Fixes DACH-NY/cn-test-failures#8237.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
