### PR TITLE
Traffic-Based App Reward: Support bootstrapping with TBA enabled

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/CryptoHashEquivalenceIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/CryptoHashEquivalenceIntegrationTest.scala
@@ -147,6 +147,7 @@ class CryptoHashEquivalenceIntegrationTest extends IntegrationTest with WalletTe
         storage,
         updateHistory,
         DbAppActivityRecordStore.IngestionVersions(1, 0),
+        isFirstSv = false,
         loggerFactory,
       )
       rewardsStore = new DbScanAppRewardsStore(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -114,7 +114,10 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       // oldest=5: rounds 5,6,7 open. R8 will have
       // both dryRunVersion and mintingVersion set.
       clue("vote to enable dryRunVersion + mintingVersion") {
-        changeRewardConfig(enableDryRun = true, enableMinting = true)
+        changeRewardConfig(
+          enableDryRun = true,
+          rewardVersion = RewardVersion.REWARDVERSION_TRAFFICBASEDAPPREWARDS,
+        )
       }
 
       val svBackends = Seq(sv1Backend, sv2Backend, sv3Backend, sv4Backend)
@@ -409,14 +412,13 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
 
   private def changeRewardConfig(
       enableDryRun: Boolean,
-      enableMinting: Boolean = false,
+      rewardVersion: RewardVersion = RewardVersion.REWARDVERSION_FEATUREDAPPMARKERS,
   )(implicit env: SpliceTestConsoleEnvironment): Unit = {
     val amuletRules = sv1Backend.getDsoInfo().amuletRules
     val existing = AmuletConfigSchedule(amuletRules).getConfigAsOf(env.environment.clock.now)
     val rc = existing.rewardConfig.get()
     val newRc = new RewardConfig(
-      if (enableMinting) RewardVersion.REWARDVERSION_TRAFFICBASEDAPPREWARDS
-      else RewardVersion.REWARDVERSION_FEATUREDAPPMARKERS,
+      rewardVersion,
       if (enableDryRun) Optional.of(RewardVersion.REWARDVERSION_TRAFFICBASEDAPPREWARDS)
       else Optional.empty[RewardVersion](),
       rc.batchSize,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -67,6 +67,7 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       .addConfigTransform((_, config) =>
         ConfigTransforms.withRewardConfig(
           InitialRewardConfig(
+            mintingVersion = "RewardVersion_FeaturedAppMarkers",
             dryRunVersion = None,
             appRewardCouponThreshold = BigDecimal("0"),
           )
@@ -415,7 +416,7 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
     val rc = existing.rewardConfig.get()
     val newRc = new RewardConfig(
       if (enableMinting) RewardVersion.REWARDVERSION_TRAFFICBASEDAPPREWARDS
-      else rc.mintingVersion,
+      else RewardVersion.REWARDVERSION_FEATUREDAPPMARKERS,
       if (enableDryRun) Optional.of(RewardVersion.REWARDVERSION_TRAFFICBASEDAPPREWARDS)
       else Optional.empty[RewardVersion](),
       rc.batchSize,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -272,6 +272,27 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
                   s"CalculateRewardsV2 should exist for round $round"
               }
             }
+            // Test the archiveDryRunRewardAccountingContracts admin API
+            // by archiving a few early rounds. The remaining rounds are
+            // consumed by triggers naturally.
+            if (dryRunEnabled) {
+              clue("Archive dry-run CalculateRewardsV2 for rounds 0..2 via sv admin API") {
+                sv1Backend.archiveDryRunRewardAccountingContracts((0L to 2L).toSeq)
+              }
+              clue("CalculateRewardsV2 contracts for rounds 0..2 are gone") {
+                eventually() {
+                  val remaining = sv1Backend.appState.dsoStore
+                    .listCalculateRewardsV2()
+                    .futureValue
+                    .map(_.payload.round.number)
+                    .toSet
+                  (0L to 2L).foreach { round =>
+                    remaining should not contain round withClue
+                      s"CalculateRewardsV2 for round $round should be archived"
+                  }
+                }
+              }
+            }
           }
 
           (id0, id1, id3, id4, id5, id6, id7, aliceCreateId, svExpireId)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -272,49 +272,6 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
                   s"CalculateRewardsV2 should exist for round $round"
               }
             }
-            // For rounds 0..5 scan will not be able calculate activity totals
-            // and root hashes, so archiving them here keep the
-            // CalculateRewardsTrigger's logs clean, as they expect each round
-            // with CalculateRewardsV2 to have a root hash.
-            if (dryRunEnabled) {
-              clue("Archive dry-run CalculateRewardsV2 for rounds 0..5 via sv admin API") {
-                sv1Backend.archiveDryRunRewardAccountingContracts((0L to 5L).toSeq)
-              }
-            } else {
-              // TODO (#5624): add support for bootstrapping
-              // Bootstrapping a network with mintingVersion set to trafficBasedAppRewards
-              // is in principle not supported, as the round 0 will never have
-              // activity totals/root-hash calculated, and its CalculateRewardsV2 cannot be processed.
-              // So the only way to handle this in test is via direct archive.
-              clue("Archive CalculateRewardsV2 for rounds 0..5 directly as dso") {
-                val cids = sv1Backend.appState.dsoStore
-                  .listCalculateRewardsV2()
-                  .futureValue
-                  .filter(c => c.payload.round.number >= 0L && c.payload.round.number <= 5L)
-                  .map(_.contractId)
-                if (cids.nonEmpty) {
-                  sv1Backend.participantClientWithAdminToken.ledger_api_extensions.commands
-                    .submitJava(
-                      userId = sv1Backend.config.ledgerApiUser,
-                      actAs = Seq(dsoParty),
-                      commands = cids.flatMap(_.exerciseArchive().commands.asScala.toSeq),
-                    )
-                }
-              }
-            }
-            clue("CalculateRewardsV2 contracts for rounds 0..5 are gone") {
-              eventually() {
-                val remaining = sv1Backend.appState.dsoStore
-                  .listCalculateRewardsV2()
-                  .futureValue
-                  .map(_.payload.round.number)
-                  .toSet
-                (0L to 5L).foreach { round =>
-                  remaining should not contain round withClue
-                    s"CalculateRewardsV2 for round $round should be archived"
-                }
-              }
-            }
           }
 
           (id0, id1, id3, id4, id5, id6, id7, aliceCreateId, svExpireId)

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -71,7 +71,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
-      .simpleTopology1SvWithSimTime(this.getClass.getSimpleName)
+      .simpleTopology4SvsWithSimTime(this.getClass.getSimpleName)
       .withAdditionalSetup(implicit env => {
         Seq(
           sv1ValidatorBackend,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -71,7 +71,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
-      .simpleTopology4SvsWithSimTime(this.getClass.getSimpleName)
+      .simpleTopology1SvWithSimTime(this.getClass.getSimpleName)
       .withAdditionalSetup(implicit env => {
         Seq(
           sv1ValidatorBackend,
@@ -393,8 +393,8 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
     }
 
     val totalsByRound: Map[Long, definitions.RewardAccountingActivityTotalsOk] =
-      clue("Rounds 6..10 activity totals and root hash are computed") {
-        (6L to 10L).map { round =>
+      clue("Rounds 0..10 activity totals and root hash are computed") {
+        (0L to 10L).map { round =>
           val totalsOk = inside(sv1ScanBackend.getRewardAccountingActivityTotals(round)) {
             case GetRewardAccountingActivityTotalsResponse.members
                   .RewardAccountingActivityTotalsOk(t) =>
@@ -409,9 +409,8 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
         }.toMap
       }
 
-    // For rounds 0..5 scan cannot do totals calcs/produce a root hash, rounds
-    // 0..4 had no activity records; round 5 is excluded as the earliest round
-    // with records, and round 11 has not closed yet.
+    // Rounds 0..4 have no activity records (totals are zero);
+    // rounds 5..10 have activity. Round 11 has not closed yet.
     clue(
       "Minting allowances: rounds 6, 7, 10 reward both parties; round 9 only alice"
     ) {
@@ -458,19 +457,18 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
         .futureValue
         .map(_.payload.round.number)
 
-    clue("CalculateRewards and ProcessRewards triggers consume middle-round (6..10) contracts") {
-      // V2 contracts for rounds 6..10 should be processed by SVs
+    clue("CalculateRewards and ProcessRewards triggers consume contracts for rounds < 11") {
       eventually() {
         val remainingCalculate = sv1Backend.appState.dsoStore
           .listCalculateRewardsV2()
           .futureValue
-          .filter(c => c.payload.round.number >= 6L && c.payload.round.number <= 10L)
+          .filter(c => c.payload.round.number < 11L)
         remainingCalculate shouldBe empty withClue
-          "Middle-round CalculateRewardsV2 contracts (6..10) should be consumed"
+          "CalculateRewardsV2 contracts for rounds < 11 should be consumed"
         val remainingProcess = listProcessRewardsV2Rounds()
-          .filter(r => r >= 6L && r <= 10L)
+          .filter(r => r < 11L)
         remainingProcess shouldBe empty withClue
-          "Middle-round ProcessRewardsV2 contracts (6..10) should be consumed"
+          "ProcessRewardsV2 contracts for rounds < 11 should be consumed"
       }
     }
   }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -279,6 +279,7 @@ class ScanApp(
                 AppActivityComputation.ActivityIngestionCodeVersion,
                 config.activityIngestionUserVersion.fold(0)(_.toInt),
               ),
+              config.isFirstSv,
               loggerFactory,
             )
           )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -100,6 +100,7 @@ class DbAppActivityRecordStore(
     storage: DbStorage,
     updateHistory: UpdateHistory,
     val ingestionVersions: DbAppActivityRecordStore.IngestionVersions,
+    isFirstSv: Boolean,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit
     ec: ExecutionContext
@@ -170,7 +171,13 @@ class DbAppActivityRecordStore(
               and m.last_archived_round >= m.earliest_ingested_round + 1
       """.as[Option[Long]].headOption.map(_.flatten),
       "appActivity.earliestRoundWithCompleteAppActivity",
-    )
+    ).map {
+      // The first SV has complete history from genesis, so round 0 is always
+      // the earliest complete round. The query still runs to confirm ingestion
+      // has started (returns None if no meta row or no activity records).
+      case Some(_) if isFirstSv => Some(0L)
+      case other => other
+    }
   }
 
   /** Find the latest round with complete app activity.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -171,17 +171,11 @@ class DbAppActivityRecordStore(
               and m.last_archived_round >= m.earliest_ingested_round + 1
       """.as[Option[Long]].headOption.map(_.flatten),
       "appActivity.earliestRoundWithCompleteAppActivity",
-    ).flatMap {
-      case Some(n) if isFirstSv =>
-        // First SV: round 0 unless a version bump occurred.
-        runQuerySingle(
-          hasPriorIngestionVersionDBIO.map(Some(_)),
-          "appActivity.hasPriorVersionMeta",
-        ).map {
-          case Some(true) => Some(n) // version bump — respect meta table
-          case _ => Some(0L) // fresh network — round 0
-        }
-      case other => Future.successful(other)
+    ).map {
+      // Some(1) means earliest_ingested_round = 0 (query returns 0 + 1).
+      // First SV has complete history, so round 0 is complete.
+      case Some(1L) if isFirstSv => Some(0L)
+      case other => other
     }
   }
 
@@ -467,11 +461,15 @@ class DbAppActivityRecordStore(
               case None =>
                 DBIO.successful(NotReady: EnsureResult)
               case Some((firstRecordTimeMicros, earliestRound)) =>
+                // First SV on fresh network: earliest complete round is
+                // always 0, so override the given value.
+                val adjustedEarliestRound =
+                  if (isFirstSv && maxVersions.isEmpty) 0L else earliestRound
                 insertActivityRecordMetaDBIO(
                   codeVersion,
                   userVersion,
                   firstRecordTimeMicros,
-                  earliestRound,
+                  adjustedEarliestRound,
                   lastArchivedRoundO,
                 ).map { _ =>
                   metaChecked.set(true)
@@ -487,21 +485,6 @@ class DbAppActivityRecordStore(
             DBIO.successful(Checked(d): EnsureResult)
         }
       } yield result
-    }
-  }
-
-  /** True if a prior ingestion version exists (version bump occurred). */
-  private def hasPriorIngestionVersionDBIO: DBIOAction[Boolean, NoStream, Effect.Read] = {
-    val cv = ingestionVersions.code
-    val uv = ingestionVersions.user
-    sql"""select min(activity_ingestion_code_version),
-                 min(activity_ingestion_user_version)
-          from #${Tables.activityRecordMeta}
-          where history_id = $historyId
-    """.as[(Option[Int], Option[Int])].headOption.map {
-      case Some((Some(minCode), Some(minUser))) =>
-        minCode < cv || (minCode == cv && minUser < uv)
-      case _ => false
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -171,12 +171,17 @@ class DbAppActivityRecordStore(
               and m.last_archived_round >= m.earliest_ingested_round + 1
       """.as[Option[Long]].headOption.map(_.flatten),
       "appActivity.earliestRoundWithCompleteAppActivity",
-    ).map {
-      // The first SV has complete history from genesis, so round 0 is always
-      // the earliest complete round. The query still runs to confirm ingestion
-      // has started (returns None if no meta row or no activity records).
-      case Some(_) if isFirstSv => Some(0L)
-      case other => other
+    ).flatMap {
+      case Some(n) if isFirstSv =>
+        // First SV: round 0 unless a version bump occurred.
+        runQuerySingle(
+          hasPriorIngestionVersionDBIO.map(Some(_)),
+          "appActivity.hasPriorVersionMeta",
+        ).map {
+          case Some(true) => Some(n) // version bump — respect meta table
+          case _ => Some(0L) // fresh network — round 0
+        }
+      case other => Future.successful(other)
     }
   }
 
@@ -482,6 +487,21 @@ class DbAppActivityRecordStore(
             DBIO.successful(Checked(d): EnsureResult)
         }
       } yield result
+    }
+  }
+
+  /** True if a prior ingestion version exists (version bump occurred). */
+  private def hasPriorIngestionVersionDBIO: DBIOAction[Boolean, NoStream, Effect.Read] = {
+    val cv = ingestionVersions.code
+    val uv = ingestionVersions.user
+    sql"""select min(activity_ingestion_code_version),
+                 min(activity_ingestion_user_version)
+          from #${Tables.activityRecordMeta}
+          where history_id = $historyId
+    """.as[(Option[Int], Option[Int])].headOption.map {
+      case Some((Some(minCode), Some(minUser))) =>
+        minCode < cv || (minCode == cv && minUser < uv)
+      case _ => false
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -171,12 +171,7 @@ class DbAppActivityRecordStore(
               and m.last_archived_round >= m.earliest_ingested_round + 1
       """.as[Option[Long]].headOption.map(_.flatten),
       "appActivity.earliestRoundWithCompleteAppActivity",
-    ).map {
-      // Some(1) means earliest_ingested_round = 0 (query returns 0 + 1).
-      // First SV has complete history, so round 0 is complete.
-      case Some(1L) if isFirstSv => Some(0L)
-      case other => other
-    }
+    )
   }
 
   /** Find the latest round with complete app activity.
@@ -461,10 +456,11 @@ class DbAppActivityRecordStore(
               case None =>
                 DBIO.successful(NotReady: EnsureResult)
               case Some((firstRecordTimeMicros, earliestRound)) =>
-                // First SV on fresh network: earliest complete round is
-                // always 0, so override the given value.
+                // First SV on fresh network: set earliest_ingested_round to -1
+                // so that round 0 passes assertCompleteActivity (0 > -1)
+                // and earliestRoundWithCompleteAppActivity returns -1 + 1 = 0.
                 val adjustedEarliestRound =
-                  if (isFirstSv && maxVersions.isEmpty) 0L else earliestRound
+                  if (isFirstSv && maxVersions.isEmpty) -1L else earliestRound
                 insertActivityRecordMetaDBIO(
                   codeVersion,
                   userVersion,

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -451,7 +451,7 @@ class DbAppActivityRecordStoreTest
         }
       }
 
-      "not override when earliest_ingested_round > 0" in {
+      "return earliest_ingested_round + 1 when earliest_ingested_round > 0" in {
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
@@ -473,7 +473,7 @@ class DbAppActivityRecordStoreTest
 
     "on first SV after version bump" should {
 
-      "respect meta table" in {
+      "return version 2 earliest round after version bump" in {
         for {
           (store, historyId) <- newStore(
             versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
@@ -501,7 +501,7 @@ class DbAppActivityRecordStoreTest
         }
       }
 
-      "not override after version bump" in {
+      "return version 2 earliest round when version bump via ensureMeta" in {
         for {
           (store, historyId) <- newStore(
             versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
@@ -734,29 +734,32 @@ class DbAppActivityRecordStoreTest
       }
     }
 
-    "set earliest_ingested_round to -1 on fresh network when isFirstSv" in {
-      for {
-        (store, _) <- newStore(isFirstSv = true)
-        r1 <- runEnsureMeta(store, Some((1000000L, 10L)))
-        meta <- store.lookupActivityRecordMeta(1, 0)
-      } yield {
-        r1 shouldBe Checked(InsertMeta)
-        meta.value.earliestIngestedRound shouldBe -1L
-      }
-    }
+    "on first SV" should {
 
-    "not override earliest_ingested_round on version bump when isFirstSv" in {
-      for {
-        (store, _) <- newStore(
-          versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
-          isFirstSv = true,
-        )
-        _ <- store.insertActivityRecordMeta(1, 0, 1000000L, 5L, None)
-        r1 <- runEnsureMeta(store, Some((2000000L, 10L)))
-        meta <- store.lookupActivityRecordMeta(2, 0)
-      } yield {
-        r1 shouldBe Checked(InsertMeta)
-        meta.value.earliestIngestedRound shouldBe 10L
+      "set earliest_ingested_round to -1 on fresh network" in {
+        for {
+          (store, _) <- newStore(isFirstSv = true)
+          r1 <- runEnsureMeta(store, Some((1000000L, 10L)))
+          meta <- store.lookupActivityRecordMeta(1, 0)
+        } yield {
+          r1 shouldBe Checked(InsertMeta)
+          meta.value.earliestIngestedRound shouldBe -1L
+        }
+      }
+
+      "use actual earliest_ingested_round on version bump" in {
+        for {
+          (store, _) <- newStore(
+            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+            isFirstSv = true,
+          )
+          _ <- store.insertActivityRecordMeta(1, 0, 1000000L, 5L, None)
+          r1 <- runEnsureMeta(store, Some((2000000L, 10L)))
+          meta <- store.lookupActivityRecordMeta(2, 0)
+        } yield {
+          r1 shouldBe Checked(InsertMeta)
+          meta.value.earliestIngestedRound shouldBe 10L
+        }
       }
     }
   }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -418,118 +418,152 @@ class DbAppActivityRecordStoreTest
       }
     }
 
-    "return round 0 on first SV when ingestion started from genesis" in {
-      for {
-        (store, historyId) <- newStore(isFirstSv = true)
-        baseTs = CantonTimestamp.now()
-        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-0", 0L),
-          ("round-1", 1L),
-        )
-        result <- store.earliestRoundWithCompleteAppActivity()
-      } yield {
-        result.value shouldBe 0L
+    "on first SV with no version bump" should {
+
+      "return round 0 when ingestion started from genesis" in {
+        for {
+          (store, historyId) <- newStore(isFirstSv = true)
+          baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-0", 0L),
+            ("round-1", 1L),
+          )
+          result <- store.earliestRoundWithCompleteAppActivity()
+        } yield {
+          result.value shouldBe 0L
+        }
+      }
+
+      "not return round 0 until the next round exists" in {
+        for {
+          (store, historyId) <- newStore(isFirstSv = true)
+          baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- insertRecordsForRounds(store, historyId, baseTs, ("round-0", 0L))
+          result <- store.earliestRoundWithCompleteAppActivity()
+        } yield {
+          result shouldBe None
+        }
+      }
+
+      "return round 0 even when first activity is after round 0" in {
+        for {
+          (store, historyId) <- newStore(isFirstSv = true)
+          baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, None)
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-10", 10L),
+            ("round-11", 11L),
+          )
+          result <- store.earliestRoundWithCompleteAppActivity()
+        } yield {
+          result.value shouldBe 0L
+        }
       }
     }
 
-    "not return round 0 on first SV until the next round exists" in {
-      for {
-        (store, historyId) <- newStore(isFirstSv = true)
-        baseTs = CantonTimestamp.now()
-        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-        _ <- insertRecordsForRounds(store, historyId, baseTs, ("round-0", 0L))
-        result <- store.earliestRoundWithCompleteAppActivity()
-      } yield {
-        result shouldBe None
-      }
-    }
+    "on first SV after version bump" should {
 
-    "return round 0 on first SV even when ingestion started after genesis" in {
-      for {
-        (store, historyId) <- newStore(isFirstSv = true)
-        baseTs = CantonTimestamp.now()
-        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, None)
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-10", 10L),
-          ("round-11", 11L),
-        )
-        result <- store.earliestRoundWithCompleteAppActivity()
-      } yield {
-        result.value shouldBe 0L
+      "respect meta table" in {
+        for {
+          (store, historyId) <- newStore(
+            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+            isFirstSv = true,
+          )
+          baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- store.insertActivityRecordMeta(2, 0, baseTs.plusSeconds(10L).toMicros, 10L, None)
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-10", 10L),
+            ("round-11", 11L),
+          )
+          result <- store.earliestRoundWithCompleteAppActivity()
+        } yield {
+          result.value shouldBe 11L
+        }
       }
     }
   }
 
   "assertCompleteActivity" should {
 
-    "accept round 0 on first SV (no prior round needed)" in {
-      for {
-        (store, historyId) <- newStore(isFirstSv = true)
-        baseTs = CantonTimestamp.now()
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-0", 0L),
-          ("round-1", 1L),
-        )
-        _ <- store.assertCompleteActivity(0L)
-      } yield succeed
-    }
+    "on first SV" should {
 
-    "reject round 0 on non-first SV (no prior round exists)" in {
-      for {
-        (store, historyId) <- newStore()
-        baseTs = CantonTimestamp.now()
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-0", 0L),
-          ("round-1", 1L),
-        )
-        result <- store.assertCompleteActivity(0L).failed
-      } yield {
-        result.getMessage should include("Incomplete app activity for round 0")
+      "accept round 0 (no prior round needed)" in {
+        for {
+          (store, historyId) <- newStore(isFirstSv = true)
+          baseTs = CantonTimestamp.now()
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-0", 0L),
+            ("round-1", 1L),
+          )
+          _ <- store.assertCompleteActivity(0L)
+        } yield succeed
+      }
+
+      "accept round with no prior records" in {
+        for {
+          (store, historyId) <- newStore(isFirstSv = true)
+          baseTs = CantonTimestamp.now()
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-5", 5L),
+            ("round-6", 6L),
+          )
+          _ <- store.assertCompleteActivity(5L)
+        } yield succeed
       }
     }
 
-    "accept round with no prior records on first SV" in {
-      for {
-        (store, historyId) <- newStore(isFirstSv = true)
-        baseTs = CantonTimestamp.now()
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-5", 5L),
-          ("round-6", 6L),
-        )
-        _ <- store.assertCompleteActivity(5L)
-      } yield succeed
-    }
+    "on non-first SV" should {
 
-    "reject round with no prior records on non-first SV" in {
-      for {
-        (store, historyId) <- newStore()
-        baseTs = CantonTimestamp.now()
-        _ <- insertRecordsForRounds(
-          store,
-          historyId,
-          baseTs,
-          ("round-5", 5L),
-          ("round-6", 6L),
-        )
-        result <- store.assertCompleteActivity(5L).failed
-      } yield {
-        result.getMessage should include("Incomplete app activity for round 5")
+      "reject round 0 (no prior round exists)" in {
+        for {
+          (store, historyId) <- newStore()
+          baseTs = CantonTimestamp.now()
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-0", 0L),
+            ("round-1", 1L),
+          )
+          result <- store.assertCompleteActivity(0L).failed
+        } yield {
+          result.getMessage should include("Incomplete app activity for round 0")
+        }
+      }
+
+      "reject round with no prior records" in {
+        for {
+          (store, historyId) <- newStore()
+          baseTs = CantonTimestamp.now()
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-5", 5L),
+            ("round-6", 6L),
+          )
+          result <- store.assertCompleteActivity(5L).failed
+        } yield {
+          result.getMessage should include("Incomplete app activity for round 5")
+        }
       }
     }
   }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -424,7 +424,7 @@ class DbAppActivityRecordStoreTest
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, Some(1L))
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -454,7 +454,7 @@ class DbAppActivityRecordStoreTest
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, None)
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, Some(11L))
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -464,7 +464,8 @@ class DbAppActivityRecordStoreTest
           )
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
-          result.value shouldBe 0L
+          // earliest_ingested_round = 10, query returns 11 — not 1, so isFirstSv override doesn't fire
+          result.value shouldBe 11L
         }
       }
     }
@@ -478,8 +479,14 @@ class DbAppActivityRecordStoreTest
             isFirstSv = true,
           )
           baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-          _ <- store.insertActivityRecordMeta(2, 0, baseTs.plusSeconds(10L).toMicros, 10L, None)
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, Some(1L))
+          _ <- store.insertActivityRecordMeta(
+            2,
+            0,
+            baseTs.plusSeconds(10L).toMicros,
+            10L,
+            Some(11L),
+          )
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -501,9 +508,9 @@ class DbAppActivityRecordStoreTest
           )
           baseTs = CantonTimestamp.now()
           // Version 1 meta row exists from prior run
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, Some(1L))
           // Version 2 meta row added by ensureMeta
-          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
+          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)), Some(11L))
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -516,127 +523,6 @@ class DbAppActivityRecordStoreTest
           // Query reads version 2 meta (earliest_ingested_round = 10),
           // returns Some(11) — the case Some(1L) override does not fire.
           result.value shouldBe 11L
-        }
-      }
-    }
-  }
-
-  "assertCompleteActivity" should {
-
-    "on first SV" should {
-
-      "accept round 0 (no prior round needed)" in {
-        for {
-          (store, historyId) <- newStore(isFirstSv = true)
-          baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-0", 0L),
-            ("round-1", 1L),
-          )
-          _ <- store.assertCompleteActivity(0L)
-        } yield succeed
-      }
-
-      "accept round with no prior records on fresh network" in {
-        for {
-          (store, historyId) <- newStore(isFirstSv = true)
-          baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-5", 5L),
-            ("round-6", 6L),
-          )
-          _ <- store.assertCompleteActivity(5L)
-        } yield succeed
-      }
-
-      "reject round with no prior records after version bump" in {
-        for {
-          (store, historyId) <- newStore(
-            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
-            isFirstSv = true,
-          )
-          baseTs = CantonTimestamp.now()
-          // Version 1 meta row exists from prior run
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-          // Version 2 meta row added by ensureMeta
-          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-10", 10L),
-            ("round-11", 11L),
-          )
-          // 2 meta rows → isFirstSvFreshNetwork is false → prior round required
-          result <- store.assertCompleteActivity(10L).failed
-        } yield {
-          result.getMessage should include("Incomplete app activity for round 10")
-        }
-      }
-
-      "accept round with prior records after version bump" in {
-        for {
-          (store, historyId) <- newStore(
-            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
-            isFirstSv = true,
-          )
-          baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
-          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-10", 10L),
-            ("round-11", 11L),
-            ("round-12", 12L),
-          )
-          _ <- store.assertCompleteActivity(11L)
-        } yield succeed
-      }
-    }
-
-    "on non-first SV" should {
-
-      "reject round 0 (no prior round exists)" in {
-        for {
-          (store, historyId) <- newStore()
-          baseTs = CantonTimestamp.now()
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-0", 0L),
-            ("round-1", 1L),
-          )
-          result <- store.assertCompleteActivity(0L).failed
-        } yield {
-          result.getMessage should include("Incomplete app activity for round 0")
-        }
-      }
-
-      "reject round with no prior records" in {
-        for {
-          (store, historyId) <- newStore()
-          baseTs = CantonTimestamp.now()
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-5", 5L),
-            ("round-6", 6L),
-          )
-          result <- store.assertCompleteActivity(5L).failed
-        } yield {
-          result.getMessage should include("Incomplete app activity for round 5")
         }
       }
     }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -424,7 +424,8 @@ class DbAppActivityRecordStoreTest
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, Some(1L))
+          // ensureMetaDBIO sets earliest_ingested_round = -1 for isFirstSv fresh network
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, -1L, Some(1L))
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -442,7 +443,7 @@ class DbAppActivityRecordStoreTest
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, -1L, None)
           _ <- insertRecordsForRounds(store, historyId, baseTs, ("round-0", 0L))
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
@@ -464,7 +465,7 @@ class DbAppActivityRecordStoreTest
           )
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
-          // earliest_ingested_round = 10, query returns 11 — not 1, so isFirstSv override doesn't fire
+          // earliest_ingested_round = 10, query returns 11
           result.value shouldBe 11L
         }
       }
@@ -521,7 +522,7 @@ class DbAppActivityRecordStoreTest
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
           // Query reads version 2 meta (earliest_ingested_round = 10),
-          // returns Some(11) — the case Some(1L) override does not fire.
+          // returns Some(11).
           result.value shouldBe 11L
         }
       }
@@ -733,14 +734,14 @@ class DbAppActivityRecordStoreTest
       }
     }
 
-    "set earliest_ingested_round to 0 on fresh network when isFirstSv" in {
+    "set earliest_ingested_round to -1 on fresh network when isFirstSv" in {
       for {
         (store, _) <- newStore(isFirstSv = true)
         r1 <- runEnsureMeta(store, Some((1000000L, 10L)))
         meta <- store.lookupActivityRecordMeta(1, 0)
       } yield {
         r1 shouldBe Checked(InsertMeta)
-        meta.value.earliestIngestedRound shouldBe 0L
+        meta.value.earliestIngestedRound shouldBe -1L
       }
     }
 

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -420,11 +420,11 @@ class DbAppActivityRecordStoreTest
 
     "on first SV" should {
 
-      "return round 0 when ingestion started from genesis" in {
+      "return round 0 on fresh network" in {
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
-          // ensureMetaDBIO sets earliest_ingested_round = -1 for isFirstSv fresh network
+          // ensureMetaDBIO sets earliest_ingested_round = -1 on fresh isFirstSv network
           _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, -1L, Some(1L))
           _ <- insertRecordsForRounds(
             store,
@@ -435,11 +435,12 @@ class DbAppActivityRecordStoreTest
           )
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
+          // query returns -1 + 1 = 0
           result.value shouldBe 0L
         }
       }
 
-      "not return round 0 until the next round exists" in {
+      "return None until last_archived_round is set" in {
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
@@ -448,25 +449,6 @@ class DbAppActivityRecordStoreTest
           result <- store.earliestRoundWithCompleteAppActivity()
         } yield {
           result shouldBe None
-        }
-      }
-
-      "return earliest_ingested_round + 1 when earliest_ingested_round > 0" in {
-        for {
-          (store, historyId) <- newStore(isFirstSv = true)
-          baseTs = CantonTimestamp.now()
-          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, Some(11L))
-          _ <- insertRecordsForRounds(
-            store,
-            historyId,
-            baseTs,
-            ("round-10", 10L),
-            ("round-11", 11L),
-          )
-          result <- store.earliestRoundWithCompleteAppActivity()
-        } yield {
-          // earliest_ingested_round = 10, query returns 11
-          result.value shouldBe 11L
         }
       }
     }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -417,6 +417,121 @@ class DbAppActivityRecordStoreTest
         result shouldBe None
       }
     }
+
+    "return round 0 on first SV when ingestion started from genesis" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-0", 0L),
+          ("round-1", 1L),
+        )
+        result <- store.earliestRoundWithCompleteAppActivity()
+      } yield {
+        result.value shouldBe 0L
+      }
+    }
+
+    "not return round 0 on first SV until the next round exists" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+        _ <- insertRecordsForRounds(store, historyId, baseTs, ("round-0", 0L))
+        result <- store.earliestRoundWithCompleteAppActivity()
+      } yield {
+        result shouldBe None
+      }
+    }
+
+    "return round 0 on first SV even when ingestion started after genesis" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, None)
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-10", 10L),
+          ("round-11", 11L),
+        )
+        result <- store.earliestRoundWithCompleteAppActivity()
+      } yield {
+        result.value shouldBe 0L
+      }
+    }
+  }
+
+  "assertCompleteActivity" should {
+
+    "accept round 0 on first SV (no prior round needed)" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-0", 0L),
+          ("round-1", 1L),
+        )
+        _ <- store.assertCompleteActivity(0L)
+      } yield succeed
+    }
+
+    "reject round 0 on non-first SV (no prior round exists)" in {
+      for {
+        (store, historyId) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-0", 0L),
+          ("round-1", 1L),
+        )
+        result <- store.assertCompleteActivity(0L).failed
+      } yield {
+        result.getMessage should include("Incomplete app activity for round 0")
+      }
+    }
+
+    "accept round with no prior records on first SV" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-5", 5L),
+          ("round-6", 6L),
+        )
+        _ <- store.assertCompleteActivity(5L)
+      } yield succeed
+    }
+
+    "reject round with no prior records on non-first SV" in {
+      for {
+        (store, historyId) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- insertRecordsForRounds(
+          store,
+          historyId,
+          baseTs,
+          ("round-5", 5L),
+          ("round-6", 6L),
+        )
+        result <- store.assertCompleteActivity(5L).failed
+      } yield {
+        result.getMessage should include("Incomplete app activity for round 5")
+      }
+    }
   }
 
   "lookupActivityRecordMeta" should {
@@ -780,7 +895,8 @@ class DbAppActivityRecordStoreTest
     */
   private def newStore(
       versions: DbAppActivityRecordStore.IngestionVersions =
-        DbAppActivityRecordStore.IngestionVersions(1, 0)
+        DbAppActivityRecordStore.IngestionVersions(1, 0),
+      isFirstSv: Boolean = false,
   ): Future[(DbAppActivityRecordStore, Long)] = {
     val n = storeCounter.getAndIncrement()
     val participantId = mkParticipantId(s"activity-test-$n")
@@ -801,6 +917,7 @@ class DbAppActivityRecordStoreTest
         storage.underlying,
         updateHistory,
         versions,
+        isFirstSv,
         loggerFactory,
       )
       (store, updateHistory.historyId)
@@ -810,7 +927,9 @@ class DbAppActivityRecordStoreTest
   /** Creates both an app activity record store and a verdict store backed by
     * the same UpdateHistory, for testing insertVerdictsWithAppActivityRecords.
     */
-  private def newStores(): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
+  private def newStores(
+      isFirstSv: Boolean = false
+  ): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
     val participantId = mkParticipantId("activity-test")
     val updateHistory = new UpdateHistory(
       storage.underlying,
@@ -829,6 +948,7 @@ class DbAppActivityRecordStoreTest
         storage.underlying,
         updateHistory,
         DbAppActivityRecordStore.IngestionVersions(1, 0),
+        isFirstSv,
         loggerFactory,
       )
       val verdictStore = new DbScanVerdictStore(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -492,6 +492,32 @@ class DbAppActivityRecordStoreTest
           result.value shouldBe 11L
         }
       }
+
+      "not override after version bump" in {
+        for {
+          (store, historyId) <- newStore(
+            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+            isFirstSv = true,
+          )
+          baseTs = CantonTimestamp.now()
+          // Version 1 meta row exists from prior run
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          // Version 2 meta row added by ensureMeta
+          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-10", 10L),
+            ("round-11", 11L),
+          )
+          result <- store.earliestRoundWithCompleteAppActivity()
+        } yield {
+          // Query reads version 2 meta (earliest_ingested_round = 10),
+          // returns Some(11) — the case Some(1L) override does not fire.
+          result.value shouldBe 11L
+        }
+      }
     }
   }
 
@@ -528,6 +554,52 @@ class DbAppActivityRecordStoreTest
             ("round-6", 6L),
           )
           _ <- store.assertCompleteActivity(5L)
+        } yield succeed
+      }
+
+      "reject round with no prior records after version bump" in {
+        for {
+          (store, historyId) <- newStore(
+            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+            isFirstSv = true,
+          )
+          baseTs = CantonTimestamp.now()
+          // Version 1 meta row exists from prior run
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          // Version 2 meta row added by ensureMeta
+          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-10", 10L),
+            ("round-11", 11L),
+          )
+          // 2 meta rows → isFirstSvFreshNetwork is false → prior round required
+          result <- store.assertCompleteActivity(10L).failed
+        } yield {
+          result.getMessage should include("Incomplete app activity for round 10")
+        }
+      }
+
+      "accept round with prior records after version bump" in {
+        for {
+          (store, historyId) <- newStore(
+            versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+            isFirstSv = true,
+          )
+          baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
+          _ <- runEnsureMeta(store, Some((baseTs.toMicros + 1000000L, 10L)))
+          _ <- insertRecordsForRounds(
+            store,
+            historyId,
+            baseTs,
+            ("round-10", 10L),
+            ("round-11", 11L),
+            ("round-12", 12L),
+          )
+          _ <- store.assertCompleteActivity(11L)
         } yield succeed
       }
     }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -418,7 +418,7 @@ class DbAppActivityRecordStoreTest
       }
     }
 
