### PR TITLE
improve stack reference mocking in expected files generator to account for participant migration related references

### DIFF
--- a/cluster/pulumi/canton-network/package.json
+++ b/cluster/pulumi/canton-network/package.json
@@ -23,8 +23,6 @@
     "dump-config": "env -u KUBECONFIG ts-node ./dump-config.ts"
   },
   "devDependencies": {
-    "@types/ip": "^1.1.3",
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
+    "@types/ip": "^1.1.3"
   }
 }

--- a/cluster/pulumi/common/package.json
+++ b/cluster/pulumi/common/package.json
@@ -35,9 +35,7 @@
     "@jest/globals": "^30.3.0",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.17.24",
-    "@types/sinon": "^21.0.1",
     "@types/ws": "^8.18.1",
-    "dedent": "^1.7.2",
-    "sinon": "^21.1.2"
+    "dedent": "^1.7.2"
   }
 }

--- a/cluster/pulumi/common/src/dump-config-common.ts
+++ b/cluster/pulumi/common/src/dump-config-common.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as pulumi from '@pulumi/pulumi';
 import * as path from 'path';
-import * as sinon from 'sinon';
 import { setMocks } from '@pulumi/pulumi/runtime/mocks';
 
 import {
@@ -197,7 +196,9 @@ export const svRunbookAuth0Config = {
 };
 
 /*eslint no-process-env: "off"*/
-export async function initDumpConfig(): Promise<void> {
+export async function initDumpConfig({
+  stackOutputsProvider = infraStackOutputsProvider,
+}: MockSettings = {}): Promise<void> {
   // DO NOT ADD NON SECRET VALUES HERE, ALL THE VALUES SHOULD BE DEFINED BY THE CLUSTER ENVIRONMENT in .envrc.vars
   // THIS IS REQUIRED TO ENSURE THAT THE DEPLOYMENT OPERATOR HAS THE SAME ENV AS A LOCAL RUN
   process.env.AUTH0_CN_MANAGEMENT_API_CLIENT_ID = 'mgmt';
@@ -212,28 +213,6 @@ export async function initDumpConfig(): Promise<void> {
   process.env.PULUMI_VERSION = '0.0.0';
   // the project name in setMocks seems to be ignored and we need to load the proper config, so we override it here to ensure we  always use the same config as in prod
   process.env.CONFIG_PROJECT_NAME = path.basename(process.cwd());
-  // StackReferences cannot be mocked in tests currently
-  // (see https://github.com/pulumi/pulumi/issues/9212)
-  sinon
-    .stub(pulumi.StackReference.prototype, 'requireOutput')
-    .callsFake((name: pulumi.Input<string>) => {
-      switch (name.valueOf()) {
-        case 'istioDashboardVersions':
-          return pulumi.output('1234');
-        case 'ingressNs':
-          return pulumi.output('cn-namespace');
-        case 'ingressIp':
-          return pulumi.output('127.0.0.2');
-        case 'auth0':
-          return pulumi.output({
-            svRunbook: svRunbookAuth0Config,
-            cantonNetwork: cantonNetworkAuth0Config,
-            mainnet: cantonNetworkAuth0Config,
-          } as Auth0ClusterConfig);
-        default:
-          throw new Error(`unknown name for requireOutput(): ${name}`);
-      }
-    });
 
   const projectName = 'test-project';
   const stackName = 'test-stack';
@@ -248,10 +227,21 @@ export async function initDumpConfig(): Promise<void> {
         process.stdout.write(buffer);
         process.stdout.write('\n');
 
-        return {
-          id: args.inputs.name + '_id',
-          state: args.inputs,
-        };
+        if (args.type === 'pulumi:pulumi:StackReference') {
+          const [organization, project, stack] = args.name.split('/');
+          return {
+            id: args.name + '_id',
+            state: {
+              ...args.inputs,
+              outputs: pulumi.output(stackOutputsProvider(project, stack) ?? {}),
+            },
+          };
+        } else {
+          return {
+            id: args.inputs.name + '_id',
+            state: args.inputs,
+          };
+        }
       },
       call: function (args: pulumi.runtime.MockCallArgs) {
         switch (args.token) {
@@ -392,3 +382,25 @@ export async function initDumpConfig(): Promise<void> {
     stackName
   );
 }
+
+export type MockSettings = {
+  stackOutputsProvider?: StackOutputsProvider;
+};
+
+export type StackOutputsProvider = (
+  project: string,
+  stack: string
+) => Partial<Record<string, any>> | undefined;
+
+export const infraStackOutputsProvider: StackOutputsProvider = (project: string) => {
+  return project === 'infra'
+    ? {
+        istioDashboardVersions: '1234',
+        auth0: {
+          svRunbook: svRunbookAuth0Config,
+          cantonNetwork: cantonNetworkAuth0Config,
+          mainnet: cantonNetworkAuth0Config,
+        } as Auth0ClusterConfig,
+      }
+    : undefined;
+};

--- a/cluster/pulumi/gcp/package.json
+++ b/cluster/pulumi/gcp/package.json
@@ -17,9 +17,5 @@
     "lint:fix": "eslint --fix --max-warnings=0 -- src",
     "lint:check": "eslint --max-warnings=0 -- src",
     "dump-config": "env -u KUBECONFIG ts-node ./dump-config.ts"
-  },
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
   }
 }

--- a/cluster/pulumi/multi-validator/package.json
+++ b/cluster/pulumi/multi-validator/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@lfdecentralizedtrust/splice-pulumi-multi-validator",
   "main": "src/index.ts",
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
-  },
   "dependencies": {
     "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0"
   },

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -66,9 +66,7 @@
                 "ip": "^2.0.1"
             },
             "devDependencies": {
-                "@types/ip": "^1.1.3",
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
+                "@types/ip": "^1.1.3"
             }
         },
         "circleci": {
@@ -110,10 +108,8 @@
                 "@jest/globals": "^30.3.0",
                 "@types/js-yaml": "^4.0.5",
                 "@types/lodash": "^4.17.24",
-                "@types/sinon": "^21.0.1",
                 "@types/ws": "^8.18.1",
-                "dedent": "^1.7.2",
-                "sinon": "^21.1.2"
+                "dedent": "^1.7.2"
             }
         },
         "common-sv": {
@@ -147,10 +143,6 @@
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@types/auth0": "^3.3.11",
                 "auth0": "^5.6.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         },
         "gcp-project": {
@@ -184,10 +176,6 @@
             "name": "@lfdecentralizedtrust/splice-pulumi-multi-validator",
             "dependencies": {
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3298,27 +3286,6 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@sinonjs/samsam": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-            "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.1",
-                "type-detect": "^4.1.0"
-            }
-        },
-        "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -3750,22 +3717,6 @@
             "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
             "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
             "license": "MIT"
-        },
-        "node_modules/@types/sinon": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
-            "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/sinonjs__fake-timers": "*"
-            }
-        },
-        "node_modules/@types/sinonjs__fake-timers": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
-            "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-            "dev": true
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
@@ -5976,16 +5927,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/diff": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
             }
         },
         "node_modules/doctrine": {
@@ -11125,23 +11066,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/sinon": {
-            "version": "21.1.2",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
-            "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.1",
-                "@sinonjs/fake-timers": "^15.3.2",
-                "@sinonjs/samsam": "^10.0.2",
-                "diff": "^8.0.4"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/sinon"
-            }
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12607,10 +12531,6 @@
             "dependencies": {
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         },
         "sv": {
@@ -12628,10 +12548,6 @@
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@lfdecentralizedtrust/splice-pulumi-common-sv": "1.0.0",
                 "@pulumi/pulumi": "^3.230.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         },
         "sv-runbook": {
@@ -12643,9 +12559,7 @@
                 "@lfdecentralizedtrust/splice-pulumi-sv-canton": "1.0.0"
             },
             "devDependencies": {
-                "@types/node-fetch": "^2.6.12",
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
+                "@types/node-fetch": "^2.6.12"
             }
         },
         "validator-runbook": {
@@ -12653,10 +12567,6 @@
             "dependencies": {
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         },
         "validator1": {
@@ -12664,10 +12574,6 @@
             "dependencies": {
                 "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
                 "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"
-            },
-            "devDependencies": {
-                "@types/sinon": "^21.0.1",
-                "sinon": "^21.1.2"
             }
         }
     }

