### PR TITLE
add support for cometbft add hoc helm values

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -194,6 +194,9 @@ svs:
       nodeId: d825622358065aea3cb3b3479cf64d172675037e
       validatorKeyAddress: 2D21D8AB2306770E9F93E8BD0E0F07B3E86817D7
       keysGcpSecret: svda1-mock-cometbft-keys
+      additionalHelmValues:
+        node:
+          snapshotHeightDelta: 200
     svApp:
       auth0:
         clientId: bxjt0vzLyRG2rk2fapXfOzH5lzK4mrl7

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -3661,6 +3661,7 @@
           "keysSecret": "",
           "privateKey": "svda1-mock-cometbft-keys-node-private-key",
           "retainBlocks": 5040000,
+          "snapshotHeightDelta": 200,
           "validator": {
             "keyAddress": "2D21D8AB2306770E9F93E8BD0E0F07B3E86817D7",
             "privateKey": "svda1-mock-cometbft-keys-validator-private-key",

--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -31,6 +31,9 @@ const SvCometbftConfigSchema = z
         ttlSeconds: z.number().optional(),
       })
       .optional(),
+    // Ad-hoc Helm values to be merged (nested) into the values passed to the splice-cometbft chart.
+    // Values provided here override values computed by pulumi for the same nested key.
+    additionalHelmValues: z.record(z.string(), z.any()).optional(),
   })
   .strict();
 const EnvVarConfigSchema = z.object({

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -165,6 +165,9 @@ export function installCometBftNode(
     serviceAccountName: imagePullServiceAccountName,
     resources: svConfiguration.cometbft?.resources,
   });
+  if (svConfiguration.cometbft?.additionalHelmValues) {
+    _.merge(cometbftChartValues, svConfiguration.cometbft.additionalHelmValues);
+  }
   const protectCometBft = svsConfig?.cometbft?.protected ?? false;
   const release = installSpliceHelmChart(
     xns,


### PR DESCRIPTION
will be used to reduce the snapshot interval in ciperiodic

[static]

part of https://github.com/DACH-NY/cn-test-failures/issues/8366

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
