### PR TITLE
Make sure that we can run locking on GitHub Actions

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -279,7 +279,6 @@ function _assert_lock() {
                 _error "Could not determine approver for CI workflow"
             fi
         fi
-        
         if [[ -n "$approver" ]]; then
             local -a names
             readarray -t names < <( _get_holder_names "$approver" )

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -267,6 +267,11 @@ function _assert_lock() {
         fi
 
         # Check lock for CI...
+        if env-bool CN_INFRA_RUNNER; then
+            _info "CI workflow ran by $GITHUB_ACTOR and locked by ${lockholder}"
+            return
+        fi
+
         if ! approver=$( "$SPLICE_ROOT/build-tools/approved-by.sh" ); then
             _error "Could not determine approver for CI workflow"
         fi

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -267,15 +267,19 @@ function _assert_lock() {
         fi
 
         # Check lock for CI...
-        if env-bool CN_INFRA_RUNNER; then
-            _info "CI workflow ran by $GITHUB_ACTOR and locked by ${lockholder}"
-            return
+        approver=""
+        # Check for GHA
+        if env-bool GITHUB_ACTIONS; then
+            approver="${GITHUB_ACTOR:-}"
         fi
 
-        if ! approver=$( "$SPLICE_ROOT/build-tools/approved-by.sh" ); then
-            _error "Could not determine approver for CI workflow"
+        # Check for CCI
+        if env-bool CIRCLECI; then
+            if ! approver=$( "$SPLICE_ROOT/build-tools/approved-by.sh" ); then
+                _error "Could not determine approver for CI workflow"
+            fi
         fi
-
+        
         if [[ -n "$approver" ]]; then
             local -a names
             readarray -t names < <( _get_holder_names "$approver" )


### PR DESCRIPTION
This PR makes sure that we can verify the locker of scratchnets on GHA.

For context:
- as a part of porting [infra_up](https://github.com/DACH-NY/canton-network-internal/pull/5175/changes) I've ran into errors related to lock ownership
- in particular `$SPLICE_ROOT/build-tools/approved-by.sh` could not execute as the job did not have CCI token (and it does not make sense under GHA anyway)
- from a quick search it seems that the logic cannot really be replicated 1:1 under GHA as deployments don't have a direct API for this (unless we're speaking about approval from forks, than we have [this](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10&utm_source=openai#get-the-review-history-for-a-workflow-run) endpoint)
- the closest thing would be a github actor (if we're talking about running workflows from GHA UI) or maybe [custom deployment protection rule](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10&utm_source=openai#review-custom-deployment-protection-rules-for-a-workflow-run)

Solution:
- since we're running those jobs manually anyway we can for sure just use `GITHUB_ACTOR` (or `GITHUB_TRIGGERING_ACTOR`) 
- later on I'll change cluster_test (and others) to just print the cli command needed to run the workflow without doing any magic underneath which will be both simpler to understand and simpler to run
- CIRCLECI is always populated by CCI as you can see [here](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/67309/workflows/dc03d805-654f-4ece-be1c-4d915253b493/jobs/397896), so no functionality is lost - [tested](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/67312) with cluster_test on CCI side ✅ 

Refs:
- [GITHUB_ACTIONS / GITHUB_ACTOR](https://docs.github.com/en/actions/reference/workflows-and-actions/variables?utm_source=openai#default-environment-variables)
- [CCI env var](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/67309/workflows/dc03d805-654f-4ece-be1c-4d915253b493/jobs/397896)