### PR TITLE
Scan: Reward accounting root-hash and activity-totals return three values

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -385,7 +385,7 @@ abstract class ScanAppReference(
   @Help.Summary("Get CIP-0104 activity totals for a specific round")
   def getRewardAccountingActivityTotals(
       roundNumber: Long
-  ): Option[definitions.GetRewardAccountingActivityTotalsResponse] =
+  ): definitions.GetRewardAccountingActivityTotalsResponse =
     consoleEnvironment.run {
       httpCommand(HttpScanAppClient.GetRewardAccountingActivityTotals(roundNumber))
     }
@@ -393,7 +393,7 @@ abstract class ScanAppReference(
   @Help.Summary("Get CIP-0104 root hash for a specific round")
   def getRewardAccountingRootHash(
       roundNumber: Long
-  ): Option[definitions.GetRewardAccountingRootHashResponse] =
+  ): definitions.GetRewardAccountingRootHashResponse =
     consoleEnvironment.run {
       httpCommand(HttpScanAppClient.GetRewardAccountingRootHash(roundNumber))
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -19,6 +19,8 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
 }
 import org.lfdecentralizedtrust.splice.http.v0.definitions
 import definitions.DamlValueEncoding.members.CompactJson
+import definitions.GetRewardAccountingActivityTotalsResponse
+import definitions.GetRewardAccountingRootHashResponse
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
 import org.lfdecentralizedtrust.splice.integration.tests.TokenStandardTest.CreateAllocationRequestResult
@@ -88,9 +90,11 @@ class TrafficBasedRewardsTimeBasedIntegrationTest
 
     assertOldestOpenRound(0)
 
-    clue("Reward accounting endpoints return 404 before any data is available") {
+    clue("Reward accounting endpoints report 'Undetermined' before any data is available") {
       sv1ScanBackend.getRewardAccountingEarliestAvailableRound() shouldBe None
-      sv1ScanBackend.getRewardAccountingActivityTotals(0L) shouldBe None
+      sv1ScanBackend.getRewardAccountingActivityTotals(0L) shouldBe an[
+        GetRewardAccountingActivityTotalsResponse.members.RewardAccountingActivityTotalsUndetermined
+      ]
     }
 
     // Here we perform all settlements with verdict ingestion paused just to
@@ -237,26 +241,38 @@ class TrafficBasedRewardsTimeBasedIntegrationTest
     }
 
     clue("Verify activity totals for the computed round") {
-      val totals = sv1ScanBackend.getRewardAccountingActivityTotals(earliest)
-      totals.value.roundNumber shouldBe earliest
-      totals.value.activityRecordsCount should be > 0L
+      val totals = inside(sv1ScanBackend.getRewardAccountingActivityTotals(earliest)) {
+        case GetRewardAccountingActivityTotalsResponse.members
+              .RewardAccountingActivityTotalsOk(t) =>
+          t
+      }
+      totals.roundNumber shouldBe earliest
+      totals.activityRecordsCount should be > 0L
     }
 
     clue("Verify root hash is available") {
-      val rootHash = sv1ScanBackend.getRewardAccountingRootHash(earliest)
-      rootHash shouldBe defined
-      rootHash.value.roundNumber shouldBe earliest
-      rootHash.value.rootHash should have length 64 // hex-encoded SHA-256
+      val rootHash = inside(sv1ScanBackend.getRewardAccountingRootHash(earliest)) {
+        case GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashOk(h) => h
+      }
+      rootHash.roundNumber shouldBe earliest
+      rootHash.rootHash should have length 64 // hex-encoded SHA-256
     }
 
     clue("Verify batch lookup for root hash returns batch contents") {
-      val rootHashHex = sv1ScanBackend.getRewardAccountingRootHash(earliest).value.rootHash
+      val rootHashHex = inside(sv1ScanBackend.getRewardAccountingRootHash(earliest)) {
+        case GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashOk(h) =>
+          h.rootHash
+      }
       sv1ScanBackend.getRewardAccountingBatch(earliest, rootHashHex) shouldBe defined
     }
 
