### PR TITLE
Fix backup/restore scripts for when we have archived migrations

### DIFF
--- a/cluster/scripts/node-backup.sh
+++ b/cluster/scripts/node-backup.sh
@@ -303,7 +303,7 @@ function main() {
   local hyperdisk_enabled
   hyperdisk_enabled=$(echo "$config" | yq '.cluster.hyperdiskSupport.enabled // false')
   local logical_synchronizer_mode="false"
-  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration[]? | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
+  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .archived + [.active] + [.upgrade] + [.legacy] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
   if [ -z "$logical_synchronizer_mode" ]; then
     logical_synchronizer_mode="false"
   fi

--- a/cluster/scripts/node-restore.sh
+++ b/cluster/scripts/node-restore.sh
@@ -435,7 +435,7 @@ function main() {
   local hyperdisk_enabled
   hyperdisk_enabled=$(echo "$config" | yq '.cluster.hyperdiskSupport.enabled // false')
   local logical_synchronizer_mode
-  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration[]? | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
+  logical_synchronizer_mode=$(echo "$config" | yq ".synchronizerMigration | .archived + [.active] + [.upgrade] + [.legacy] | .[] | select(.id == ${migration_id}) | .enableLogicalSynchronizerDeploymentMode // false")
   if [ -z "$logical_synchronizer_mode" ]; then
     logical_synchronizer_mode="false"
   fi


### PR DESCRIPTION
This is #5578 , filtered for what makes sense on main + extended for correctness to also work with upgrade and legacy migration IDs.

[static]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