--- a/cluster/pulumi/splitwell/package.json
+++ b/cluster/pulumi/splitwell/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@lfdecentralizedtrust/splice-pulumi-splitwell",
   "main": "src/index.ts",
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
-  },
   "dependencies": {
     "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
     "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"

--- a/cluster/pulumi/sv-canton/package.json
+++ b/cluster/pulumi/sv-canton/package.json
@@ -19,9 +19,5 @@
     "preview": "PULUMI_CONFIG_PASSPHRASE= ts-node ./pulumiPreview.ts",
     "down": "PULUMI_CONFIG_PASSPHRASE= ts-node ./runPulumiDown.ts",
     "up": "PULUMI_CONFIG_PASSPHRASE= ts-node ./pulumiUp.ts"
-  },
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
   }
 }

--- a/cluster/pulumi/sv-runbook/package.json
+++ b/cluster/pulumi/sv-runbook/package.json
@@ -2,9 +2,7 @@
   "name": "@lfdecentralizedtrust/splice-pulumi-sv-runbook",
   "main": "src/index.ts",
   "devDependencies": {
-    "@types/node-fetch": "^2.6.12",
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
+    "@types/node-fetch": "^2.6.12"
   },
   "dependencies": {
     "@lfdecentralizedtrust/canton-network-pulumi-deployment": "1.0.0",

--- a/cluster/pulumi/sv/dump-config.ts
+++ b/cluster/pulumi/sv/dump-config.ts
@@ -4,13 +4,25 @@ import { allSvsToDeploy } from '@lfdecentralizedtrust/splice-pulumi-common-sv';
 
 import {
   cantonNetworkAuth0Config,
+  infraStackOutputsProvider,
   initDumpConfig,
   SecretsFixtureMap,
   svRunbookAuth0Config,
 } from '../common/src/dump-config-common';
 
 async function main() {
-  await initDumpConfig();
+  await initDumpConfig({
+    stackOutputsProvider: (project: string, stack: string) => {
+      if (project === 'sv-canton') {
+        return {
+          participantDatabaseId: `${stack}-participant-db`,
+          participantDatabaseSecretName: `${stack}-participant-db-secret`,
+        };
+      } else {
+        return infraStackOutputsProvider(project, stack);
+      }
+    },
+  });
   const installNode = await import('./src/installNode');
   const secrets = new SecretsFixtureMap();
   for (const sv of allSvsToDeploy) {

--- a/cluster/pulumi/validator-runbook/package.json
+++ b/cluster/pulumi/validator-runbook/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@lfdecentralizedtrust/splice-pulumi-validator-runbook",
   "main": "src/index.ts",
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
-  },
   "dependencies": {
     "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
     "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"

--- a/cluster/pulumi/validator1/package.json
+++ b/cluster/pulumi/validator1/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@lfdecentralizedtrust/splice-pulumi-validator1",
   "main": "src/index.ts",
-  "devDependencies": {
-    "@types/sinon": "^21.0.1",
-    "sinon": "^21.1.2"
-  },
   "dependencies": {
     "@lfdecentralizedtrust/splice-pulumi-common": "1.0.0",
     "@lfdecentralizedtrust/splice-pulumi-common-validator": "1.0.0"


### PR DESCRIPTION
This change was needed to make expected files generation for prod clusters happy. The reason is that participant migration introduces a dependency from the `sv` project to `sv-canton` in form of `participantDatabaseId` and `participantDatabaseSecretName` stack outputs. They need to be properly mocked when generating expected files during the migration.