### PR TITLE
Bump Selenium to 4.44

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -25,7 +25,6 @@ import org.openqa.selenium.{
   WebDriverException,
   WebElement,
 }
-import org.openqa.selenium.html5.WebStorage
 import org.openqa.selenium.json.{Json, JsonInput}
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.scalatest.{Assertion, ParallelTestExecution}
@@ -158,7 +157,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
 
   val frontendNames: Seq[String] = Seq()
 
-  type WebDriverType = WebDriver with TakesScreenshot with JavascriptExecutor with WebStorage
+  type WebDriverType = WebDriver with TakesScreenshot with JavascriptExecutor
 
   val aliceWalletUIPort = 3000
   val bobWalletUIPort = 3001
@@ -259,7 +258,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
 
     biDi.addListener[LogEntry](
       Log.entryAdded(),
-      logEntry => {
+      (logEntry: LogEntry) => {
         logEntry.getConsoleLogEntry.toScala.foreach { consoleLogEntry =>
           val msg = consoleLogEntry.getText
           val ctx = traceContextFromConsoleMessage(msg)
@@ -271,7 +270,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
           }
         }
       },
-    );
+    )
     val JSON = new Json()
     biDi.addListener[NavigationInfo](
       new Event[NavigationInfo](
@@ -282,7 +281,8 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
           NavigationInfo.fromJson(input)
         },
       ),
-      navigationInfo => logger.debug(s"dom content loaded for ${navigationInfo.url}"),
+      (navigationInfo: NavigationInfo) =>
+        logger.debug(s"dom content loaded for ${navigationInfo.url}"),
     );
   }
 
@@ -324,12 +324,11 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
               // You cannot reset session storage of about:blank so
               // we exclude this.
               if (currentUrl != "about:blank") {
-                webDriver.getSessionStorage().clear()
+                webDriver.executeScript("""sessionStorage.clear()""")
                 eventually() {
-                  webDriver
-                    .getSessionStorage()
-                    .keySet
-                    .asScala shouldBe empty withClue "webDriver sessionStorage"
+                  webDriver.executeScript(
+                    """return sessionStorage.length"""
+                  ) shouldBe 0
                 }
               }
             }
@@ -524,14 +523,17 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
     }
   }
 
+  @annotation.nowarn("msg=possible missing interpolator")
   protected def logLocalAndSessionStorage()(implicit webDriver: WebDriverType): Unit = {
     clue("Logging local and session storage") {
       // Note: only logging keys, as values might contain sensitive information
       Try {
-        val localStorageKeys = webDriver.getLocalStorage.keySet.asScala
-        logger.debug(s"localStorage:\n${localStorageKeys.mkString("\n")}")
-        val sessionStorageKeys = webDriver.getSessionStorage.keySet.asScala
-        logger.debug(s"sessionStorage:\n${sessionStorageKeys.mkString("\n")}")
+        webDriver.executeScript("""
+          console.debug(`localStorage = [${Object.keys(localStorage).join(", ")}]`);
+        """)
+        webDriver.executeScript("""
+          console.debug(`sessionStorage = [${Object.keys(sessionStorage).join(", ")}]`);
+        """)
       }.fold(e => logger.debug(s"Failed to log storage: $e"), _ => ())
     }
   }
@@ -629,18 +631,27 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
 
           // Next, clear local storage, as our oauth library puts data in there
           // Note: again, you can only access the local storage of the current page.
-          clue("Clearing local storage") {
-            val auth0LocalState =
-              webDriver.getLocalStorage.keySet.asScala.filter(_.startsWith("oidc."))
-            logger.debug(
-              s"Deleting the following keys from localStorage: $auth0LocalState"
-            )
-            auth0LocalState.foreach(webDriver.getSessionStorage.removeItem)
-          }
+          clearAuth0WebStorage()
+
           // Finally, navigate away from the current page to clear any JavaScript state
           go to "about:blank"
           throw e
       }
