### PR TITLE
Use fsgroup to grant nonroot permissions to volumes

### DIFF
--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -40,6 +40,10 @@ spec:
         {{- end }}
     spec:
       {{- include "splice-util-lib.service-account" .Values | nindent 6 }}
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       containers:
       - name: mediator
         image: "{{ .Values.imageRepo }}/canton-mediator:{{ .Chart.AppVersion }}{{ ((.Values.imageDigests).canton_mediator) }}"

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -32,6 +32,10 @@ spec:
         {{- end }}
     spec:
       {{- include "splice-util-lib.service-account" .Values | nindent 6 }}
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       containers:
         - name: sequencer
         {{- if eq .Values.sequencer.driver.type "cometbft"}}

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -32,3 +32,8 @@
 
         If you need to access data for any of the parties on your node
         use the ledger API.
+
+    - SV deployment
+
+        - The sequencer and mediator helm charts are now setting the same ``fsGroup``, ``runAsUser``, and ``runAsGroup``
+          in the security context of the pods as the participant, validator app, and sv app charts.


### PR DESCRIPTION
Like https://github.com/canton-network/splice/pull/2696, but for the sequencer and mediator.

Noticed because the `/persistent-data` mount for debug data is not writeable by the java process.

[cluster test](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/63934/workflows/588b13a8-9cad-419d-b5e1-bca5e80c255a)