### PR TITLE
Use Lsu abbreviation consistently for class names

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -33,10 +33,7 @@ import org.lfdecentralizedtrust.splice.sv.config.{
   SvSynchronizerNodeConfig,
   SvSynchronizerNodesConfig,
 }
-import org.lfdecentralizedtrust.splice.sv.lsu.{
-  LogicalSyncUpgradeTransferTrafficTrigger,
-  LogicalSynchronizerUpgradeTrigger,
-}
+import org.lfdecentralizedtrust.splice.sv.lsu.{LsuTransferTrafficTrigger, LsuTrigger}
 import org.lfdecentralizedtrust.splice.util.*
 import org.lfdecentralizedtrust.splice.wallet.config.WalletAppClientConfig
 import org.lfdecentralizedtrust.splice.wallet.store.TxLogEntry.Http.BuyTrafficRequestStatus
@@ -354,7 +351,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
         "Pause traffic transfer trigger on sv2 to simulate a participant that is connected to a non initialized sequencer past upgrade tiem"
       ) {
         sv2Backend.dsoAutomation
-          .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
+          .trigger[LsuTransferTrafficTrigger]
           .pause()
           .futureValue
       }
@@ -389,7 +386,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
         sv2Backend.stop()
         sv2Backend.startSync()
         sv2Backend.dsoAutomation
-          .trigger[LogicalSyncUpgradeTransferTrafficTrigger]
+          .trigger[LsuTransferTrafficTrigger]
           .resume()
       }
 
