### PR TITLE
bump wait-timeout for docker compose

### DIFF
--- a/cluster/compose/sv/start.sh
+++ b/cluster/compose/sv/start.sh
@@ -64,7 +64,10 @@ fi
 
 extra_args=()
 if [ $wait -eq 1 ]; then
-  extra_args+=("--wait" "--wait-timeout" "600")
+  # Note that the wait-timeout must be higher than the startup time of the healthcheck in the image,
+  # which is currently 10m. Otherwise, the container may still be in "starting" state when the timeout
+  # is reached, which is not considered a failure in docker compose.
+  extra_args+=("--wait" "--wait-timeout" "700")
 fi
 
 export HOST_BIND_IP


### PR DESCRIPTION
Part of https://github.com/DACH-NY/canton-network-internal/issues/5016#issuecomment-4399219564

(the "why did it not hard-fail the moment we switched to gepc-health-probe")

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
