### PR TITLE
helm, splice-info: Add status.json

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/info-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/info-values.yaml
@@ -1,6 +1,8 @@
 nginxImage: nginx:latest  # Replace `:latest` with `@sha256:digest` of a chosen image for security reasons
+updaterImage: registry.gitlab.com/gitlab-ci-utils/curl-jq:latest # Replace `:latest` with `@sha256:digest` of a chosen image for security reasons
 
 runtimeDetails:
+  migrationId: MIGRATION_ID
   scanUrl: "http://scan-app.sv:5012"
 
 deploymentDetails:  # optional, exposes static configuration under path /

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
@@ -42,6 +42,7 @@ class DsoPreflightIntegrationTest
       val urls = Array(
         s"${infoUrl}",
         s"${infoUrl}/runtime/dso.json",
+        s"${infoUrl}/runtime/status.json",
       )
 
       urls.foreach { url =>

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2373,6 +2373,7 @@
           "host": "info.sv-2.mock.global.canton.network.digitalasset.com"
         },
         "runtimeDetails": {
+          "migrationId": 9,
           "scanUrl": "http://scan-app.sv-1:5012"
         },
         "tolerations": [
@@ -3577,6 +3578,7 @@
           "host": "info.sv-1.mock.global.canton.network.digitalasset.com"
         },
         "runtimeDetails": {
+          "migrationId": 9,
           "scanUrl": "http://scan-app.sv-da-1:5012"
         },
         "tolerations": [

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -240,6 +240,7 @@
         },
         "nginxImage": "nginx:latest",
         "runtimeDetails": {
+          "migrationId": 2,
           "scanUrl": "http://scan-app.sv:5012"
         },
         "tolerations": [
@@ -248,7 +249,8 @@
             "key": "cn_apps",
             "operator": "Exists"
           }
-        ]
+        ],
+        "updaterImage": "registry.gitlab.com/gitlab-ci-utils/curl-jq:latest"
       },
       "version": "0.3.20"
     },

--- a/cluster/helm/splice-info/scripts/get-dso.sh
+++ b/cluster/helm/splice-info/scripts/get-dso.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURL_TIMEOUT="${CURL_TIMEOUT:-15}"
+
+TLS_SKIP_VERIFY="${TLS_SKIP_VERIFY:-false}"
+CURL_CMD=(curl -fs -m "$CURL_TIMEOUT")
+[[ $TLS_SKIP_VERIFY == true ]] && CURL_CMD+=(-k)
+
+result=$("${CURL_CMD[@]}" "$SCAN_URL/api/scan/v0/dso") || exit 1
+echo "$result"

--- a/cluster/helm/splice-info/scripts/get-dso.sh
+++ b/cluster/helm/splice-info/scripts/get-dso.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 CURL_TIMEOUT="${CURL_TIMEOUT:-15}"

--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SV_METRICS_URL="${SV_METRICS_URL:-http://sv-app:10013/metrics}"

