### PR TITLE
Fix the right apps at end of RollForwardLsuDRIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
@@ -473,7 +473,9 @@ class RollForwardLsuDRIntegrationTest
         }
 
         clue("stop apps manually to prevent errors from the synchronizer being force stopped") {
-          stopAllAsync(((allSvLocalBackends: Seq[AppBackendReference]) ++ allScanLocalBackends)*).futureValue
+          stopAllAsync(
+            ((allSvLocalBackends: Seq[AppBackendReference]) ++ allScanLocalBackends)*
+          ).futureValue
           allSvLocalBackends.par.foreach(
             _.participantClient.synchronizers.disconnect_all()
           )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuDRIntegrationTest.scala
@@ -473,7 +473,7 @@ class RollForwardLsuDRIntegrationTest
         }
 
         clue("stop apps manually to prevent errors from the synchronizer being force stopped") {
-          stopAllAsync(allNodes*).futureValue
+          stopAllAsync(((allSvLocalBackends: Seq[AppBackendReference]) ++ allScanLocalBackends)*).futureValue
           allSvLocalBackends.par.foreach(
             _.participantClient.synchronizers.disconnect_all()
           )


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#8419

Corrects #5489 ; the apps stopped there are not running anymore here...

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
