### PR TITLE
0.6.2 backport: Upgade istio to latest 1.28 (#5356)

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1145,7 +1145,7 @@
           "istioNamespace": "cluster-ingress"
         }
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-base",
     "provider": "",
@@ -1326,7 +1326,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress-cometbft",
     "provider": "",
@@ -1510,7 +1510,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress",
     "provider": "",
@@ -1611,7 +1611,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istiod",
     "provider": "",

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -34,7 +34,7 @@ interface ConfiguredIstio {
 }
 
 export const istioVersion = {
-  istio: '1.28.1',
+  istio: '1.28.6',
   //   updated from https://grafana.com/orgs/istio/dashboards, must be updated on each istio version
   dashboards: {
     general: 280,


### PR DESCRIPTION
Running on CILR and AFAICT all good there.

See https://github.com/canton-network/splice/pull/5356

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
