### PR TITLE
Upgade istio to latest 1.28

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1145,7 +1145,7 @@
           "istioNamespace": "cluster-ingress"
         }
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-base",
     "provider": "",
@@ -1326,7 +1326,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress-cometbft",
     "provider": "",
@@ -1510,7 +1510,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress",
     "provider": "",
@@ -1611,7 +1611,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istiod",
     "provider": "",

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -34,7 +34,7 @@ interface ConfiguredIstio {
 }
 
 export const istioVersion = {
-  istio: '1.28.1',
+  istio: '1.28.6',
   //   updated from https://grafana.com/orgs/istio/dashboards, must be updated on each istio version
   dashboards: {
     general: 280,


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/4901

Will apply to CILR, then backport to DevNet, TestNet, MainNet.

Will make a follow-up issue to bump to 1.29 independently of that issue.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
