### PR TITLE
helm, info, status: Fix runtime root json

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
@@ -41,6 +41,7 @@ class DsoPreflightIntegrationTest
 
       val urls = Array(
         s"${infoUrl}",
+        s"${infoUrl}/runtime/",
         s"${infoUrl}/runtime/dso.json",
         s"${infoUrl}/runtime/status.json",
       )
@@ -60,6 +61,12 @@ class DsoPreflightIntegrationTest
             val body = response.body()
             val json = parse(body).getOrElse(fail("Invalid JSON"))
             assert(json.isObject, s"Response body must be a JSON object, but got: $body")
+            if (url == s"${infoUrl}/runtime/") {
+              val expected = parse(
+                """{"dso":"/runtime/dso.json","status":"/runtime/status.json"}"""
+              ).getOrElse(fail("Hardcoded JSON invalid"))
+              assert(json == expected, s"Expected $expected but got $json")
+            }
           }
         }
       }

--- a/cluster/helm/splice-info/scripts/updater.sh
+++ b/cluster/helm/splice-info/scripts/updater.sh
@@ -21,8 +21,8 @@ jq -n \
   --arg status "/$status_json_path" \
   '
     {
-      dso,
-      status,
+      $dso,
+      $status,
     }
   ' > "$runtime_index_file"
 


### PR DESCRIPTION
Before: `{"dso":null,"status":null}`
After: `{"dso":"/runtime/dso.json","status":"/runtime/status.json"}`