### PR TITLE
Fix bug where we would try to process a wrong LSU announcement

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuNodeInitializer.scala
@@ -95,14 +95,15 @@ class LsuNodeInitializer(
             Right(())
         },
         (_: String) => {
+          val initParams = parameters.copy(
+            protocolVersion = successorSynchronizerId.protocolVersion
+          )
           logger.info(
-            show"Initializing sequencer from predecessor with $parameters"
+            show"Initializing sequencer from predecessor with $initParams"
           )
           successorSynchronizerNode.sequencerAdminConnection.initializeFromPredecessor(
             state.synchronizerStatePath,
-            parameters.copy(
-              protocolVersion = successorSynchronizerId.protocolVersion
-            ),
+            initParams,
             ignorePsidCheck,
           )
         },

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/lsu/LsuTrigger.scala
@@ -192,7 +192,9 @@ class LsuTrigger(
       .listLsuAnnouncements(synchronizerId.logical)
       .map(_.filter { announcement =>
         announcement.base.validFrom
-          .isBefore(now.toInstant) && announcement.mapping.successorSynchronizerId != synchronizerId
+          .isBefore(
+            now.toInstant
+          ) && announcement.mapping.successorSynchronizerId.serial > synchronizerId.serial
       })
   }
 


### PR DESCRIPTION
We now process just announcements newer than the current psid. Also improve a confusing log.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
