### PR TITLE
GHA: Install artifactory creds via pulumi

### DIFF
--- a/cluster/pulumi/common/package.json
+++ b/cluster/pulumi/common/package.json
@@ -12,6 +12,7 @@
     "@pulumi/pulumi": "^3.230.0",
     "@pulumi/random": "4.19.2",
     "@pulumi/std": "2.3.2",
+    "@pulumi/github": "6.13.1",
     "@types/auth0": "^3.3.11",
     "auth0": "^5.6.0",
     "js-yaml": "^4.1.0",

--- a/cluster/pulumi/common/src/dockerConfig.ts
+++ b/cluster/pulumi/common/src/dockerConfig.ts
@@ -110,7 +110,7 @@ export class DockerConfig {
     return Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
   }
 
-  private static fetchCredentialsFromSecret(secretName: string): pulumi.Output<Credentials> {
+  public static fetchCredentialsFromSecret(secretName: string): pulumi.Output<Credentials> {
     const temp = getSecretVersionOutput({ secret: secretName });
     return temp.apply(k => {
       const secretData = k.secretData;

--- a/cluster/pulumi/common/src/dockerConfig.ts
+++ b/cluster/pulumi/common/src/dockerConfig.ts
@@ -5,7 +5,7 @@ import * as pulumi from '@pulumi/pulumi';
 import { getSecretVersionOutput } from '@pulumi/gcp/secretmanager/getSecretVersion';
 import { Secret } from '@pulumi/kubernetes/core/v1';
 
-type Credentials = {
+export type Credentials = {
   username: string;
   password: string;
 };

--- a/cluster/pulumi/gha/src/github.ts
+++ b/cluster/pulumi/gha/src/github.ts
@@ -10,24 +10,25 @@ export function installGithubRepo(repo: string): void {
     owner: ghaConfig.githubOrg.replaceAll('https://github.com/', ''), // TODO(#5570): after we change the config to be just the org, remove the replaceAll
   });
 
-  DockerConfig.fetchCredentialsFromSecret('artifactory-keys').apply(creds => {
-    new github.ActionsVariable(
-      'artifactory-user',
-      {
-        repository: repo,
-        variableName: 'ARTIFACTORY_USER',
-        value: creds.username,
-      },
-      { provider: orgProvider }
-    );
-    new github.ActionsSecret(
-      'artifactory-password',
-      {
-        repository: repo,
-        secretName: 'ARTIFACTORY_PASSWORD',
-        value: creds.password,
-      },
-      { provider: orgProvider }
-    );
-  });
+  // A bit ugly that we reuse this straight from DockerConfig, but we plan to
+  // retire artifactory altogether soon, so we don't bother cleaning this up.
+  const creds = DockerConfig.fetchCredentialsFromSecret('artifactory-keys');
+  new github.ActionsVariable(
+    `artifactory-user-${repo}`,
+    {
+      repository: repo,
+      variableName: 'ARTIFACTORY_USER',
+      value: creds.apply(creds => creds.username),
+    },
+    { provider: orgProvider }
+  );
+  new github.ActionsSecret(
+    `artifactory-password-${repo}`,
+    {
+      repository: repo,
+      secretName: 'ARTIFACTORY_PASSWORD',
+      value: creds.apply(creds => creds.password),
+    },
+    { provider: orgProvider }
+  );
 }

--- a/cluster/pulumi/gha/src/github.ts
+++ b/cluster/pulumi/gha/src/github.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as github from '@pulumi/github';
+
+import { ghaConfig } from './config';
+
+export function installGithubRepo(repo: string): void {
+  const githubRepo = `${ghaConfig.githubOrg}/${repo}`;
+  new github.ActionsVariable('example-variable', {
+    repository: githubRepo,
+    variableName: 'test_var',
+    value: 'test_value',
+  });
+}

--- a/cluster/pulumi/gha/src/github.ts
+++ b/cluster/pulumi/gha/src/github.ts
@@ -1,14 +1,23 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as github from '@pulumi/github';
+import { DockerConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/dockerConfig';
 
 import { ghaConfig } from './config';
 
 export function installGithubRepo(repo: string): void {
   const githubRepo = `${ghaConfig.githubOrg}/${repo}`;
-  new github.ActionsVariable('example-variable', {
-    repository: githubRepo,
-    variableName: 'test_var',
-    value: 'test_value',
+
+  DockerConfig.fetchCredentialsFromSecret('artifactory-keys').apply(creds => {
+    new github.ActionsVariable('example-variable', {
+      repository: githubRepo,
+      variableName: 'test_var',
+      value: creds.username,
+    });
+    new github.ActionsSecret('example-secret', {
+      repository: githubRepo,
+      secretName: 'test_secret',
+      value: creds.password,
+    });
   });
 }

--- a/cluster/pulumi/gha/src/github.ts
+++ b/cluster/pulumi/gha/src/github.ts
@@ -6,21 +6,28 @@ import { DockerConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/doc
 import { ghaConfig } from './config';
 
 export function installGithubRepo(repo: string): void {
-
-  const orgProvider = new github.Provider("canton-network-provider", {
-    owner: ghaConfig.githubOrg.replaceAll('https://github.com/', ''), // FIXME: This is ugly. change the config to not include the url prefix
+  const orgProvider = new github.Provider('canton-network-provider', {
+    owner: ghaConfig.githubOrg.replaceAll('https://github.com/', ''), // TODO(#5570): after we change the config to be just the org, remove the replaceAll
   });
 
   DockerConfig.fetchCredentialsFromSecret('artifactory-keys').apply(creds => {
-    new github.ActionsVariable('example-variable', {
-      repository: repo,
-      variableName: 'test_var',
-      value: creds.username,
-    }, { provider: orgProvider });
-    new github.ActionsSecret('example-secret', {
-      repository: repo,
-      secretName: 'test_secret',
-      value: creds.password,
-    }, { provider: orgProvider });
+    new github.ActionsVariable(
+      'artifactory-user',
+      {
+        repository: repo,
+        variableName: 'ARTIFACTORY_USER',
+        value: creds.username,
+      },
+      { provider: orgProvider }
+    );
+    new github.ActionsSecret(
+      'artifactory-password',
+      {
+        repository: repo,
+        secretName: 'ARTIFACTORY_PASSWORD',
+        value: creds.password,
+      },
+      { provider: orgProvider }
+    );
   });
 }

--- a/cluster/pulumi/gha/src/github.ts
+++ b/cluster/pulumi/gha/src/github.ts
@@ -6,18 +6,21 @@ import { DockerConfig } from '@lfdecentralizedtrust/splice-pulumi-common/src/doc
 import { ghaConfig } from './config';
 
 export function installGithubRepo(repo: string): void {
-  const githubRepo = `${ghaConfig.githubOrg}/${repo}`;
+
+  const orgProvider = new github.Provider("canton-network-provider", {
+    owner: ghaConfig.githubOrg.replaceAll('https://github.com/', ''), // FIXME: This is ugly. change the config to not include the url prefix
+  });
 
   DockerConfig.fetchCredentialsFromSecret('artifactory-keys').apply(creds => {
     new github.ActionsVariable('example-variable', {
-      repository: githubRepo,
+      repository: repo,
       variableName: 'test_var',
       value: creds.username,
-    });
+    }, { provider: orgProvider });
     new github.ActionsSecret('example-secret', {
-      repository: githubRepo,
+      repository: repo,
       secretName: 'test_secret',
       value: creds.password,
-    });
+    }, { provider: orgProvider });
   });
 }

--- a/cluster/pulumi/gha/src/index.ts
+++ b/cluster/pulumi/gha/src/index.ts
@@ -3,6 +3,7 @@
 import { ghaConfig } from './config';
 import { installController } from './controller';
 import { installDockerRegistryMirror } from './dockerMirror';
+import { installGithubRepo } from './github';
 import { installRunnerScaleSets } from './runners';
 
 installDockerRegistryMirror();
@@ -11,4 +12,5 @@ for (const repo of ghaConfig.githubRepos) {
   const runnersNamespaceName = `gha-runners-${repo}`;
   const controller = installController(repo, runnersNamespaceName);
   installRunnerScaleSets(controller, runnersNamespaceName, repo);
+  installGithubRepo(repo);
 }

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -79,7 +79,8 @@ function installDockerRunnerScaleSet(
       version: ghaConfig.runnerScaleSetVersion,
       namespace: runnersNamespace.metadata.name,
       values: {
-        githubConfigUrl: `${ghaConfig.githubOrg}/${repo}`,
+        // TODO(#5570): Change the org to not include the url, and drop the condition below (we made it conditional for backwards compatibility for now).
+        githubConfigUrl: `${ghaConfig.githubOrg.startsWith('https://github.com/') ? ghaConfig.githubOrg : `https://github.com/${ghaConfig.githubOrg}`}/${repo}`,
         githubConfigSecret: tokenSecret.metadata.name,
         runnerScaleSetName: name,
         listenerTemplate: {

--- a/cluster/pulumi/package-lock.json
+++ b/cluster/pulumi/package-lock.json
@@ -91,6 +91,7 @@
                 "@kubernetes/client-node": "^1.4.0",
                 "@pulumi/command": "1.2.1",
                 "@pulumi/gcp": "^9.18.0",
+                "@pulumi/github": "6.13.1",
                 "@pulumi/kubernetes": "4.28.0",
                 "@pulumi/pulumi": "^3.230.0",
                 "@pulumi/random": "4.19.2",
@@ -2953,6 +2954,15 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@pulumi/github": {
+            "version": "6.13.1",
+            "resolved": "https://registry.npmjs.org/@pulumi/github/-/github-6.13.1.tgz",
+            "integrity": "sha512-dvQtwXvhIqx7HHTe0+PzLooyboiNapDHOnxEbGd0jY6boFFuFJpT5LKapK25cjsc6s4qKduvLo2HZdo9UtH05g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.142.0"
             }
         },
         "node_modules/@pulumi/kubernetes": {

--- a/nix/extra-pulumi-packages.nix
+++ b/nix/extra-pulumi-packages.nix
@@ -60,6 +60,10 @@
         sha256 = "5be9d42d6393d1c4d58ea7a414f268f5bd237c445df57809d97533d6df474bf9";
       }
       {
+        url = "https://github.com/pulumi/pulumi-github/releases/download/v6.13.1/pulumi-resource-github-v6.13.1-linux-amd64.tar.gz";
+        sha256 = "0eabd8ab218b262185eae59e4dd754658e2715d6e2a570fc03230280dadc74e9";
+      }
+      {
         url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.16.3/pulumi-resource-grafana-v0.16.3-linux-amd64.tar.gz";
         sha256 = "4bbb9ad5ff6be2d74ad678c0dba925f95b770d05b5b2845829cea1871c863144";
       }
@@ -168,6 +172,10 @@
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v9.18.0/pulumi-resource-gcp-v9.18.0-darwin-amd64.tar.gz";
         sha256 = "4486d4815a7d8522c593cd7cd3841d914e23cd5ba82511141ead43d6d8fca446";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-github/releases/download/v6.13.1/pulumi-resource-github-v6.13.1-darwin-amd64.tar.gz";
+        sha256 = "5883098cba452a9b0200e76ff8bd9d4de4da171bc57c823bc1828b6d5fb7ba39";
       }
       {
         url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.16.3/pulumi-resource-grafana-v0.16.3-darwin-amd64.tar.gz";
@@ -280,6 +288,10 @@
         sha256 = "2df68e1ce24eb320fa65995e1ce998866e8a2d12ac04c98e367fc7fe07e332b2";
       }
       {
+        url = "https://github.com/pulumi/pulumi-github/releases/download/v6.13.1/pulumi-resource-github-v6.13.1-linux-arm64.tar.gz";
+        sha256 = "d36842a8fc03f9a5753b9b6fad7c4ac0e42f0190ed6d6043ce5205a5c0cab348";
+      }
+      {
         url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.16.3/pulumi-resource-grafana-v0.16.3-linux-arm64.tar.gz";
         sha256 = "993abf5c2d4e0fe4d3e36523eecb864503426c9c2ebfce1dde830d3f51f0faf4";
       }
@@ -388,6 +400,10 @@
       {
         url = "https://github.com/pulumi/pulumi-gcp/releases/download/v9.18.0/pulumi-resource-gcp-v9.18.0-darwin-arm64.tar.gz";
         sha256 = "7db7b67954330e47057e3f0e29bc30f9a9e7c5e5b62443c9facbc6c111096d4b";
+      }
+      {
+        url = "https://github.com/pulumi/pulumi-github/releases/download/v6.13.1/pulumi-resource-github-v6.13.1-darwin-arm64.tar.gz";
+        sha256 = "44893e8d79c2cc45e5ff22fdcb8266ae74a780b5da6b5b79a29d191c232bdfbb";
       }
       {
         url = "https://github.com/pulumiverse/pulumi-grafana/releases/download/v0.16.3/pulumi-resource-grafana-v0.16.3-darwin-arm64.tar.gz";

--- a/nix/generate_pulumi_packages.sh
+++ b/nix/generate_pulumi_packages.sh
@@ -22,6 +22,7 @@ plugins=(
   "pulumi/auth0=3.39.0"
   "pulumi/command=1.1.3"
   "pulumi/kubernetes-cert-manager=0.2.0"
+  "pulumi/github=6.13.1"
   "pulumiverse/grafana=0.16.3"
   # old versions so that old pulumi state can be interpreted
   # each can be removed once MainNet uses a newer version


### PR DESCRIPTION
Part of https://github.com/canton-network/splice/issues/5570

Tested manually via the submodule.
Unfortunately there's no "description" field, or somewhere we can comment that this is managed by pulumi..

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
