### PR TITLE
Use canton-basic in canton standalone configs

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/StandaloneCanton.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/StandaloneCanton.scala
@@ -58,7 +58,8 @@ trait StandaloneCanton extends PostgresAroundEach with NamedLogging with Process
       }
 
     val configs =
-      conditionalConf(svs123 && participants, "standalone-participants-sv123.conf") ++
+      Seq(testResourcesPath / "include" / "canton-basic.conf") ++
+        conditionalConf(svs123 && participants, "standalone-participants-sv123.conf") ++
         conditionalConf(
           svs123 && sequencersMediators,
           "standalone-sequencers-mediators-sv123.conf",


### PR DESCRIPTION
That should ensure that we request request logging as we get normally as well.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
