### PR TITLE
use gh token from secret when auto-assigning PRs

### DIFF
--- a/.github/workflows/assign_fork_prs.yml
+++ b/.github/workflows/assign_fork_prs.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Assign PR from fork
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ secrets.GH_CREATE_PRS_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             // Only add assignees if the PR isn't already assigned to someone

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule ".github/runners/runner-container-hooks"]
 	path = .github/runners/runner-container-hooks
-	url = ../../hyperledger-labs/splice-runner-container-hooks.git
+	url = ../../canton-network/splice-runner-container-hooks.git
 [submodule "splice-shared-gha"]
 	path = splice-shared-gha
-	url = ../../hyperledger-labs/splice-shared-gha.git
+	url = ../../canton-network/splice-shared-gha.git


### PR DESCRIPTION
Not sure how it worked before, maybe LFDT's defaults were more permissive than CF's, but it's failing now: 
https://github.com/canton-network/splice/actions/runs/25217710856/job/73988004397?pr=5337

I hope this will fix it, can check only after merge because it's a `on: pull_request_target` job.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/hyperledger-labs/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/hyperledger-labs/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
