### PR TITLE
Use PV 34 on Canton simtime

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/EnvironmentDefinition.scala
@@ -612,10 +612,12 @@ object EnvironmentDefinition extends CommonAppInstanceReferences {
   }
 
   def simpleTopology1SvWithSimTime(testName: String): EnvironmentDefinition =
-    simpleTopology1Sv(testName).withSimTime
+    // TODO(DACH-NY/cn-test-failures#8276) Remove protocol version overwrite when this is fixed
+    simpleTopology1Sv(testName).withSimTime.withProtocolVersion(ProtocolVersion.v34)
 
   def simpleTopology4SvsWithSimTime(testName: String): EnvironmentDefinition =
-    simpleTopology4Svs(testName).withSimTime
+    // TODO(DACH-NY/cn-test-failures#8276) Remove protocol version overwrite when this is fixed
+    simpleTopology4Svs(testName).withSimTime.withProtocolVersion(ProtocolVersion.v34)
 
   def preflightTopology(testName: String): EnvironmentDefinition = {
     fromResource("preflight-topology.conf", testName).clearConfigTransforms()


### PR DESCRIPTION
This is way too flaky.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
