### PR TITLE
update Github org references to canton-network

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,9 @@
 - [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
 
 #### PR Guidelines
-- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
+- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
 - [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
-- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool
+- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool
 
 
 #### Merge Guidelines

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   backport:
-    uses: hyperledger-labs/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
+    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
     with:
       commit_sha: ${{ inputs.commit_sha }}
       pr_number: ${{ fromJSON(inputs.pr_number) }}

--- a/.github/workflows/backport_reminder.yml
+++ b/.github/workflows/backport_reminder.yml
@@ -11,7 +11,7 @@ jobs:
   add-backport-reminder:
     runs-on: ubuntu-24.04
     steps:
-        - uses: hyperledger-labs/splice-shared-gha/actions/backport_reminder@a78684a826be866b199ae7a05471a7fad2c9c76c
+        - uses: canton-network/splice-shared-gha/actions/backport_reminder@a78684a826be866b199ae7a05471a7fad2c9c76c
           with:
             pr_number: ${{ github.event.pull_request.number }}
             lookup_prod_cluster_configs: false

--- a/.github/workflows/do_backports.yml
+++ b/.github/workflows/do_backports.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       branches: ${{ steps.parse_backport_comments.outputs.backport_branches }}
     steps:
-      - uses: hyperledger-labs/splice-shared-gha/actions/parse_backport_comments@a78684a826be866b199ae7a05471a7fad2c9c76c
+      - uses: canton-network/splice-shared-gha/actions/parse_backport_comments@a78684a826be866b199ae7a05471a7fad2c9c76c
         id: parse_backport_comments
         with:
           pr_number: ${{ github.event.pull_request.number }}
@@ -25,7 +25,7 @@ jobs:
       matrix:
         branch: ${{ fromJSON(needs.get_backport_branches.outputs.branches) }}
       fail-fast: false
-    uses: hyperledger-labs/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
+    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
     secrets:
       strong_token: ${{ secrets.GH_CREATE_PRS_TOKEN }}
     with:

--- a/.github/workflows/notify_readme_changes.yml
+++ b/.github/workflows/notify_readme_changes.yml
@@ -24,7 +24,7 @@ jobs:
             echo "Setting GITHUB_COMMIT_URL as document change is detected in commit $commit"
             {
               echo "FOUND_DOCUMENT_CHANGES=true" ;
-              echo "GITHUB_COMMIT_URL=https://github.com/hyperledger-labs/splice/commit/${commit}"
+              echo "GITHUB_COMMIT_URL=https://github.com/canton-network/splice/commit/${commit}"
               echo "CHANGED_DOC_FILES=${changed_files_list}"
               echo "GIT_LOG=\\\"$(git log -1 --oneline --no-color | sed s/\"//g | sed s/\`//g | sed s/\'//g)\\\""
             } >> "$GITHUB_OUTPUT"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule ".github/runners/runner-container-hooks"]
 	path = .github/runners/runner-container-hooks
-	url = ../../hyperledger-labs/splice-runner-container-hooks.git
+	url = ../../canton-network/splice-runner-container-hooks.git
 [submodule "splice-shared-gha"]
 	path = splice-shared-gha
-	url = ../../hyperledger-labs/splice-shared-gha.git
+	url = ../../canton-network/splice-shared-gha.git

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Splice maintainers
-*       @hyperledger-labs/splice-maintainers
+*       @canton-network/splice-maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ In order to setup your development environment, please see the [Development READ
 
 Splice maintainers may use the following GitHub issue labels to highlight issues suitable for newer contributors:
 
-- [`help wanted`](https://github.com/hyperledger-labs/splice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22):
+- [`help wanted`](https://github.com/canton-network/splice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22):
   tasks of various sizes and difficulty levels suitable for contributors outside of the maintainers team
-- [`good first issue`](https://github.com/hyperledger-labs/splice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22):
+- [`good first issue`](https://github.com/canton-network/splice/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22):
   easier tasks that are well-suited for onboarding to the code base
 
 Note that not all `good first issue`s are also `help wanted`; some may require access to infrastructure (CI, test deployments) that is not openly available.
@@ -273,6 +273,6 @@ To convert, import `scala.jdk.CollectionConverters.*`. You can then use `asScala
 ## Dev Docs
 
 We publish docs from each commit from `main` to
-https://hyperledger-labs.github.io/splice/. This can
+https://canton-network.github.io/splice/. This can
 often be useful to answer support requests with a docs link even if
 those docs are still very recent.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ contains a list of additional arguments passed to scalatest which is
 then picked up when running the tests.
 
 To trigger the compat tests for a PR go to
-https://github.com/hyperledger-labs/splice/actions/workflows/build.yml
+https://github.com/canton-network/splice/actions/workflows/build.yml
 and click on `Run workflow`. Select the branch of your PR and the
 splice version you want to test compatibility against and input the
 commit sha of your branch.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -159,5 +159,5 @@ To inspect a manifest locally, you can run e.g. `docker buildx imagetools inspec
 
 ## Bumping splice-shared-gha
 
-In order to bump [splice-shared-gha](https://github.com/hyperledger-labs/splice-shared-gha), please run [Bump splice-shared-gha version](https://github.com/hyperledger-labs/splice/actions/workflows/bump_splice_shared_gha.yml) job and merge the PR that will
+In order to bump [splice-shared-gha](https://github.com/canton-network/splice-shared-gha), please run [Bump splice-shared-gha version](https://github.com/canton-network/splice/actions/workflows/bump_splice_shared_gha.yml) job and merge the PR that will
 be created by the job.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ This guide outlines steps to resolve common issues that a contributor might enco
 
 ### 1. Setup Environment
 
-- Clone the repository: `git clone https://github.com/hyperledger-labs/splice.git`.
+- Clone the repository: `git clone https://github.com/canton-network/splice.git`.
 - Navigate to the project directory: `cd splice`.
 - Enable **`direnv`** to load environment variables (e.g., `DAML_COMPILER_VERSION`):
 

--- a/apps/app/src/test/resources/include/participants.conf
+++ b/apps/app/src/test/resources/include/participants.conf
@@ -25,7 +25,7 @@ _participant_template {
     engine.enable-additional-consistency-checks = true
     # TODO(DACH-NY/canton-network-internal#2050) Remove once ACS commitment processing does not block anymore.
     do-not-await-on-checking-incoming-commitments = true
-    # TODO(hyperledger-labs/splice#3302) - re-enable after it's ported to canton main
+    # TODO(canton-network/splice#3302) - re-enable after it's ported to canton main
     #commitment-processor-nr-acs-changes-behind-to-trigger-catch-up = 10000
     # Bump batch size to make acs imports faster
     batching.max-acs-import-batch-size = 10000

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorFaucetCapZeroTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ValidatorFaucetCapZeroTimeBasedIntegrationTest.scala
@@ -17,7 +17,7 @@ import org.lfdecentralizedtrust.splice.util.{DisclosedContracts, TimeTestUtil, W
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
-// TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+// TODO(canton-network/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
 @org.lfdecentralizedtrust.splice.util.scalatesttags.NoDamlCompatibilityCheck
 class ValidatorFaucetCapZeroTimeBasedIntegrationTest
     extends IntegrationTestWithIsolatedEnvironment
@@ -26,7 +26,7 @@ class ValidatorFaucetCapZeroTimeBasedIntegrationTest
 
   // Package versions from Splice 0.5.11 — the Daml versions currently deployed on MainNet,
   // which do not include the Daml-side fix for the division-by-zero bug on cap=0 rounds.
-  // TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+  // TODO(canton-network/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
   private val initialPackageConfig = InitialPackageConfig(
     amuletVersion = "0.1.16",
     amuletNameServiceVersion = "0.1.17",
@@ -39,7 +39,7 @@ class ValidatorFaucetCapZeroTimeBasedIntegrationTest
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology1SvWithSimTime(this.getClass.getSimpleName)
-      // TODO(hyperledger-labs/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
+      // TODO(canton-network/splice#3461): Remove once MainNet has adopted the Daml versions from 0.5.16 or later
       .withNoVettedPackages(implicit env => env.validators.local.map(_.participantClient))
       .addConfigTransform((_, config) => ConfigTransforms.withValidatorFaucetCap(0)(config))
       .addConfigTransform((_, config) =>

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/setup/NodeInitializer.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/setup/NodeInitializer.scala
@@ -132,7 +132,7 @@ class NodeInitializer(
             //    b. a participant that is still bootstrapping, and not yet set its Id from the db
             // as a (temporary) work around, if participant has no id set, we retry getId for a maximum of 5s duration
             // we chose 5s, because, according to logs, 5s is enough for the participant to set its id, if it already has one
-            // TODO(hyperledger-labs/splice#4508): this shouldn't be required once we have a Canton fix
+            // TODO(canton-network/splice#4508): this shouldn't be required once we have a Canton fix
             val currentDeadlineOpt = emptyIdDeadline.updateAndGet {
               case None => Some(5.seconds.fromNow) // Start clock now
               case existing => existing

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsQueries.scala
@@ -282,7 +282,7 @@ trait AcsQueries extends AcsJdbcTypes {
   }
 
   /*
-   * TODO(#3900) move to use toInClause when canton fork has it: https://github.com/hyperledger-labs/splice/issues/3900
+   * TODO(#3900) move to use toInClause when canton fork has it: https://github.com/canton-network/splice/issues/3900
    */
   protected def inClause[V: ClassTag](
       field: String,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/DarResourcesUtil.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/DarResourcesUtil.scala
@@ -39,7 +39,7 @@ object DarResourcesUtil extends NamedLogging {
   def lookupAllPackageVersions(name: PackageName): Seq[DarResource] =
     packageResources.view.flatMap(_.all).toSeq.filter(_.metadata.name == name)
 
-  // TODO(hyperledger-labs/splice#4049): remove `enableUnsupportedDarsUnvetting` once not needed anymore
+  // TODO(canton-network/splice#4049): remove `enableUnsupportedDarsUnvetting` once not needed anymore
   def getRequiredPackageVersions(
       name: PackageName,
       upToRequiredVersion: PackageVersion,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/ScanTables.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/ScanTables.scala
@@ -280,7 +280,7 @@ object ScanTables extends AcsTables {
       record match {
         case _: BalanceChangeTxLogEntry =>
           // the balance changes are no longer indexed, or written, to the tx log table,
-          // See https://github.com/hyperledger-labs/splice/pull/3734
+          // See https://github.com/canton-network/splice/pull/3734
           None
         case entry => Some(fromEntry(entry))
       }

--- a/apps/sv/frontend/src/components/votes/actions/CreateUnallocatedUnclaimedActivityRecord.tsx
+++ b/apps/sv/frontend/src/components/votes/actions/CreateUnallocatedUnclaimedActivityRecord.tsx
@@ -108,7 +108,7 @@ const CreateUnallocatedUnclaimedActivityRecord: React.FC<{
             setAmount(newValue);
 
             // TODO(#1520): Check that amount <=  amount of unclaimed rewards available.
-            // https://github.com/hyperledger-labs/splice/issues/1520
+            // https://github.com/canton-network/splice/issues/1520
             try {
               const decimal = new Decimal(newValue);
               if (decimal.lte(0)) {

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -484,7 +484,7 @@ class ValidatorApp(
       logger: TracedLogger,
       retryProvider: RetryProvider,
   )(implicit traceContext: TraceContext): Future[ByteString] =
-    // TODO (hyperledger-labs/splice#4026) use the standard BftScanConnection instead of creating a new SingleScanConnection.
+    // TODO (canton-network/splice#4026) use the standard BftScanConnection instead of creating a new SingleScanConnection.
     retryProvider.retry(
       RetryFor.WaitingOnInitDependency,
       "get_acs_snapshot_from_single_scan",

--- a/cluster/configs/shared/base-sv.yaml
+++ b/cluster/configs/shared/base-sv.yaml
@@ -24,7 +24,7 @@ participant:
     - !include(./participant_pruning.yaml)
 validatorApp:
   additionalEnvVars:
-    # enable https://github.com/hyperledger-labs/splice/pull/2499
+    # enable https://github.com/canton-network/splice/pull/2499
     - name: ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT
       value: |
         canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m

--- a/cluster/configs/shared/scratch-default-synchronizer-migration.yaml
+++ b/cluster/configs/shared/scratch-default-synchronizer-migration.yaml
@@ -4,7 +4,7 @@ synchronizerMigration:
     version: "local"
     releaseReference:
       gitReference: "refs/heads/main"
-      repoUrl: https://github.com/hyperledger-labs/splice
+      repoUrl: https://github.com/canton-network/splice
       pulumiStacksDir: "cluster/stacks/prod"
       pulumiBaseDir: "splice/cluster/pulumi"
       deploymentDir: "cluster/deployment"

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -44,7 +44,7 @@ synchronizerMigration:
       version: 0.3.18
       releaseReference:
         gitReference: "981227e62011e386cca3cdb5f00b472cf05a12c4"
-        repoUrl: https://github.com/hyperledger-labs/splice
+        repoUrl: https://github.com/canton-network/splice
         pulumiStacksDir: "cluster/stacks/prod"
         pulumiBaseDir: "splice/cluster/pulumi"
         deploymentDir: "cluster/deployment"
@@ -53,7 +53,7 @@ synchronizerMigration:
       version: 0.3.19
       releaseReference:
         gitReference: "refs/heads/release-line-0.3.19"
-        repoUrl: https://github.com/hyperledger-labs/splice
+        repoUrl: https://github.com/canton-network/splice
         pulumiStacksDir: "cluster/stacks/prod"
         pulumiBaseDir: "splice/cluster/pulumi"
         deploymentDir: "cluster/deployment"
@@ -63,7 +63,7 @@ synchronizerMigration:
     version: 0.3.20
     releaseReference:
       gitReference: "refs/heads/release-line-0.3.20"
-      repoUrl: https://github.com/hyperledger-labs/splice
+      repoUrl: https://github.com/canton-network/splice
       pulumiStacksDir: "cluster/stacks/prod"
       pulumiBaseDir: "splice/cluster/pulumi"
       deploymentDir: "cluster/deployment"
@@ -78,7 +78,7 @@ synchronizerMigration:
       enableBftSequencer: true
     releaseReference:
       gitReference: "refs/heads/release-line-0.3.21"
-      repoUrl: https://github.com/hyperledger-labs/splice
+      repoUrl: https://github.com/canton-network/splice
       pulumiStacksDir: "cluster/stacks/prod"
       pulumiBaseDir: "splice/cluster/pulumi"
       deploymentDir: "cluster/deployment"
@@ -256,7 +256,7 @@ cluster:
       minNodes: 0
       maxNodes: 1
 gha:
-  githubRepo: "https://github.com/hyperledger-labs/splice"
+  githubRepo: "https://github.com/canton-network/splice"
   runnerVersion: "0.5.10"
   runnerHookVersion: "0.5.10"
   runnerScaleSetVersion: "0.13.1"

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -1709,7 +1709,7 @@ synchronizerMigration:
       publicConfigsDir: 'cluster/configs/configs'
       pulumiBaseDir: 'splice/cluster/pulumi'
       pulumiStacksDir: 'cluster/stacks/prod'
-      repoUrl: 'https://github.com/hyperledger-labs/splice'
+      repoUrl: 'https://github.com/canton-network/splice'
       spliceRoot: 'splice'
     version: 'local'
 validator1:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -1709,7 +1709,7 @@ synchronizerMigration:
       publicConfigsDir: 'cluster/configs/configs'
       pulumiBaseDir: 'splice/cluster/pulumi'
       pulumiStacksDir: 'cluster/stacks/prod'
-      repoUrl: 'https://github.com/hyperledger-labs/splice'
+      repoUrl: 'https://github.com/canton-network/splice'
       spliceRoot: 'splice'
     version: 'local'
 validator1:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -1709,7 +1709,7 @@ synchronizerMigration:
       publicConfigsDir: 'cluster/configs/configs'
       pulumiBaseDir: 'splice/cluster/pulumi'
       pulumiStacksDir: 'cluster/stacks/prod'
-      repoUrl: 'https://github.com/hyperledger-labs/splice'
+      repoUrl: 'https://github.com/canton-network/splice'
       spliceRoot: 'splice'
     version: 'local'
 validator1:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -1709,7 +1709,7 @@ synchronizerMigration:
       publicConfigsDir: 'cluster/configs/configs'
       pulumiBaseDir: 'splice/cluster/pulumi'
       pulumiStacksDir: 'cluster/stacks/prod'
-      repoUrl: 'https://github.com/hyperledger-labs/splice'
+      repoUrl: 'https://github.com/canton-network/splice'
       spliceRoot: 'splice'
     version: 'local'
 validator1:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -1709,7 +1709,7 @@ synchronizerMigration:
       publicConfigsDir: 'cluster/configs/configs'
       pulumiBaseDir: 'splice/cluster/pulumi'
       pulumiStacksDir: 'cluster/stacks/prod'
-      repoUrl: 'https://github.com/hyperledger-labs/splice'
+      repoUrl: 'https://github.com/canton-network/splice'
       spliceRoot: 'splice'
     version: 'local'
 validator1:

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -297,7 +297,7 @@
             "publicConfigsDir": "cluster/configs/configs",
             "pulumiBaseDir": "splice/cluster/pulumi",
             "pulumiStacksDir": "cluster/stacks/prod",
-            "repoUrl": "https://github.com/hyperledger-labs/splice",
+            "repoUrl": "https://github.com/canton-network/splice",
             "spliceRoot": "splice"
           },
           "sequencer": {
@@ -318,7 +318,7 @@
               "gitReference": "981227e62011e386cca3cdb5f00b472cf05a12c4",
               "pulumiBaseDir": "splice/cluster/pulumi",
               "pulumiStacksDir": "cluster/stacks/prod",
-              "repoUrl": "https://github.com/hyperledger-labs/splice",
+              "repoUrl": "https://github.com/canton-network/splice",
               "spliceRoot": "splice"
             },
             "sequencer": {
@@ -338,7 +338,7 @@
               "gitReference": "refs/heads/release-line-0.3.19",
               "pulumiBaseDir": "splice/cluster/pulumi",
               "pulumiStacksDir": "cluster/stacks/prod",
-              "repoUrl": "https://github.com/hyperledger-labs/splice",
+              "repoUrl": "https://github.com/canton-network/splice",
               "spliceRoot": "splice"
             },
             "sequencer": {
@@ -363,7 +363,7 @@
             "publicConfigsDir": "cluster/configs/configs",
             "pulumiBaseDir": "splice/cluster/pulumi",
             "pulumiStacksDir": "cluster/stacks/prod",
-            "repoUrl": "https://github.com/hyperledger-labs/splice",
+            "repoUrl": "https://github.com/canton-network/splice",
             "spliceRoot": "splice"
           },
           "sequencer": {

--- a/cluster/expected/deployment/expected.json
+++ b/cluster/expected/deployment/expected.json
@@ -952,7 +952,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-active-base",
@@ -1040,7 +1040,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-active",
@@ -1070,7 +1070,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-1-base",
@@ -1123,7 +1123,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-1",
@@ -1153,7 +1153,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-2-base",
@@ -1206,7 +1206,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-2",
@@ -1236,7 +1236,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-3-base",
@@ -1289,7 +1289,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-3",
@@ -1319,7 +1319,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-4-base",
@@ -1372,7 +1372,7 @@
         "secretRef": {
           "name": "github"
         },
-        "url": "https://github.com/hyperledger-labs/splice"
+        "url": "https://github.com/canton-network/splice"
       }
     },
     "name": "splice-node-migration-4",

--- a/cluster/pulumi/canton-network/src/bigQuery.ts
+++ b/cluster/pulumi/canton-network/src/bigQuery.ts
@@ -165,7 +165,7 @@ function installDatastream(
             datasetId: pulumi.interpolate`projects/${bigQueryDataset.project}/datasets/${bigQueryDataset.datasetId}`,
           },
           // editing dataFreshness does not alter existing BQ tables, see its
-          // docstring or https://github.com/hyperledger-labs/splice/issues/2011
+          // docstring or https://github.com/canton-network/splice/issues/2011
           dataFreshness: clusterProdLike ? '14400s' : '0s',
         },
         destinationConnectionProfile: destination.name,

--- a/cluster/pulumi/gcp/README.md
+++ b/cluster/pulumi/gcp/README.md
@@ -2,4 +2,4 @@
 
 Stale and to be faded out in favor of [../gcp-project](../gcp-project).
 
-S.a. https://github.com/hyperledger-labs/splice/issues/674
+S.a. https://github.com/canton-network/splice/issues/674

--- a/docs/api-templates/splice-token-standard-test-index-template.rst
+++ b/docs/api-templates/splice-token-standard-test-index-template.rst
@@ -8,7 +8,7 @@
 splice-token-standard-test docs
 ===============================
 
-Copy the code of this package from https://github.com/hyperledger-labs/splice
+Copy the code of this package from https://github.com/canton-network/splice
 to gain access to test infrastructure for:
 
 - building apps that use the token standard

--- a/docs/src/app_dev/daml_api/index.rst
+++ b/docs/src/app_dev/daml_api/index.rst
@@ -33,7 +33,7 @@ Featured App Activity Markers API (CIP-0047)
   for its background on its design and its specification.
 
 * See the reference docs below for the Daml interfaces that are part of the Featured App Activity Markers API;
-  or `read the source code <https://github.com/hyperledger-labs/splice/blob/main/daml/splice-api-featured-app-v2/daml/Splice/Api/FeaturedAppRightV2.daml>`__.
+  or `read the source code <https://github.com/canton-network/splice/blob/main/daml/splice-api-featured-app-v2/daml/Splice/Api/FeaturedAppRightV2.daml>`__.
 
    .. toctree::
       :maxdepth: 1
@@ -126,7 +126,7 @@ to get credit for the activity of your wallet users as follows.
         alongside the disclosed contracts received from the registry API
         when exercising the choice.
 
-        See this `Daml test script <https://github.com/hyperledger-labs/splice/blob/main/daml/splice-util-featured-app-proxies-test/daml/Splice/Util/FeaturedApp/IntegrationTests/TestWalletUserProxy.daml#L47>`__
+        See this `Daml test script <https://github.com/canton-network/splice/blob/main/daml/splice-util-featured-app-proxies-test/daml/Splice/Util/FeaturedApp/IntegrationTests/TestWalletUserProxy.daml#L47>`__
         for a complete example of how to construct the choice.
 
 

--- a/docs/src/app_dev/overview/splice_app_apis.rst
+++ b/docs/src/app_dev/overview/splice_app_apis.rst
@@ -33,7 +33,7 @@ in the diagram below:
 The Ledger API is not part of Splice, and thus not documented here. See :ref:`app_dev_ledger_api` for details on how to use the Ledger API.
 
 Some of the Splice apps also define additional HTTP APIs that are considered internal and are subject to change without notice.
-If you do need some of them for your app, please create an issue on https://github.com/hyperledger-labs/splice,
+If you do need some of them for your app, please create an issue on https://github.com/canton-network/splice,
 so that you can align with the Splice team on the API, your needs, and the required stability guarantees.
 
 .. toctree::

--- a/docs/src/app_dev/scan_api/scan_bulk_data_api.rst
+++ b/docs/src/app_dev/scan_api/scan_bulk_data_api.rst
@@ -73,7 +73,7 @@ The below table provides a quick overview of the endpoints that the Scan Bulk Da
      - Returns the ACS Snapshot for a given record time
 
 If you would rather read the yaml Open API specification file directly, this can be found in the Splice repository at
-`scan.yaml <https://github.com/hyperledger-labs/splice/blob/08fc692cf2952a52cce00473793d1dca08c0fba5/apps/scan/src/main/openapi/scan.yaml>`_.
+`scan.yaml <https://github.com/canton-network/splice/blob/08fc692cf2952a52cce00473793d1dca08c0fba5/apps/scan/src/main/openapi/scan.yaml>`_.
 
 Example URLs for accessing the Scan Bulk Data API are:
 
@@ -145,7 +145,7 @@ and ``after_migration_id`` is the migration ID that was active at that time.
 
 Note that the record time ranges of different migrations may overlap,
 i.e., the record time can go back after a hard domain migration.
-Read the `OpenAPI documentation <https://github.com/hyperledger-labs/splice/blob/main/apps/scan/src/main/openapi/scan.yaml>`_
+Read the `OpenAPI documentation <https://github.com/canton-network/splice/blob/main/apps/scan/src/main/openapi/scan.yaml>`_
 to understand how the ``after_migration_id`` field affects the response.
 
 If you don't know what migration ID was active at the chosen time,
@@ -226,7 +226,7 @@ An exercised event has the following important fields:
   traverse events in preorder (process them recursively).
 * **consuming**: A boolean indicating whether the contract is archived by the exercise. If true, the contract is archived. This is important if you want to track the ACS.
 
-See the `ExercisedEvent <https://github.com/hyperledger-labs/splice/blob/7345124f9f05395ab4797c0478c7e1dd37186369/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto#L166>`_ protobuf message definition for a complete description of the event.
+See the `ExercisedEvent <https://github.com/canton-network/splice/blob/7345124f9f05395ab4797c0478c7e1dd37186369/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto#L166>`_ protobuf message definition for a complete description of the event.
 
 An example of an exercised event in the ``events_by_id`` object is shown below:
 
@@ -351,7 +351,7 @@ A created event has the following important fields:
 * **contract_id**: The contract ID uniquely identifies the contract.
 * **create_arguments**: The arguments used to create the contract, encoded in JSON
 
-See the `CreatedEvent <https://github.com/hyperledger-labs/splice/blob/7345124f9f05395ab4797c0478c7e1dd37186369/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto#L33>`_ protobuf message definition for a complete description of the event.
+See the `CreatedEvent <https://github.com/canton-network/splice/blob/7345124f9f05395ab4797c0478c7e1dd37186369/canton/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto#L33>`_ protobuf message definition for a complete description of the event.
 
 In this case the ``create_arguments`` contains the fields that are used to create the contract, such as the round number, the price of the Amulet,
 the time the round opens and closes, and the configuration for Amulet transfers and issuance.

--- a/docs/src/app_dev/token_standard/index.rst
+++ b/docs/src/app_dev/token_standard/index.rst
@@ -15,7 +15,7 @@ Overview
 
 * See the `text of the CIP-0056 <https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md>`__
   for an overview of the APIs that are part of the Canton Network Token Standard.
-* See the `README in its source-code <https://github.com/hyperledger-labs/splice/tree/main/token-standard#readme>`__ for background on how to use the APIs.
+* See the `README in its source-code <https://github.com/canton-network/splice/tree/main/token-standard#readme>`__ for background on how to use the APIs.
 
 
 .. _holding_utxo_management:
@@ -151,10 +151,10 @@ There are five kinds of integration patterns:
   * :ref:`token_standard_usage_custom_daml_code`
 
 These integrations patterns have recently been nicely packaged in the wallet SDK
-maintained as part of `hyperledger-labs/splice-wallet-kernel <https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/sdk/wallet-sdk>`__
+maintained as part of `canton-network/splice-wallet-kernel <https://github.com/canton-network/splice-wallet-kernel/tree/main/sdk/wallet-sdk>`__
 and `documented here <https://docs.digitalasset.com/integrate/devnet/index.html>`__.
 
-All of these integration patterns are also demonstrated in the form of executable code as part of the `experimental command-line interface <https://github.com/hyperledger-labs/splice/tree/main/token-standard#cli>`_ for token standard assets.
+All of these integration patterns are also demonstrated in the form of executable code as part of the `experimental command-line interface <https://github.com/canton-network/splice/tree/main/token-standard#cli>`_ for token standard assets.
 The sections below explaining the patterns below thus all start with a link to the code.
 They then provide additional context for an implementor.
 
@@ -170,7 +170,7 @@ Check out the `Authentication docs <https://docs.digitalasset.com/operate/3.4/ho
 Reading contracts implementing a Token Standard interface for a party
 ---------------------------------------------------------------------
 
-Reference code from the Token Standard CLI  to `list contracts by interface <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/commands/listContractsByInterface.ts>`_
+Reference code from the Token Standard CLI  to `list contracts by interface <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/listContractsByInterface.ts>`_
 
 The Token Standard includes several interfaces that are implemented by Daml templates.
 To list all contracts implementing a particular interface,
@@ -218,7 +218,7 @@ Additionally, there's three flags that can be set:
 The response for such a query will contain the ``createdEvent`` of the contract, including the interface views requested (if any).
 The ``viewValue`` within it will be the JSON-serialized Daml interface view.
 If more than one interface is requested, you can distinguish them by checking the ``interfaceId`` field.
-You can find an `example response for Holdings here <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/__tests__/mocks/data/holdings.json>`_.
+You can find an `example response for Holdings here <https://github.com/canton-network/splice/blob/main/token-standard/cli/__tests__/mocks/data/holdings.json>`_.
 
 
 .. _token_standard_usage_reading_tx_history:
@@ -226,7 +226,7 @@ You can find an `example response for Holdings here <https://github.com/hyperled
 Reading and parsing transaction history involving Token Standard contracts
 --------------------------------------------------------------------------
 
-Example code: `Token Standard CLI's code to list transactions <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/commands/listHoldingTransactions.ts>`_
+Example code: `Token Standard CLI's code to list transactions <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/listHoldingTransactions.ts>`_
 
 The participant has an `endpoint to list all transactions <https://github.com/digital-asset/canton/blob/f608ec2cbb7b3e9331b7cc564eb260916606d815/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L1#L763>`_ involving the provided parties and interfaces.
 
@@ -281,7 +281,7 @@ and continue by passing the offset of the last transaction from the previous res
 Parsing the history
 ^^^^^^^^^^^^^^^^^^^
 
-Example code: `the parser here <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/txparse/parser.ts>`_.
+Example code: `the parser here <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/txparse/parser.ts>`_.
 It extracts a user-readable wallet history by parsing transactions involving the ``Holding`` and ``TransferInstruction`` interfaces.
 
 The endpoint returns transaction trees as an array.
@@ -329,7 +329,7 @@ In each Token Standard exercise node, one can find:
 Executing a factory choice
 --------------------------
 
-Example code: `Token Standard CLI's code to create a transfer via TransferFactory <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/commands/transfer.ts>`_
+Example code: `Token Standard CLI's code to create a transfer via TransferFactory <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/transfer.ts>`_
 
 To execute a choice via a Token Standard factory, first you need need to fetch the factory from the corresponding registry.
 
@@ -369,7 +369,7 @@ In both cases, you must include an ``ExerciseCommand`` in your payload with the 
 Executing a non-factory choice
 ------------------------------
 
-Example code: `Token Standard CLI's code to accept a transfer instruction <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/commands/acceptTransferInstruction.ts>`_
+Example code: `Token Standard CLI's code to accept a transfer instruction <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/acceptTransferInstruction.ts>`_
 
 To execute a choice on a contract implementing a Token Standard interface for external parties,
 you must call the `prepare <https://github.com/digital-asset/canton/blob/f608ec2cbb7b3e9331b7cc564eb260916606d815/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L1#L1553>`_

--- a/docs/src/app_dev/validator_api/index.rst
+++ b/docs/src/app_dev/validator_api/index.rst
@@ -57,7 +57,7 @@ where the subject claim of the token is the user whose wallet the endpoint opera
 
 **Backwards compatibility:** External API with backwards compatibility guarantees.
 
-**Reference:** For details, see the `wallet-external.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/wallet/src/main/openapi/wallet-external.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `wallet-external.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/wallet/src/main/openapi/wallet-external.yaml>`__ OpenAPI spec.
 
 .. _validator-api-user-wallet-transfer-offers:
 
@@ -137,7 +137,7 @@ where the subject claim of the token is the user whose wallet the endpoint opera
 
 **Backwards compatibility:** Internal API with no guarantees.
 
-**Reference:** For details, see the `wallet-internal.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/wallet/src/main/openapi/wallet-internal.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `wallet-internal.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/wallet/src/main/openapi/wallet-internal.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10
@@ -203,7 +203,7 @@ are the same node and that party should hold and transfer Canton Coin, the valid
 
 **Backwards compatibility:** Internal API with no guarantees.
 
-**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10
@@ -239,7 +239,7 @@ or the user onboarding itself (for ``/v0/register``).
 
 **Backwards compatibility:** Internal API with no guarantees.
 
-**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10
@@ -266,7 +266,7 @@ where the subject claim of the token is the validator operator user.
 
 **Backwards compatibility:** Internal API with no guarantees.
 
-**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `validator-internal.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/validator/src/main/openapi/validator-internal.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10
@@ -292,7 +292,7 @@ where the subject claim of the token is the user who is requesting the new ANS e
 
 **Backwards compatibility:** External API with backwards compatibility guarantees.
 
-**Reference:** For details, see the `ans-external.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/validator/src/main/openapi/ans-external.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `ans-external.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/validator/src/main/openapi/ans-external.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10 30
@@ -325,7 +325,7 @@ then each call to one of these endpoints is simply forwarded to the scan service
 
 **Backwards compatibility:** See the corresponding endpoint in the :ref:`app_dev_scan_api`.
 
-**Reference:** For details, see the `scan-proxy.yaml <https://raw.githubusercontent.com/hyperledger-labs/splice/refs/heads/main/apps/validator/src/main/openapi/scan-proxy.yaml>`__ OpenAPI spec.
+**Reference:** For details, see the `scan-proxy.yaml <https://raw.githubusercontent.com/canton-network/splice/refs/heads/main/apps/validator/src/main/openapi/scan-proxy.yaml>`__ OpenAPI spec.
 
 .. list-table::
    :widths: 10

--- a/docs/src/background/preapprovals.rst
+++ b/docs/src/background/preapprovals.rst
@@ -113,7 +113,7 @@ If you are working through APIs instead, in particular for external parties,
 the preferred way of exercising a Canton Coin transfer is through the
 Token Standard APIs which will also use a preapproval where
 possible. Refer to the `CIP <https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md>`_
-and the `token standard reference CLI <https://github.com/hyperledger-labs/splice/blob/main/token-standard/cli/src/commands/transfer.ts>`_
+and the `token standard reference CLI <https://github.com/canton-network/splice/blob/main/token-standard/cli/src/commands/transfer.ts>`_
 for examples of how to use it.
 
 Lastly, the legacy external signing APIs for non-standard Canton Coin

--- a/docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst
+++ b/docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst
@@ -110,7 +110,7 @@ section. The second is to update the application code:
    ``templateId`` to the fully qualified interface ID above.
 
    4. For testing examples, please review the example DamlScript test
-   `here <https://github.com/hyperledger-labs/splice/blob/a32995a0df2d447b9e76d81b770a06c296295ab5/daml/splice-dso-governance-test/daml/Splice/Scripts/TestFeaturedAppActivityMarkers.daml#L4>`__.
+   `here <https://github.com/canton-network/splice/blob/a32995a0df2d447b9e76d81b770a06c296295ab5/daml/splice-dso-governance-test/daml/Splice/Scripts/TestFeaturedAppActivityMarkers.daml#L4>`__.
 
 Consider a single, simple transaction of a RWA which creates a single
 ``FeaturedAppActivityMarker`` activity record for one ``provider`` and

--- a/docs/src/background/tokenomics/overview_tokenomics.rst
+++ b/docs/src/background/tokenomics/overview_tokenomics.rst
@@ -20,7 +20,7 @@ the first phase, any fee values for that round are written to the ledger
 (the fees can be obtained from the :ref:`Scan State API <scan_current_state_api>`).
 The second phase is called the *activity recording* and it is when
 activity records are created; records created in this phase belong to that round. The next phase calculates
-a `CC-issuance-per-activity-weight <https://github.com/hyperledger-labs/splice/blob/332e06a7ae9e13fde5bba0bf7dcb059aa36f979e/daml/splice-amulet/daml/Splice/Issuance.daml#L67>`__
+a `CC-issuance-per-activity-weight <https://github.com/canton-network/splice/blob/332e06a7ae9e13fde5bba0bf7dcb059aa36f979e/daml/splice-amulet/daml/Splice/Issuance.daml#L67>`__
 for each kind of activity record which is the share of total CC
 that can be minted for this type of activity record.
 This is followed by

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -115,7 +115,7 @@ html_theme_options = {
 # See https://docs.readthedocs.com/platform/latest/guides/edit-source-links-sphinx.html
 html_context = {
     "display_github": True,
-    "github_user": "hyperledger-labs",
+    "github_user": "canton-network",
     "github_repo": "splice",
     "github_version": "main",
     "conf_py_path": "/docs/src/",

--- a/docs/src/deployment/configuration.rst
+++ b/docs/src/deployment/configuration.rst
@@ -26,9 +26,9 @@ All the environment variables passed to the apps, that start with `ADDITIONAL_CO
 The full configuration for each app can be observed in the scala code,
 with the configuration key being kebab case compared to the camel case in the scala code:
 
--  `ValidatorAppConfig.scala <https://github.com/hyperledger-labs/splice/blob/main/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala#L141>`__
--  `SvAppConfig.scala <https://github.com/hyperledger-labs/splice/blob/main/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala#L199>`__
--  `ScanAppConfig.scala <https://github.com/hyperledger-labs/splice/blob/main/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala#L28>`__
+-  `ValidatorAppConfig.scala <https://github.com/canton-network/splice/blob/main/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala#L141>`__
+-  `SvAppConfig.scala <https://github.com/canton-network/splice/blob/main/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala#L199>`__
+-  `ScanAppConfig.scala <https://github.com/canton-network/splice/blob/main/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala#L28>`__
 
 Furthermore, the participant and other synchronizer components can be configured independently as well. Further information on such configurations can be found in the `Canton docs <https://docs.digitalasset.com/operate/3.4/howtos/configure/general/conf_file.html>`__.
 

--- a/docs/src/deployment/troubleshooting.rst
+++ b/docs/src/deployment/troubleshooting.rst
@@ -27,7 +27,7 @@ Canton logs into ``canton.log``.
 
 **When the node is launched in a kubernetes cluster**, we recommend to setup a log collector so that you can capture logs of at least the last day. For now, the default log level is set to Debug.
 
-We recommend to use ``lnav`` to read the logs. A guideline is provided in `this documentation <https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#setting-up-lnav-to-inspect-canton-and-cometbft-logs>`_.
+We recommend to use ``lnav`` to read the logs. A guideline is provided in `this documentation <https://github.com/canton-network/splice/blob/main/TESTING.md#setting-up-lnav-to-inspect-canton-and-cometbft-logs>`_.
 
 .. note::
     Logging in kubernetes (note that this only provides logs for a limited timeframe):

--- a/docs/src/faq.rst
+++ b/docs/src/faq.rst
@@ -109,7 +109,7 @@ Validators
 
   Is there an API to get the validator party ID?
 
-    See `/v0/validator-user <https://github.com/hyperledger-labs/splice/blob/c712e75775a7d3229eff2a1837b06417a02b03f3/apps/validator/src/main/openapi/validator-internal.yaml#L14>`__.
+    See `/v0/validator-user <https://github.com/canton-network/splice/blob/c712e75775a7d3229eff2a1837b06417a02b03f3/apps/validator/src/main/openapi/validator-internal.yaml#L14>`__.
 
 
 Application Development
@@ -159,7 +159,7 @@ ________
     An example where this can occur is a transaction with one root for the marker creation and one root for the actual user command. This error message is indicative of
     trying a transaction with multiple roots:  ``Only single root transactions can currently be externally signed``.
 
-    The recommended approach is to wrap the two calls in a little helper contract. Here is `an example <https://github.com/hyperledger-labs/splice/pull/1907/files#diff-90d0ed0955b3e59b9edec55e5191d155335bae39a258dbd029b53a4e53e15db3>`__.
+    The recommended approach is to wrap the two calls in a little helper contract. Here is `an example <https://github.com/canton-network/splice/pull/1907/files#diff-90d0ed0955b3e59b9edec55e5191d155335bae39a258dbd029b53a4e53e15db3>`__.
 
   How can our application match registered public keys with their corresponding parties to identify the party associated with an onboarded user?
 
@@ -220,12 +220,12 @@ ______________
 
   What would be the best practice to including the ``DAR`` file of token standard into my `daml` project for data-dependencies  to point to?
 
-    * Copy the token standard dars from `the repo <https://github.com/hyperledger-labs/splice/tree/main/daml/dars>`__
+    * Copy the token standard dars from `the repo <https://github.com/canton-network/splice/tree/main/daml/dars>`__
       and check them into your own repo.
     * Make sure to only depend on ``splice-token-api-*`` packages for your main files. These are guaranteed to be stable.
     * Put your Daml script tests for your workflow into separate ``*-test`` daml
-      projects as done `in splice <https://github.com/hyperledger-labs/splice/tree/b91cf9a77bad6c513658401a57db87d975f9a526/token-standard/splice-token-standard-test>`__.
-      See the `daml.yaml <https://github.com/hyperledger-labs/splice/blob/b91cf9a77bad6c513658401a57db87d975f9a526/token-standard/splice-token-standard-test/daml.yaml>`__
+      projects as done `in splice <https://github.com/canton-network/splice/tree/b91cf9a77bad6c513658401a57db87d975f9a526/token-standard/splice-token-standard-test>`__.
+      See the `daml.yaml <https://github.com/canton-network/splice/blob/b91cf9a77bad6c513658401a57db87d975f9a526/token-standard/splice-token-standard-test/daml.yaml>`__
       for details.
 
   Is there any open-source wallet implementation for canton coins?

--- a/docs/src/overview/overview.rst
+++ b/docs/src/overview/overview.rst
@@ -23,7 +23,7 @@ Global Synchronizer
 The Global Synchronizer is a decentrally operated service, using a 2/3 majority Byzantine Fault Tolerant (:term:`BFT`) consensus protocol for message ordering and confirmation, and BFT majority voting on governance changes.
 
 Its infrastructure is operated by independently acting organizations, called Super Validators, that run components of the decentralized infrastructure, and coordinate activities via an on-chain governance application.
-Its open source code is maintained in `Splice <https://github.com/hyperledger-labs/splice>`__.
+Its open source code is maintained in `Splice <https://github.com/canton-network/splice>`__.
 
 The `Global Synchronizer Foundation ("GSF") <https://sync.global>`__ has been created in partnership with the Linux Foundation to coordinate the governance of the Global Synchronizer and lead efforts to grow the Global Synchronizer ecosystem.
 The GSF provides transparency into Super Validator governance and operations. The GSF also operates a Super Validator node, and takes part in governance votes on behalf of its members.

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -226,10 +226,10 @@
           `CIP-104 incremental roll-out plan <https://github.com/canton-foundation/cips/blob/main/cip-0104/cip-0104.md#incremental-roll-out>`_.
 
           The responses from the ``/v0/events`` and ``/v0/events/{update_id}``
-          `endpoints <https://github.com/hyperledger-labs/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L1579-L1639>`_
+          `endpoints <https://github.com/canton-network/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L1579-L1639>`_
           now include the
-          ``traffic_summary`` (`schema <https://github.com/hyperledger-labs/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L4007-L4026>`_) and
-          ``app_activity_records`` (`schema <https://github.com/hyperledger-labs/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L4027-L4063>`_)
+          ``traffic_summary`` (`schema <https://github.com/canton-network/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L4007-L4026>`_) and
+          ``app_activity_records`` (`schema <https://github.com/canton-network/splice/blob/004f19622e4a145840f18d3fda9d71c9a751a282/apps/scan/src/main/openapi/scan.yaml#L4027-L4063>`_)
           fields.
 
           .. note::
@@ -617,7 +617,7 @@
 
     - Wallet backend
 
-      - Fix a bug (`#3970 <https://github.com/hyperledger-labs/splice/issues/3970>`__) that caused transaction history
+      - Fix a bug (`#3970 <https://github.com/canton-network/splice/issues/3970>`__) that caused transaction history
         for entries created by Splice versions prior to 0.5.11 to fail to decode in the backend and thus not show in the
         wallet UI.
         These entries are now shown again in the wallet UI.
@@ -898,7 +898,7 @@
           ``DevelopmentFundCoupon``, restoring its amount to an ``UnclaimedDevelopmentFundCoupon``.
 
       Note that the UI changes in the Wallet app required to allocate funds are not yet implemented and will be delivered in a later release. Please refer to
-      this issue: `Tracking - CIP-0082 - 5% Development Fund <https://github.com/hyperledger-labs/splice/issues/3218>`.
+      this issue: `Tracking - CIP-0082 - 5% Development Fund <https://github.com/canton-network/splice/issues/3218>`.
 
       These Daml changes require an upgrade to the following Daml versions **before**
       voting to set the transfer fees to zero:
@@ -1128,13 +1128,13 @@
 
     - Scan
 
-        - Cache open rounds with a default TTL of 30s. This should reduce load when rounds change and lots of clients try to read the open rounds. `View PR 2860. <https://github.com/hyperledger-labs/splice/pull/2860>`_
+        - Cache open rounds with a default TTL of 30s. This should reduce load when rounds change and lots of clients try to read the open rounds. `View PR 2860. <https://github.com/canton-network/splice/pull/2860>`_
 
-        - Reduce database load when the connection to the mediator verdict ingestion is restarted. `View PR 2861. <https://github.com/hyperledger-labs/splice/pull/2861>`_
+        - Reduce database load when the connection to the mediator verdict ingestion is restarted. `View PR 2861. <https://github.com/canton-network/splice/pull/2861>`_
 
   - Deployment
 
-    - Increased the resource allocation for most apps, double check any changes if you override the default resources. `View PR 2972. <https://github.com/hyperledger-labs/splice/pull/2972>`_
+    - Increased the resource allocation for most apps, double check any changes if you override the default resources. `View PR 2972. <https://github.com/canton-network/splice/pull/2972>`_
 
 .. release-notes:: 0.4.22
 
@@ -1366,7 +1366,7 @@
 
     - Allow disabling the deployment of ``ans-web-ui`` and ``wallet-web-ui`` in the ``splice-validator`` helm chart by setting
       ``.ansWebUi.enabled`` and ``validatorWebUi.enabled`` to ``false``.
-      Thanks to Marcin Kocur for contributing this change in https://github.com/hyperledger-labs/splice/pull/2171
+      Thanks to Marcin Kocur for contributing this change in https://github.com/canton-network/splice/pull/2171
 
 - LocalNet
 
@@ -1375,7 +1375,7 @@
 - Community docs
 
   - Add :ref:`Keycloak Configuration Guide for Validators <keycloak_canton_validator_config_guide>`.
-    Thanks to mikeProDev for contributing this change in https://github.com/hyperledger-labs/splice/pull/2247
+    Thanks to mikeProDev for contributing this change in https://github.com/canton-network/splice/pull/2247
 
 0.4.16
 ------
@@ -1506,13 +1506,13 @@
 
     - Add Vagrantfile as a convenient way to spin up a local development
       environment for Splice. See `README.vagrant.md
-      <https://github.com/hyperledger-labs/splice/blob/0.4.12/README.vagrant.md>`_
+      <https://github.com/canton-network/splice/blob/0.4.12/README.vagrant.md>`_
       and `Vagrantfile
-      <https://github.com/hyperledger-labs/splice/blob/0.4.12/Vagrantfile>`_ for
+      <https://github.com/canton-network/splice/blob/0.4.12/Vagrantfile>`_ for
       details.
 
   - A subset of the tests now run on PRs from forks without approval from a maintainer
-    (see `TESTING.md <https://github.com/hyperledger-labs/splice/blob/0.4.12/TESTING.md>` for details)
+    (see `TESTING.md <https://github.com/canton-network/splice/blob/0.4.12/TESTING.md>` for details)
 
 - Performance improvements
 
@@ -1658,11 +1658,11 @@ which can happen in certain cases when the sequencer is down.
 
 - Scan
 
-  - Fix `bug #1252 <https://github.com/hyperledger-labs/splice/issues/1252>`_:
+  - Fix `bug #1252 <https://github.com/canton-network/splice/issues/1252>`_:
     populate the token metadata total supply using the aggregates used for closed rounds.
     The data used corresponds to the data served by the ``/v0/total-amulet-balance``
     endpoint in :ref:`app_dev_scan_api` for the latest closed round.
-  - Fix `bug #1280 <https://github.com/hyperledger-labs/splice/pull/1280>`_:
+  - Fix `bug #1280 <https://github.com/canton-network/splice/pull/1280>`_:
     ``record_time`` in Scan API ``/updates`` is now right-padded to 6 digits (microseconds).
 
 - Validator
@@ -1747,7 +1747,7 @@ which can happen in certain cases when the sequencer is down.
             weight: 1000
 
     Thanks to Divam Narula for contributing this change
-    in https://github.com/hyperledger-labs/splice/pull/1371
+    in https://github.com/canton-network/splice/pull/1371
 
 - Daml
 
@@ -1904,7 +1904,7 @@ which can happen in certain cases when the sequencer is down.
 
 - Scan
 
-  - Fix a `bug (#1254) <https://github.com/hyperledger-labs/splice/issues/1254>`_ where the token metadata name and acronym for Amulet were not populated
+  - Fix a `bug (#1254) <https://github.com/canton-network/splice/issues/1254>`_ where the token metadata name and acronym for Amulet were not populated
     based on the ``splice-instance-names`` config.
 
 - Validator
@@ -1937,10 +1937,10 @@ which can happen in certain cases when the sequencer is down.
 
 - Validator
 
-  - Fix a `bug (#1216) <https://github.com/hyperledger-labs/splice/issues/1216>`_ where sends through transfer preapprovals failed with a ``CONTRACT_NOT_FOUND`` ERROR
+  - Fix a `bug (#1216) <https://github.com/canton-network/splice/issues/1216>`_ where sends through transfer preapprovals failed with a ``CONTRACT_NOT_FOUND`` ERROR
     if the receiver's provider party was featured.
   - Fix a bug where uploading dars would not immediately vet the dependencies that had a vetting entry effective in the future.
-  - Fix a `bug (#1215)  <https://github.com/hyperledger-labs/splice/issues/1215>`_ where wallet transaction could get stuck when creating transfer offers from the wallet UI.
+  - Fix a `bug (#1215)  <https://github.com/canton-network/splice/issues/1215>`_ where wallet transaction could get stuck when creating transfer offers from the wallet UI.
 
 - Synchronizer Migrations
 
@@ -1978,7 +1978,7 @@ which can happen in certain cases when the sequencer is down.
     specify path to `identities.json` and not directory containing it. This is
     consistent with the :ref:`documented
     <validator_disaster_recovery-docker-compose-deployment>` behavior.  See
-    `#387 <https://github.com/hyperledger-labs/splice/pull/387>`_
+    `#387 <https://github.com/canton-network/splice/pull/387>`_
 
 - Auth
 
@@ -2000,7 +2000,7 @@ which can happen in certain cases when the sequencer is down.
 - Define `standard k8s labels <https://helm.sh/docs/chart_best_practices/labels/#standard-labels>`_
   for most k8s resources deployed through Splice Helm charts.
   Thanks to Stephane Loeuillet for contributing an initial proposal for this change
-  in https://github.com/hyperledger-labs/splice/pull/296.
+  in https://github.com/canton-network/splice/pull/296.
 
 - Scan
 
@@ -2041,7 +2041,7 @@ which can happen in certain cases when the sequencer is down.
   - Add jemalloc into the docker images. This is not enabled by
     default but allows for easier testing. Thanks to Stanislav
     German-Evtushenko for contributing this in
-    https://github.com/hyperledger-labs/splice/pull/318
+    https://github.com/canton-network/splice/pull/318
 
 - Validator
 
@@ -2056,7 +2056,7 @@ which can happen in certain cases when the sequencer is down.
 
   - Improve the error message when trying to use the wallet outside of
     localhost or https. Thanks to Stephane Loeuillet for contributing
-    this in https://github.com/hyperledger-labs/splice/pull/322.
+    this in https://github.com/canton-network/splice/pull/322.
 
 - Scan
 
@@ -2252,7 +2252,7 @@ which can happen in certain cases when the sequencer is down.
 
   * Move ``topup`` section from the ``validator-values.yaml`` example file to the ``standalone-validator.yaml`` example file
     to make it more clear that configuring topups is a reasonable option only for non-SV validators.
-    See `hyperledger-labs/splice#255 <https://github.com/hyperledger-labs/splice/pull/255>`_
+    See `canton-network/splice#255 <https://github.com/canton-network/splice/pull/255>`_
 
   * Added the ``initialAmuletPrice`` helm option to set the initial amulet price vote (i.e., the price for which your SV node will vote when onboarded).
     See the :ref:`configuration instructions <helm-configure-global-domain>`.
@@ -2574,7 +2574,7 @@ Signatures required from these external parties can be collected via a crypto cu
 can involve multiple human confirmers. Transactions submitted in the name of these parties can thus take
 multiple hours from the creation of the transaction signing request to the final commit of the transaction on the network.
 This increased latency required several changes in the Daml models underlying Amulet.
-They can be reviewed in detail by diffing the ``daml`` directory in the https://github.com/hyperledger-labs/splice
+They can be reviewed in detail by diffing the ``daml`` directory in the https://github.com/canton-network/splice
 repo.
 
 The key changes are summarized below:

--- a/docs/src/sv_operator/sv_operations.rst
+++ b/docs/src/sv_operator/sv_operations.rst
@@ -388,7 +388,7 @@ minting proposal.
 
 The script is part of the Splice repository:
 
-`unclaimed_sv_rewards.py <https://github.com/hyperledger-labs/splice/blob/main/scripts/scan-txlog/unclaimed_sv_rewards.py>`_
+`unclaimed_sv_rewards.py <https://github.com/canton-network/splice/blob/main/scripts/scan-txlog/unclaimed_sv_rewards.py>`_
 
 ``unclaimed_sv_rewards.py`` is intended for operational use by SV node operators. It does
 not modify on-ledger state; it reads from the Scan API and produces a deterministic and

--- a/docs/src/validator_operator/validator_delegations.rst
+++ b/docs/src/validator_operator/validator_delegations.rst
@@ -234,7 +234,7 @@ Then create the proposal using curl:
    "$LEDGER_API_URL/v2/commands"
 
 See the `MintingDelegationProposal template source code
-<https://github.com/hyperledger-labs/splice/blob/main/daml/splice-wallet/daml/Splice/Wallet/MintingDelegation.daml>`_
+<https://github.com/canton-network/splice/blob/main/daml/splice-wallet/daml/Splice/Wallet/MintingDelegation.daml>`_
 for the complete Daml definition.
 
 Monitoring Proposal Status

--- a/scripts/migrate-github-issues.py
+++ b/scripts/migrate-github-issues.py
@@ -418,7 +418,7 @@ def migrate_todo_comments(all, public_repo_path, internal_repo_path, public_issu
         todo_refs.add(ref)
         if ref in all.public:
             # Referencing a public issue from code in the internal repo
-            new_ref = f"hyperledger-labs/splice#{public_issues_map[ref]}"
+            new_ref = f"canton-network/splice#{public_issues_map[ref]}"
         elif ref in all.internal:
             # Referencing an internal issue from code in the internal repo
             new_ref = f"#{internal_issues_map[ref]}"
@@ -518,7 +518,7 @@ def main():
     parser.add_argument("--dump-filename", type=str, default="issues-dump.json", help="Filename to read/write the issues dump (default: issues-dump.json).")
     parser.add_argument("--source-repo", type=str, default="DACH-NY/canton-network-node", help="GitHub repository to read issues from (default: DACH-NY/canton-network-node).")
     parser.add_argument("--dry-run", action="store_true", default=False, help="If set, the script will not modify any data, only print what it would do.")
-    parser.add_argument("--public-repo", type=str, default="hyperledger-labs/splice", help="Public GitHub repository to migrate issues to (default: hyperledger-labs/splice).")
+    parser.add_argument("--public-repo", type=str, default="canton-network/splice", help="Public GitHub repository to migrate issues to (default: canton-network/splice).")
     parser.add_argument("--public-repo-path", type=str, help= "Path to the public repo (used for TODO comments)")
     parser.add_argument("--internal-repo", type=str, default="DACH-NY/canton-network-internal", help="Internal GitHub repository to migrate issues to (default: DACH-NY/canton-network-internal).")
     parser.add_argument("--internal-repo-path", type=str, help= "Path to the internal repo (used for TODO comments)")

--- a/token-standard/CHANGELOG.md
+++ b/token-standard/CHANGELOG.md
@@ -146,7 +146,7 @@ Polishing changes:
 
 Major changes:
 
-* Move development https://github.com/hyperledger-labs/splice/tree/canton-3.3/token-standard.
+* Move development https://github.com/canton-network/splice/tree/canton-3.3/token-standard.
   to reflect that the API definitions of the token standard will be developed and open sourced as part of the splice project.
 * Rename modules as follows
   * `Canton.Network.RC1.TokenMetadata` -> `Splice.Api.Token.MetadataV1`


### PR DESCRIPTION
Fixing GitHub URL references.

- [x] advance to canton-network/splice-shared-gha#59
  - [x] auto-bump [not going to work](https://github.com/canton-network/splice/actions/runs/25228906992/job/73979291354)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
