### PR TITLE
Fix sequencer flow control in istio

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -27,6 +27,11 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      # See https://github.com/DACH-NY/canton-network-internal/issues/4901
+      # The values are somewhat arbitrary so more fine tuning may be appropriate.
+      initialStreamWindowSize: 524288        # 512 KiB max per stream
+      initialConnectionWindowSize: 52428800  # 50 MiB max per connection
 # configs specific for the pulumi project
 # will be applied to all the stacks in the project
 pulumiProjectConfig:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -27,6 +27,9 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      initialConnectionWindowSize: 52428800
+      initialStreamWindowSize: 524288
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -27,6 +27,9 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      initialConnectionWindowSize: 52428800
+      initialStreamWindowSize: 524288
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -27,6 +27,9 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      initialConnectionWindowSize: 52428800
+      initialStreamWindowSize: 524288
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -27,6 +27,9 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      initialConnectionWindowSize: 52428800
+      initialStreamWindowSize: 524288
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -27,6 +27,9 @@ infra:
     proxyForIstioHttp: false
   istio:
     enableIngressAccessLogging: true
+    sequencerFlowControl:
+      initialConnectionWindowSize: 52428800
+      initialStreamWindowSize: 524288
   prometheus:
     retentionDuration: '30d'
     retentionSize: '200GB'

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -2185,6 +2185,83 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "apiVersion": "networking.istio.io/v1alpha3",
+      "kind": "EnvoyFilter",
+      "metadata": {
+        "name": "sequencer-flow-control",
+        "namespace": "cluster-ingress"
+      },
+      "spec": {
+        "configPatches": [
+          {
+            "applyTo": "NETWORK_FILTER",
+            "match": {
+              "context": "SIDECAR_INBOUND",
+              "listener": {
+                "filterChain": {
+                  "filter": {
+                    "name": "envoy.filters.network.http_connection_manager"
+                  }
+                }
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "http2_protocol_options": {
+                    "connection_keepalive": {
+                      "interval": "30s",
+                      "timeout": "5s"
+                    },
+                    "initial_connection_window_size": 52428800,
+                    "initial_stream_window_size": 524288
+                  }
+                }
+              }
+            }
+          },
+          {
+            "applyTo": "CLUSTER",
+            "match": {
+              "cluster": {
+                "portNumber": 5008
+              }
+            },
+            "patch": {
+              "operation": "MERGE",
+              "value": {
+                "typed_extension_protocol_options": {
+                  "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                    "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                    "use_downstream_protocol_config": {
+                      "http2_protocol_options": {
+                        "connection_keepalive": {
+                          "interval": "30s",
+                          "timeout": "5s"
+                        },
+                        "initial_connection_window_size": 52428800,
+                        "initial_stream_window_size": 524288
+                      },
+                      "http_protocol_options": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "name": "sequencer-flow-control",
+    "provider": "",
+    "type": "kubernetes:networking.istio.io/v1alpha3:EnvoyFilter"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "security.istio.io/v1",
       "kind": "AuthorizationPolicy",
       "metadata": {

--- a/cluster/pulumi/infra/src/config.ts
+++ b/cluster/pulumi/infra/src/config.ts
@@ -55,6 +55,10 @@ export const InfraConfigSchema = z.object({
       enableIngressAccessLogging: z.boolean(),
       enableClusterAccessLogging: z.boolean().default(false),
       istiodValues: z.object({}).catchall(z.any()).default({}),
+      sequencerFlowControl: z.object({
+        initialStreamWindowSize: z.int(),
+        initialConnectionWindowSize: z.int(),
+      }),
     }),
     extraCustomResources: z.object({}).catchall(z.any()).default({}),
   }),

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -811,6 +811,100 @@ function configureSequencerHighPerformanceGrpcDestinationRule(
   });
 }
 
+// Istio proxies lots of client connections over relatively few connections. If one of the client connections gets stuck
+// (e.g. because the client died) buffers will fill up and eventually istio will stop sending connection-level window updates
+// to the sequencer and trigger netty flow control. This surfaces as requests that send back response headers but then nothing else until the client times out.
+// To mitigate that we set the connection window size meaningfully higher than the stream window size. To fully mitigate it it likely needs to be
+// connection window size >= stream window size * maxConcurrentStreams but that would increase istio memory significantly so for now the values are usually just high enough that it
+// doesn't happen in practice but not enough to fully prevent it.
+// We also enable http2 pings to ensure that connections get closed when clients go away and the istio buffers are cleared again.
+// Note that we deliberately do not set stream idle timeouts as this doesn't work with long running requests.
+// See https://github.com/DACH-NY/canton-network-internal/issues/4901#issuecomment-4461257908 for more details.
+function configureSequencerFlowControl(
+  ingressNs: k8s.core.v1.Namespace
+): k8s.apiextensions.CustomResource {
+  return new k8s.apiextensions.CustomResource('sequencer-flow-control', {
+    apiVersion: 'networking.istio.io/v1alpha3',
+    kind: 'EnvoyFilter',
+    metadata: {
+      name: 'sequencer-flow-control',
+      namespace: ingressNs.metadata.name,
+    },
+    spec: {
+      configPatches: [
+        {
+          // downstream (aka participant) -> istio
+          applyTo: 'NETWORK_FILTER',
+          match: {
+            context: 'SIDECAR_INBOUND',
+            listener: {
+              filterChain: {
+                filter: {
+                  name: 'envoy.filters.network.http_connection_manager',
+                },
+              },
+            },
+          },
+          patch: {
+            operation: 'MERGE',
+            value: {
+              typed_config: {
+                '@type':
+                  'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
+                http2_protocol_options: {
+                  initial_stream_window_size:
+                    infraConfig.istio.sequencerFlowControl.initialStreamWindowSize,
+                  initial_connection_window_size:
+                    infraConfig.istio.sequencerFlowControl.initialConnectionWindowSize,
+                  connection_keepalive: {
+                    interval: '30s',
+                    timeout: '5s',
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          // istio -> upstream (aka sequencer)
+          applyTo: 'CLUSTER',
+          match: {
+            cluster: {
+              portNumber: 5008,
+              // Ideally we would just apply it everywhere. But doing it without this portNumber breaks http1 configs. In theory there is `auto_config` which should do the right thing but then it doesn't apply it at all anymore.
+              // So for now we just apply it to the sequencer which is the only externally exposed http2 server so the only thing where this really should matter in practice.
+            },
+          },
+          patch: {
+            operation: 'MERGE',
+            value: {
+              typed_extension_protocol_options: {
+                'envoy.extensions.upstreams.http.v3.HttpProtocolOptions': {
+                  '@type':
+                    'type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions',
+                  use_downstream_protocol_config: {
+                    http_protocol_options: {},
+                    http2_protocol_options: {
+                      initial_stream_window_size:
+                        infraConfig.istio.sequencerFlowControl.initialStreamWindowSize,
+                      initial_connection_window_size:
+                        infraConfig.istio.sequencerFlowControl.initialConnectionWindowSize,
+                      connection_keepalive: {
+                        interval: '30s',
+                        timeout: '5s',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+}
+
 export function configureIstio(
   ingressNs: ExactNamespace,
   ingressIp: pulumi.Output<string>,
@@ -837,12 +931,14 @@ export function configureIstio(
   const sequencerHighPerformanceGrpcRules = configureSequencerHighPerformanceGrpcDestinationRules(
     ingressNs.ns
   );
+  const sequencerFlowControl = configureSequencerFlowControl(ingressNs.ns);
   return {
     allResources: [
       ...gateways,
       ...docsAndReleases,
       ...publicInfo,
       ...sequencerHighPerformanceGrpcRules,
+      ...[sequencerFlowControl],
     ],
     httpServiceName: 'istio-ingress',
     istioResource: gwSvc,


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/4901

This just applies the config we already manually applied and tested. There is almost certainly further config tweaking we could do here but for now this definitely works far better than the default.

Note that the initial stream window size is quite a bit smaller than the default of 16mb. The connection window size is larger than the default of 24mb though. This is different from what https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge recommends but after searching around a bit it seems like the values there likely don't work well with grpc streams so this is a tradeoff to make sure we don't get performance regressions while still improving the situation.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