+    }
+  }
+
+  @annotation.nowarn("msg=possible missing interpolator")
+  protected def clearAuth0WebStorage()(implicit webDriver: WebDriverType): Unit = {
+    clue("Clearing auth0 local storage") {
+      Try(
+        webDriver.executeScript(
+          """
+          const auth0LocalState = Object.keys(localStorage).filter(k => k.startsWith("oidc."));
+          console.debug(`Deleting the following keys from localStorage: [${auth0LocalState.join(", ")}]`);
+          auth0LocalState.forEach(k => localStorage.removeItem(k));
+        """
+        )
+      ).fold(e => logger.debug(s"Failed to clear web storage: $e"), _ => ())
     }
   }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -324,12 +324,16 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
               // You cannot reset session storage of about:blank so
               // we exclude this.
               if (currentUrl != "about:blank") {
-                webDriver.executeScript("""sessionStorage.clear()""")
-                eventually() {
-                  webDriver.executeScript(
-                    """return sessionStorage.length"""
-                  ) shouldBe 0
-                }
+                actAndCheck(
+                  "Clear session storage",
+                  webDriver.executeScript("""sessionStorage.clear()"""),
+                )(
+                  "Session storage is now empty",
+                  _ =>
+                    webDriver.executeScript(
+                      """return sessionStorage.length"""
+                    ) shouldBe 0,
+                )
               }
             }
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/FrontendIntegrationTest.scala
@@ -256,7 +256,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
     webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(0))
     registerWebDriver(name, webDriver)
 
-    biDi.addListener[LogEntry](
+    biDi.addListener(
       Log.entryAdded(),
       (logEntry: LogEntry) => {
         logEntry.getConsoleLogEntry.toScala.foreach { consoleLogEntry =>
@@ -272,7 +272,7 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
       },
     )
     val JSON = new Json()
-    biDi.addListener[NavigationInfo](
+    biDi.addListener(
       new Event[NavigationInfo](
         "browsingContext.domContentLoaded",
         params => {
@@ -534,8 +534,6 @@ trait FrontendTestCommon extends TestCommon with WebBrowser with CustomMatchers 
       Try {
         webDriver.executeScript("""
           console.debug(`localStorage = [${Object.keys(localStorage).join(", ")}]`);
-        """)
-        webDriver.executeScript("""
           console.debug(`sessionStorage = [${Object.keys(sessionStorage).join(", ")}]`);
         """)
       }.fold(e => logger.debug(s"Failed to log storage: $e"), _ => ())

--- a/build.sbt
+++ b/build.sbt
@@ -2055,8 +2055,10 @@ lazy val `apps-app`: Project =
       `apps-common-frontend`,
     )
     .settings(
+      // scalatestplus-selenium is lagging behind, it depends on selenium 4.12,
+      // but that's fine as it's compatible with selenium 4.44 that we end up using
       libraryDependencies += "org.scalatestplus" %% "selenium-4-12" % "3.2.17.0" % "test",
-      libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "4.12.1" % "test",
+      libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "4.44.0" % "test",
       libraryDependencies += "eu.rekawek.toxiproxy" % "toxiproxy-java" % "2.1.4" % "test",
       libraryDependencies += auth0,
       libraryDependencies += kubernetes_client,


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/8524

```
> sbt dependencyList | grep selenium

[info] org.scalatestplus:selenium-4-41_2.13:3.2.19.0
[info] org.seleniumhq.selenium:htmlunit-driver:4.13.0
[info] org.seleniumhq.selenium:selenium-api:4.44.0
[info] org.seleniumhq.selenium:selenium-chrome-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-chromium-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-devtools-v146:4.44.0
[info] org.seleniumhq.selenium:selenium-devtools-v147:4.44.0
[info] org.seleniumhq.selenium:selenium-devtools-v148:4.44.0
[info] org.seleniumhq.selenium:selenium-edge-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-firefox-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-http:4.44.0
[info] org.seleniumhq.selenium:selenium-ie-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-java:4.44.0
[info] org.seleniumhq.selenium:selenium-json:4.44.0
[info] org.seleniumhq.selenium:selenium-manager:4.44.0
[info] org.seleniumhq.selenium:selenium-os:4.44.0
[info] org.seleniumhq.selenium:selenium-remote-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-safari-driver:4.44.0
[info] org.seleniumhq.selenium:selenium-support:4.44.0
```

Note: last Selenium bump was reverted in https://github.com/canton-network/splice/pull/3959.

This PR differs in one point from the reverted PR: it doesn't clear local storage at https://github.com/canton-network/splice/commit/e86c0ac360ad9173e2028fb351ac6fefbfd0bd21#diff-7ce58b4a68a63ccf8fe6f363a72d2af966badf0f62c0dc12b056a508deff37ebR318, which was a functional change and could have caused the issues last time.