### PR TITLE
0.5.18 backport: Upgade istio to latest 1.28 (#5356)

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1682,7 +1682,7 @@
           "istioNamespace": "cluster-ingress"
         }
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-base",
     "provider": "",
@@ -1902,7 +1902,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress-cometbft",
     "provider": "",
@@ -2086,7 +2086,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istio-ingress",
     "provider": "",
@@ -2332,7 +2332,7 @@
           }
         ]
       },
-      "version": "1.28.1"
+      "version": "1.28.6"
     },
     "name": "istiod",
     "provider": "",

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -34,7 +34,7 @@ interface ConfiguredIstio {
 }
 
 export const istioVersion = {
-  istio: '1.28.1',
+  istio: '1.28.6',
   //   updated from https://grafana.com/orgs/istio/dashboards, must be updated on each istio version
   dashboards: {
     general: 280,


### PR DESCRIPTION
See https://github.com/canton-network/splice/pull/5356

I don't see why this should cause an issue, but will wait for https://github.com/canton-network/splice/pull/5429 to fully apply on DevNet before merging the internal PR to bump MainNet with this.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