-    clue("Verify 404 for non-existent data") {
-      sv1ScanBackend.getRewardAccountingActivityTotals(earliest + 100) shouldBe None
-      sv1ScanBackend.getRewardAccountingRootHash(earliest + 100) shouldBe None
+    clue("Verify response for non-existent data") {
+      sv1ScanBackend.getRewardAccountingActivityTotals(earliest + 100) shouldBe an[
+        GetRewardAccountingActivityTotalsResponse.members.RewardAccountingActivityTotalsUndetermined
+      ]
+      sv1ScanBackend.getRewardAccountingRootHash(earliest + 100) shouldBe an[
+        GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashUndetermined
+      ]
       sv1ScanBackend.getRewardAccountingBatch(earliest, "0" * 64) shouldBe None
     }
   }

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1901,8 +1901,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GetRewardAccountingActivityTotalsResponse"
-        "404":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
 
   /v0/reward-accounting-process/rounds/{round_number}/root-hash:
     get:
@@ -1926,8 +1924,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GetRewardAccountingRootHashResponse"
-        "404":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
 
   /v0/reward-accounting-process/rounds/{round_number}/batches/{batch_hash}:
     get:
@@ -4701,12 +4697,28 @@ components:
 
     GetRewardAccountingActivityTotalsResponse:
       type: object
+      oneOf:
+        - "$ref": "#/components/schemas/RewardAccountingActivityTotalsOk"
+        - "$ref": "#/components/schemas/RewardAccountingActivityTotalsUndetermined"
+        - "$ref": "#/components/schemas/RewardAccountingActivityTotalsCannotProvide"
+      discriminator:
+        propertyName: status
+        mapping:
+          Ok: "#/components/schemas/RewardAccountingActivityTotalsOk"
+          Undetermined: "#/components/schemas/RewardAccountingActivityTotalsUndetermined"
+          CannotProvide: "#/components/schemas/RewardAccountingActivityTotalsCannotProvide"
+
+    RewardAccountingActivityTotalsOk:
+      type: object
       required:
+        - status
         - round_number
         - total_app_activity_weight
         - active_parties_count
         - activity_records_count
       properties:
+        status:
+          type: string
         round_number:
           type: integer
           format: int64
@@ -4720,18 +4732,66 @@ components:
           type: integer
           format: int64
 
-    GetRewardAccountingRootHashResponse:
+    RewardAccountingActivityTotalsUndetermined:
       type: object
       required:
+        - status
+      properties:
+        status:
+          type: string
+
+    RewardAccountingActivityTotalsCannotProvide:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+
+    GetRewardAccountingRootHashResponse:
+      type: object
+      oneOf:
+        - "$ref": "#/components/schemas/RewardAccountingRootHashOk"
+        - "$ref": "#/components/schemas/RewardAccountingRootHashUndetermined"
+        - "$ref": "#/components/schemas/RewardAccountingRootHashCannotProvide"
+      discriminator:
+        propertyName: status
+        mapping:
+          Ok: "#/components/schemas/RewardAccountingRootHashOk"
+          Undetermined: "#/components/schemas/RewardAccountingRootHashUndetermined"
+          CannotProvide: "#/components/schemas/RewardAccountingRootHashCannotProvide"
+
+    RewardAccountingRootHashOk:
+      type: object
+      required:
+        - status
         - round_number
         - root_hash
       properties:
+        status:
+          type: string
         round_number:
           type: integer
           format: int64
         root_hash:
           type: string
           description: Hex-encoded root hash
+
+    RewardAccountingRootHashUndetermined:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+
+    RewardAccountingRootHashCannotProvide:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
 
     GetRewardAccountingBatchResponse:
       type: object

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1859,7 +1859,7 @@ paths:
         "500":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
 
-  /v0/reward-accounting-process/rounds/earliest-available:
+  /v0/internal/reward-accounting-process/rounds/earliest-available:
     get:
       tags: [internal, scan]
       x-jvm-package: scan
@@ -1878,7 +1878,7 @@ paths:
         "404":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
 
-  /v0/reward-accounting-process/rounds/{round_number}/activity-totals:
+  /v0/internal/reward-accounting-process/rounds/{round_number}/activity-totals:
     get:
       tags: [internal, scan]
       x-jvm-package: scan
@@ -1902,7 +1902,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/GetRewardAccountingActivityTotalsResponse"
 
-  /v0/reward-accounting-process/rounds/{round_number}/root-hash:
+  /v0/internal/reward-accounting-process/rounds/{round_number}/root-hash:
     get:
       tags: [internal, scan]
       x-jvm-package: scan
@@ -1925,7 +1925,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/GetRewardAccountingRootHashResponse"
 
