### PR TITLE
Revert "Fix grpc-health-probe to use multi-arch version (#5447)"

### DIFF
--- a/cluster/images/canton-participant/Dockerfile
+++ b/cluster/images/canton-participant/Dockerfile
@@ -4,13 +4,7 @@
 ARG canton_version
 ARG image_sha256
 
-# TODO(DACH-NY/cn-test-failures#8301) fix upstream instead
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48@sha256:b615f8b80a6796490b91bfe0f7f4d59cf73767d4921968495cb8b4024090e151 AS grpc-health-probe-multi-arch
-
 FROM europe-docker.pkg.dev/da-images/public-all/docker/canton-participant:${canton_version}@${image_sha256}
-
-# TODO(DACH-NY/cn-test-failures#8301) fix upstream instead / find solution that allows fingerprint pinning
-COPY --from=grpc-health-probe-multi-arch /ko-app/grpc-health-probe /bin/grpc-health-probe
 
 COPY additional-config.conf /app/
 COPY target/logback.xml /app/

--- a/scripts/check-base-images.sh
+++ b/scripts/check-base-images.sh
@@ -24,8 +24,7 @@ for dockerfile in "${dockerfiles[@]}"; do
   # We exclude "${base_version}", which we use for base images that are built from this repo in the same version
   # and parameterized digests which we use for the Canton images
   # shellcheck disable=SC2016
-  # TODO(DACH-NY/cn-test-failures#8301) consider removing the ` AS ` part again
-  if grep -Hn "^\s*FROM\b" "$dockerfile" | grep -v ':\${base_version}' | grep -v '@${image_sha256}' | grep -v ' AS ' &&
+  if grep -Hn "^\s*FROM\b" "$dockerfile" | grep -v ':\${base_version}' | grep -v '@${image_sha256}' &&
     get_base_image "$dockerfile" | grep -vq '@sha256:'; then
     _error "docker image '$dockerfile' must pin base image to a specific digest"
   fi


### PR DESCRIPTION
This reverts commit 27e2f8d0a009e18db8163a61820e0bc97f02e1e8.

(Upstreamed to canton, included in the canton version we bumped to already, so can remove this now)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
