### PR TITLE
handle variable-width subsecond components in Daml timestamps in wallet UI

### DIFF
--- a/apps/wallet/frontend/src/__tests__/timestampConversion.test.ts
+++ b/apps/wallet/frontend/src/__tests__/timestampConversion.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+
+import { damlTimestampToOpenApiTimestamp } from '../utils/timestampConversion';
+
+describe('damlTimestampToOpenApiTimestamp', () => {
+  const jan0124 = new Date('2024-01-01T00:00:00Z').valueOf() * 1000;
+  const jun1524 = new Date('2024-06-15T00:00:00Z').valueOf() * 1000;
+  const may1126noon = new Date('2026-05-11T12:00:00Z').valueOf() * 1000;
+  const timestamps: Record<string, number> = {
+    '2024-01-01T00:00:00.123456Z': jan0124 + 123456,
+    '2024-01-01T00:00:00Z': jan0124,
+    '2024-01-01T00:00:00.500Z': jan0124 + 500000,
+    '2024-01-01T00:00:00.1Z': jan0124 + 100000,
+    '2024-06-15T12:30:00Z': jun1524 + (12 * 60 + 30) * 60 * 1000000,
+    '2024-01-01T00:00:00.000001Z': jan0124 + 1,
+    '2026-05-11T12:00:00Z': may1126noon,
+    '2026-05-11T12:00:00.000000Z': may1126noon,
+    '2026-05-11T12:00:00.123Z': may1126noon + 123000,
+    '2026-05-11T12:00:00.123456Z': may1126noon + 123456,
+  };
+
+  it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
+    expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
+  });
+});

--- a/apps/wallet/frontend/src/__tests__/timestampConversion.test.ts
+++ b/apps/wallet/frontend/src/__tests__/timestampConversion.test.ts
@@ -19,6 +19,8 @@ describe('damlTimestampToOpenApiTimestamp', () => {
     '2026-05-11T12:00:00.000000Z': may1126noon,
     '2026-05-11T12:00:00.123Z': may1126noon + 123000,
     '2026-05-11T12:00:00.123456Z': may1126noon + 123456,
+    // just drop after micros, Daml won't produce them anyway
+    '2026-05-11T12:00:00.123456789Z': may1126noon + 123456,
   };
 
   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {

--- a/apps/wallet/frontend/src/utils/timestampConversion.ts
+++ b/apps/wallet/frontend/src/utils/timestampConversion.ts
@@ -7,7 +7,7 @@ export const DAML_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}
 export function isValidDamlTimestamp(str: string): boolean {
   return DAML_TIMESTAMP_REGEX.test(str);
 }
-// only call this if the timestamp is valid
+// only call this if the timestamp is valid or produced by Daml JSON codec
 // this is necessary only because JS doesn't support microsecond precision
 export function damlTimestampToOpenApiTimestamp(str: string): number {
   const timestampWithMillisecondPrecision = new Date(str);

--- a/apps/wallet/frontend/src/utils/timestampConversion.ts
+++ b/apps/wallet/frontend/src/utils/timestampConversion.ts
@@ -13,7 +13,7 @@ export function damlTimestampToOpenApiTimestamp(str: string): number {
   const timestampWithMillisecondPrecision = new Date(str);
   // valueOf returns milliseconds since epoch
   const millis = timestampWithMillisecondPrecision.valueOf();
-  // get the last 3 characters (microseconds), excluding the Z (timezone, UTC)
-  const micros = Number(str.slice(str.length - 4, str.length - 1));
-  return millis * 1000 + micros;
+  const frac = str.match(/\.(\d+)Z$/)?.[1] ?? '';
+  const subMillisMicros = Number(frac.padEnd(6, '0').slice(3, 6));
+  return millis * 1000 + subMillisMicros;
 }

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -10,3 +10,8 @@
     - Scan UI
 
       - Bring back the governance page that was removed in release 0.5.18.
+
+    - Wallet UI
+
+      - Fix a corner case in the wallet Allocations UI where invalid values would be passed to ``/v0/allocations`` when creating allocations from allocation requests.
+        This could manifest as a browser error when clicking ``Accept`` on an allocation request.


### PR DESCRIPTION
[`ISO_INSTANT`, as JDK-documented](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#ISO_INSTANT), uses a variable number of digits for the subsecond component when converting contracts to JSON

https://github.com/canton-network/splice/blob/afcce7cff9d823bc06db51b9077b0f3c431fbda2/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/daml/lf/value/json/ApiValueImplicits.scala#L17

but `damlTimestampToOpenApiTimestamp` assumes a fixed-width subsecond component

https://github.com/canton-network/splice/blob/5a42cdc0937f268f83bde66b321dfa46a66ad8ff/apps/wallet/frontend/src/utils/timestampConversion.ts#L16-L17

When it is zero-width, the result is `NaN` which JSONs to `null`:

```js
> Number(':42')
NaN
> const x = 50000 + Number(':42')
> x
NaN
> JSON.stringify({result: x})
'{"result":null}'
```

<details>
<summary>The included tests fail like the enclosed without the conversion fix.</summary>

```js
 FAIL  src/__tests__/timestampConversion.test.ts > damlTimestampToOpenApiTimestamp > 2024-01-01T00:00:00Z -> 1704067200000000
AssertionError: expected NaN to be 1704067200000000 // Object.is equality

- Expected
+ Received

- 1704067200000000
+ NaN

 ❯ src/__tests__/timestampConversion.test.ts:25:52
     23| 
     24|   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
     25|     expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
       |                                                    ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  src/__tests__/timestampConversion.test.ts > damlTimestampToOpenApiTimestamp > 2024-01-01T00:00:00.500Z -> 1704067200500000
AssertionError: expected 1704067200500500 to be 1704067200500000 // Object.is equality

- Expected
+ Received

- 1704067200500000
+ 1704067200500500

 ❯ src/__tests__/timestampConversion.test.ts:25:52
     23| 
     24|   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
     25|     expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
       |                                                    ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  src/__tests__/timestampConversion.test.ts > damlTimestampToOpenApiTimestamp > 2024-06-15T12:30:00Z -> 1718454600000000
AssertionError: expected NaN to be 1718454600000000 // Object.is equality

- Expected
+ Received

- 1718454600000000
+ NaN

 ❯ src/__tests__/timestampConversion.test.ts:25:52
     23| 
     24|   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
     25|     expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
       |                                                    ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  src/__tests__/timestampConversion.test.ts > damlTimestampToOpenApiTimestamp > 2026-05-11T12:00:00Z -> 1778500800000000
AssertionError: expected NaN to be 1778500800000000 // Object.is equality

- Expected
+ Received

- 1778500800000000
+ NaN

 ❯ src/__tests__/timestampConversion.test.ts:25:52
     23| 
     24|   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
     25|     expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
       |                                                    ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  src/__tests__/timestampConversion.test.ts > damlTimestampToOpenApiTimestamp > 2026-05-11T12:00:00.123Z -> 1778500800123000
AssertionError: expected 1778500800123123 to be 1778500800123000 // Object.is equality

- Expected
+ Received

- 1778500800123000
+ 1778500800123123

 ❯ src/__tests__/timestampConversion.test.ts:25:52
     23| 
     24|   it.each(Object.entries(timestamps))('%s -> %d', (input, expected) => {
     25|     expect(damlTimestampToOpenApiTimestamp(input)).toBe(expected);
       |                                                    ^
     26|   });
     27| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯
```
</details>

Fixes a corner case in the wallet Allocations UI where bad values would be passed to `POST` endpoints. This doesn't change the UI for form timestamp *entry*, where you must still enter exactly 6 microsecond digits.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
