### PR TITLE
Resolve binaries in parent shell before tmux send-keys

### DIFF
--- a/start-canton.sh
+++ b/start-canton.sh
@@ -107,6 +107,16 @@ do
     shift
 done
 
+# Resolve binaries in the parent shell so the panes execute the binary from
+# the active environment's PATH. Without this, if tmux is launched from one
+# nix env and start-canton.sh is then re-run from another, the panes pick up
+# the binary from the tmux server's inherited PATH (the first env), which is
+# silent and confusing. See https://github.com/canton-network/splice/issues/458.
+# Assumes the binaries are real executables on PATH; aliases and shell
+# functions would resolve to strings that are not usable as a tmux command.
+canton_input=$CANTON
+CANTON=$(command -v "$canton_input") || { echo "start-canton.sh: '$canton_input' not found on PATH" >&2; exit 1; }
+
 tmux_session="canton"
 tmux_window=0
 
@@ -217,7 +227,7 @@ tmux_cmd_canton() {
     "EXTRA_CLASSPATH=$COMETBFT_DRIVER/driver.jar \
      COMETBFT_DOCKER_IP=${COMETBFT_DOCKER_IP-} \
      LOG_LEVEL_API_REQUEST=DEBUG \
-     CANTON_TOKEN_FILENAME=$tokensFile CANTON_PARTICIPANTS_FILENAME=$participantsFile JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS\" $CANTON \
+     CANTON_TOKEN_FILENAME=$tokensFile CANTON_PARTICIPANTS_FILENAME=$participantsFile JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS\" \"$CANTON\" \
       -c $baseConfig $confOverrides \
       --log-level-canton=DEBUG \
       --log-encoder json \
@@ -254,7 +264,8 @@ else
   echo "-D specified, not waiting for canton to start "
 fi
 
-tmux_cmd toxiproxy "toxiproxy-server 2>&1 | tee -a log/toxi.log"
+TOXIPROXY_SERVER=$(command -v toxiproxy-server) || { echo "start-canton.sh: 'toxiproxy-server' not found on PATH" >&2; exit 1; }
+tmux_cmd toxiproxy "\"$TOXIPROXY_SERVER\" 2>&1 | tee -a log/toxi.log"
 
 if [ $daemon -eq 0 ]; then
   if [ -z "${TMUX-}" ]; then

--- a/start-frontends.sh
+++ b/start-frontends.sh
@@ -79,14 +79,14 @@ function start_frontend() {
 
   tmux send-keys -t "${tmux_session}:$((tmux_window - 1))" \
     "BROWSER=none PORT=$port JSON_API_URL=$JSON_API_URL VITE_SPLICE_CONFIG=\"\$(cat $config_file)\" \
-    npm start 2>&1 | tee -a $log_file" C-m
+    \"$NPM\" start 2>&1 | tee -a $log_file" C-m
 }
 
 function start_test() {
   local app=$1
   local frontend_dir="${SPLICE_ROOT}/apps/${app}/frontend"
 
-  tmux_cmd "${app}-test" "${frontend_dir}" "npm run test"
+  tmux_cmd "${app}-test" "${frontend_dir}" "\"$NPM\" run test"
 }
 
 function usage() {
@@ -135,6 +135,15 @@ while getopts "hdapvsmtl" arg; do
   esac
 done
 
+# Resolve binaries in the parent shell so the panes execute the binary from
+# the active environment's PATH. Without this, if tmux is launched from one
+# nix env and start-frontends.sh is then re-run from another, the panes pick
+# up the binary from the tmux server's inherited PATH (the first env), which
+# is silent and confusing. See https://github.com/canton-network/splice/issues/458.
+# Assumes the binaries are real executables on PATH; aliases and shell
+# functions would resolve to strings that are not usable as a tmux command.
+NPM=$(command -v npm) || { echo "start-frontends.sh: 'npm' not found on PATH" >&2; exit 1; }
+
 tmux_session="cn-frontends"
 tmux_window=0
 
@@ -154,7 +163,7 @@ function wait_for_workspace_build() {
   local log_file="${LOG_DIR}/npm-${log_file_suffix}.out"
   echo "Logging to ${log_file}"
 
-  tmux_cmd "$workspace" "$SPLICE_ROOT/apps" "npm run start --workspace $workspace 2>&1 | tee -a $log_file"
+  tmux_cmd "$workspace" "$SPLICE_ROOT/apps" "\"$NPM\" run start --workspace $workspace 2>&1 | tee -a $log_file"
 
   local count=0
   while [ ! -f "$SPLICE_ROOT/apps/$index" ]; do


### PR DESCRIPTION
Fixes #458.

## Problem

If tmux is launched from one nix env and `start-canton.sh` or `start-frontends.sh` is later re-run from another nix env, the panes pick up the binary from the tmux server's inherited PATH (the first env) rather than the active env. The failure is silent and produces confusing debugging sessions, as flagged by @moritzkiefer-da on DACH-NY/canton-network-node#19787.

## Fix

Resolve `canton`, `toxiproxy-server`, and `npm` via `command -v` in the parent shell and substitute the absolute path into the tmux command string. The pane invokes the binary directly regardless of the tmux server's PATH.

If the binary is missing on PATH, fail fast in the parent shell with a clear message before any tmux session is created, instead of failing silently inside a pane.

This matches the first idea from the issue body (resolve via `which`, execute the result). The second idea (`nix develop path:nix` in every pane) is not used here because the issue notes a prior attempt made CI startup measurably slower.

## Scope

- `start-canton.sh`: `$CANTON` (default `canton`, overridable via `-c`) and `toxiproxy-server`.
- `start-frontends.sh`: `npm` (used by `start_frontend`, `start_test`, and `wait_for_workspace_build` panes).

Out of scope: `tee` and other coreutils — these were not the reported failure mode and are typically identical across nix envs. `sbt` and `jq`/`jsonnet` are invoked from the parent shell, not from a tmux pane, so they already pick up the active env's PATH.

## Behavior

- Default invocation (single nix env): no behavior change. `command -v canton` returns the same absolute path the pane would have resolved through PATH.
- Mixed nix envs (the bug): pane runs the binary the user's current shell sees, not the tmux server's first-env binary.
- Missing binary: script exits with `start-canton.sh: 'canton' not found on PATH` (or similar) before any tmux session is created.
- `-c <custom-canton>` with an absolute path: passes through unchanged via `command -v`.