### PR TITLE
Switch integration tests to pv35

### DIFF
--- a/.github/workflows/pv_34_test.yml
+++ b/.github/workflows/pv_34_test.yml
@@ -1,4 +1,4 @@
-name: Integration tests against PV 35
+name: Integration tests against PV 34
 on:
   schedule:
     - cron: '0 5 * * *'
@@ -18,5 +18,5 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      protocol_version: "35"
+      protocol_version: "34"
     secrets: inherit

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
@@ -2,13 +2,13 @@ package org.lfdecentralizedtrust.splice.integration
 
 import better.files.{File, Resource, *}
 import com.digitalasset.canton.admin.api.client.data.User
-import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
-import com.digitalasset.canton.config.RequireTypes.{NonNegativeLong, NonNegativeNumeric}
 import com.digitalasset.canton.config.{
   ClockConfig,
   NonNegativeFiniteDuration,
   TestingConfigInternal,
 }
+import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
+import com.digitalasset.canton.config.RequireTypes.{NonNegativeLong, NonNegativeNumeric}
 import com.digitalasset.canton.console.TestConsoleOutput
 import com.digitalasset.canton.environment.EnvironmentFactory
 import com.digitalasset.canton.integration.{
@@ -37,15 +37,15 @@ import org.lfdecentralizedtrust.splice.environment.{
 }
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.SpliceTestConsoleEnvironment
 import org.lfdecentralizedtrust.splice.sv.config.{
-  SvCantonIdentifierConfig,
   SvAppBackendConfig,
+  SvCantonIdentifierConfig,
   SvSynchronizerNodeConfig,
 }
 import org.lfdecentralizedtrust.splice.sv.config.SvOnboardingConfig.InitialPackageConfig
 import org.lfdecentralizedtrust.splice.util.CommonAppInstanceReferences
 import org.lfdecentralizedtrust.splice.validator.config.ValidatorCantonIdentifierConfig
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inside, Inspectors, OptionValues}
+import org.scalatest.matchers.should.Matchers
 
 /** Analogue to Canton's CommunityEnvironmentDefinition. */
 case class EnvironmentDefinition(
@@ -100,7 +100,8 @@ case class EnvironmentDefinition(
       .withMultiSyncFeatureFlag()
       .withTrafficTopupsEnabled
       .withInitialPackageVersions
-      .withProtocolVersion
+      .withProtocolVersion(ProtocolVersion.v35)
+      .withProtocolVersionFromEnv
       .withEagerAppActivityMarkerConversion
 
   def withAllocatedUsers(
@@ -176,17 +177,19 @@ case class EnvironmentDefinition(
         )(config),
     )
 
-  def withProtocolVersion: EnvironmentDefinition =
-    addConfigTransforms((_, config) => {
-      val protocolVersionO = sys.env.get("PROTOCOL_VERSION").filter(_ != "")
-      protocolVersionO.fold(config)(pv =>
-        ConfigTransforms.updateAllSvAppConfigs_(
-          updateAllSynchronizerNodeConfigs(
-            _.focus(_.protocolVersion).replace(ProtocolVersion.tryCreate(pv))
-          )
-        )(config)
-      )
-    })
+  def withProtocolVersionFromEnv: EnvironmentDefinition = {
+    val protocolVersionO = sys.env.get("PROTOCOL_VERSION").filter(_ != "")
+    protocolVersionO.fold(this)(pv => withProtocolVersion(ProtocolVersion.tryCreate(pv)))
+  }
+
+  def withProtocolVersion(protocolVersion: ProtocolVersion): EnvironmentDefinition =
+    addConfigTransforms((_, config) =>
+      ConfigTransforms.updateAllSvAppConfigs_(
+        updateAllSynchronizerNodeConfigs(
+          _.focus(_.protocolVersion).replace(protocolVersion)
+        )
+      )(config)
+    )
 
   def withInitializedNodes(): EnvironmentDefinition =
     copy(setup = implicit env => {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -15,6 +15,7 @@ import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId.Synchronizer
 import com.digitalasset.canton.topology.store.TimeQuery
 import com.digitalasset.canton.topology.transaction.TopologyChangeOp
 import com.digitalasset.canton.util.HexString
+import com.digitalasset.canton.version.ProtocolVersion
 import org.lfdecentralizedtrust.splice.config.{ConfigTransforms, NetworkAppClientConfig}
 import org.lfdecentralizedtrust.splice.console.*
 import org.lfdecentralizedtrust.splice.environment.{
@@ -86,7 +87,11 @@ class LogicalSynchronizerUpgradeIntegrationTest
           .updateAllSvAppConfigs { (name, config) =>
             config.copy(
               localSynchronizerNodes = config.localSynchronizerNodes
-                .copy(successor = config.localSynchronizerNodes.current.some),
+                .copy(successor =
+                  config.localSynchronizerNodes.current
+                    .copy(protocolVersion = ProtocolVersion.v35)
+                    .some
+                ),
               domainMigrationDumpPath = Some(
                 (SynchronizerUpgradeUtil.migrationTestDumpDir(
                   name

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -89,6 +89,9 @@ class LogicalSynchronizerUpgradeIntegrationTest
               localSynchronizerNodes = config.localSynchronizerNodes
                 .copy(successor =
                   config.localSynchronizerNodes.current
+                    // always set the successor PV to 35
+                    // thus with the daily run with PV34 we will run a PV34 -> PV35 LSU
+                    // otherwise we will run a PV35 -> PV35 LSU
                     .copy(protocolVersion = ProtocolVersion.v35)
                     .some
                 ),

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/LsuTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/LsuTestUtil.scala
@@ -23,7 +23,10 @@ trait LsuTestUtil extends SvTestUtil with TestCommon {
         topologyFreezeTime.toInstant,
         upgradeTime.toInstant,
         serial,
-        sv1Backend.config.localSynchronizerNodes.current.protocolVersion.toString,
+        sv1Backend.config.localSynchronizerNodes.successor
+          .map(_.protocolVersion)
+          .getOrElse(sv1Backend.config.localSynchronizerNodes.current.protocolVersion)
+          .toString,
       ),
     )
   }


### PR DESCRIPTION
Change the nightly to run with pv34
Change the LSU test to always upgrade to PV35 thus testing PV34->PV35 and PV35->PV35

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