-    "on first SV with no version bump" should {
+    "on first SV" should {
 
       "return round 0 when ingestion started from genesis" in {
         for {
@@ -450,7 +450,7 @@ class DbAppActivityRecordStoreTest
         }
       }
 
-      "return round 0 even when first activity is after round 0" in {
+      "not override when earliest_ingested_round > 0" in {
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
@@ -503,6 +503,7 @@ class DbAppActivityRecordStoreTest
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -514,10 +515,11 @@ class DbAppActivityRecordStoreTest
         } yield succeed
       }
 
-      "accept round with no prior records" in {
+      "accept round with no prior records on fresh network" in {
         for {
           (store, historyId) <- newStore(isFirstSv = true)
           baseTs = CantonTimestamp.now()
+          _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 0L, None)
           _ <- insertRecordsForRounds(
             store,
             historyId,
@@ -772,6 +774,32 @@ class DbAppActivityRecordStoreTest
         meta.value.earliestIngestedRound shouldBe 10L
       }
     }
+
+    "set earliest_ingested_round to 0 on fresh network when isFirstSv" in {
+      for {
+        (store, _) <- newStore(isFirstSv = true)
+        r1 <- runEnsureMeta(store, Some((1000000L, 10L)))
+        meta <- store.lookupActivityRecordMeta(1, 0)
+      } yield {
+        r1 shouldBe Checked(InsertMeta)
+        meta.value.earliestIngestedRound shouldBe 0L
+      }
+    }
+
+    "not override earliest_ingested_round on version bump when isFirstSv" in {
+      for {
+        (store, _) <- newStore(
+          versions = DbAppActivityRecordStore.IngestionVersions(2, 0),
+          isFirstSv = true,
+        )
+        _ <- store.insertActivityRecordMeta(1, 0, 1000000L, 5L, None)
+        r1 <- runEnsureMeta(store, Some((2000000L, 10L)))
+        meta <- store.lookupActivityRecordMeta(2, 0)
+      } yield {
+        r1 shouldBe Checked(InsertMeta)
+        meta.value.earliestIngestedRound shouldBe 10L
+      }
+    }
   }
 
   "latestRoundWithCompleteAppActivity" should {
@@ -961,9 +989,7 @@ class DbAppActivityRecordStoreTest
   /** Creates both an app activity record store and a verdict store backed by
     * the same UpdateHistory, for testing insertVerdictsWithAppActivityRecords.
     */
-  private def newStores(
-      isFirstSv: Boolean = false
-  ): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
+  private def newStores(): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
     val participantId = mkParticipantId("activity-test")
     val updateHistory = new UpdateHistory(
       storage.underlying,
@@ -982,7 +1008,7 @@ class DbAppActivityRecordStoreTest
         storage.underlying,
         updateHistory,
         DbAppActivityRecordStore.IngestionVersions(1, 0),
-        isFirstSv,
+        isFirstSv = false,
         loggerFactory,
       )
       val verdictStore = new DbScanVerdictStore(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -457,9 +457,8 @@ class DbScanAppRewardsStoreTest
     "aggregateActivityTotals — succeeds for round 0 when isFirstSv" in {
       for {
         (store, historyId) <- newStore(isFirstSv = true)
-        _ <- insertActivityRecordMeta(historyId, 0L)
+        _ <- markRoundComplete(historyId, 0L)
         _ <- insertActivityRecord(historyId, 0L, Seq("alice::provider"), Seq(500L))
-        // Next-round sentinel only — no prior round needed for isFirstSv
         _ <- insertActivityRecord(historyId, 1L, Seq("sentinel::provider"), Seq(1L))
         _ <- store.aggregateActivityTotals(0L)
         totals <- store.getAppActivityPartyTotalsByRound(0L)
@@ -1120,20 +1119,6 @@ class DbScanAppRewardsStoreTest
       )
     }.map(_ => ())
   }
-
-  private def insertActivityRecordMeta(
-      historyId: Long,
-      earliestIngestedRound: Long,
-  ): Future[Unit] =
-    futureUnlessShutdownToFuture(
-      storage.underlying.queryAndUpdate(
-        sqlu"""insert into app_activity_record_meta
-               (history_id, activity_ingestion_code_version, activity_ingestion_user_version,
-                started_ingesting_at, earliest_ingested_round)
-               values ($historyId, 1, 0, 0, $earliestIngestedRound)""".map(_ => ()),
-        "test.insertActivityRecordMeta",
-      )
-    )
 
   /** Insert a meta row marking `round` as complete
     * satisfying the completeness precondition in aggregateActivityTotals.

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -457,6 +457,7 @@ class DbScanAppRewardsStoreTest
     "aggregateActivityTotals — succeeds for round 0 when isFirstSv" in {
       for {
         (store, historyId) <- newStore(isFirstSv = true)
+        _ <- insertActivityRecordMeta(historyId, 0L)
         _ <- insertActivityRecord(historyId, 0L, Seq("alice::provider"), Seq(500L))
         // Next-round sentinel only — no prior round needed for isFirstSv
         _ <- insertActivityRecord(historyId, 1L, Seq("sentinel::provider"), Seq(1L))
@@ -1119,6 +1120,20 @@ class DbScanAppRewardsStoreTest
       )
     }.map(_ => ())
   }
+
+  private def insertActivityRecordMeta(
+      historyId: Long,
+      earliestIngestedRound: Long,
+  ): Future[Unit] =
+    futureUnlessShutdownToFuture(
+      storage.underlying.queryAndUpdate(
+        sqlu"""insert into app_activity_record_meta
+               (history_id, activity_ingestion_code_version, activity_ingestion_user_version,
+                started_ingesting_at, earliest_ingested_round)
+               values ($historyId, 1, 0, 0, $earliestIngestedRound)""".map(_ => ()),
+        "test.insertActivityRecordMeta",
+      )
+    )
 
   /** Insert a meta row marking `round` as complete
     * satisfying the completeness precondition in aggregateActivityTotals.

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbScanAppRewardsStoreTest.scala
@@ -454,6 +454,31 @@ class DbScanAppRewardsStoreTest
       }
     }
 
+    "aggregateActivityTotals — succeeds for round 0 when isFirstSv" in {
+      for {
+        (store, historyId) <- newStore(isFirstSv = true)
+        _ <- insertActivityRecord(historyId, 0L, Seq("alice::provider"), Seq(500L))
+        // Next-round sentinel only — no prior round needed for isFirstSv
+        _ <- insertActivityRecord(historyId, 1L, Seq("sentinel::provider"), Seq(1L))
+        _ <- store.aggregateActivityTotals(0L)
+        totals <- store.getAppActivityPartyTotalsByRound(0L)
+      } yield {
+        totals should have size 1
+        totals.head.appProviderParty shouldBe "alice::provider"
+      }
+    }
+
+    "aggregateActivityTotals — rejects round 0 when not isFirstSv" in {
+      for {
+        (store, historyId) <- newStore()
+        _ <- insertActivityRecord(historyId, 0L, Seq("alice::provider"), Seq(500L))
+        _ <- insertActivityRecord(historyId, 1L, Seq("sentinel::provider"), Seq(1L))
+        result <- store.aggregateActivityTotals(0L).failed
+      } yield {
+        result.getMessage should include("Incomplete app activity for round 0")
+      }
+    }
+
     "roundsWithComputedRewards" should {
 
       "returns empty set for empty input" in {
@@ -1183,7 +1208,8 @@ class DbScanAppRewardsStoreTest
   private val storeCounter = new java.util.concurrent.atomic.AtomicLong(1)
 
   private def newStore(
-      rewardMintingAllowanceTolerance: BigDecimal = BigDecimal(0.001)
+      rewardMintingAllowanceTolerance: BigDecimal = BigDecimal(0.001),
+      isFirstSv: Boolean = false,
   ): Future[(DbScanAppRewardsStore, Long)] = {
     val n = storeCounter.getAndIncrement()
     val participantId = mkParticipantId(s"rewards-test-$n")
@@ -1204,6 +1230,7 @@ class DbScanAppRewardsStoreTest
         storage.underlying,
         updateHistory,
         DbAppActivityRecordStore.IngestionVersions(1, 0),
+        isFirstSv,
         loggerFactory,
       )
       val store = new DbScanAppRewardsStore(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -241,7 +241,7 @@ object SvOnboardingConfig {
 }
 
 final case class InitialRewardConfig(
-    mintingVersion: String = "RewardVersion_TrafficBasedAppRewards",
+    mintingVersion: String = "RewardVersion_FeaturedAppMarkers",
     dryRunVersion: Option[String] = None,
     batchSize: Long = 100,
     rewardCouponTimeToLiveMicros: Long = 36L * 60 * 60 * 1000000, // 36 hours

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -241,7 +241,7 @@ object SvOnboardingConfig {
 }
 
 final case class InitialRewardConfig(
-    mintingVersion: String = "RewardVersion_FeaturedAppMarkers",
+    mintingVersion: String = "RewardVersion_TrafficBasedAppRewards",
     dryRunVersion: Option[String] = None,
     batchSize: Long = 100,
     rewardCouponTimeToLiveMicros: Long = 36L * 60 * 60 * 1000000, // 36 hours


### PR DESCRIPTION
Fixes #5624

Assumes the following to detect bootstrapping:
- the activity meta table is initially empty if bootstrapping
- so if there is any existing row, then it's not bootstrapping

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
