### PR TITLE
Lower default Canton log level to INFO and document overrides

### DIFF
--- a/cluster/helm/splice-scan/values-template.yaml
+++ b/cluster/helm/splice-scan/values-template.yaml
@@ -64,7 +64,7 @@ spliceInstanceNames:
 service:
   ui:
     port: 80
-logLevel: DEBUG
+logLevel: INFO
 
 # bulk storage configuration (still in dev, please do not enable in prod)
 # bulk-storage:

--- a/cluster/helm/splice-sv-node/values-template.yaml
+++ b/cluster/helm/splice-sv-node/values-template.yaml
@@ -68,7 +68,7 @@ spliceInstanceNames:
 service:
   ui:
     port: 80
-logLevel: DEBUG
+logLevel: INFO
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true

--- a/cluster/helm/splice-util-lib/templates/_helpers.tpl
+++ b/cluster/helm/splice-util-lib/templates/_helpers.tpl
@@ -203,6 +203,8 @@ spec:
   value: {{ .logLevel | default "INFO" }}
 - name: LOG_API_REQUEST_CANTON
   value: {{ .apiRequestLogLevel | default "DEBUG" }}
+- name: LOG_LEVEL_CN
+  value: {{ .logLevelCn | default "DEBUG" }}
 - name: LOG_LEVEL_STDOUT
   value: {{ .logLevelStdout | default "DEBUG" }}
 - name: LOG_IMMEDIATE_FLUSH

--- a/cluster/helm/splice-validator/values-template.yaml
+++ b/cluster/helm/splice-validator/values-template.yaml
@@ -85,7 +85,7 @@ validatorWebUi:
 
 # set to true to disable auth (this is highly insecure)
 disableAuth: false
-logLevel: DEBUG
+logLevel: INFO
 
 # should stakater reloader annotation be added (note: reloader needs to be installed separately)
 enableReloader: true

--- a/cluster/images/common/entrypoint.sh
+++ b/cluster/images/common/entrypoint.sh
@@ -16,7 +16,7 @@ if [[ ! " ${*} " =~ " --console " ]]; then
     ARGS+=( daemon --no-tty )
 fi
 
-ARGS+=( --log-encoder=json --log-level-stdout="${LOG_LEVEL_STDOUT:-DEBUG}" --log-level-canton="${LOG_LEVEL_CANTON:-DEBUG}" --log-file-appender=off --log-immediate-flush="${LOG_IMMEDIATE_FLUSH:-false}")
+ARGS+=( --log-encoder=json --log-level-stdout="${LOG_LEVEL_STDOUT:-DEBUG}" --log-level-canton="${LOG_LEVEL_CANTON:-INFO}" --log-file-appender=off --log-immediate-flush="${LOG_IMMEDIATE_FLUSH:-false}")
 
 if [ -f /app/logback.xml ]; then
    export JAVA_TOOL_OPTIONS="-Dlogback.configurationFile=/app/logback.xml ${JAVA_TOOL_OPTIONS:-}"

--- a/docs/src/deployment/troubleshooting.rst
+++ b/docs/src/deployment/troubleshooting.rst
@@ -23,9 +23,9 @@ Where to find logs
 Canton logs into ``canton.log``.
 
 .. note::
-    The default log levels in container deployments (the splice-node image used by both SV and validator Helm charts) are ``INFO`` for Canton classes (loggers under ``com.daml`` and ``com.digitalasset``) and ``DEBUG`` for the stdout sink, which keeps Canton Network application logs (``org.lfdecentralizedtrust.splice``) at ``DEBUG`` while reducing the log volume produced by Canton itself.
+    The default log levels in container deployments (the splice-node image used by both SV and validator Helm charts) are ``INFO`` for Canton classes (loggers under ``com.daml`` and ``com.digitalasset``), ``DEBUG`` for Canton Network application classes (``org.lfdecentralizedtrust.splice``), and ``DEBUG`` for the stdout sink. This keeps application-level debugging signal available while reducing the log volume produced by Canton itself.
 
-    The levels can be overridden via the ``LOG_LEVEL_CANTON`` and ``LOG_LEVEL_STDOUT`` environment variables on the splice-node container (for Helm deployments, set these through ``additionalEnvVars`` on the affected pods), or via the ``--log-level-canton`` and ``--log-level-stdout`` CLI flags when invoking ``splice-node`` directly (for example ``splice-node --config "${OUTPUT_CONFIG}" --log-level-canton=DEBUG ...``).
+    The levels can be overridden via the ``LOG_LEVEL_CANTON``, ``LOG_LEVEL_CN``, and ``LOG_LEVEL_STDOUT`` environment variables on the splice-node container (for Helm deployments, set these through ``additionalEnvVars`` on the affected pods, or via the ``logLevel`` / ``logLevelCn`` / ``logLevelStdout`` chart values). The ``--log-level-canton`` and ``--log-level-stdout`` CLI flags can also be used when invoking ``splice-node`` directly (for example ``splice-node --config "${OUTPUT_CONFIG}" --log-level-canton=DEBUG ...``).
 
     Debugging support is best-effort under non-default log levels: maintainers may ask you to reproduce issues with the defaults restored before investigating further.
 

