### PR TITLE
Fix wallet delegation tests by scoping button lookup to active dialog

### DIFF
--- a/apps/wallet/frontend/src/__tests__/wallet.test.tsx
+++ b/apps/wallet/frontend/src/__tests__/wallet.test.tsx
@@ -674,7 +674,8 @@ describe('Wallet user can', () => {
     await user.click(cancelButtons[0]);
 
     // Confirm the cancellation in the confirmation dialog
-    const proceedButton = await screen.findByRole('button', { name: 'Proceed' });
+    const confirmationDialog = await screen.findByRole('dialog');
+    const proceedButton = within(confirmationDialog).getByRole('button', { name: 'Proceed' });
     await user.click(proceedButton);
 
     // Assert the cancel API was called once
@@ -711,7 +712,8 @@ describe('Wallet user can', () => {
     await user.click(buttons[0]);
 
     // Confirm the acceptance in the confirmation dialog
-    const proceedButton = await screen.findByRole('button', { name: 'Proceed' });
+    const confirmationDialog = await screen.findByRole('dialog');
+    const proceedButton = within(confirmationDialog).getByRole('button', { name: 'Proceed' });
     await user.click(proceedButton);
 
     await waitFor(() => expect(calledArgs).toHaveLength(1));
@@ -747,7 +749,8 @@ describe('Wallet user can', () => {
     await user.click(buttons[0]);
 
     // Confirm the rejection in the confirmation dialog
-    const proceedButton = await screen.findByRole('button', { name: 'Proceed' });
+    const confirmationDialog = await screen.findByRole('dialog');
+    const proceedButton = within(confirmationDialog).getByRole('button', { name: 'Proceed' });
     await user.click(proceedButton);
 
     await waitFor(() => expect(calledArgs).toHaveLength(1));
@@ -798,7 +801,8 @@ describe('Wallet user can', () => {
     expect(newMaxAmulets?.textContent).toBe('25');
 
     // Click proceed
-    const proceedButton = await screen.findByRole('button', { name: 'Proceed' });
+    const confirmationDialog = await screen.findByRole('dialog');
+    const proceedButton = within(confirmationDialog).getByRole('button', { name: 'Proceed' });
     await user.click(proceedButton);
 
     // Verify accept was called (backend handles replacement automatically)

--- a/apps/wallet/frontend/src/__tests__/wallet.test.tsx
+++ b/apps/wallet/frontend/src/__tests__/wallet.test.tsx
@@ -104,7 +104,7 @@ describe('Wallet user can', () => {
     await user.type(input, userLogin);
 
     const button = screen.getByRole('button', { name: 'Log In' });
-    user.click(button);
+    await user.click(button);
 
     expect(await screen.findByText(aliceEntry.name)).toBeDefined();
   });


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#8344

Fix is stolen from #5249, thanks @samsondav

I removed things from the original fix proposal that don't seem required to fix above issue, based on my local testing.

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
