### PR TITLE
Add deprecated banner to Splice docs

### DIFF
--- a/docs/src/_static/deprecated-banner.css
+++ b/docs/src/_static/deprecated-banner.css
@@ -1,0 +1,67 @@
+.deprecated-docs-banner {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: min(100%, calc(100vw - 2rem));
+  max-width: 100%;
+  margin: 0 0 1.5rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid #d8ccff;
+  border-radius: 0.375rem;
+  background: #f7f4ff;
+  color: #2f2358;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.deprecated-docs-banner__label {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.5rem;
+  padding: 0.125rem 0.625rem;
+  border-radius: 999px;
+  background: #734be2;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.deprecated-docs-banner__message {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.deprecated-docs-banner__link {
+  flex: 0 0 auto;
+  color: #5c3db8;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.deprecated-docs-banner__link:hover,
+.deprecated-docs-banner__link:focus {
+  color: #2f2358;
+}
+
+@media screen and (max-width: 768px) {
+  .deprecated-docs-banner {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    padding: 0.875rem;
+    font-size: 0.875rem;
+  }
+
+  .deprecated-docs-banner__link {
+    align-self: flex-start;
+  }
+}

--- a/docs/src/_templates/deprecated_banner.html
+++ b/docs/src/_templates/deprecated_banner.html
@@ -1,0 +1,7 @@
+<div class="deprecated-docs-banner" role="note" aria-label="Deprecated documentation notice">
+  <span class="deprecated-docs-banner__label">Deprecated</span>
+  <p class="deprecated-docs-banner__message">
+    This Splice documentation site is deprecated. Use the current Canton Network docs.
+  </p>
+  <a class="deprecated-docs-banner__link" href="https://docs.canton.network/">Open current docs</a>
+</div>

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -1,0 +1,5 @@
+{%- extends "!layout.html" %}
+{% block document %}
+{% include "deprecated_banner.html" %}
+{{ super() }}
+{% endblock %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -87,6 +87,7 @@ copybutton_prompt_text = "@ "
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
+html_static_path = ["_static"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -121,6 +122,7 @@ html_context = {
     "conf_py_path": "/docs/src/",
 }
 
+html_css_files = ["deprecated-banner.css"]
 html_js_files = ["script.js"]
 
 SPLICE_ROOT = os.getenv("SPLICE_ROOT")


### PR DESCRIPTION
## Summary

Adds a global deprecated-site banner to the Splice Sphinx docs published at `docs.sync.global`.

The banner is injected through the shared Sphinx layout so normal docs pages, search, and generated index pages all receive the notice. The only generated HTML files without the banner in the smoke build are the two `sphinx-reredirects` redirect stubs, which immediately redirect to `sv_helm.html`, where the banner is present.

The visual treatment now reuses the Canton Network docs brand palette from `digital-asset/cf-docs` (`#734BE2`, `#5C3DB8`, and a light lavender surface) rather than a generic warning-orange style.

## Design artifacts

- Figma flow diagram: https://www.figma.com/board/CuPjtik4q5Ru3xAhZ38RCd?utm_source=codex&utm_content=edit_in_figjam&oai_id=&request_id=d309b53b-fc1e-4b46-955c-617fef55746e
- High-fidelity Figma mockup: https://www.figma.com/design/O6R2PSKSq5pHbXyaFgoiua
- Website-accurate captured mockup frame: https://www.figma.com/design/O6R2PSKSq5pHbXyaFgoiua?node-id=8-2

## Screenshots

### Desktop overview page

Shows the deprecated banner below the existing breadcrumbs/edit area and above the page heading, using the Canton Network docs purple/lavender brand treatment.

![Desktop overview page](https://raw.githubusercontent.com/danielporterda/splice/d826958ef1051abe3873c1a8cd77c5022c3242e6/.pr-assets/sync-docs-deprecated-banner/desktop-overview.png)

### Mobile overview page

Shows the banner stacked for narrow viewports with the call-to-action still visible before the deprecated page content.

![Mobile overview page](https://raw.githubusercontent.com/danielporterda/splice/d826958ef1051abe3873c1a8cd77c5022c3242e6/.pr-assets/sync-docs-deprecated-banner/mobile-overview.png)

## Validation

- `git diff --check`
- Local Sphinx smoke build with a temporary Python venv: `sphinx-build -b html -q docs/src /tmp/splice-docs-banner-smoke`
- Verified generated output contains the banner and stylesheet on 83 of 85 generated HTML files; the two exceptions are redirect-only stubs: `sv_operator/bootstrap.html` and `sv_operator/onboarding.html`.
- Verified `index.html`, `search.html`, `genindex.html`, and `overview/overview.html` include the banner and stylesheet.
- Captured desktop and mobile screenshots from the rendered local Sphinx output using headless Chromium.

Note: I attempted to use the repo `direnv`/Nix shell first. The worktree `.envrc` needed flakes enabled, and after setting `NIX_CONFIG='extra-experimental-features = nix-command flakes'`, `nix print-dev-env` did not finish materializing the dev shell in a practical window. The smoke build above uses the same Sphinx config path but does not run the repo's full `sbt docs/bundle`, so it reports existing warnings for generated Daml API and metrics pages that are normally produced by the full bundle task.