### PR TITLE
Allow decimal numbers in Create Unclaimed Activity Record proposal

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -1487,7 +1487,7 @@ class SvFrontendIntegrationTest
 
     "NEW UI: Create Unclaimed Activity Record" in { implicit env =>
       val beneficiary = sv3Backend.getDsoInfo().svParty.toProtoPrimitive
-      val amount = "100"
+      val amount = "100.5"
 
       assertCreateProposal(
         "SRARC_CreateUnallocatedUnclaimedActivityRecord",

--- a/apps/sv/frontend/src/__tests__/governance/forms/create-unallocated-unclaimed-activity-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/create-unallocated-unclaimed-activity-form.test.tsx
@@ -140,6 +140,39 @@ describe('Create Unallocated Unclaimed Activity Record Form', () => {
     expect(submitButton.getAttribute('disabled')).toBeNull();
   });
 
+  test('amount accepts decimals but rejects more than 10 decimal places', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <CreateUnallocatedUnclaimedActivityRecordForm />
+      </Wrapper>
+    );
+
+    const amountInput = screen.getByTestId('create-unallocated-unclaimed-activity-record-amount');
+    const amountError = screen.getByTestId(
+      'create-unallocated-unclaimed-activity-record-amount-error'
+    );
+
+    await user.type(amountInput, '100.1234567891');
+    await waitFor(() => {
+      expect(amountError.textContent).toBe('');
+    });
+
+    await user.clear(amountInput);
+    await user.type(amountInput, '100.12345678912');
+    await waitFor(() => {
+      expect(amountError.textContent).toBe('Amount can have at most 10 decimal places');
+    });
+
+    // an invalid number (e.g. trailing dot) triggers the generic error, not the decimal-places one
+    await user.clear(amountInput);
+    await user.type(amountInput, '100.');
+    await waitFor(() => {
+      expect(amountError.textContent).toBe('Amount must be a valid number');
+    });
+  });
+
   test('expiry date must be in the future', async () => {
     render(
       <Wrapper>

--- a/apps/sv/frontend/src/components/forms/formValidators.ts
+++ b/apps/sv/frontend/src/components/forms/formValidators.ts
@@ -57,7 +57,7 @@ export const svWeightSchema = z
 export const rewardAmountSchema = z
   .string()
   .min(1, { message: 'Amount is required' })
-  .regex(/^\d+$/, { message: 'Amount must be a valid number' });
+  .regex(/^\d+(\.\d+)?$/, { message: 'Amount must be a valid number' });
 
 export const validateWeight = (value: string): string | false => {
   const result = svWeightSchema.safeParse(value);

--- a/apps/sv/frontend/src/components/forms/formValidators.ts
+++ b/apps/sv/frontend/src/components/forms/formValidators.ts
@@ -57,7 +57,14 @@ export const svWeightSchema = z
 export const rewardAmountSchema = z
   .string()
   .min(1, { message: 'Amount is required' })
-  .regex(/^\d+(\.\d+)?$/, { message: 'Amount must be a valid number' });
+  .regex(/^\d+(\.\d+)?$/, { message: 'Amount must be a valid number' })
+  .refine(
+    v => {
+      const dotIndex = v.indexOf('.');
+      return dotIndex === -1 || v.length - dotIndex - 1 <= 10;
+    },
+    { message: 'Amount can have at most 10 decimal places' }
+  );
 
 export const validateWeight = (value: string): string | false => {
   const result = svWeightSchema.safeParse(value);


### PR DESCRIPTION
Fixes #5617

<img width="437" height="177" alt="image" src="https://github.com/user-attachments/assets/7338ad3e-e576-4fc4-8131-2b626b139306" />

<img width="594" height="539" alt="image" src="https://github.com/user-attachments/assets/8ccf09a8-8a2a-4ae7-ae9d-78a5ae53da6b" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
