### PR TITLE
Allow overriding vars in the private envrc.vars

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,8 +14,14 @@ use_flake_subdir() {
   fi
 }
 
-# Private .envrc
-[[ -f .envrc.private ]] && [[ -z "$IGNORE_PRIVATE_ENVRC" ]] && source_env .envrc.private || true
+source_envrc_private() {
+  [[ -f .envrc.private ]] && [[ -z "$IGNORE_PRIVATE_ENVRC" ]] && source_env .envrc.private || true
+}
+
+# Source .envrc.private before use_flake_subdir because it provides ARTIFACTORY_PASSWORD
+# which determines whether the enterprise or OSS nix shell is used.
+# This workaround can be removed once the enterprise edition is removed.
+source_envrc_private
 
 # TODO(DACH-NY/canton-network-node#3876) work around for $TMPDIR is removed. #3876 to investigate more
 OLD_TMPDIR=$TMPDIR
@@ -26,6 +32,10 @@ use flake_subdir
 export TMPDIR=$OLD_TMPDIR
 
 source_env .envrc.vars
+
+# Re-source .envrc.private so it can override any vars from .envrc.vars
+source_envrc_private
+
 
 source "${TOOLS_LIB}/libcli.source"
 


### PR DESCRIPTION
Fixes issues where not sourcing the private vars before loading nix loads the oss edition

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