--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SV_METRICS_URL="${SV_METRICS_URL:-http://sv-app:10013/metrics}"
+SEQUENCER_METRICS_URL="${SEQUENCER_METRICS_URL:-http://global-domain-$MIGRATION_ID-sequencer:10013/metrics}"
+SCAN_URL="${SCAN_URL:-http://scan-app:5012}"
+
+SV_THRESHOLD="${SV_THRESHOLD:-600}"
+MEDIATOR_THRESHOLD="${MEDIATOR_THRESHOLD:-900}"
+SCAN_THRESHOLD="${SCAN_THRESHOLD:-900}"
+
+CURL_TIMEOUT="${CURL_TIMEOUT:-15}"
+
+TLS_SKIP_VERIFY="${TLS_SKIP_VERIFY:-false}"
+CURL_CMD=(curl -fs -m "$CURL_TIMEOUT")
+[[ $TLS_SKIP_VERIFY == true ]] && CURL_CMD+=(-k)
+
+prom2json() {
+  P2J_VERSION="1.5.0"
+  P2J_ARCH="linux-amd64"
+  P2J_BIN="$HOME/.prom2json-$P2J_VERSION"
+  P2J_URL="https://github.com/prometheus/prom2json/releases/download/v$P2J_VERSION/prom2json-$P2J_VERSION.$P2J_ARCH.tar.gz"
+  P2J_EXPECTED_SHA="5935363cc8c88360e3aa275ddc5a754ad95f6bab6b6052978e686300baa5a4d6"
+
+  if [[ ! -f "$P2J_BIN" ]]; then
+    P2J_DIST=$(mktemp)
+    P2J_TMPDIR=$(mktemp -d)
+
+    echo "Downloading prom2json..." >&2
+    curl -Ls "$P2J_URL" -o "$P2J_DIST"
+    echo "$P2J_EXPECTED_SHA  $P2J_DIST" | sha256sum --check >&2 || return 1
+    tar -xzf "$P2J_DIST" -C "$P2J_TMPDIR" --strip-components=1 "prom2json-$P2J_VERSION.$P2J_ARCH/prom2json"
+    mv "$P2J_TMPDIR/prom2json" "$P2J_BIN"
+
+    rm -rf "$P2J_TMPDIR" "$P2J_DIST"
+  fi
+
+  "$P2J_BIN"
+}
+
+sv_get_status() {
+  SV_METRIC=splice_sv_status_report_creation_time_us
+
+  local exit_code
+
+  local response; response=$(
+    "${CURL_CMD[@]}" "$SV_METRICS_URL?name[]=$SV_METRIC" |
+      prom2json |
+      jq -e \
+        --arg threshold "$SV_THRESHOLD" \
+        --arg metric "$SV_METRIC" \
+        '
+          ($threshold | tonumber) as $threshold
+          | .[]
+          | select(.name == $metric).metrics
+          | map(
+              {
+                (.labels.report_publisher): (if (now - (.value | tonumber)/pow (10;6)) < $threshold then 0 else 1 end)
+              }
+            )
+          | add
+        '
+  ) && exit_code=$? || exit_code=$?
+
+  [[ $exit_code -eq 0 ]] && echo "$response" || echo '{}'
+}
+
+get_sequencer_metric_data() {
+  local metric_name=$1
+
+  "${CURL_CMD[@]}" "$SEQUENCER_METRICS_URL?name[]=$metric_name" |
+    prom2json ||
+    echo '[]'
+}
+
+get_status_from_sequencer_metric_data() {
+  local metric_json=$1
+  local metric_name=$2
+  local category_name=$3
+  local threshold=$4
+
+  local exit_code
+
+  local result; result=$(
+    echo "$metric_json" |
+      jq -e \
+        --arg metric "$metric_name" \
+        --arg category_name "$category_name" \
+        --arg threshold "$threshold" \
+        '
+          ($threshold | tonumber) as $threshold
+          | .[]
+          | select(.name == $metric).metrics
+          | map(
+              (.labels.member | split("::")) as [$category, $name, $fingerprint] |
+              select($category == $category_name) |
+              {
+                ($name): (if (now - (.value | tonumber)/pow (10;6)) < $threshold then 0 else 1 end)
+              }
+            )
+          | add
+        '
+  ) && exit_code=$? || exit_code=$?
+
+  [[ $exit_code -eq 0 ]] && echo "$result" || echo '{}'
+}
+
+scan_get_status() {
+  local scan_url=$SCAN_URL
+  local scans_info_url="$scan_url/api/scan/v0/scans"
+
+  local scan_info; scan_info=$("${CURL_CMD[@]}" "$scans_info_url" || echo '{}')
+
+  local scan_svnames_and_urls; IFS=$'\n' read -r -d '' -a scan_svnames_and_urls < <(
+    echo "$scan_info" |
+      jq -r '.scans[].scans[] | [.svName, .publicUrl + "/api/scan/v0/open-and-issuing-mining-rounds"] | join(" ")' && printf '\0'
+  )
+
+  local scan_data; scan_data=$(
+    local -i proc_count=0
+    local proc_max=8
+    local lockfile; lockfile=$(mktemp)
+
+    for svname_and_url in "${scan_svnames_and_urls[@]}"; do
+      local svname url
+      read -r svname url <<< "$svname_and_url";
+
+      # Limit the number of concurrent processes
+      if (( proc_count >= proc_max )); then
+        wait -n
+        proc_count=$(( proc_count - 1 ))
+      fi
+
+      (
+        scan_response=$(
+          "${CURL_CMD[@]}" \
+             --compressed \
+             --json '{"cached_open_mining_round_contract_ids":[],"cached_issuing_round_contract_ids":[]}' \
+             "$url" | jq -e .
+        ) && exit_code=$? || exit_code=$?
+
+        [[ $exit_code -ne 0 ]] && scan_response='{}'
+
+        scan_status=$(
+          echo "$scan_response" |
+          jq \
+            --arg threshold "$SCAN_THRESHOLD" \
+            --arg svname "$svname" \
+            '
+              def get_delay(field; $now):
+                  [ field[]?.contract.created_at ]
+                  | sort[-1]
+                  | (try(.[0:19] + "Z" | ($now - fromdate) | round) // null)
+              ;
+
+              ($threshold | tonumber) as $threshold |
+              now as $now |
+              get_delay(.open_mining_rounds; $now) as $open_delay |
+              get_delay(.issuing_mining_rounds; $now) as $issuing_delay |
+              [$open_delay, $issuing_delay] as $delays |
+              {
+                ($svname): if ($delays | all) and ($delays | max < $threshold) then 0 else 1 end
+              }
+            '
+        )
+
+        # Use an exlusive lock to make sure we don't mix up the outputs
+        exec {LOCK_FD}<>"$lockfile"
+        flock "$LOCK_FD"
+
+        echo "$scan_status"
+      ) &
+
+      proc_count=$(( proc_count + 1 ))
+    done
+
+    # Wait for all remaining processes to finish
+    wait
+    rm "$lockfile"
+  )
+
+  local exit_code
+
+  local scan_status; scan_status=$(
+    echo "$scan_data" | jq -es 'sort | add'
+  ) && exit_code=$? || exit_code=$?
+
+  [[ $exit_code -eq 0 ]] && echo "$scan_status" || echo '{}'
+}
+
+sv_status=$(sv_get_status)
+
+sequencer_metric_name=daml_sequencer_block_acknowledgments_micros
+sequencer_metric_data=$(get_sequencer_metric_data "$sequencer_metric_name")
+
+mediator_status=$(get_status_from_sequencer_metric_data "$sequencer_metric_data" "$sequencer_metric_name" MED "$MEDIATOR_THRESHOLD")
+scan_status=$(scan_get_status)
+
+jq -n \
+  --argjson sv "$sv_status" \
+  --argjson sv_threshold "$SV_THRESHOLD" \
+  --argjson mediator "$mediator_status" \
+  --argjson mediator_threshold "$MEDIATOR_THRESHOLD" \
+  --argjson scan "$scan_status" \
+  --argjson scan_threshold "$SCAN_THRESHOLD" \
+  '
+    {
+      status: {
+        sv:       {nodes: $sv,       description: "Last status report within \($sv_threshold) seconds"},
+        mediator: {nodes: $mediator, description: "Last acknowledgment within \($mediator_threshold) seconds"},
+        scan:     {nodes: $scan,     description: "Last open and issuing rounds are within \($scan_threshold) seconds"},
+      },
+      generatedAt: (now | todate),
+    }
+  '

--- a/cluster/helm/splice-info/scripts/updater.sh
+++ b/cluster/helm/splice-info/scripts/updater.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+period=60
+
+html_dir=/usr/share/nginx/html
+runtime_index_file="$html_dir/runtime/index.html"
+
+dso_json_path=runtime/dso.json
+dso_json_file="$html_dir/$dso_json_path"
+
+status_json_path=runtime/status.json
+status_json_file="$html_dir/$status_json_path"
+
+jq -n \
+  --arg dso "/$dso_json_path" \
+  --arg status "/$status_json_path" \
+  '
+    {
+      dso,
+      status,
+    }
+  ' > "$runtime_index_file"
+
+while true; do
+  start_time=$(date +%s);
+
+  if result=$(/scripts/get-dso.sh); then
+    dest="$dso_json_file"
+    echo "$result" > "$dest.new"
+    mv "$dest.new" "$dest"
+  fi &
+
+  if result=$(/scripts/get-status.sh); then
+    dest="$status_json_file"
+    echo "$result" > "$dest.new"
+    mv "$dest.new" "$dest"
+  fi &
+
+  wait
+
+  end_time=$(date +%s);
+  sleep "$((period - (end_time - start_time)))"
+done

--- a/cluster/helm/splice-info/scripts/updater.sh
+++ b/cluster/helm/splice-info/scripts/updater.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -eu
 
 period=60

--- a/cluster/helm/splice-info/templates/configmap-config.yaml
+++ b/cluster/helm/splice-info/templates/configmap-config.yaml
@@ -10,7 +10,8 @@ data:
   staticfile.conf: |
     server_tokens off;
 
-    add_header Cache-Control no-cache;
+    add_header Cache-Control no-cache always;
+    add_header Access-Control-Allow-Origin * always;
 
     gzip on;
     gzip_types {{ .Values.contentType }};

--- a/cluster/helm/splice-info/templates/configmap-scripts.yaml
+++ b/cluster/helm/splice-info/templates/configmap-scripts.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.runtimeDetails }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+{{ (.Files.Glob "scripts/*").AsConfig | indent 2 }}
+{{- end }}

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -20,6 +20,11 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+        {{- if .Values.runtimeDetails }}
+        checksum/updater: {{ .Files.Get "scripts/updater.sh" | sha256sum }}
+        {{- end }}
     spec:
       containers:
       - name: nginx