--- a/docs/src/deployment/troubleshooting.rst
+++ b/docs/src/deployment/troubleshooting.rst
@@ -23,9 +23,13 @@ Where to find logs
 Canton logs into ``canton.log``.
 
 .. note::
-    The default log level, initially set to Debug, can be changed using the ``--log-level-canton`` flag, for example: ``splice-node --config "${OUTPUT_CONFIG}" --log-level-canton=DEBUG ...``
+    The default log levels in container deployments (the splice-node image used by both SV and validator Helm charts) are ``INFO`` for Canton classes (loggers under ``com.daml`` and ``com.digitalasset``) and ``DEBUG`` for the stdout sink, which keeps Canton Network application logs (``org.lfdecentralizedtrust.splice``) at ``DEBUG`` while reducing the log volume produced by Canton itself.
 
-**When the node is launched in a kubernetes cluster**, we recommend to setup a log collector so that you can capture logs of at least the last day. For now, the default log level is set to Debug.
+    The levels can be overridden via the ``LOG_LEVEL_CANTON`` and ``LOG_LEVEL_STDOUT`` environment variables on the splice-node container (for Helm deployments, set these through ``additionalEnvVars`` on the affected pods), or via the ``--log-level-canton`` and ``--log-level-stdout`` CLI flags when invoking ``splice-node`` directly (for example ``splice-node --config "${OUTPUT_CONFIG}" --log-level-canton=DEBUG ...``).
+
+    Debugging support is best-effort under non-default log levels: maintainers may ask you to reproduce issues with the defaults restored before investigating further.
+
+**When the node is launched in a kubernetes cluster**, we recommend to setup a log collector so that you can capture logs of at least the last day.
 
 We recommend to use ``lnav`` to read the logs. A guideline is provided in `this documentation <https://github.com/canton-network/splice/blob/main/TESTING.md#setting-up-lnav-to-inspect-canton-and-cometbft-logs>`_.
 

--- a/docs/src/faq.rst
+++ b/docs/src/faq.rst
@@ -49,7 +49,7 @@ Validators
 
     **Option 2:** check the participant logs for the actual traffic used for a specific transaction. To do so, follow these steps:
 
-    1. Ensure you have ``DEBUG`` logs enabled in your participant configuration.
+    1. Ensure ``DEBUG`` logs are enabled for the relevant Canton classes. The container default for ``LOG_LEVEL_CANTON`` is ``INFO``, which suppresses these ``c.d.c.s.t.TrafficStateController`` lines — set ``LOG_LEVEL_CANTON=DEBUG`` on the participant container (via ``additionalEnvVars`` in Helm or the ``--log-level-canton=DEBUG`` CLI flag) before reproducing.
     2. Determine the trace-id of your command submission in your participant logs.
     3. Search for the ``DEBUG`` log lines containing ``EventCost`` and that ``trace-id``.
        There are typically two such log lines, due to how the `Canton protocol <https://docs.daml.com/canton/architecture/overview.html#transaction-processing-in-canton>`_ works.

--- a/scripts/canton-logback.xml
+++ b/scripts/canton-logback.xml
@@ -320,7 +320,7 @@
       <logger name="com.digitalasset" level="${LOG_LEVEL_CANTON:-INFO}"/>
       <logger name="com.digitalasset.canton.logging.audit" level="${LOG_LEVEL_API_REQUEST:-DEBUG}" />
       <logger name="com.daml" level="${LOG_LEVEL_CANTON:-INFO}"/>
-      <logger name="org.lfdecentralizedtrust.splice" level="${LOG_LEVEL_CANTON:-INFO}"/>
+      <logger name="org.lfdecentralizedtrust.splice" level="${LOG_LEVEL_CN:-DEBUG}"/>
     </else>
   </if>
 


### PR DESCRIPTION
## Summary

Fixes #721.

The splice-node container and the SV / scan / validator Helm charts defaulted Canton classes (`com.daml`, `com.digitalasset`) to `DEBUG`, which SVs have flagged as expensive for log aggregation. The shared `scripts/canton-logback.xml` further conflated the Canton Network application logger (`org.lfdecentralizedtrust.splice`) onto the same `LOG_LEVEL_CANTON` variable, so it was not possible to express the issue's requested config — Canton at `INFO`, CN at `DEBUG` — without a logback change.

