### PR TITLE
bump CCI nix cache size

### DIFF
--- a/cluster/pulumi/circleci/src/index.ts
+++ b/cluster/pulumi/circleci/src/index.ts
@@ -45,8 +45,7 @@ new gcp.projects.IAMMember('cci-gcp-service-account-workload-identity-role', {
 // Grant the CCI GCP SA the necessary roles to access GCP resources.
 // => via infra Pulumi project as it affects other GCP projects
 
-// filestore minimum capacity to provision a hdd instance is 1TB
-const capacityGb = 1024;
+const capacityGb = 2048;
 const filestore = new gcp.filestore.Instance(`cci-filestore`, {
   tier: 'BASIC_HDD',
   fileShares: {


### PR DESCRIPTION
according to GCP UI, we're currently paying $140/month on the current nfs size. We reset it last less than 3 months ago, and have run out of disk space again now. seems like it's worth doubling to not have to deal with this every 2-3 months.

I applied manually already to the existing pvc, hopefully pulumi will manage picking that up after a refresh..

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
