### PR TITLE
set numTrustedProxies to 0 in NLB istio mode

### DIFF
--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1885,7 +1885,7 @@
           "accessLogFormat": "{\"trace_id\":\"%REQ(traceparent)%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"bytes_received\":\"%BYTES_RECEIVED%\",\"bytes_sent\":\"%BYTES_SENT%\",\"downstream_local_address\":\"%DOWNSTREAM_LOCAL_ADDRESS%\",\"downstream_remote_address\":\"%DOWNSTREAM_REMOTE_ADDRESS%\",\"duration\":\"%DURATION%\",\"method\":\"%REQ(:METHOD)%\",\"path\":\"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\"protocol\":\"%PROTOCOL%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"requested_server_name\":\"%REQUESTED_SERVER_NAME%\",\"response_code\":\"%RESPONSE_CODE%\",\"response_code_details\":\"%RESPONSE_CODE_DETAILS%\",\"response_flags\":\"%RESPONSE_FLAGS%\",\"start_time\":\"%START_TIME%\",\"upstream_cluster\":\"%UPSTREAM_CLUSTER%\",\"upstream_host\":\"%UPSTREAM_HOST%\",\"upstream_local_address\":\"%UPSTREAM_LOCAL_ADDRESS%\",\"upstream_service_time\":\"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"x_forwarded_for\":\"%REQ(X-FORWARDED-FOR)%\"}",
           "defaultConfig": {
             "gatewayTopology": {
-              "numTrustedProxies": 1
+              "numTrustedProxies": 0
             },
             "holdApplicationUntilProxyStarts": true
           },

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -130,12 +130,14 @@ function configureIstiod(
       // https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging  disable as we don't use annotations
       enablePrometheusMerge: false,
       defaultConfig: {
-        // It is expected that a single load balancer (GCP NLB) is used in front of K8s.
-        // https://istio.io/latest/docs/tasks/security/authorization/authz-ingress/#http-https
-        // Also see:
+        // The GCP NLB with externalTrafficPolicy: Local preserves the client's
+        // source IP without adding X-Forwarded-For hops, so there are no trusted
+        // proxies to account for. This ensures remoteIpBlocks in AuthorizationPolicy
+        // uses the direct connection IP rather than the X-Forwarded-For header.
+        // https://istio.io/latest/docs/tasks/security/authorization/authz-ingress/#network
+        // By contrast, the GKE L7 Gateway path overrides this to 2 via pod annotation,
+        // the minimum value per testing (as that gateway adds more Envoy hops).
         // https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/#configuring-x-forwarded-for-headers
-        // This controls the value populated by the ingress gateway in the X-Envoy-External-Address header which can be reliably used
-        // by the upstream services to access client’s original IP address.
         gatewayTopology: {
           numTrustedProxies: 0,
         },

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -137,7 +137,7 @@ function configureIstiod(
         // This controls the value populated by the ingress gateway in the X-Envoy-External-Address header which can be reliably used
         // by the upstream services to access client’s original IP address.
         gatewayTopology: {
-          numTrustedProxies: 1,
+          numTrustedProxies: 0,
         },
         // wait for the istio container to start before starting apps to avoid network errors
         holdApplicationUntilProxyStarts: true,


### PR DESCRIPTION
Fixes DACH-NY/canton-network-internal#5207.

- [x] [preflight e0de6e7e07](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/65859/workflows/1cbc16b9-23cb-4f8e-88fe-df19979e1913)
- [x] hold off backports <0.6.4 until that one is confirmed

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
