### PR TITLE
Switch wget timeout to 1s

### DIFF
--- a/cluster/images/multi-validator/health-check.sh
+++ b/cluster/images/multi-validator/health-check.sh
@@ -16,7 +16,7 @@ function check_endpoint() {
     # S.a. the comment in `cluster/images/splice-app/Dockerfile`.
     # We add the `-O` flag to ensure that `wget` doesn't end up creating huge numbers of `readyz.12345` files,
     # which will slow it down to the point of checks failing.
-    if ! response=$(wget --timeout=0.5 --server-response --quiet "http://127.0.0.1:${validator_admin_port}/$endpoint" -O tmp 2>&1); then
+    if ! response=$(wget --timeout=1 --server-response --quiet "http://127.0.0.1:${validator_admin_port}/$endpoint" -O tmp 2>&1); then
       echo "Connection to $validator_admin_port timed out"
       exit 1
     fi


### PR DESCRIPTION
Don't ask me why but the new base images have a wget that does not like 0.5.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
