### PR TITLE
Backport #5190 to release-line-0.5.18

### DIFF
--- a/cluster/pulumi/sv/src/index.ts
+++ b/cluster/pulumi/sv/src/index.ts
@@ -3,6 +3,7 @@
 import {
   Auth0ClientType,
   config,
+  DecentralizedSynchronizerUpgradeConfig,
   getAuth0Config,
 } from '@lfdecentralizedtrust/splice-pulumi-common';
 
@@ -23,5 +24,7 @@ async function main() {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-main();
+if (DecentralizedSynchronizerUpgradeConfig.active.enableLogicalSynchronizerDeploymentMode) {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  main();
+}


### PR DESCRIPTION
Since mainnet uses 0.5.18 I want to backport https://github.com/canton-network/splice/pull/5190 to make sure that mainnet previews stay clean.