### PR TITLE
Fix grpc-health-probe to use multi-arch version

### DIFF
--- a/cluster/images/canton-participant/Dockerfile
+++ b/cluster/images/canton-participant/Dockerfile
@@ -4,7 +4,13 @@
 ARG canton_version
 ARG image_sha256
 
+# TODO(DACH-NY/cn-test-failures#8301) fix upstream instead
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48@sha256:b615f8b80a6796490b91bfe0f7f4d59cf73767d4921968495cb8b4024090e151 AS grpc-health-probe-multi-arch
+
 FROM europe-docker.pkg.dev/da-images/public-all/docker/canton-participant:${canton_version}@${image_sha256}
+
+# TODO(DACH-NY/cn-test-failures#8301) fix upstream instead / find solution that allows fingerprint pinning
+COPY --from=grpc-health-probe-multi-arch /ko-app/grpc-health-probe /bin/grpc-health-probe
 
 COPY additional-config.conf /app/
 COPY target/logback.xml /app/

--- a/scripts/check-base-images.sh
+++ b/scripts/check-base-images.sh
@@ -24,7 +24,8 @@ for dockerfile in "${dockerfiles[@]}"; do
   # We exclude "${base_version}", which we use for base images that are built from this repo in the same version
   # and parameterized digests which we use for the Canton images
   # shellcheck disable=SC2016
-  if grep -Hn "^\s*FROM\b" "$dockerfile" | grep -v ':\${base_version}' | grep -v '@${image_sha256}' &&
+  # TODO(DACH-NY/cn-test-failures#8301) consider removing the ` AS ` part again
+  if grep -Hn "^\s*FROM\b" "$dockerfile" | grep -v ':\${base_version}' | grep -v '@${image_sha256}' | grep -v ' AS ' &&
     get_base_image "$dockerfile" | grep -vq '@sha256:'; then
     _error "docker image '$dockerfile' must pin base image to a specific digest"
   fi


### PR DESCRIPTION
Main fix for https://github.com/DACH-NY/canton-network-internal/issues/5016

[static]
