### PR TITLE
Integration tests: ignore `onboard/validator` timeout warnings

### DIFF
--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -159,3 +159,6 @@ Waiting for.*has not completed after
 Gave up waiting for.*as we are shutting down
 
 Ryuk has been disabled
+
+# Calls to this have retries; if the retries were not enough, we'll get a louder error.
+api/sv/v0/onboard/validator (POST) resulted in a timeout


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#8111

Calls to this have retries; if the retries were not enough, we'll get a louder error.

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
