### PR TITLE
Add physical synchronizer id to periodic topology snapshot metadata

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
@@ -7,11 +7,10 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.time.Clock
-import com.digitalasset.canton.topology.{PhysicalSynchronizerId, SynchronizerId}
+import com.digitalasset.canton.topology.PhysicalSynchronizerId
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.tracing.TraceContext
 import io.circe.Json
-import io.circe.syntax.*
 import io.grpc.{Status, StatusRuntimeException}
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.actor.ActorSystem

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
@@ -10,6 +10,8 @@ import com.digitalasset.canton.time.Clock
 import com.digitalasset.canton.topology.{PhysicalSynchronizerId, SynchronizerId}
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.tracing.TraceContext
+import io.circe.Json
+import io.circe.syntax.*
 import io.grpc.{Status, StatusRuntimeException}
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.actor.ActorSystem
@@ -117,11 +119,9 @@ class PeriodicTopologySnapshotTrigger(
       metadataMap = summary.map(e => (e._1.code, e._2.toString)) +
         ("sequencerId" -> sequencerId.toProtoPrimitive) +
         ("physicalSynchronizerId" -> physicalSynchronizerId.toProtoPrimitive)
-      metadataKv = metadataMap
-        .map { case (key, value) =>
-          s"$key,$value"
-        }
-        .mkString("\n")
+      metadataJson = Json
+        .obj(metadataMap.map { case (k, v) => k -> Json.fromString(v) }.toSeq*)
+        .spaces2
       _ <- Future {
         blocking {
           val fileDesc =
@@ -137,7 +137,7 @@ class PeriodicTopologySnapshotTrigger(
             BackupDump.write(
               config.location,
               Paths.get(s"$folderName/metadata"),
-              metadataKv,
+              metadataJson,
               loggerFactory,
             ),
           )

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/PeriodicTopologySnapshotTrigger.scala
@@ -7,7 +7,7 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.time.Clock
-import com.digitalasset.canton.topology.SynchronizerId
+import com.digitalasset.canton.topology.{PhysicalSynchronizerId, SynchronizerId}
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.tracing.TraceContext
 import io.grpc.{Status, StatusRuntimeException}
@@ -23,7 +23,7 @@ import org.lfdecentralizedtrust.splice.sv.LocalSynchronizerNode
 import org.lfdecentralizedtrust.splice.util.BackupDump
 
 import java.nio.file.Paths
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.{Failure, Success}
 
 /** As taking a topology snapshot is not a cheap operation, we limit this trigger to produce at most one snapshot per day.
@@ -46,12 +46,12 @@ class PeriodicTopologySnapshotTrigger(
       task: PeriodicTaskTrigger.PeriodicTask
   )(implicit traceContext: TraceContext): Future[TaskOutcome] = {
     participantAdminConnection
-      .getSynchronizerId(synchronizerAlias)
+      .getPhysicalSynchronizerId(synchronizerAlias)
       .transformWith {
         case Failure(s: StatusRuntimeException) if s.getStatus.getCode == Status.Code.NOT_FOUND =>
           Future.successful(TaskNoop)
         case Failure(e) => Future.failed(e)
-        case Success(synchronizerId) =>
+        case Success(physicalSynchronizerId) =>
           val now = clock.now
           val utcDate = now.toInstant.toString.split("T").head
           val folderName = s"topology_snapshot_${now.toInstant}"
@@ -63,7 +63,7 @@ class PeriodicTopologySnapshotTrigger(
                   folderName,
                   now,
                   utcDate,
-                  synchronizerId,
+                  physicalSynchronizerId,
                 )
               else Future.successful(TaskSuccess("Today's topology snapshot already exists."))
           } yield res
@@ -83,7 +83,7 @@ class PeriodicTopologySnapshotTrigger(
       folderName: String,
       now: CantonTimestamp,
       utcDate: String,
-      synchronizerId: SynchronizerId,
+      physicalSynchronizerId: PhysicalSynchronizerId,
   )(implicit
       traceContext: TraceContext,
       esf: ExecutionSequencerFactory,
@@ -110,13 +110,18 @@ class PeriodicTopologySnapshotTrigger(
       authorizedStore <- sequencerAdminConnection.exportAuthorizedStoreSnapshot(sequencerId.uid)
       // list a summary of the transactions state at the time of the snapshot to validate further imports
       summary <- sequencerAdminConnection.getTopologyTransactionsSummary(
-        TopologyStoreId.Synchronizer(synchronizerId),
+        TopologyStoreId.Synchronizer(physicalSynchronizerId.logical),
         clock.now,
       )
       // we create a single metadata file to store the amounts of the different transactions along the sequencerId
-      metadata = summary.map(e =>
-        (e._1.code, e._2.toString)
-      ) + ("sequencerId" -> sequencerId.toProtoPrimitive)
+      metadataMap = summary.map(e => (e._1.code, e._2.toString)) +
+        ("sequencerId" -> sequencerId.toProtoPrimitive) +
+        ("physicalSynchronizerId" -> physicalSynchronizerId.toProtoPrimitive)
+      metadataKv = metadataMap
+        .map { case (key, value) =>
+          s"$key,$value"
+        }
+        .mkString("\n")
       _ <- Future {
         blocking {
           val fileDesc =
@@ -132,7 +137,7 @@ class PeriodicTopologySnapshotTrigger(
             BackupDump.write(
               config.location,
               Paths.get(s"$folderName/metadata"),
-              metadata.toString(),
+              metadataKv,
               loggerFactory,
             ),
           )


### PR DESCRIPTION
We need the physical synchronizer Id the snapshot was taken from to correctly validate it in canton CI tests.
This PR adds it to the existing metadata file.
It also writes in a CSV-style format instead of `toString` the map which resulted in a not so nice to parse `HashMap(key -> value)` content

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
