### PR TITLE
Denormalize the history_id for app_activity_records

### DIFF
--- a/apps/common/src/main/resources/db/migration/canton-network/postgres/stable/V066__app_activity_record_store_history_id.sql
+++ b/apps/common/src/main/resources/db/migration/canton-network/postgres/stable/V066__app_activity_record_store_history_id.sql
@@ -1,0 +1,38 @@
+-- Drop and recreate app_activity_record_store to add history_id column.
+-- see #5320 / #5279 for details
+-- In short this denormalization removes potential expensive join to scan_verdict_store
+
+drop table app_activity_record_store;
+
+create table app_activity_record_store
+(
+    -- History identifier for update history partitioning (same as scan_verdict_store.history_id).
+    history_id                  bigint not null,
+    -- References the parent verdict in scan_verdict_store
+    verdict_row_id              bigint not null,
+    -- The mining round number to which this activity is assigned
+    round_number                bigint not null,
+    -- App providers for which app activity should be recorded
+    app_provider_parties        text[] not null,
+    -- Activity weight assigned to the app providers (bytes of traffic),
+    -- in one-to-one correspondence with app_provider_parties.
+    app_activity_weights        bigint[] not null,
+    -- One activity record per verdict
+    constraint app_activity_record_store_pkey primary key (verdict_row_id),
+    -- Referential integrity to parent verdict
+    foreign key (verdict_row_id) references scan_verdict_store (row_id)
+);
+
+-- Used to compute the per-party totals for a round
+create index app_activity_record_store_hi_rn_idx on
+  app_activity_record_store (history_id, round_number);
+
+-- Truncate downstream reward-accounting tables; they aggregate from
+-- app_activity_record_store and would otherwise be inconsistent with the
+-- now-empty activity record table.
+truncate table app_activity_party_totals,
+               app_activity_round_totals,
+               app_reward_party_totals,
+               app_reward_round_totals,
+               app_reward_batch_hashes,
+               app_reward_root_hashes;

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -58,7 +58,6 @@ class DbAppActivityRecordStore(
 
   object Tables {
     val appActivityRecords = "app_activity_record_store"
-    val verdicts = "scan_verdict_store"
   }
 
   private def historyId = updateHistory.historyId
@@ -88,32 +87,22 @@ class DbAppActivityRecordStore(
       tc: TraceContext
   ): Future[Option[Long]] = {
 
-    // The inner `where exists` is used to make sure we only consider activity records for the correct history
-    // `order by ... limit 1` is used instead of min/max to force the query planner to use the index on round_number
+    // `order by ... limit 1` is used instead of min/max to force the query planner
+    // to use the (history_id, round_number) index.
     runQuerySingle(
       sql"""select min_round + 1
             from (
               select a.round_number as min_round
               from #${Tables.appActivityRecords} a
-              where exists (
-                select 1
-                from #${Tables.verdicts} v
-                where v.row_id = a.verdict_row_id
-                and v.history_id = $historyId
-              )
+              where a.history_id = $historyId
               order by a.round_number asc
               limit 1
             ) sub
             where exists (
               select 1
               from #${Tables.appActivityRecords} a
-              where a.round_number = sub.min_round + 1
-              and exists (
-                select 1
-                from #${Tables.verdicts} v
-                where v.row_id = a.verdict_row_id
-                and v.history_id = $historyId
-              )
+              where a.history_id = $historyId
+              and a.round_number = sub.min_round + 1
               order by a.round_number asc
               limit 1
             )
@@ -132,32 +121,22 @@ class DbAppActivityRecordStore(
       tc: TraceContext
   ): Future[Option[Long]] = {
 
-    // The inner `where exists` is used to make sure we only consider activity records for the correct history
-    // `order by ... limit 1` is used instead of min/max to force the query planner to use the index on round_number
+    // `order by ... limit 1` is used instead of min/max to force the query planner
+    // to use the (history_id, round_number) index.
     runQuerySingle(
       sql"""select max_round - 1
             from (
               select a.round_number as max_round
               from #${Tables.appActivityRecords} a
-              where exists (
-                select 1
-                from #${Tables.verdicts} v
-                where v.row_id = a.verdict_row_id
-                and v.history_id = $historyId
-              )
+              where a.history_id = $historyId
               order by a.round_number desc
               limit 1
             ) sub
             where exists (
               select 1
               from #${Tables.appActivityRecords} a
-              where a.round_number = sub.max_round - 1
-              and exists (
-                select 1
-                from #${Tables.verdicts} v
-                where v.row_id = a.verdict_row_id
-                and v.history_id = $historyId
-              )
+              where a.history_id = $historyId
+              and a.round_number = sub.max_round - 1
               order by a.round_number desc
               limit 1
             )
@@ -179,15 +158,13 @@ class DbAppActivityRecordStore(
         for {
           hasPrev <- sql"""select exists(
                              select 1 from #${Tables.appActivityRecords} a
-                             join #${Tables.verdicts} v on a.verdict_row_id = v.row_id
-                             where a.round_number = ${roundNumber - 1}
-                               and v.history_id = $historyId
+                             where a.history_id = $historyId
+                               and a.round_number = ${roundNumber - 1}
                            )""".as[Boolean].head
           hasNext <- sql"""select exists(
                              select 1 from #${Tables.appActivityRecords} a
-                             join #${Tables.verdicts} v on a.verdict_row_id = v.row_id
-                             where a.round_number = ${roundNumber + 1}
-                               and v.history_id = $historyId
+                             where a.history_id = $historyId
+                               and a.round_number = ${roundNumber + 1}
                            )""".as[Boolean].head
           _ = if (!hasPrev || !hasNext)
             throw Status.FAILED_PRECONDITION
@@ -240,14 +217,14 @@ class DbAppActivityRecordStore(
     } else {
       val values = sqlCommaSeparated(
         items.map { row =>
-          sql"""(${row.verdictRowId},
+          sql"""($historyId, ${row.verdictRowId},
                 ${row.roundNumber}, ${row.appProviderParties}, ${row.appActivityWeights})"""
         }
       )
 
       (sql"""
         insert into #${Tables.appActivityRecords}(
-          verdict_row_id, round_number, app_provider_parties, app_activity_weights
+          history_id, verdict_row_id, round_number, app_provider_parties, app_activity_weights
         ) values """ ++ values).asUpdate
     }
   }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanAppRewardsStore.scala
@@ -685,11 +685,10 @@ class DbScanAppRewardsStore(
     sql"""unnested as (
             select party, weight
             from app_activity_record_store a
-            join scan_verdict_store v on a.verdict_row_id = v.row_id
             cross join lateral unnest(a.app_provider_parties, a.app_activity_weights)
                  as party_and_weight(party, weight)
-            where a.round_number = $roundNumber
-              and v.history_id = $historyId
+            where a.history_id = $historyId
+              and a.round_number = $roundNumber
           ),
           aggregated as (
             select party, sum(weight) as total_weight,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -969,8 +969,8 @@ class DbScanAppRewardsStoreTest
       futureUnlessShutdownToFuture(
         storage.underlying.queryAndUpdate(
           sqlu"""insert into app_activity_record_store
-                 (verdict_row_id, round_number, app_provider_parties, app_activity_weights)
-                 values ($verdictId, $round,
+                 (history_id, verdict_row_id, round_number, app_provider_parties, app_activity_weights)
+                 values ($historyId, $verdictId, $round,
                          #${"'" + partiesArray + "'"},
                          #${"'" + weightsArray + "'"})""",
           "test.insertActivityRecord",

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -6,3 +6,13 @@
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
 .. release-notes:: Upcoming
+
+    - Scan app
+
+        - The ``app_activity_record_store`` table has been modified to avoid unexpected DB performance issues.
+          This required clearing the existing data in this table which has been ingested since the ``0.5.18`` release.
+          This impacts the data being served via the experimental field ``app_activity_records`` on the ``/v0/events`` and ``/v0/events/{update_id}`` endpoints.
+          Specifically the ``app_activity_records`` field will not contain the
+          data which has been provided for the events which happened between the ``0.5.18`` and this release.
+          Note that the ``app_activity_records`` data already provided for events during this period is correct
+          and the network explorers who have ingested this data should keep a copy of it.


### PR DESCRIPTION
Fixes https://github.com/hyperledger-labs/splice/issues/5320

I ran query plan analyze on dummy data, and confirmed that all queries were < 0.01 ms.

Before and after of migration
```
splice_apps=# \d app_activity_record_store
             Table "public.app_activity_record_store"
        Column        |   Type   | Collation | Nullable | Default 
----------------------+----------+-----------+----------+---------
 verdict_row_id       | bigint   |           | not null | 
 round_number         | bigint   |           | not null | 
 app_provider_parties | text[]   |           | not null | 
 app_activity_weights | bigint[] |           | not null | 
Indexes:
    "app_activity_record_store_pkey" PRIMARY KEY, btree (verdict_row_id)
    "app_activity_record_store_round_nr_idx" btree (round_number)
Foreign-key constraints:
    "app_activity_record_store_verdict_row_id_fkey" FOREIGN KEY (verdict_row_id) REFERENCES scan_verdict_store(row_id)

splice_apps=# \d app_activity_record_store
             Table "public.app_activity_record_store"
        Column        |   Type   | Collation | Nullable | Default 
----------------------+----------+-----------+----------+---------
 history_id           | bigint   |           | not null | 
 verdict_row_id       | bigint   |           | not null | 
 round_number         | bigint   |           | not null | 
 app_provider_parties | text[]   |           | not null | 
 app_activity_weights | bigint[] |           | not null | 
Indexes:
    "app_activity_record_store_pkey" PRIMARY KEY, btree (verdict_row_id)
    "app_activity_record_store_hi_rn_idx" btree (history_id, round_number)
Foreign-key constraints:
    "app_activity_record_store_verdict_row_id_fkey" FOREIGN KEY (verdict_row_id) REFERENCES scan_verdict_store(row_id)

```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
