### PR TITLE
gha pulumi: support multiple repos

### DIFF
--- a/cluster/pulumi/common/src/dockerConfig.ts
+++ b/cluster/pulumi/common/src/dockerConfig.ts
@@ -63,7 +63,7 @@ export class DockerConfig {
 
   public createDockerClientConfigSecret(
     namespaceName: string | pulumi.Input<string>,
-    secretName: string = 'docker-client-config',
+    secretName: string,
     dependsOn: pulumi.Resource[] = []
   ): Secret {
     return new k8s.core.v1.Secret(
@@ -85,7 +85,7 @@ export class DockerConfig {
 
   public createImagePullSecret(
     namespaceName: string,
-    secretName: string = 'docker-reg-cred',
+    secretName: string,
     dependsOn: pulumi.Resource[] = []
   ): Secret {
     return new k8s.core.v1.Secret(

--- a/cluster/pulumi/gha/src/cache.ts
+++ b/cluster/pulumi/gha/src/cache.ts
@@ -7,15 +7,18 @@ import { spliceEnvConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/
 
 export function createCachePvc(
   runnersNamespace: k8s.core.v1.Namespace,
-  cachePvcName: string
+  repo: string
 ): k8s.core.v1.PersistentVolumeClaim {
   // A filestore for the cache drives that are mounted directly to the runners
   // filestore minimum capacity to provision an ssd instance is 2.5TB
   const capacityGb = 2560;
-  const filestore = new gcp.filestore.Instance(`gha-filestore`, {
+  // For backward compat of the existing splice cache, we keep the old unsuffixed name for the splice repo, and add repo suffix only for other repos
+  const filestoreInstanceName = repo == 'splice' ? 'gha-filestore' : `gha-filestore-${repo}`;
+  const filestoreName = repo == 'splice' ? 'gha_share' : `gha_share-${repo}`;
+  const filestore = new gcp.filestore.Instance(filestoreInstanceName, {
     tier: 'BASIC_SSD',
     fileShares: {
-      name: 'gha_share',
+      name: filestoreName,
       capacityGb: capacityGb,
     },
     networks: [
@@ -27,9 +30,9 @@ export function createCachePvc(
     location: spliceEnvConfig.requireEnv('DB_CLOUDSDK_COMPUTE_ZONE'),
   });
   const filestoreIpAddress = filestore.networks[0].ipAddresses[0];
-  const persistentVolume = new k8s.core.v1.PersistentVolume('gha-cache-pv', {
+  const persistentVolume = new k8s.core.v1.PersistentVolume(`gha-cache-pv-${repo}`, {
     metadata: {
-      name: 'gha-cache-pv',
+      name: `gha-cache-pv-${repo}`,
       namespace: runnersNamespace.metadata.name,
     },
     spec: {
@@ -49,9 +52,9 @@ export function createCachePvc(
       },
     },
   });
-  const cachePvc = new k8s.core.v1.PersistentVolumeClaim(cachePvcName, {
+  const cachePvc = new k8s.core.v1.PersistentVolumeClaim(`gha-cache-pvc-${repo}`, {
     metadata: {
-      name: cachePvcName,
+      name: `gha-cache-pvc-${repo}`,
       namespace: runnersNamespace.metadata.name,
     },
     spec: {

--- a/cluster/pulumi/gha/src/config.ts
+++ b/cluster/pulumi/gha/src/config.ts
@@ -7,7 +7,8 @@ import { z } from 'zod';
 
 const GhaConfigSchema = z.object({
   gha: z.object({
-    githubRepo: z.string(),
+    githubOrg: z.string(),
+    githubRepos: z.array(z.string()),
     // these a Splice versions
     runnerVersion: z.string(),
     runnerHookVersion: z.string(),

--- a/cluster/pulumi/gha/src/controller.ts
+++ b/cluster/pulumi/gha/src/controller.ts
@@ -9,14 +9,14 @@ import { Namespace } from '@pulumi/kubernetes/core/v1';
 
 import { ghaConfig } from './config';
 
-export function installController(): k8s.helm.v3.Release {
-  const controllerNamespace = new Namespace('gha-runner-controller', {
+export function installController(repo: string): k8s.helm.v3.Release {
+  const controllerNamespace = new Namespace(`gha-runner-controller-${repo}`, {
     metadata: {
-      name: 'gha-runner-controller',
+      name: `gha-runner-controller-${repo}`,
     },
   });
 
-  return new k8s.helm.v3.Release('gha-runner-scale-set-controller', {
+  return new k8s.helm.v3.Release(`gha-runner-scale-set-controller-${repo}`, {
     chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
     version: ghaConfig.runnerScaleSetVersion,
     namespace: controllerNamespace.metadata.name,

--- a/cluster/pulumi/gha/src/index.ts
+++ b/cluster/pulumi/gha/src/index.ts
@@ -1,9 +1,13 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ghaConfig } from './config';
 import { installController } from './controller';
 import { installDockerRegistryMirror } from './dockerMirror';
 import { installRunnerScaleSets } from './runners';
 
 installDockerRegistryMirror();
-const controller = installController();
-installRunnerScaleSets(controller);
+for (const repo of ghaConfig.githubRepos) {
+  console.error(`Configuring GHA runner for repository: ${repo}`);
+  const controller = installController(repo);
+  installRunnerScaleSets(controller, repo);
+}

--- a/cluster/pulumi/gha/src/runners.test.ts
+++ b/cluster/pulumi/gha/src/runners.test.ts
@@ -11,7 +11,8 @@ import { installRunnerScaleSets } from './runners';
 jest.mock('./config', () => ({
   __esModule: true,
   ghaConfig: {
-    githubRepo: 'https://dummy-gh-repo.com',
+    githubOrg: 'https://dummy-gh-repo.com',
+    githubRepo: ['test-repo'],
     runnerVersion: '1.2',
     runnerHookVersion: '1.1',
     runnerScaleSetVersion: '1.1',
@@ -57,7 +58,7 @@ jest.mock('@lfdecentralizedtrust/splice-pulumi-common/src/config/envConfig', () 
   },
 }));
 
-test('GHA runner k8s resources are in the gha-runners namespace', async () => {
+test('GHA runner k8s resources are in the gha-runners-<repo> namespace', async () => {
   await pulumi.runtime.setMocks({
     newResource(args) {
       return {
@@ -83,7 +84,7 @@ test('GHA runner k8s resources are in the gha-runners namespace', async () => {
   } as unknown as k8s.helm.v3.Release;
 
   const [, resources] = await collectResources(() => {
-    installRunnerScaleSets(mockController);
+    installRunnerScaleSets(mockController, 'test-repo');
   });
 
   // check that each k8s resource is in the gha-runners namespace
@@ -102,7 +103,7 @@ test('GHA runner k8s resources are in the gha-runners namespace', async () => {
     // check the namespace and return useful information on error
     pulumi.all([resource.urn, namespace]).apply(([urn, namespace]) => {
       try {
-        expect(namespace).toEqual('gha-runners');
+        expect(namespace).toEqual('gha-runners-test-repo');
       } catch (error) {
         throw new Error(
           `Resource [${urn}] should be created in namespace [gha-runners] but is in [${namespace}].`

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -727,10 +727,10 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
   };
 
   const tokenSecret = new k8s.core.v1.Secret(
-    'gh-access-token',
+    `gh-access-token-${repo}`,
     {
       metadata: {
-        name: 'gh-access-token',
+        name: `gh-access-token-${repo}`,
         namespace: runnersNamespace.metadata.name,
       },
       stringData: {

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -640,7 +640,8 @@ function installRunnersServiceAccount(runnersNamespace: Namespace, name: string)
     }
   );
 
-  imagePullSecretByNamespaceNameForServiceAccount('gha-runners', name, [sa]);
+  runnersNamespace.metadata.name.apply(nsName =>
+    imagePullSecretByNamespaceNameForServiceAccount(nsName, name, [sa]));
 }
 
 function installK8sRunnerScaleSets(

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -753,7 +753,7 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
   // For security reasons, we isolate the caches of different repos
   const cachePvc = createCachePvc(runnersNamespace, repo);
 
-  const saName = 'k8s-runners';
+  const saName = `k8s-runners-${repo}`;
   installRunnersServiceAccount(runnersNamespace, saName);
 
   const performanceTestsDb = repo === 'splice' ? createCloudSQLInstanceForPerformanceTests(exactNs) : undefined;

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -294,7 +294,8 @@ function installDockerRunnerScaleSets(
   );
 
   const dockerClientConfigSecret = DockerConfig.getConfig().createDockerClientConfigSecret(
-    runnersNamespace.metadata.name
+    runnersNamespace.metadata.name,
+    `docker-client-config-${repo}`,
   );
 
   const dependsOn = [tokenSecret, controller, configMap, cachePvc, dockerClientConfigSecret];

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -332,7 +332,7 @@ function installK8sRunnerScaleSet(
   serviceAccountName: string,
   repo: string,
   dependsOn: Resource[],
-  performanceTestsDb: PerformanceTestDb
+  performanceTestsDb?: PerformanceTestDb
 ): Release {
   const podConfigMapName = `${name}-pod-config`;
   // A configMap that will be mounted to runner pods and provide additional pod spec for the workflow pods
@@ -463,12 +463,13 @@ function installK8sRunnerScaleSet(
                     name: 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE',
                     value: '/pod.yaml',
                   },
-                  {
-                    name: 'PERFORMANCE_TESTS_DB_HOST',
-                    value: performanceTestsDb.address,
-                  },
-                  {
-                    name: 'PERFORMANCE_TESTS_DB_USER',
+                  ...(performanceTestsDb ? [
+                    {
+                      name: 'PERFORMANCE_TESTS_DB_HOST',
+                      value: performanceTestsDb.address,
+                    },
+                    {
+                      name: 'PERFORMANCE_TESTS_DB_USER',
                     value: 'cnadmin',
                   },
                   {
@@ -479,7 +480,8 @@ function installK8sRunnerScaleSet(
                         name: performanceTestsDb.secretName,
                       },
                     },
-                  },
+                    },
+                  ] : []),
                 ],
                 volumeMounts: [
                   {
@@ -650,10 +652,15 @@ function installK8sRunnerScaleSets(
   tokenSecret: Secret,
   cachePvcName: pulumi.Output<string>,
   serviceAccountName: string,
-  performanceTestsDb: PerformanceTestDb,
-  repo: string
+  repo: string,
+  performanceTestsDb?: PerformanceTestDb
 ): void {
-  const dependsOn = [controller, runnersNamespace, tokenSecret, performanceTestsDb.db];
+  const dependsOn = [
+    controller,
+    runnersNamespace,
+    tokenSecret,
+    ...(performanceTestsDb ? [performanceTestsDb.db] : [])
+  ];
 
   ghaConfig.runnerSpecs
     .filter(spec => spec.k8s)
@@ -749,7 +756,7 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
   const saName = 'k8s-runners';
   installRunnersServiceAccount(runnersNamespace, saName);
 
-  const performanceTestsDb = createCloudSQLInstanceForPerformanceTests(exactNs);
+  const performanceTestsDb = repo === 'splice' ? createCloudSQLInstanceForPerformanceTests(exactNs) : undefined;
   installDockerRunnerScaleSets(controller, runnersNamespace, tokenSecret, cachePvc, saName, repo);
   installK8sRunnerScaleSets(
     controller,
@@ -757,8 +764,8 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
     tokenSecret,
     cachePvc.metadata.name,
     saName,
-    performanceTestsDb,
-    repo
+    repo,
+    performanceTestsDb
   );
   installPodMonitor(runnersNamespace);
 }

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -295,7 +295,7 @@ function installDockerRunnerScaleSets(
 
   const dockerClientConfigSecret = DockerConfig.getConfig().createDockerClientConfigSecret(
     runnersNamespace.metadata.name,
-    `docker-client-config-${repo}`,
+    `docker-client-config-${repo}`
   );
 
   const dependsOn = [tokenSecret, controller, configMap, cachePvc, dockerClientConfigSecret];
@@ -337,84 +337,88 @@ function installK8sRunnerScaleSet(
 ): Release {
   const podConfigMapName = `${name}-pod-config-${repo}`;
   // A configMap that will be mounted to runner pods and provide additional pod spec for the workflow pods
-  const workflowPodConfigMap = cachePvcName.apply(cachePvcName =>
-    new k8s.core.v1.ConfigMap(
-    podConfigMapName,
-    {
-      metadata: {
-        name: podConfigMapName,
-        namespace: runnersNamespace.metadata.name,
-      },
-      data: {
-        'pod.yaml': yaml.dump({
-          spec: {
-            hostAliases: localnetHostAliases,
-            volumes: [
-              {
-                name: 'cache',
-                persistentVolumeClaim: {
-                  claimName: cachePvcName,
-                },
-              },
-              {
-                name: 'logs',
-                emptyDir: {},
-              },
-            ],
-            containers: [
-              {
-                name: '$job',
-                volumeMounts: [
+  const workflowPodConfigMap = cachePvcName.apply(
+    cachePvcName =>
+      new k8s.core.v1.ConfigMap(
+        podConfigMapName,
+        {
+          metadata: {
+            name: podConfigMapName,
+            namespace: runnersNamespace.metadata.name,
+          },
+          data: {
+            'pod.yaml': yaml.dump({
+              spec: {
+                hostAliases: localnetHostAliases,
+                volumes: [
                   {
                     name: 'cache',
-                    mountPath: '/cache',
+                    persistentVolumeClaim: {
+                      claimName: cachePvcName,
+                    },
                   },
                   {
                     name: 'logs',
-                    mountPath: '/logs',
+                    emptyDir: {},
                   },
                 ],
-                // required to mount the nix store inside the container from the NFS
-                securityContext: {
-                  privileged: true,
-                },
-                resources: {
-                  // See note above on resource requests and limits.
-                  requests: {
-                    // We set the requests to a tiny non-zero number, just to prevent k8s from
-                    // using the limits as the requests values.
-                    cpu: '1m',
-                    memory: '1m',
-                    'ephemeral-storage': '1',
-                  },
-                  limits: resources ? singleResourcesSpecFromConfig(resources.limits) : undefined,
-                },
-                ports: [
+                containers: [
                   {
-                    name: 'metrics',
-                    containerPort: 8000,
-                    protocol: 'TCP',
+                    name: '$job',
+                    volumeMounts: [
+                      {
+                        name: 'cache',
+                        mountPath: '/cache',
+                      },
+                      {
+                        name: 'logs',
+                        mountPath: '/logs',
+                      },
+                    ],
+                    // required to mount the nix store inside the container from the NFS
+                    securityContext: {
+                      privileged: true,
+                    },
+                    resources: {
+                      // See note above on resource requests and limits.
+                      requests: {
+                        // We set the requests to a tiny non-zero number, just to prevent k8s from
+                        // using the limits as the requests values.
+                        cpu: '1m',
+                        memory: '1m',
+                        'ephemeral-storage': '1',
+                      },
+                      limits: resources
+                        ? singleResourcesSpecFromConfig(resources.limits)
+                        : undefined,
+                    },
+                    ports: [
+                      {
+                        name: 'metrics',
+                        containerPort: 8000,
+                        protocol: 'TCP',
+                      },
+                    ],
+                    imagePullPolicy: 'Always',
                   },
                 ],
-                imagePullPolicy: 'Always',
+                serviceAccountName: serviceAccountName,
+                ...appsAffinityAndTolerations,
               },
-            ],
-            serviceAccountName: serviceAccountName,
-            ...appsAffinityAndTolerations,
+              metadata: {
+                // prevent eviction by the gke autoscaler
+                annotations: {
+                  'cluster-autoscaler.kubernetes.io/safe-to-evict': 'false',
+                },
+              },
+            }),
           },
-          metadata: {
-            // prevent eviction by the gke autoscaler
-            annotations: {
-              'cluster-autoscaler.kubernetes.io/safe-to-evict': 'false',
-            },
-          },
-        }),
-      },
-    },
-    {
-      dependsOn: runnersNamespace,
-    }
-    ));
+        },
+        {
+          dependsOn: runnersNamespace,
+        }
+      )
+  );
 
   const runnerImage = `${DOCKER_REPO}/splice-test-runner-hook:${ghaConfig.runnerHookVersion}`;
 
@@ -464,25 +468,27 @@ function installK8sRunnerScaleSet(
                     name: 'ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE',
                     value: '/pod.yaml',
                   },
-                  ...(performanceTestsDb ? [
-                    {
-                      name: 'PERFORMANCE_TESTS_DB_HOST',
-                      value: performanceTestsDb.address,
-                    },
-                    {
-                      name: 'PERFORMANCE_TESTS_DB_USER',
-                    value: 'cnadmin',
-                  },
-                  {
-                    name: 'PERFORMANCE_TESTS_DB_PASSWORD',
-                    valueFrom: {
-                      secretKeyRef: {
-                        key: 'postgresPassword',
-                        name: performanceTestsDb.secretName,
-                      },
-                    },
-                    },
-                  ] : []),
+                  ...(performanceTestsDb
+                    ? [
+                        {
+                          name: 'PERFORMANCE_TESTS_DB_HOST',
+                          value: performanceTestsDb.address,
+                        },
+                        {
+                          name: 'PERFORMANCE_TESTS_DB_USER',
+                          value: 'cnadmin',
+                        },
+                        {
+                          name: 'PERFORMANCE_TESTS_DB_PASSWORD',
+                          valueFrom: {
+                            secretKeyRef: {
+                              key: 'postgresPassword',
+                              name: performanceTestsDb.secretName,
+                            },
+                          },
+                        },
+                      ]
+                    : []),
                 ],
                 volumeMounts: [
                   {
@@ -644,7 +650,8 @@ function installRunnersServiceAccount(runnersNamespace: Namespace, name: string)
   );
 
   runnersNamespace.metadata.name.apply(nsName =>
-    imagePullSecretByNamespaceNameForServiceAccount(nsName, name, [sa]));
+    imagePullSecretByNamespaceNameForServiceAccount(nsName, name, [sa])
+  );
 }
 
 function installK8sRunnerScaleSets(
@@ -660,7 +667,7 @@ function installK8sRunnerScaleSets(
     controller,
     runnersNamespace,
     tokenSecret,
-    ...(performanceTestsDb ? [performanceTestsDb.db] : [])
+    ...(performanceTestsDb ? [performanceTestsDb.db] : []),
   ];
 
   ghaConfig.runnerSpecs
@@ -757,7 +764,8 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
   const saName = `k8s-runners-${repo}`;
   installRunnersServiceAccount(runnersNamespace, saName);
 
-  const performanceTestsDb = repo === 'splice' ? createCloudSQLInstanceForPerformanceTests(exactNs) : undefined;
+  const performanceTestsDb =
+    repo === 'splice' ? createCloudSQLInstanceForPerformanceTests(exactNs) : undefined;
   installDockerRunnerScaleSets(controller, runnersNamespace, tokenSecret, cachePvc, saName, repo);
   installK8sRunnerScaleSets(
     controller,

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -336,7 +336,8 @@ function installK8sRunnerScaleSet(
 ): Release {
   const podConfigMapName = `${name}-pod-config`;
   // A configMap that will be mounted to runner pods and provide additional pod spec for the workflow pods
-  const workflowPodConfigMap = new k8s.core.v1.ConfigMap(
+  const workflowPodConfigMap = cachePvcName.apply(cachePvcName =>
+    new k8s.core.v1.ConfigMap(
     podConfigMapName,
     {
       metadata: {
@@ -412,7 +413,7 @@ function installK8sRunnerScaleSet(
     {
       dependsOn: runnersNamespace,
     }
-  );
+    ));
 
   const runnerImage = `${DOCKER_REPO}/splice-test-runner-hook:${ghaConfig.runnerHookVersion}`;
 

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
 import {
   appsAffinityAndTolerations,
   DOCKER_REPO,
@@ -67,9 +68,9 @@ function installDockerRunnerScaleSet(
   dockerConfigSecret: Secret,
   resources: K8sResourceSchema,
   serviceAccountName: string,
+  repo: string,
   dependsOn: Resource[]
 ): k8s.helm.v3.Release {
-  const repo = ghaConfig.githubRepo;
   return new k8s.helm.v3.Release(
     name,
     {
@@ -77,7 +78,7 @@ function installDockerRunnerScaleSet(
       version: ghaConfig.runnerScaleSetVersion,
       namespace: runnersNamespace.metadata.name,
       values: {
-        githubConfigUrl: repo,
+        githubConfigUrl: `${ghaConfig.githubOrg}/${repo}`,
         githubConfigSecret: tokenSecret.metadata.name,
         runnerScaleSetName: name,
         listenerTemplate: {
@@ -256,7 +257,8 @@ function installDockerRunnerScaleSets(
   runnersNamespace: Namespace,
   tokenSecret: Secret,
   cachePvc: PersistentVolumeClaim,
-  serviceAccountName: string
+  serviceAccountName: string,
+  repo: string
 ): void {
   const configMap = new k8s.core.v1.ConfigMap(
     'gha-runner-config',
@@ -309,6 +311,7 @@ function installDockerRunnerScaleSets(
         dockerClientConfigSecret,
         spec.resources,
         serviceAccountName,
+        repo,
         dependsOn
       );
     });
@@ -324,9 +327,10 @@ function installK8sRunnerScaleSet(
   runnersNamespace: Namespace,
   name: string,
   tokenSecret: Secret,
-  cachePvcName: string,
+  cachePvcName: pulumi.Output<string>,
   resources: K8sResourceSchema,
   serviceAccountName: string,
+  repo: string,
   dependsOn: Resource[],
   performanceTestsDb: PerformanceTestDb
 ): Release {
@@ -412,8 +416,6 @@ function installK8sRunnerScaleSet(
 
   const runnerImage = `${DOCKER_REPO}/splice-test-runner-hook:${ghaConfig.runnerHookVersion}`;
 
-  const repo = ghaConfig.githubRepo;
-
   return new k8s.helm.v3.Release(
     name,
     {
@@ -421,7 +423,7 @@ function installK8sRunnerScaleSet(
       version: ghaConfig.runnerScaleSetVersion,
       namespace: runnersNamespace.metadata.name,
       values: {
-        githubConfigUrl: repo,
+        githubConfigUrl: `${ghaConfig.githubOrg}/${repo}`,
         githubConfigSecret: tokenSecret.metadata.name,
         runnerScaleSetName: name,
         listenerTemplate: {
@@ -644,9 +646,10 @@ function installK8sRunnerScaleSets(
   controller: k8s.helm.v3.Release,
   runnersNamespace: Namespace,
   tokenSecret: Secret,
-  cachePvcName: string,
+  cachePvcName: pulumi.Output<string>,
   serviceAccountName: string,
-  performanceTestsDb: PerformanceTestDb
+  performanceTestsDb: PerformanceTestDb,
+  repo: string
 ): void {
   const dependsOn = [controller, runnersNamespace, tokenSecret, performanceTestsDb.db];
 
@@ -660,6 +663,7 @@ function installK8sRunnerScaleSets(
         cachePvcName,
         spec.resources,
         serviceAccountName,
+        repo,
         dependsOn,
         performanceTestsDb
       );
@@ -700,16 +704,17 @@ function installPodMonitor(runnersNamespace: Namespace) {
   );
 }
 
-const GHA_NAMESPACE_NAME = 'gha-runners';
-export function installRunnerScaleSets(controller: k8s.helm.v3.Release): void {
-  const runnersNamespace = new Namespace(GHA_NAMESPACE_NAME, {
+export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: string): void {
+  const namespace_name = `gha-runners-${repo}`;
+
+  const runnersNamespace = new Namespace(namespace_name, {
     metadata: {
-      name: GHA_NAMESPACE_NAME,
+      name: namespace_name,
     },
   });
   const exactNs: ExactNamespace = {
     ns: runnersNamespace,
-    logicalName: GHA_NAMESPACE_NAME,
+    logicalName: namespace_name,
   };
 
   const tokenSecret = new k8s.core.v1.Secret(
@@ -736,21 +741,22 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release): void {
       dependsOn: runnersNamespace,
     }
   );
-  const cachePvcName = 'gha-cache-pvc';
-  const cachePvc = createCachePvc(runnersNamespace, cachePvcName);
+  // For security reasons, we isolate the caches of different repos
+  const cachePvc = createCachePvc(runnersNamespace, repo);
 
   const saName = 'k8s-runners';
   installRunnersServiceAccount(runnersNamespace, saName);
 
   const performanceTestsDb = createCloudSQLInstanceForPerformanceTests(exactNs);
-  installDockerRunnerScaleSets(controller, runnersNamespace, tokenSecret, cachePvc, saName);
+  installDockerRunnerScaleSets(controller, runnersNamespace, tokenSecret, cachePvc, saName, repo);
   installK8sRunnerScaleSets(
     controller,
     runnersNamespace,
     tokenSecret,
-    cachePvcName,
+    cachePvc.metadata.name,
     saName,
-    performanceTestsDb
+    performanceTestsDb,
+    repo
   );
   installPodMonitor(runnersNamespace);
 }

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -679,11 +679,11 @@ function installK8sRunnerScaleSets(
     });
 }
 
-function installPodMonitor(runnersNamespace: Namespace) {
+function installPodMonitor(runnersNamespace: Namespace, repo: string) {
   // Define a PodMonitor to scrape metrics from the workflow runner pods
   // (identified by the presence of the 'runner-pod' label).
   return new k8s.apiextensions.CustomResource(
-    'workflow-runner-pod-monitor',
+    `workflow-runner-pod-monitor-${repo}`,
     {
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'PodMonitor',
@@ -767,5 +767,5 @@ export function installRunnerScaleSets(controller: k8s.helm.v3.Release, repo: st
     repo,
     performanceTestsDb
   );
-  installPodMonitor(runnersNamespace);
+  installPodMonitor(runnersNamespace, repo);
 }

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -335,7 +335,7 @@ function installK8sRunnerScaleSet(
   dependsOn: Resource[],
   performanceTestsDb?: PerformanceTestDb
 ): Release {
-  const podConfigMapName = `${name}-pod-config`;
+  const podConfigMapName = `${name}-pod-config-${repo}`;
   // A configMap that will be mounted to runner pods and provide additional pod spec for the workflow pods
   const workflowPodConfigMap = cachePvcName.apply(cachePvcName =>
     new k8s.core.v1.ConfigMap(

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -72,7 +72,7 @@ function installDockerRunnerScaleSet(
   dependsOn: Resource[]
 ): k8s.helm.v3.Release {
   return new k8s.helm.v3.Release(
-    name,
+    `${name}-${repo}`,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,
@@ -419,7 +419,7 @@ function installK8sRunnerScaleSet(
   const runnerImage = `${DOCKER_REPO}/splice-test-runner-hook:${ghaConfig.runnerHookVersion}`;
 
   return new k8s.helm.v3.Release(
-    name,
+    `${name}-${repo}`,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -261,10 +261,10 @@ function installDockerRunnerScaleSets(
   repo: string
 ): void {
   const configMap = new k8s.core.v1.ConfigMap(
-    'gha-runner-config',
+    `gha-runner-config-${repo}`,
     {
       metadata: {
-        name: 'gha-runner-config',
+        name: `gha-runner-config-${repo}`,
         namespace: runnersNamespace.metadata.name,
       },
       data: {


### PR DESCRIPTION
Goal: support feature-forks of Splice

I initially thought we'd have a stack per repo, but then decided that we want them fully aligned, otherwise it will just be confusing, so a single stack for all seems like a better way to guarantee that.

Tested with previews from cn-internal that with only splice, the change is only stuff (including the namespace) getting a `-splice` suffix, and that with more repos, more copies get created in other namespaces.

(the config is not backward compatible, was a bit too annoying to make it such, so bumping splice in cn-internal to this will need to come with a small config change in `deployments/splice`)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