-  /v0/reward-accounting-process/rounds/{round_number}/batches/{batch_hash}:
+  /v0/internal/reward-accounting-process/rounds/{round_number}/batches/{batch_hash}:
     get:
       tags: [internal, scan]
       x-jvm-package: scan

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -36,6 +36,8 @@ import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.http.v0.definitions.{
   AnsEntry,
   GetDsoInfoResponse,
+  GetRewardAccountingBatchResponse,
+  GetRewardAccountingRootHashResponse,
   HoldingsSummaryRequestV1,
   HoldingsSummaryResponse,
   HoldingsSummaryResponseV1,
@@ -740,6 +742,18 @@ class BftScanConnection(
       ec: ExecutionContext,
       tc: TraceContext,
   ): Future[NonNegativeInt] = bftCall(_.getActivePhysicalSynchronizerSerial())
+
+  override def getRewardAccountingRootHash(roundNumber: Long)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[GetRewardAccountingRootHashResponse] =
+    bftCall(_.getRewardAccountingRootHash(roundNumber))
+
+  override def getRewardAccountingBatch(roundNumber: Long, batchHash: String)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[Option[GetRewardAccountingBatchResponse]] =
+    bftCall(_.getRewardAccountingBatch(roundNumber, batchHash))
 }
 trait HasUrl {
   def url: Uri

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
@@ -25,6 +25,8 @@ import org.lfdecentralizedtrust.splice.environment.*
 import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.http.v0.definitions.{
   GetDsoInfoResponse,
+  GetRewardAccountingBatchResponse,
+  GetRewardAccountingRootHashResponse,
   HoldingsSummaryResponse,
   HoldingsSummaryResponseV1,
   LookupTransferCommandStatusResponse,
@@ -322,6 +324,16 @@ trait ScanConnection
       ec: ExecutionContext,
       tc: TraceContext,
   ): Future[NonNegativeInt]
+
+  def getRewardAccountingRootHash(roundNumber: Long)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[GetRewardAccountingRootHashResponse]
+
+  def getRewardAccountingBatch(roundNumber: Long, batchHash: String)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[Option[GetRewardAccountingBatchResponse]]
 
 }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
