### PR TITLE
use gh token from secret for backport reminders

### DIFF
--- a/.github/workflows/backport_reminder.yml
+++ b/.github/workflows/backport_reminder.yml
@@ -15,3 +15,4 @@ jobs:
           with:
             pr_number: ${{ github.event.pull_request.number }}
             lookup_prod_cluster_configs: false
+            token: ${{ secrets.GH_CREATE_PRS_TOKEN }}


### PR DESCRIPTION
We seem to already have support for [passing a token here](https://github.com/canton-network/splice-shared-gha/blob/009fc4df6cc49c56067943d067d0b33489517a5d/src/actions/backport_reminder.ts#L7), we just don't use it..

Fixes https://github.com/canton-network/splice/issues/5345

(AFAICT, doing the actual backport actually uses the token already, so optimistic that it's only this)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