@@ -613,7 +610,7 @@ class LogicalSynchronizerUpgradeIntegrationTest
 
       clue("sv4 upgrades") {
         loggerFactory.suppress(
-          SuppressionRule.forLogger[LogicalSynchronizerUpgradeTrigger] && SuppressionRule.Level(
+          SuppressionRule.forLogger[LsuTrigger] && SuppressionRule.Level(
             org.slf4j.event.Level.WARN
           )
         ) {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -50,10 +50,10 @@ import org.lfdecentralizedtrust.splice.sv.automation.singlesv.onboarding.*
 import org.lfdecentralizedtrust.splice.sv.automation.singlesv.scan.AggregatingScanConnection
 import org.lfdecentralizedtrust.splice.sv.config.{SequencerPruningConfig, SvAppBackendConfig}
 import org.lfdecentralizedtrust.splice.sv.lsu.{
-  LogicalSynchronizerUpgradeAnnouncementTrigger,
-  LogicalSynchronizerUpgradeSequencingTestTrigger,
-  LogicalSynchronizerUpgradeTrigger,
-  LogicalSyncUpgradeTransferTrafficTrigger,
+  LsuAnnouncementTrigger,
+  LsuSequencingTestTrigger,
+  LsuTransferTrafficTrigger,
+  LsuTrigger,
 }
 import org.lfdecentralizedtrust.splice.sv.onboarding.SynchronizerNodeReconciler
 import org.lfdecentralizedtrust.splice.sv.store.{SvDsoStore, SvSvStore}
@@ -241,7 +241,7 @@ class SvDsoAutomationService(
     )
 
     registerTrigger(
-      new LogicalSynchronizerUpgradeAnnouncementTrigger(
+      new LsuAnnouncementTrigger(
         triggerContext,
         dsoStore,
         participantAdminConnection,
@@ -287,7 +287,7 @@ class SvDsoAutomationService(
     synchronizerNodeService.nodes.successor match {
       case Some(successorSynchronizerNode) =>
         registerTrigger(
-          new LogicalSynchronizerUpgradeTrigger(
+          new LsuTrigger(
             triggerContext,
             synchronizerNodeReconciler,
             synchronizerNodeService.nodes,
@@ -301,14 +301,14 @@ class SvDsoAutomationService(
           )
         )
         registerTrigger(
-          new LogicalSyncUpgradeTransferTrafficTrigger(
+          new LsuTransferTrafficTrigger(
             triggerContext,
             synchronizerNodeService.nodes.current,
             successorSynchronizerNode,
           )
         )
         registerTrigger(
-          new LogicalSynchronizerUpgradeSequencingTestTrigger(
+          new LsuSequencingTestTrigger(
             config,
             triggerContext,
             synchronizerNodeService.nodes.current,
@@ -582,9 +582,9 @@ object SvDsoAutomationService extends AutomationServiceCompanion {
       aTrigger[CopyVotesTrigger],
       aTrigger[AmuletPriceMetricsTrigger],
       aTrigger[CreateBootstrapExternalPartyConfigStateInstructionTrigger],
-      aTrigger[LogicalSynchronizerUpgradeTrigger],
-      aTrigger[LogicalSynchronizerUpgradeAnnouncementTrigger],
-      aTrigger[LogicalSyncUpgradeTransferTrafficTrigger],
-      aTrigger[LogicalSynchronizerUpgradeSequencingTestTrigger],
+      aTrigger[LsuTrigger],
+      aTrigger[LsuAnnouncementTrigger],
+      aTrigger[LsuTransferTrafficTrigger],
+      aTrigger[LsuSequencingTestTrigger],
     )
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuAnnouncementTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuAnnouncementTrigger.scala
@@ -22,13 +22,13 @@ import org.lfdecentralizedtrust.splice.automation.{
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.LogicalSynchronizerUpgradeSchedule
 import org.lfdecentralizedtrust.splice.environment.ParticipantAdminConnection
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType
-import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSynchronizerUpgradeAnnouncementTrigger.LsuAnnouncementTask
+import org.lfdecentralizedtrust.splice.sv.lsu.LsuAnnouncementTrigger.LsuAnnouncementTask
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.OptionConverters.*
 
-class LogicalSynchronizerUpgradeAnnouncementTrigger(
+class LsuAnnouncementTrigger(
     override protected val context: TriggerContext,
     store: SvDsoStore,
     connection: ParticipantAdminConnection,
@@ -110,7 +110,7 @@ class LogicalSynchronizerUpgradeAnnouncementTrigger(
 
 }
 
-object LogicalSynchronizerUpgradeAnnouncementTrigger {
+object LsuAnnouncementTrigger {
 
   case class LsuAnnouncementTask(
       synchronizerId: SynchronizerId,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuSequencingTestTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuSequencingTestTrigger.scala
@@ -14,7 +14,7 @@ import org.lfdecentralizedtrust.splice.sv.config.SvAppBackendConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class LogicalSynchronizerUpgradeSequencingTestTrigger(
+class LsuSequencingTestTrigger(
     svAppConfig: SvAppBackendConfig,
     baseContext: TriggerContext,
     currentSynchronizerNode: LocalSynchronizerNode,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuTrigger.scala
@@ -25,7 +25,7 @@ import org.lfdecentralizedtrust.splice.environment.{
 }
 import org.lfdecentralizedtrust.splice.environment.SynchronizerNode.LocalSynchronizerNodes
 import org.lfdecentralizedtrust.splice.sv.LocalSynchronizerNode
-import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSynchronizerUpgradeTrigger.LsuTransferTask
+import org.lfdecentralizedtrust.splice.sv.lsu.LsuTrigger.LsuTransferTask
 import org.lfdecentralizedtrust.splice.sv.onboarding.SynchronizerNodeReconciler
 import org.lfdecentralizedtrust.splice.sv.onboarding.SynchronizerNodeReconciler.SynchronizerNodeState.OnboardedImmediately
 import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
@@ -33,7 +33,7 @@ import org.lfdecentralizedtrust.splice.sv.store.SvDsoStore
 import java.nio.file.Path
 import scala.concurrent.{ExecutionContext, Future}
 
-class LogicalSynchronizerUpgradeTrigger(
+class LsuTrigger(
     baseContext: TriggerContext,
     reconciler: SynchronizerNodeReconciler,
     localSynchronizerNodes: LocalSynchronizerNodes[LocalSynchronizerNode],
@@ -221,7 +221,7 @@ class LogicalSynchronizerUpgradeTrigger(
   }
 }
 
-object LogicalSynchronizerUpgradeTrigger {
+object LsuTrigger {
   case class LsuTransferTask(announcement: LsuAnnouncement) extends PrettyPrinting {
 
     override def pretty: Pretty[this.type] = prettyOfClass(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuUpgradeTransferTrafficTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuUpgradeTransferTrafficTrigger.scala
@@ -24,7 +24,7 @@ import org.lfdecentralizedtrust.splice.sv.lsu.LogicalSyncUpgradeTransferTrafficT
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Future}
 
-class LogicalSyncUpgradeTransferTrafficTrigger(
+class LsuTransferTrafficTrigger(
     baseContext: TriggerContext,
     currentSynchronizerNode: SvSynchronizerNode,
     successorSynchronizerNode: SvSynchronizerNode,


### PR DESCRIPTION
We currently have three different variants, Lsu, LogicalSyncUpgrade and LogicalSynchronizerUpgrade which just seems needlessly confusing.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
