### PR TITLE
Fix unvetAllSupportedPackagesIntegrationTest after dars bump

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AdditionalPackagesToUnvetIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AdditionalPackagesToUnvetIntegrationTest.scala
@@ -225,8 +225,7 @@ class DowngradeSvPackagesIntegrationTest extends AdditionalPackagesToUnvetIntegr
   }
 }
 
-/** This test verifies that an SV can unvet all supported packages that are above the minimum initialization versions,
-  * but not the ones equal to the minimum initialization versions.
+/** This test verifies that an SV can unvet all supported packages.
   */
 class UnvetAllSupportedPackagesIntegrationTest
     extends AdditionalPackagesToUnvetIntegrationTestBase {
@@ -239,7 +238,7 @@ class UnvetAllSupportedPackagesIntegrationTest
   override val additionalPackagesToUnvetSv1Local: Seq[DarResource] =
     nonMinimalSupportedPackageVersions ++ minimalPackageVersions
 
-  "sv1 cannot unvet all vetted and supported packages" in { implicit env =>
+  "sv1 can unvet all supported packages" in { implicit env =>
     import env.executionContext
 
     startAllSync(
@@ -250,7 +249,7 @@ class UnvetAllSupportedPackagesIntegrationTest
     val synchronizerId =
       sv1Backend.participantClient.synchronizers.list_connected().head.synchronizerId
 
-    clue(s"sv1 succeeds to unvets all packages but the minimal supported ones: ${additionalPackagesToUnvetSv1
+    clue(s"sv1 succeeds to unvet all packages but the minimal supported ones: ${additionalPackagesToUnvetSv1
         .map(pkg => pkg.metadata.name -> pkg.metadata.version)}") {
       eventually() {
         val vettedPackageIds = getVettedPackageIds(
@@ -268,7 +267,7 @@ class UnvetAllSupportedPackagesIntegrationTest
     }
 
     clue(
-      s"sv1 fails to unvet the minimum required supported packages: ${additionalPackagesToUnvetSv1Local
+      s"sv1 then unvets all minimum required supported packages: ${additionalPackagesToUnvetSv1Local
           .map(pkg => pkg.metadata.name -> pkg.metadata.version)}"
     ) {
       startAllSync(
@@ -283,7 +282,7 @@ class UnvetAllSupportedPackagesIntegrationTest
         vettedPackageIds should contain noElementsOf nonMinimalSupportedPackageVersions.map(
           _.packageId
         )
-        vettedPackageIds should contain allElementsOf Seq(
+        vettedPackageIds should contain noElementsOf Seq(
           DarResources.amulet,
           DarResources.amuletNameService,
           DarResources.dsoGovernance,


### PR DESCRIPTION
fixes https://github.com/DACH-NY/cn-test-failures/issues/8359

An sv can unvet all supported packages since this change: https://github.com/canton-network/splice/commit/4c16f63a0bcff93cb0aa88c11c4d57a589bf6a7b#diff-5216ea26a45b3f34fd2d8ffed5aac4d41c452152272d3ccd9c67ce9258ed83f0R59

I think this test still makes sense to have and work only in two steps.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