This PR makes both halves of that split land in the defaults.

Changes:

- `scripts/canton-logback.xml`: the `org.lfdecentralizedtrust.splice` logger now reads from a separate `LOG_LEVEL_CN` env var, defaulting to `DEBUG`. `com.daml` / `com.digitalasset` stay on `LOG_LEVEL_CANTON` (with the existing `INFO` fallback in this file).
- `cluster/images/common/entrypoint.sh`: `LOG_LEVEL_CANTON` default `DEBUG` → `INFO`; `LOG_LEVEL_STDOUT` default `DEBUG` unchanged.
- `cluster/helm/splice-util-lib/templates/_helpers.tpl`: emit `LOG_LEVEL_CN` alongside `LOG_LEVEL_CANTON` / `LOG_LEVEL_STDOUT`, value coming from a chart-side `logLevelCn` (default `DEBUG`).
- `cluster/helm/splice-{sv-node,scan,validator}/values-template.yaml`: `logLevel: DEBUG` → `INFO`. The helper already defaults this to `INFO` when omitted; this aligns the chart-bundled defaults with that.
- `docs/src/deployment/troubleshooting.rst`: rewrite the stale Debug-by-default note. Document the three env vars (`LOG_LEVEL_CANTON`, `LOG_LEVEL_CN`, `LOG_LEVEL_STDOUT`) and corresponding chart values (`logLevel`, `logLevelCn`, `logLevelStdout`). Include the disclaimer that debugging support is best-effort under non-default levels.
- `docs/src/faq.rst`: the `TrafficStateController` traffic-cost troubleshooting step previously assumed `DEBUG` was on for Canton classes by default. Update step 1 to instruct setting `LOG_LEVEL_CANTON=DEBUG` on the participant container before reproducing.

Effective container defaults after this PR:

| Class group | Logger root | Env var | Default |
|---|---|---|---|
| Canton | `com.daml`, `com.digitalasset` | `LOG_LEVEL_CANTON` | `INFO` |
| Canton Network app | `org.lfdecentralizedtrust.splice` | `LOG_LEVEL_CN` | `DEBUG` |
| Stdout sink filter | (appender) | `LOG_LEVEL_STDOUT` | `DEBUG` |

Out of scope (per the maintainer comment on the issue):

- General documentation of arbitrary Canton config overrides via `additionalEnvVars` / `ADDITIONAL_CONFIG_` — left for a separate issue if maintainers want it.
- Docker-compose paths (`cluster/compose/{sv,validator}/compose.yaml`) — already default to `INFO` via `LOG_LEVEL:-INFO`. They don't currently set `LOG_LEVEL_CN`, so the logback default `DEBUG` applies, matching the new helm defaults.
- Multi-validator pulumi path — already defaults to `INFO` via `cluster/pulumi/multi-validator/src/config.ts`; with the logback change, splice loggers pick up the `LOG_LEVEL_CN` default `DEBUG` from the same file.
- `splice-global-domain` chart — already inherits the helper's `INFO` default (no `logLevel:` in `values-template.yaml`); the helper now also injects `LOG_LEVEL_CN`. The existing `splice-global-domain/tests/sequencer_test.yaml` tests use `contains` assertions on `LOG_LEVEL_CANTON` and `LOG_LEVEL_STDOUT` and are unaffected.
- `splice-cometbft` chart — uses cometbft's own `logLevel: info` semantic (separate subsystem).

Note: the `docs/src/` Sphinx site was just deprecated (#5644) in favor of `docs.canton.network`. The notes have been updated in the existing location since that is where today's operators land; happy to mirror the override paragraph into cf-docs in a follow-up if maintainers prefer.

## Test plan

- [x] `shellcheck cluster/images/common/entrypoint.sh` — clean (only pre-existing SC1091 infos for runtime-mounted `tools.sh` / `pre-bootstrap.sh`).
- [x] Reviewed the helper at `cluster/helm/splice-util-lib/templates/_helpers.tpl` and the consumer charts (`splice-{sv-node,scan,validator,participant,splitwell-app,global-domain}/templates/*.yaml`) — all rely on the helper for `LOG_LEVEL_*` injection, so the new `LOG_LEVEL_CN` reaches every pod.
- [x] Verified `cluster/helm/splice-global-domain/tests/sequencer_test.yaml` uses `contains` assertions (not exact-list), so the added env var does not break the existing log-level wiring tests.
- [x] Verified `cluster/expected/multi-validator/expected.json` snapshots use the multi-validator pulumi path (`cluster/pulumi/multi-validator/src/multiValidator.ts`), not `splice-util-lib.log-level`, so the new env var does not affect those snapshots.
- [ ] CI: helm chart tests — let CI confirm.
- [ ] CI: docs build — let CI confirm the reST renders cleanly.