@@ -31,6 +31,8 @@ import org.lfdecentralizedtrust.splice.environment.{
 }
 import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.http.v0.definitions.{
+  GetRewardAccountingBatchResponse,
+  GetRewardAccountingRootHashResponse,
   HoldingsSummaryRequestV1,
   HoldingsSummaryResponse,
   HoldingsSummaryResponseV1,
@@ -823,6 +825,24 @@ class SingleScanConnection private[client] (
     runHttpCmd(
       config.adminApi.url,
       HttpScanAppClient.GetActivePhysicalSynchronizerSerial(),
+    )
+
+  override def getRewardAccountingRootHash(roundNumber: Long)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[GetRewardAccountingRootHashResponse] =
+    runHttpCmd(
+      config.adminApi.url,
+      HttpScanAppClient.GetRewardAccountingRootHash(roundNumber),
+    )
+
+  override def getRewardAccountingBatch(roundNumber: Long, batchHash: String)(implicit
+      ec: ExecutionContext,
+      tc: TraceContext,
+  ): Future[Option[GetRewardAccountingBatchResponse]] =
+    runHttpCmd(
+      config.adminApi.url,
+      HttpScanAppClient.GetRewardAccountingBatch(roundNumber, batchHash),
     )
 }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -2900,7 +2900,7 @@ object HttpScanAppClient {
   case class GetRewardAccountingActivityTotals(roundNumber: Long)
       extends InternalBaseCommand[
         http.GetRewardAccountingActivityTotalsResponse,
-        Option[definitions.GetRewardAccountingActivityTotalsResponse],
+        definitions.GetRewardAccountingActivityTotalsResponse,
       ] {
     override def submitRequest(
         client: ScanClient,
@@ -2913,16 +2913,14 @@ object HttpScanAppClient {
 
     override def handleOk()(implicit decoder: TemplateJsonDecoder) = {
       case http.GetRewardAccountingActivityTotalsResponse.OK(response) =>
-        Right(Some(response))
-      case http.GetRewardAccountingActivityTotalsResponse.NotFound(_) =>
-        Right(None)
+        Right(response)
     }
   }
 
   case class GetRewardAccountingRootHash(roundNumber: Long)
       extends InternalBaseCommand[
         http.GetRewardAccountingRootHashResponse,
-        Option[definitions.GetRewardAccountingRootHashResponse],
+        definitions.GetRewardAccountingRootHashResponse,
       ] {
     override def submitRequest(
         client: ScanClient,
@@ -2935,9 +2933,7 @@ object HttpScanAppClient {
 
     override def handleOk()(implicit decoder: TemplateJsonDecoder) = {
       case http.GetRewardAccountingRootHashResponse.OK(response) =>
-        Right(Some(response))
-      case http.GetRewardAccountingRootHashResponse.NotFound(_) =>
-        Right(None)
+        Right(response)
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2998,31 +2998,53 @@ class HttpScanHandler(
   ] = {
     implicit val tc = extracted
     withSpan(s"$workflowId.getRewardAccountingActivityTotals") { _ => _ =>
-      appRewardsStoreO match {
-        case None =>
+      (appRewardsStoreO, appActivityStoreO) match {
+        case (Some(appRewardsStore), Some(appActivityStore)) =>
+          appRewardsStore.getAppActivityRoundTotalByRound(roundNumber).flatMap {
+            case Some(roundTotal) =>
+              Future.successful(
+                ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
+                  definitions.GetRewardAccountingActivityTotalsResponse(
+                    definitions.RewardAccountingActivityTotalsOk(
+                      status = "Ok",
+                      roundNumber = roundTotal.roundNumber,
+                      totalAppActivityWeight = roundTotal.totalRoundAppActivityWeight,
+                      activePartiesCount = roundTotal.activeAppProviderPartiesCount,
+                      activityRecordsCount = roundTotal.activityRecordsCount,
+                    )
+                  )
+                )
+              )
+            case None =>
+              appActivityStore.earliestRoundWithCompleteAppActivity().map {
+                case Some(earliest) if roundNumber < earliest =>
+                  ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
+                    definitions.GetRewardAccountingActivityTotalsResponse(
+                      definitions.RewardAccountingActivityTotalsCannotProvide(
+                        status = "CannotProvide"
+                      )
+                    )
+                  )
+                case _ =>
+                  ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
+                    definitions.GetRewardAccountingActivityTotalsResponse(
+                      definitions.RewardAccountingActivityTotalsUndetermined(
+                        status = "Undetermined"
+                      )
+                    )
+                  )
+              }
+          }
+        case _ =>
           Future.successful(
-            ScanResource.GetRewardAccountingActivityTotalsResponse.NotFound(
-              ErrorResponse("Reward accounting is not enabled on this node")
+            ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
+              definitions.GetRewardAccountingActivityTotalsResponse(
+                definitions.RewardAccountingActivityTotalsCannotProvide(
+                  status = "CannotProvide"
+                )
+              )
             )
           )
-        case Some(appRewardsStore) =>
-          appRewardsStore.getAppActivityRoundTotalByRound(roundNumber).map {
-            case None =>
-              ScanResource.GetRewardAccountingActivityTotalsResponse.NotFound(
-                ErrorResponse(
-                  s"Activity totals not (yet) computed for round $roundNumber"
-                )
-              )
-            case Some(roundTotal) =>
-              ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
-                definitions.GetRewardAccountingActivityTotalsResponse(
-                  roundNumber = roundTotal.roundNumber,
-                  totalAppActivityWeight = roundTotal.totalRoundAppActivityWeight,
-                  activePartiesCount = roundTotal.activeAppProviderPartiesCount,
-                  activityRecordsCount = roundTotal.activityRecordsCount,
-                )
-              )
-          }
       }
     }
   }
@@ -3034,29 +3056,51 @@ class HttpScanHandler(
   ] = {
     implicit val tc = extracted
     withSpan(s"$workflowId.getRewardAccountingRootHash") { _ => _ =>
-      appRewardsStoreO match {
-        case None =>
+      (appRewardsStoreO, appActivityStoreO) match {
+        case (Some(appRewardsStore), Some(appActivityStore)) =>
+          appRewardsStore.getAppRewardRootHashByRound(roundNumber).flatMap {
+            case Some(rootHash) =>
+              Future.successful(
+                ScanResource.GetRewardAccountingRootHashResponse.OK(
+                  definitions.GetRewardAccountingRootHashResponse(
+                    definitions.RewardAccountingRootHashOk(
+                      status = "Ok",
+                      roundNumber = rootHash.roundNumber,
+                      rootHash = rootHash.rootHash.toHex,
+                    )
+                  )
+                )
+              )
+            case None =>
+              appActivityStore.earliestRoundWithCompleteAppActivity().map {
+                case Some(earliest) if roundNumber < earliest =>
+                  ScanResource.GetRewardAccountingRootHashResponse.OK(
+                    definitions.GetRewardAccountingRootHashResponse(
+                      definitions.RewardAccountingRootHashCannotProvide(
+                        status = "CannotProvide"
+                      )
+                    )
+                  )
+                case _ =>
+                  ScanResource.GetRewardAccountingRootHashResponse.OK(
+                    definitions.GetRewardAccountingRootHashResponse(
+                      definitions.RewardAccountingRootHashUndetermined(
+                        status = "Undetermined"
+                      )
+                    )
+                  )
+              }
+          }
+        case _ =>
           Future.successful(
-            ScanResource.GetRewardAccountingRootHashResponse.NotFound(
-              ErrorResponse("Reward accounting is not enabled on this node")
+            ScanResource.GetRewardAccountingRootHashResponse.OK(
+              definitions.GetRewardAccountingRootHashResponse(
+                definitions.RewardAccountingRootHashCannotProvide(
+                  status = "CannotProvide"
+                )
+              )
             )
           )
-        case Some(appRewardsStore) =>
-          appRewardsStore.getAppRewardRootHashByRound(roundNumber).map {
-            case None =>
-              ScanResource.GetRewardAccountingRootHashResponse.NotFound(
-                ErrorResponse(
-                  s"Root hash not (yet) computed for round $roundNumber"
-                )
-              )
-            case Some(rootHash) =>
-              ScanResource.GetRewardAccountingRootHashResponse.OK(
-                definitions.GetRewardAccountingRootHashResponse(
-                  roundNumber = rootHash.roundNumber,
-                  rootHash = rootHash.rootHash.toHex,
-                )
-              )
-          }
       }
     }
   }

--- a/cluster/configs/shared/rate-limits/unlimited.yaml
+++ b/cluster/configs/shared/rate-limits/unlimited.yaml
@@ -205,7 +205,7 @@ rateLimits:
     name: rollForwardLsu
     type: unlimited
 
-  /api/scan/v0/reward-accounting-process:
+  /api/scan/v0/internal/reward-accounting-process:
     name: reward-accounting-process
     type: unlimited
 

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -260,14 +260,14 @@ sv:
         /api/scan/v0/holdings:
           name: 'holdings'
           type: 'unlimited'
+        /api/scan/v0/internal/reward-accounting-process:
+          name: 'reward-accounting-process'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
-          type: 'unlimited'
-        /api/scan/v0/internal/reward-accounting-process:
-          name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:
           name: 'rewards-collected'

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -266,7 +266,7 @@ sv:
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
           type: 'unlimited'
-        /api/scan/v0/reward-accounting-process:
+        /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -260,14 +260,14 @@ sv:
         /api/scan/v0/holdings:
           name: 'holdings'
           type: 'unlimited'
+        /api/scan/v0/internal/reward-accounting-process:
+          name: 'reward-accounting-process'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
-          type: 'unlimited'
-        /api/scan/v0/internal/reward-accounting-process:
-          name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:
           name: 'rewards-collected'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -266,7 +266,7 @@ sv:
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
           type: 'unlimited'
-        /api/scan/v0/reward-accounting-process:
+        /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -260,14 +260,14 @@ sv:
         /api/scan/v0/holdings:
           name: 'holdings'
           type: 'unlimited'
+        /api/scan/v0/internal/reward-accounting-process:
+          name: 'reward-accounting-process'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
-          type: 'unlimited'
-        /api/scan/v0/internal/reward-accounting-process:
-          name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:
           name: 'rewards-collected'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -266,7 +266,7 @@ sv:
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
           type: 'unlimited'
-        /api/scan/v0/reward-accounting-process:
+        /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -260,14 +260,14 @@ sv:
         /api/scan/v0/holdings:
           name: 'holdings'
           type: 'unlimited'
+        /api/scan/v0/internal/reward-accounting-process:
+          name: 'reward-accounting-process'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
-          type: 'unlimited'
-        /api/scan/v0/internal/reward-accounting-process:
-          name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:
           name: 'rewards-collected'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -266,7 +266,7 @@ sv:
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
           type: 'unlimited'
-        /api/scan/v0/reward-accounting-process:
+        /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -260,14 +260,14 @@ sv:
         /api/scan/v0/holdings:
           name: 'holdings'
           type: 'unlimited'
+        /api/scan/v0/internal/reward-accounting-process:
+          name: 'reward-accounting-process'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
-          type: 'unlimited'
-        /api/scan/v0/internal/reward-accounting-process:
-          name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:
           name: 'rewards-collected'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -266,7 +266,7 @@ sv:
         /api/scan/v0/open-and-issuing-mining-rounds:
           name: 'open-and-issuing-mining-rounds'
           type: 'unlimited'
-        /api/scan/v0/reward-accounting-process:
+        /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
         /api/scan/v0/rewards-collected:

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1671,7 +1671,7 @@
           "name": "open-and-issuing-mining-rounds",
           "type": "unlimited"
         },
-        "/api/scan/v0/reward-accounting-process": {
+        "/api/scan/v0/internal/reward-accounting-process": {
           "name": "reward-accounting-process",
           "type": "unlimited"
         },
@@ -1938,7 +1938,7 @@
           "name": "open-and-issuing-mining-rounds",
           "type": "unlimited"
         },
-        "/api/scan/v0/reward-accounting-process": {
+        "/api/scan/v0/internal/reward-accounting-process": {
           "name": "reward-accounting-process",
           "type": "unlimited"
         },

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1663,16 +1663,16 @@
           "name": "holdings",
           "type": "unlimited"
         },
+        "/api/scan/v0/internal/reward-accounting-process": {
+          "name": "reward-accounting-process",
+          "type": "unlimited"
+        },
         "/api/scan/v0/migrations": {
           "name": "migrations-schedule",
           "type": "unlimited"
         },
         "/api/scan/v0/open-and-issuing-mining-rounds": {
           "name": "open-and-issuing-mining-rounds",
-          "type": "unlimited"
-        },
-        "/api/scan/v0/internal/reward-accounting-process": {
-          "name": "reward-accounting-process",
           "type": "unlimited"
         },
         "/api/scan/v0/rewards-collected": {
@@ -1930,16 +1930,16 @@
           "name": "holdings",
           "type": "unlimited"
         },
+        "/api/scan/v0/internal/reward-accounting-process": {
+          "name": "reward-accounting-process",
+          "type": "unlimited"
+        },
         "/api/scan/v0/migrations": {
           "name": "migrations-schedule",
           "type": "unlimited"
         },
         "/api/scan/v0/open-and-issuing-mining-rounds": {
           "name": "open-and-issuing-mining-rounds",
-          "type": "unlimited"
-        },
-        "/api/scan/v0/internal/reward-accounting-process": {
-          "name": "reward-accounting-process",
           "type": "unlimited"
         },
         "/api/scan/v0/rewards-collected": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -949,16 +949,16 @@
           "name": "holdings",
           "type": "unlimited"
         },
+        "/api/scan/v0/internal/reward-accounting-process": {
+          "name": "reward-accounting-process",
+          "type": "unlimited"
+        },
         "/api/scan/v0/migrations": {
           "name": "migrations-schedule",
           "type": "unlimited"
         },
         "/api/scan/v0/open-and-issuing-mining-rounds": {
           "name": "open-and-issuing-mining-rounds",
-          "type": "unlimited"
-        },
-        "/api/scan/v0/internal/reward-accounting-process": {
-          "name": "reward-accounting-process",
           "type": "unlimited"
         },
         "/api/scan/v0/rewards-collected": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -957,7 +957,7 @@
           "name": "open-and-issuing-mining-rounds",
           "type": "unlimited"
         },
-        "/api/scan/v0/reward-accounting-process": {
+        "/api/scan/v0/internal/reward-accounting-process": {
           "name": "reward-accounting-process",
           "type": "unlimited"
         },


### PR DESCRIPTION
Modified the following endpoints to return "undetermined" and "cannot-compute" values, in addition to the result.
- /v0/reward-accounting-process/rounds/{round_number}/activity-totals
- /v0/reward-accounting-process/rounds/{round_number}/root-hash

As discussed last week with Simon and Robert; these are the criterion for the return value selection.
- undetermined
  returned if scan does not see any CalculateRewardsContract with a round number <= the queried round
or if the root hash (and associated data) is not found in the store
- cannot-compute	
   if scan does not have a complete set of activity records for the round

But in the code the "undetermined" is actually a catch-all case, because even if the `CalculateRewardsV2` exist for this round, and the scan is yet to compute the totals, "undetermined" would still work since the sv-app would retry.

As these are `internal` endpoints, marked as "subject to change", the existing /v0 endpoints have been modified, and PR has no release-notes mention. (original addition of these endpoints also did not have release-notes entry)

```
  /v0/reward-accounting-process/rounds/{round_number}/root-hash:
    get:
      tags: [internal, scan]
      x-jvm-package: scan
      operationId: "getRewardAccountingRootHash"
      description: |
        SV node internal API (CIP-0104, subject to change).
        Returns the root hash computed for the specified round.

```

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
