### PR TITLE
bump GHA-referenced versions of backport workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   backport:
-    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
+    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@009fc4df6cc49c56067943d067d0b33489517a5d
     with:
       commit_sha: ${{ inputs.commit_sha }}
       pr_number: ${{ fromJSON(inputs.pr_number) }}

--- a/.github/workflows/backport_reminder.yml
+++ b/.github/workflows/backport_reminder.yml
@@ -11,7 +11,7 @@ jobs:
   add-backport-reminder:
     runs-on: ubuntu-24.04
     steps:
-        - uses: canton-network/splice-shared-gha/actions/backport_reminder@a78684a826be866b199ae7a05471a7fad2c9c76c
+        - uses: canton-network/splice-shared-gha/actions/backport_reminder@009fc4df6cc49c56067943d067d0b33489517a5d
           with:
             pr_number: ${{ github.event.pull_request.number }}
             lookup_prod_cluster_configs: false

--- a/.github/workflows/do_backports.yml
+++ b/.github/workflows/do_backports.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       branches: ${{ steps.parse_backport_comments.outputs.backport_branches }}
     steps:
-      - uses: canton-network/splice-shared-gha/actions/parse_backport_comments@a78684a826be866b199ae7a05471a7fad2c9c76c
+      - uses: canton-network/splice-shared-gha/actions/parse_backport_comments@009fc4df6cc49c56067943d067d0b33489517a5d
         id: parse_backport_comments
         with:
           pr_number: ${{ github.event.pull_request.number }}
@@ -25,7 +25,7 @@ jobs:
       matrix:
         branch: ${{ fromJSON(needs.get_backport_branches.outputs.branches) }}
       fail-fast: false
-    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@a78684a826be866b199ae7a05471a7fad2c9c76c
+    uses: canton-network/splice-shared-gha/.github/workflows/backport.yml@009fc4df6cc49c56067943d067d0b33489517a5d
     secrets:
       strong_token: ${{ secrets.GH_CREATE_PRS_TOKEN }}
     with:


### PR DESCRIPTION
Followup to #5339, to incorporate [many splice-shared-gha changes](https://github.com/canton-network/splice-shared-gha/compare/a78684a826be866b199ae7a05471a7fad2c9c76c...009fc4df6cc49c56067943d067d0b33489517a5d) in these workflows specifically..

May assist with #5345.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