@@ -45,54 +50,22 @@ spec:
         resources:
           {{ toYaml .Values.resources | nindent 12 }}
       {{- if .Values.runtimeDetails }}
-      - name: content-runtime-updater
-        image: {{ .Values.nginxImage }}
+      - name: updater
+        image: {{ .Values.updaterImage }}
         {{- with .Values.imagePullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            set -eu;
-
-            period=60;
-
-            html_dir=/usr/share/nginx/html;
-            runtime_index_file="$html_dir/runtime/index.html";
-
-            dso_json_path=runtime/dso.json;
-            dso_json_file="$html_dir/$dso_json_path";
-
-            echo "{\"dso\": \"/$dso_json_path\"}" > "$runtime_index_file";
-
-            fail_count=0
-            # prevent spamming alerts by logging only after the issues are persistent
-            while true; do
-              start_time=$(date +%s);
-
-              # prevent curl from writing to stderr while still logging them ourselves
-              if result=$(curl -m 10 -sSL --fail-with-body "$SCAN_URL/api/scan/v0/dso" 2>&1); then
-                echo "$result" > "$dso_json_file.new"
-                mv "$dso_json_file.new" "$dso_json_file";
-                fail_count=0
-              else
-                fail_count=$((fail_count + 1))
-                echo "Failed to fetch DSO from $SCAN_URL (failure #$fail_count): $result"
-                if [ $((fail_count % LOG_TO_STDERR_AFTER_FAILURES)) -eq 0 ]; then
-                  echo "ERROR: $fail_count consecutive failures fetching DSO from $SCAN_URL" 1>&2
-                fi
-              fi;
-
-              end_time=$(date +%s);
-              sleep "$((period - (end_time - start_time)))";
-            done;
-
+        command: ["/scripts/updater.sh"]
         env:
+          - name: MIGRATION_ID
+            value: {{ .Values.runtimeDetails.migrationId | quote }}
           - name: SCAN_URL
             value: {{ .Values.runtimeDetails.scanUrl | quote }}
-          - name: LOG_TO_STDERR_AFTER_FAILURES
-            value: {{ .Values.runtimeDetails.logToStderrAfterFailures | default 100 | quote }}
+          - name: TLS_SKIP_VERIFY
+            value: {{ .Values.runtimeDetails.tlsSkipVerify | default false | quote }}
         volumeMounts:
+        - name: scripts
+          mountPath: /scripts
         - name: content-runtime
           mountPath: /usr/share/nginx/html/runtime
       {{- end }}
@@ -106,6 +79,10 @@ spec:
           name: {{ .Release.Name }}-content-static
       {{- end }}
       {{- if .Values.runtimeDetails }}
+      - name: scripts
+        configMap:
+          name: {{ .Release.Name }}-scripts
+          defaultMode: 0755
       - name: content-runtime
         emptyDir:
           sizeLimit: 10Mi

--- a/cluster/helm/splice-info/tests/deployment_test.yaml
+++ b/cluster/helm/splice-info/tests/deployment_test.yaml
@@ -4,6 +4,7 @@
 suite: "Splice-info values"
 templates:
   - deployment.yaml
+  - configmap-config.yaml
 
 release:
   # Set for testing labels
@@ -18,10 +19,11 @@ nginxImage: "some-nginx-image"
 
 tests:
   - it: "should include runtime details env vars"
+    template: deployment.yaml
     set:
       runtimeDetails:
+        migrationId: 0
         scanUrl: "https://scan.url"
-        logToStderrAfterFailures: 123
     documentSelector:
       path: kind
       value: Deployment
@@ -31,8 +33,5 @@ tests:
           path: spec.template.spec.containers[0].name
           value: "nginx"
       - equal:
-          path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='SCAN_URL')].value
+          path: spec.template.spec.containers[?(@.name=='updater')].env[?(@.name=='SCAN_URL')].value
           value: "https://scan.url"
