### PR TITLE
Stop apps explicitly at end of RollForwardLsuDRIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
@@ -473,6 +473,7 @@ class RollForwardLsuDRIntegrationTest
         }
 
         clue("stop apps manually to prevent errors from the synchronizer being force stopped") {
+          stopAllAsync(allNodes*).futureValue
           allSvLocalBackends.par.foreach(
             _.participantClient.synchronizers.disconnect_all()
           )


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#8282

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
