### PR TITLE
remove migration ID from bulk storage s3 folders

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -608,7 +608,7 @@ class ScanTimeBasedIntegrationTest
     val endTime = getLedgerTime
     val lastMidnight = endTime.toInstant.truncatedTo(ChronoUnit.DAYS);
     val nextMidnight = lastMidnight.plus(1, ChronoUnit.DAYS)
-    val expectedAcsSnapshotKey = s"$lastMidnight-Migration-0-$nextMidnight/ACS_0.zstd"
+    val expectedAcsSnapshotKey = s"$lastMidnight~$nextMidnight/ACS_0.zstd"
 
     val bucketConnection = new S3BucketConnectionForTests(s3ConfigMock, loggerFactory)
     eventually() {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -635,7 +635,7 @@ class ScanTimeBasedIntegrationTest
       // at last midnight
       allS3Objs
         .map(_.key())
-        .filter(_.endsWith(s"Migration-0-$lastMidnight/updates_0.zstd")) should not be empty
+        .filter(_.endsWith(s"~$lastMidnight/updates_0.zstd")) should not be empty
 
       // Compare bulk storage data to hot storage data from scan
       // TODO(#4788): for now, bulk storage still uses v0, so we use that here as well

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -115,18 +115,18 @@ case class ScanStorageConfig(
   def getStartAndEndTimestampsForFolder(
       folder: String
   ): Either[String, (CantonTimestamp, CantonTimestamp)] = {
-    val parts = folder.stripSuffix("/").split("~")
-    if (parts.length != 2) {
-      Left(
-        s"Cannot parse folder name: $folder (wrong number of parts after splitting by '~': ${parts.length})"
-      )
-    } else {
-      for {
-        folderStart <- CantonTimestamp.fromInstant(Instant.parse(parts(0)))
-        folderEnd <- CantonTimestamp.fromInstant(Instant.parse(parts(1)))
-      } yield {
-        (folderStart, folderEnd)
-      }
+    folder.stripSuffix("/").split("~") match {
+      case Array(folderStartStr, folderEndStr) =>
+        for {
+          folderStart <- CantonTimestamp.fromInstant(Instant.parse(folderStartStr))
+          folderEnd <- CantonTimestamp.fromInstant(Instant.parse(folderEndStr))
+        } yield {
+          (folderStart, folderEnd)
+        }
+        case _ =>
+          Left(
+            s"Cannot parse folder name: $folder (wrong format, expected 'startTimestamp~endTimestamp')"
+          )
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -123,10 +123,10 @@ case class ScanStorageConfig(
         } yield {
           (folderStart, folderEnd)
         }
-        case _ =>
-          Left(
-            s"Cannot parse folder name: $folder (wrong format, expected 'startTimestamp~endTimestamp')"
-          )
+      case _ =>
+        Left(
+          s"Cannot parse folder name: $folder (wrong format, expected 'startTimestamp~endTimestamp')"
+        )
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -8,7 +8,6 @@ import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.{
   AcsSnapshot,
   IncrementalAcsSnapshot,
 }
-import org.lfdecentralizedtrust.splice.store.TimestampWithMigrationId
 
 import java.time.{Duration, Instant, ZoneOffset}
 import java.time.temporal.{ChronoField, ChronoUnit}
@@ -103,47 +102,30 @@ case class ScanStorageConfig(
       snapshotTimestamp.toInstant.atOffset(ZoneOffset.UTC).get(ChronoField.HOUR_OF_DAY)
     )
 
-  /* Note that we do not include the migration ID in the end timestamp, as it might not yet be known
-   * when we start collecting updates for the segment (e.g. if we are up-to-date, and a migration will
-   * happen soon). Once the end time will have passed, the migration ID will be
-   * deterministic given the update history, so we do not lose any information or risk
-   * inconsistency between instances of Scan.
-   * If end timestamp is not given, it will be computed from the start timestamp
-   * based on the bulkAcsSnapshotPeriodHours period
-   */
   def getSegmentFolder(
-      segmentStartTimestamp: TimestampWithMigrationId,
-      segmentEndTimestamp: Option[TimestampWithMigrationId],
+      segmentStartTimestamp: CantonTimestamp,
+      segmentEndTimestamp: Option[CantonTimestamp],
   ): String = {
-    val endTimestamp = segmentEndTimestamp.fold(
-      computeBulkSnapshotTimeAfter(segmentStartTimestamp.timestamp)
-    )(_.timestamp)
-    s"${segmentStartTimestamp.timestamp}-Migration-${segmentStartTimestamp.migrationId}-${endTimestamp}"
+    val endTimestamp = segmentEndTimestamp.getOrElse(
+      computeBulkSnapshotTimeAfter(segmentStartTimestamp)
+    )
+    s"$segmentStartTimestamp~$endTimestamp"
   }
 
   def getStartAndEndTimestampsForFolder(
       folder: String
   ): Either[String, (CantonTimestamp, CantonTimestamp)] = {
-    val parts = folder.stripSuffix("/").split("-Migration-")
+    val parts = folder.stripSuffix("/").split("~")
     if (parts.length != 2) {
       Left(
-        s"Cannot parse folder name: $folder (wrong number of parts after splitting by '-Migration-': ${parts.length})"
+        s"Cannot parse folder name: $folder (wrong number of parts after splitting by '~': ${parts.length})"
       )
     } else {
-      val folderStartStr = parts(0)
-      val parts2 = parts(1).split("-", 2)
-      if (parts2.length != 2) {
-        Left(
-          s"Cannot parse folder name: $folder (wrong number of parts when splitting ${parts(1)}: ${parts2.length})"
-        )
-      } else {
-        val folderEndStr = parts2(1)
-        for {
-          folderStart <- CantonTimestamp.fromInstant(Instant.parse(folderStartStr))
-          folderEnd <- CantonTimestamp.fromInstant(Instant.parse(folderEndStr))
-        } yield {
-          (folderStart, folderEnd)
-        }
+      for {
+        folderStart <- CantonTimestamp.fromInstant(Instant.parse(parts(0)))
+        folderEnd <- CantonTimestamp.fromInstant(Instant.parse(parts(1)))
+      } yield {
+        (folderStart, folderEnd)
       }
     }
   }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
@@ -98,7 +98,9 @@ class SingleAcsSnapshotBulkStorage(
           storageConfig,
           appConfig,
           s3Connection,
-          { objIdx => s"${storageConfig.getSegmentFolder(timestamp, None)}/ACS_$objIdx.zstd" },
+          { objIdx =>
+            s"${storageConfig.getSegmentFolder(timestamp.timestamp, None)}/ACS_$objIdx.zstd"
+          },
           loggerFactory,
         )
       )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -163,7 +163,7 @@ class UpdateHistorySegmentBulkStorage(
             appConfig,
             s3Connection,
             { objIdx =>
-              s"${storageConfig.getSegmentFolder(segment.fromTimestamp, Some(segment.toTimestamp))}/updates_$objIdx.zstd"
+              s"${storageConfig.getSegmentFolder(segment.fromTimestamp.timestamp, Some(segment.toTimestamp.timestamp))}/updates_$objIdx.zstd"
             },
             loggerFactory,
           )

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageTest.scala
@@ -109,7 +109,7 @@ class AcsSnapshotBulkStorageTest
         val objectKeys = s3Objects.contents.asScala.map(_.key()).sorted
         objectKeys should have length 7
         objectKeys.foreach(
-          _ should startWith("2026-01-02T00:00:00Z-Migration-0-2026-01-03T00:00:00Z/ACS_")
+          _ should startWith("2026-01-02T00:00:00Z~2026-01-03T00:00:00Z/ACS_")
         )
         val objectCountMetrics = metricsFactory.metrics.counters.get(
           SpliceMetrics.MetricsPrefix :+ "history" :+ "bulk-storage" :+ "object-count"
@@ -204,7 +204,7 @@ class AcsSnapshotBulkStorageTest
         val getObjectsResult = bulkStorage.getAcsSnapshotAtOrBefore(queryTs).futureValue
         getObjectsResult.objects.map(_.key) should contain theSameElementsInOrderAs
           (0 until expectedNumObjects).map(i =>
-            s"$expectedTs-Migration-0-${expectedTs.add(1.days)}/ACS_$i.zstd"
+            s"$expectedTs~${expectedTs.add(1.days)}/ACS_$i.zstd"
           )
         getObjectsResult.objects.map(_.checksum).foreach {
           // We test elsewhere that computed and persisted checksums are correct, so here we just check that they are present and not empty

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -104,8 +104,8 @@ class UpdateHistoryBulkStorageTest
       ) {
         mockStore.mockIngestion(1000)
         probe.expectNext(20.seconds) should contain theSameElementsInOrderAs Seq(
-          "1970-01-01T00:00:00.100Z-Migration-0-1970-01-01T00:00:02.300Z/updates_0.zstd",
-          "1970-01-01T00:00:00.100Z-Migration-0-1970-01-01T00:00:02.300Z/updates_1.zstd",
+          "1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/updates_0.zstd",
+          "1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/updates_1.zstd",
         )
         probe.expectComplete()
         val objectCountMetrics = metricsFactory.metrics.counters
@@ -353,16 +353,16 @@ class UpdateHistoryBulkStorageTest
         loggerFactory,
       )
 
-      val d20u0 = "2015-10-20T00:00:00Z-Migration-1-2015-10-21T00:00:00Z/updates_0.zstd"
-      val d20u1 = "2015-10-20T00:00:00Z-Migration-1-2015-10-21T00:00:00Z/updates_1.zstd"
-      val d21u0 = "2015-10-21T00:00:00Z-Migration-1-2015-10-22T00:00:00Z/updates_0.zstd"
-      val d21u1 = "2015-10-21T00:00:00Z-Migration-1-2015-10-22T00:00:00Z/updates_1.zstd"
-      val d22u0 = "2015-10-22T00:00:00Z-Migration-1-2015-10-23T00:00:00Z/updates_0.zstd"
-      val d22u1 = "2015-10-22T00:00:00Z-Migration-1-2015-10-23T00:00:00Z/updates_1.zstd"
-      val d23u0 = "2015-10-23T00:00:00Z-Migration-1-2015-10-24T00:00:00Z/updates_0.zstd"
-      val d23u1 = "2015-10-23T00:00:00Z-Migration-1-2015-10-24T00:00:00Z/updates_1.zstd"
-      val d24u0 = "2015-10-24T00:00:00Z-Migration-1-2015-10-25T00:00:00Z/updates_0.zstd"
-      val d24u1 = "2015-10-24T00:00:00Z-Migration-1-2015-10-25T00:00:00Z/updates_1.zstd"
+      val d20u0 = "2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/updates_0.zstd"
+      val d20u1 = "2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/updates_1.zstd"
+      val d21u0 = "2015-10-21T00:00:00Z~2015-10-22T00:00:00Z/updates_0.zstd"
+      val d21u1 = "2015-10-21T00:00:00Z~2015-10-22T00:00:00Z/updates_1.zstd"
+      val d22u0 = "2015-10-22T00:00:00Z~2015-10-23T00:00:00Z/updates_0.zstd"
+      val d22u1 = "2015-10-22T00:00:00Z~2015-10-23T00:00:00Z/updates_1.zstd"
+      val d23u0 = "2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/updates_0.zstd"
+      val d23u1 = "2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/updates_1.zstd"
+      val d24u0 = "2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/updates_0.zstd"
+      val d24u1 = "2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/updates_1.zstd"
       val allObjs = Seq(
         d20u0,
         d20u1,
@@ -400,7 +400,7 @@ class UpdateHistoryBulkStorageTest
         d23u0,
         d23u1,
       )
-      res1.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z-Migration-1-2015-10-24T00:00:00Z/")
+      res1.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/")
       val res1b = svc
         .getUpdatesBetweenDates(
           CantonTimestamp.tryFromInstant(Instant.parse("2015-10-10T00:00:00Z")),
@@ -410,7 +410,7 @@ class UpdateHistoryBulkStorageTest
         )
         .futureValue
       res1b.objects.map(_.key) shouldBe empty
-      res1b.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z-Migration-1-2015-10-24T00:00:00Z/")
+      res1b.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/")
 
       // A smaller range within the data
       val res2 = svc
@@ -436,7 +436,7 @@ class UpdateHistoryBulkStorageTest
         )
         .futureValue
       res3.objects.map(_.key) should contain theSameElementsInOrderAs Seq(d20u0, d20u1)
-      res3.nextPageTokenO shouldBe Some("2015-10-20T00:00:00Z-Migration-1-2015-10-21T00:00:00Z/")
+      res3.nextPageTokenO shouldBe Some("2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/")
       val res3b = svc
         .getUpdatesBetweenDates(
           CantonTimestamp.tryFromInstant(Instant.parse("2015-10-01T12:00:00Z")),
@@ -477,10 +477,10 @@ class UpdateHistoryBulkStorageTest
         .getCode shouldBe io.grpc.Status.Code.INVALID_ARGUMENT
 
       // Test handling an empty segment: Simulate no updates in 2015-10-25 to 2015-10-26
-      val d26u0 = "2015-10-26T00:00:00Z-Migration-1-2015-10-27T00:00:00Z/updates_0.zstd"
-      val d26u1 = "2015-10-26T00:00:00Z-Migration-1-2015-10-27T00:00:00Z/updates_1.zstd"
+      val d26u0 = "2015-10-26T00:00:00Z~2015-10-27T00:00:00Z/updates_0.zstd"
+      val d26u1 = "2015-10-26T00:00:00Z~2015-10-27T00:00:00Z/updates_1.zstd"
       val moreObjs = Seq(
-        "2015-10-25T00:00:00Z-Migration-1-2015-10-26T00:00:00Z/ACS_0.zstd",
+        "2015-10-25T00:00:00Z~2015-10-26T00:00:00Z/ACS_0.zstd",
         d26u0,
         d26u1,
       )
@@ -527,7 +527,7 @@ class UpdateHistoryBulkStorageTest
         .futureValue
       // First response contains all data, but with a next page token
       res5.objects.map(_.key) should contain theSameElementsInOrderAs allObjs
-      res5.nextPageTokenO shouldBe Some("2015-10-24T00:00:00Z-Migration-1-2015-10-25T00:00:00Z/")
+      res5.nextPageTokenO shouldBe Some("2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/")
       val res5b = svc
         .getUpdatesBetweenDates(
           CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T00:00:00Z")),


### PR DESCRIPTION
- We confirmed that time never travelled backward in a migration, and it never will as we have no more migrations
- This is a breaking change in the internal data structure in S3, but at this point only 2 CILR SVs and our 2 devnet SVs have started dumping, so we'll just recreate those. Worth the cleanup of not maintaining migration IDs there forever.
- I confirmed that the lookup APIs for bulk storage already did not have migration ID arguments, and were implicitly taking min/max migration ID for the given record time, so no change required there.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