-      - equal:
-          path: spec.template.spec.containers[?(@.name=='content-runtime-updater')].env[?(@.name=='LOG_TO_STDERR_AFTER_FAILURES')].value
-          value: "123"

--- a/cluster/helm/splice-info/values-template.yaml
+++ b/cluster/helm/splice-info/values-template.yaml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 nginxImage: nginx:latest  # Replace `:latest` with `@sha256:digest` of a chosen image for security reasons
+updaterImage: registry.gitlab.com/gitlab-ci-utils/curl-jq:latest  # Replace `:latest` with `@sha256:digest` of a chosen image for security reasons
 contentType: "application/json"
 
 # runtimeDetails:  # Optional, exposes the runtime configuration under path /runtime/
+#   migrationId: 4
 #   scanUrl: https://scan.sv.global.canton.network.xxx  # Scan URL to fetch the runtime configuration
+#   tlsSkipVerify: true  # Optional, the default is false
 
 # deploymentDetails:  # Optional, exposes static configuration under path /
 #   network: "dev"

--- a/cluster/helm/splice-info/values.schema.json
+++ b/cluster/helm/splice-info/values.schema.json
@@ -53,11 +53,12 @@
     },
     "runtimeDetails": {
       "type": "object",
-      "required": [ "scanUrl" ],
+      "required": [ "migrationId", "scanUrl" ],
       "additionalProperties": false,
       "properties": {
+        "migrationId": { "type": "integer", "minimum": 0, "maximum": 9 },
         "scanUrl": { "type": "string", "minLength": 1 },
-        "logToStderrAfterFailures": { "type": "integer", "minimum": 1 }
+        "tlsSkipVerify": { "type": "boolean", "default": false }
       }
     },
     "deploymentDetails": {

--- a/cluster/pulumi/canton-network/src/info.ts
+++ b/cluster/pulumi/canton-network/src/info.ts
@@ -36,6 +36,7 @@ export function installInfo(
 
   const infoValues = {
     runtimeDetails: {
+      migrationId: decentralizedSynchronizerMigrationConfig.active.id,
       scanUrl: scanUrl,
     },
     deploymentDetails: {

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -33,3 +33,8 @@
         through an ``ADDITIONAL_CONFIG`` environment variable. LSUs
         will still work but be slightly slower due to extra
         reconnects.
+
+    - SV deployment
+
+        - Splice Info endpoint now includes ``/runtime/status.json`` which provides status of core components (sv, scan and mediator at this moment) refreshed
+          every 60 seconds. ``splice-info`` helm chart now requires ``runtimeDetails.migrationId`` to be specified.


### PR DESCRIPTION
This adds `/runtime/status.json` with status for:
- mediator
- scan
- sv

What the result looks like can be viewed by following the link https://info.sv.dev.global.canton.network.sv-nodeops.com/runtime/status.v2.json 

`status.json` is refreshed every 60 seconds.

This change also:
- removes log generation after repeated failures (this can be added later if needed)
- renames container `content-runtime-updater` to shorter `updater`