### PR TITLE
Fix backup scripts for when we have archived migrations

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -440,7 +440,7 @@ function k8s_labels_for_app() {
     local domain_specific_apps="@(participant|multi-participant-[0-9][0-9])"
     local logical_synchronizer_deployment_mode
     logical_synchronizer_deployment_mode=$( \
-        get_resolved_config | yq ".synchronizerMigration[]? | select(.id == ${domain}) | .enableLogicalSynchronizerDeploymentMode" 2>/dev/null || true \
+        get_resolved_config | yq ".synchronizerMigration | .archived + [.active] | .[] | select(.id == ${domain}) | .enableLogicalSynchronizerDeploymentMode" 2>/dev/null || true \
     )
 
     # shellcheck disable=SC2076

--- a/cluster/scripts/node-backup.sh
+++ b/cluster/scripts/node-backup.sh
@@ -303,7 +303,7 @@ function main() {
   local hyperdisk_enabled
   hyperdisk_enabled=$(echo "$config" | yq '.cluster.hyperdiskSupport.enabled // false')
   local logical_synchronizer_mode="false"
-  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .acrhived + [.active] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
+  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .archived + [.active] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
   if [ -z "$logical_synchronizer_mode" ]; then
     logical_synchronizer_mode="false"
   fi

--- a/cluster/scripts/node-backup.sh
+++ b/cluster/scripts/node-backup.sh
@@ -303,7 +303,7 @@ function main() {
   local hyperdisk_enabled
   hyperdisk_enabled=$(echo "$config" | yq '.cluster.hyperdiskSupport.enabled // false')
   local logical_synchronizer_mode="false"
-  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration[]? | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
+  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .acrhived + [.active] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
   if [ -z "$logical_synchronizer_mode" ]; then
     logical_synchronizer_mode="false"
   fi

--- a/cluster/scripts/node-restore.sh
+++ b/cluster/scripts/node-restore.sh
@@ -435,7 +435,7 @@ function main() {
   local hyperdisk_enabled
   hyperdisk_enabled=$(echo "$config" | yq '.cluster.hyperdiskSupport.enabled // false')
   local logical_synchronizer_mode
-  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration[]? | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
+  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .archived + [.active] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
   if [ -z "$logical_synchronizer_mode" ]; then
     logical_synchronizer_mode="false"
   fi


### PR DESCRIPTION
...and also other places that break when we have those.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/8449

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
