### PR TITLE
Add command to update upgrade version

### DIFF
--- a/build-tools/lib/hard-domain-migration-commands
+++ b/build-tools/lib/hard-domain-migration-commands
@@ -50,19 +50,45 @@ EOF
   _update_cluster_config "$migration_config" "synchronizerMigration.$migration_type"
 }
 
-subcommand_whitelist[update_active_version]='Upgrade the version of the active migration id'
-
-function subcmd_update_active_version() {
+function update_version() {
     local cluster_directory
-    if [ "$#" -ne 1 ]; then
-        _error "Usage: $0 $SCRIPTNAME [<version>]"
+    if [ "$#" -ne 2 ]; then
+        _error "Usage: $0 $SCRIPTNAME [<version>] [migration]"
     fi
     # yq doesn't like the version being unquoted so we quote it here
-    _update_cluster_config "\"$1\"" "synchronizerMigration.active.version"
+    _update_cluster_config "\"$1\"" "synchronizerMigration.$2.version"
     if [ -z "${TARGET_CLUSTER-}" ]; then
         cluster_directory="$(pwd)"
     else
         cluster_directory="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}"
+    fi
+}
+
+subcommand_whitelist[update_active_version]='Upgrade the version of the active migration id'
+
+function subcmd_update_active_version() {
+    if [ "$#" -ne 1 ]; then
+        _error "Usage: $0 $SCRIPTNAME [<version>]"
+    fi
+    update_version "$1" "active"
+}
+
+subcommand_whitelist[update_upgrade_version]='Upgrade the version of the upgrade migration id'
+
+function subcmd_update_upgrade_version() {
+    if [ "$#" -ne 1 ]; then
+        _error "Usage: $0 $SCRIPTNAME [<version>]"
+    fi
+    if [ -z "${TARGET_CLUSTER-}" ]; then
+        configFile="config.yaml"
+    else
+        configFile="${DEPLOYMENT_DIR}/${TARGET_CLUSTER}/config.yaml"
+    fi
+    if yq -e '.synchronizerMigration.upgrade' "$configFile" > /dev/null 2>&1
+    then
+        update_version "$1" "upgrade"
+    else
+        echo "No upgrade version"
     fi
 }
 


### PR DESCRIPTION
Will use that in the cilr upgrade automation to avoid the situation we had where our staging nodes accidentally were still on an older version.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
