### PR TITLE
Restore refresh-token silent renew with renew-or-signout on 401

### DIFF
--- a/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
@@ -28,7 +28,7 @@ const rs256Config: AuthConfig = {
 };
 
 describe('AuthProvider', () => {
-  test('passes automaticSilentRenew=true to the OIDC provider', () => {
+  test('disables the library timer-based silent renew (UserProvider handles it on 401 instead)', () => {
     mockOidcAuthProvider.mockClear();
     render(
       <AuthProvider authConf={rs256Config}>
@@ -37,18 +37,7 @@ describe('AuthProvider', () => {
     );
     expect(mockOidcAuthProvider).toHaveBeenCalled();
     const props = mockOidcAuthProvider.mock.calls[0][0] as Record<string, unknown>;
-    expect(props.automaticSilentRenew).toBe(true);
-  });
-
-  test('does not pass silent_redirect_uri (iframe fallback intentionally disabled)', () => {
-    mockOidcAuthProvider.mockClear();
-    render(
-      <AuthProvider authConf={rs256Config}>
-        <div />
-      </AuthProvider>
-    );
-    const props = mockOidcAuthProvider.mock.calls[0][0] as Record<string, unknown>;
-    expect(props.silent_redirect_uri).toBeUndefined();
+    expect(props.automaticSilentRenew).toBe(false);
   });
 
   test('hs256-unsafe config short-circuits without rendering the OIDC provider', () => {

--- a/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+const mockOidcAuthProvider = vi.fn(({ children }: React.PropsWithChildren) => <>{children}</>);
+
+vi.mock('react-oidc-context', () => ({
+  AuthProvider: (props: React.PropsWithChildren<Record<string, unknown>>) =>
+    mockOidcAuthProvider(props),
+}));
+
+vi.mock('../../utils', async () => {
+  const auth = await vi.importActual<typeof import('../../utils/auth')>('../../utils/auth');
+  return { ...auth };
+});
+
+import AuthProvider from '../../components/AuthProvider';
+import { Algorithm, AuthConfig } from '../../config/schema';
+
+const rs256Config: AuthConfig = {
+  algorithm: Algorithm.RS256,
+  authority: 'https://idp.example.com/',
+  client_id: 'test-client',
+  token_audience: 'https://api.example.com',
+  token_scope: 'wallet',
+};
+
+describe('AuthProvider', () => {
+  test('passes automaticSilentRenew=true to the OIDC provider', () => {
+    mockOidcAuthProvider.mockClear();
+    render(
+      <AuthProvider authConf={rs256Config}>
+        <div />
+      </AuthProvider>
+    );
+    expect(mockOidcAuthProvider).toHaveBeenCalled();
+    const props = mockOidcAuthProvider.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.automaticSilentRenew).toBe(true);
+  });
+
+  test('does not pass silent_redirect_uri (iframe fallback intentionally disabled)', () => {
+    mockOidcAuthProvider.mockClear();
+    render(
+      <AuthProvider authConf={rs256Config}>
+        <div />
+      </AuthProvider>
+    );
+    const props = mockOidcAuthProvider.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.silent_redirect_uri).toBeUndefined();
+  });
+
+  test('hs256-unsafe config short-circuits without rendering the OIDC provider', () => {
+    mockOidcAuthProvider.mockClear();
+    render(
+      <AuthProvider
+        authConf={{
+          algorithm: Algorithm.HS256UNSAFE,
+          secret: 'shh',
+          token_audience: 'https://api.example.com',
+        }}
+      >
+        <div />
+      </AuthProvider>
+    );
+    expect(mockOidcAuthProvider).not.toHaveBeenCalled();
+  });
+});

--- a/apps/common/frontend/src/__tests__/auth/UserContextRenewOrSignout.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/UserContextRenewOrSignout.test.tsx
@@ -45,20 +45,22 @@ const fakeJwt = (sub: string): string => {
   return `${header}.${payload}.fakesig`;
 };
 
-const Harness: React.FC = () => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return (
-    <QueryClientProvider client={queryClient}>
-      <UserProvider authConf={rs256Config}>
-        <div data-testid="children" />
-      </UserProvider>
-    </QueryClientProvider>
-  );
-};
+let queryClient: QueryClient;
+let invalidateSpy: ReturnType<typeof vi.spyOn>;
+
+const Harness: React.FC = () => (
+  <QueryClientProvider client={queryClient}>
+    <UserProvider authConf={rs256Config}>
+      <div data-testid="children" />
+    </UserProvider>
+  </QueryClientProvider>
+);
 
 beforeEach(() => {
   signinSilent.mockReset();
   removeUser.mockReset();
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
   Object.defineProperty(window, 'location', {
     configurable: true,
     value: { ...window.location, origin: 'http://localhost:3000', href: 'http://localhost:3000/' },
@@ -67,6 +69,7 @@ beforeEach(() => {
 
 afterEach(() => {
   mockUser = undefined;
+  invalidateSpy.mockRestore();
 });
 
 describe('renewOrSignout on splice:auth-expired', () => {
@@ -82,6 +85,25 @@ describe('renewOrSignout on splice:auth-expired', () => {
     expect(removeUser).not.toHaveBeenCalled();
   });
 
+  test('invalidates queries after a successful refresh (deferred until token state updates)', async () => {
+    mockUser = { access_token: fakeJwt('alice'), refresh_token: 'rt-1' };
+    // Simulate the library updating the stored User on successful renewal —
+    // this is what triggers the userAccessToken state update that the
+    // deferred-invalidation effect waits on.
+    signinSilent.mockImplementation(async () => {
+      mockUser = { access_token: fakeJwt('alice-renewed'), refresh_token: 'rt-2' };
+    });
+    const { rerender } = render(<Harness />);
+
+    fireAuthExpired();
+    await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
+    // Force a re-render so the test mock's updated mockUser flows into the
+    // useAuth() return value picked up by UserProvider's effect.
+    rerender(<Harness />);
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
+  });
+
   test('signs out when there is no refresh_token in the stored user', async () => {
     mockUser = { access_token: fakeJwt('alice') };
     removeUser.mockResolvedValue(undefined);
@@ -91,6 +113,7 @@ describe('renewOrSignout on splice:auth-expired', () => {
 
     await waitFor(() => expect(removeUser).toHaveBeenCalledOnce());
     expect(signinSilent).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
   test('signs out when signinSilent rejects (refresh token revoked or IdP unreachable)', async () => {
@@ -103,6 +126,7 @@ describe('renewOrSignout on splice:auth-expired', () => {
 
     await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
     await waitFor(() => expect(removeUser).toHaveBeenCalledOnce());
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
   test('single-flights: concurrent expired events trigger one signinSilent call', async () => {
@@ -122,5 +146,18 @@ describe('renewOrSignout on splice:auth-expired', () => {
     fireAuthExpired();
     await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
     resolveSilent?.();
+  });
+
+  test('listener is removed on unmount', async () => {
+    mockUser = { access_token: fakeJwt('alice'), refresh_token: 'rt-1' };
+    signinSilent.mockResolvedValue(undefined);
+    const { unmount } = render(<Harness />);
+    unmount();
+
+    fireAuthExpired();
+
+    // Give the event loop a tick to ensure no async handler runs
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(signinSilent).not.toHaveBeenCalled();
   });
 });

--- a/apps/common/frontend/src/__tests__/auth/UserContextRenewOrSignout.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/UserContextRenewOrSignout.test.tsx
@@ -1,0 +1,126 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { fireAuthExpired } from '@lfdecentralizedtrust/splice-common-frontend-utils';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const signinSilent = vi.fn();
+const removeUser = vi.fn();
+
+let mockUser: { access_token: string; refresh_token?: string } | undefined;
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: mockUser,
+    settings: { authority: 'https://idp.example.com', client_id: 'test' },
+    signinSilent,
+    removeUser,
+    error: null,
+  }),
+}));
+
+vi.mock('../../utils', async () => {
+  const auth = await vi.importActual<typeof import('../../utils/auth')>('../../utils/auth');
+  return { ...auth };
+});
+
+import { Algorithm, AuthConfig } from '../../config/schema';
+import { UserProvider } from '../../contexts/UserContext';
+
+const rs256Config: AuthConfig = {
+  algorithm: Algorithm.RS256,
+  authority: 'https://idp.example.com/',
+  client_id: 'test-client',
+  token_audience: 'https://api.example.com',
+  token_scope: 'wallet',
+};
+
+const fakeJwt = (sub: string): string => {
+  const b64u = (s: string) => btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const header = b64u(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = b64u(JSON.stringify({ sub, exp: 9999999999, iat: 0 }));
+  return `${header}.${payload}.fakesig`;
+};
+
+const Harness: React.FC = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UserProvider authConf={rs256Config}>
+        <div data-testid="children" />
+      </UserProvider>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  signinSilent.mockReset();
+  removeUser.mockReset();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin: 'http://localhost:3000', href: 'http://localhost:3000/' },
+  });
+});
+
+afterEach(() => {
+  mockUser = undefined;
+});
+
+describe('renewOrSignout on splice:auth-expired', () => {
+  test('calls signinSilent when a refresh_token is present', async () => {
+    mockUser = { access_token: fakeJwt('alice'), refresh_token: 'rt-1' };
+    signinSilent.mockResolvedValue(undefined);
+    removeUser.mockResolvedValue(undefined);
+    render(<Harness />);
+
+    fireAuthExpired();
+
+    await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
+    expect(removeUser).not.toHaveBeenCalled();
+  });
+
+  test('signs out when there is no refresh_token in the stored user', async () => {
+    mockUser = { access_token: fakeJwt('alice') };
+    removeUser.mockResolvedValue(undefined);
+    render(<Harness />);
+
+    fireAuthExpired();
+
+    await waitFor(() => expect(removeUser).toHaveBeenCalledOnce());
+    expect(signinSilent).not.toHaveBeenCalled();
+  });
+
+  test('signs out when signinSilent rejects (refresh token revoked or IdP unreachable)', async () => {
+    mockUser = { access_token: fakeJwt('alice'), refresh_token: 'rt-1' };
+    signinSilent.mockRejectedValue(new Error('refresh token revoked'));
+    removeUser.mockResolvedValue(undefined);
+    render(<Harness />);
+
+    fireAuthExpired();
+
+    await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
+    await waitFor(() => expect(removeUser).toHaveBeenCalledOnce());
+  });
+
+  test('single-flights: concurrent expired events trigger one signinSilent call', async () => {
+    mockUser = { access_token: fakeJwt('alice'), refresh_token: 'rt-1' };
+    let resolveSilent: ((v?: undefined) => void) | undefined;
+    signinSilent.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSilent = resolve;
+        })
+    );
+    removeUser.mockResolvedValue(undefined);
+    render(<Harness />);
+
+    fireAuthExpired();
+    fireAuthExpired();
+    fireAuthExpired();
+    await waitFor(() => expect(signinSilent).toHaveBeenCalledOnce());
+    resolveSilent?.();
+  });
+});

--- a/apps/common/frontend/src/__tests__/auth/authSchema.test.ts
+++ b/apps/common/frontend/src/__tests__/auth/authSchema.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from 'vitest';
+
+import { Algorithm, authSchema } from '../../config/schema';
+
+const rs256Base = {
+  algorithm: Algorithm.RS256,
+  authority: 'https://idp.example.com/',
+  client_id: 'test-client',
+  token_audience: 'test-aud',
+  token_scope: 'wallet',
+};
+
+describe('authSchema rs256 enable_offline_scope', () => {
+  test('omitted field parses', () => {
+    const r = authSchema.safeParse(rs256Base);
+    expect(r.success).toBe(true);
+  });
+
+  test('explicit true parses', () => {
+    const r = authSchema.safeParse({ ...rs256Base, enable_offline_scope: true });
+    expect(r.success).toBe(true);
+  });
+
+  test('explicit false parses', () => {
+    const r = authSchema.safeParse({ ...rs256Base, enable_offline_scope: false });
+    expect(r.success).toBe(true);
+  });
+
+  test('string "true" is rejected (no zod coercion)', () => {
+    const r = authSchema.safeParse({ ...rs256Base, enable_offline_scope: 'true' });
+    expect(r.success).toBe(false);
+  });
+
+  test('strict() still rejects unknown keys on rs256', () => {
+    const r = authSchema.safeParse({ ...rs256Base, totally_unknown_field: true });
+    expect(r.success).toBe(false);
+  });
+
+  test('field is rejected on hs256-unsafe config (strict)', () => {
+    const r = authSchema.safeParse({
+      algorithm: Algorithm.HS256UNSAFE,
+      secret: 'shh',
+      token_audience: 'test-aud',
+      enable_offline_scope: true,
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/common/frontend/src/__tests__/auth/oidcAuthToProviderProps.test.ts
+++ b/apps/common/frontend/src/__tests__/auth/oidcAuthToProviderProps.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from 'vitest';
+
+import { Algorithm, AuthConfig } from '../../config/schema';
+import { oidcAuthToProviderProps } from '../../utils/auth';
+
+const baseConfig: AuthConfig = {
+  algorithm: Algorithm.RS256,
+  token_audience: 'test-aud',
+  token_scope: 'wallet',
+  authority: 'https://idp.example.com/',
+  client_id: 'test-client',
+};
+
+const scopes = (s: string) => s.split(' ').filter(Boolean).sort();
+
+describe('oidcAuthToProviderProps scope handling', () => {
+  test('omits offline_access by default', () => {
+    const props = oidcAuthToProviderProps(baseConfig);
+    expect(scopes(props.scope!)).toEqual(['openid', 'wallet']);
+  });
+
+  test('omits offline_access when enable_offline_scope is false', () => {
+    const props = oidcAuthToProviderProps({ ...baseConfig, enable_offline_scope: false });
+    expect(scopes(props.scope!)).toEqual(['openid', 'wallet']);
+  });
+
+  test('includes offline_access when enable_offline_scope is true', () => {
+    const props = oidcAuthToProviderProps({ ...baseConfig, enable_offline_scope: true });
+    expect(scopes(props.scope!)).toEqual(['offline_access', 'openid', 'wallet']);
+  });
+
+  test('omits the openid scope for the daml_ledger_api scope (multi-audience workaround)', () => {
+    const props = oidcAuthToProviderProps({ ...baseConfig, token_scope: 'daml_ledger_api' });
+    expect(scopes(props.scope!)).toEqual(['daml_ledger_api']);
+  });
+
+  test('passes token_audience through as extraQueryParams.audience', () => {
+    const props = oidcAuthToProviderProps(baseConfig);
+    expect(props.extraQueryParams).toEqual({ audience: 'test-aud' });
+  });
+
+  test('does not leak the enable_offline_scope field into the OidcAuthProvider props', () => {
+    const props = oidcAuthToProviderProps({ ...baseConfig, enable_offline_scope: true });
+    expect((props as Record<string, unknown>).enable_offline_scope).toBeUndefined();
+  });
+});

--- a/apps/common/frontend/src/components/AuthProvider.tsx
+++ b/apps/common/frontend/src/components/AuthProvider.tsx
@@ -38,7 +38,16 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
 
   return (
     <OidcAuthProvider
-      automaticSilentRenew={false}
+      // Enable proactive refresh_token silent renew. `oidc-client-ts` uses
+      // the refresh_token grant when one is present in the stored User and
+      // throws "No silent_redirect_uri configured" otherwise — we
+      // intentionally do not pass `silent_redirect_uri`, so the iframe
+      // fallback is structurally disabled (cookie-based silent auth is
+      // broken-by-default on Safari ITP and Firefox Total Cookie
+      // Protection). When the silent renew throws or never fires (suspended
+      // tab, clock skew), `UserProvider`'s `renewOrSignout` handler tries
+      // one more `signinSilent()` on the next 401 before signing out.
+      automaticSilentRenew
       userStore={new WebStorageStateStore({ store: window.localStorage })}
       onSigninCallback={user => {
         const redirectTo = extractRedirectToFromUser(user);

--- a/apps/common/frontend/src/components/AuthProvider.tsx
+++ b/apps/common/frontend/src/components/AuthProvider.tsx
@@ -38,16 +38,13 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
 
   return (
     <OidcAuthProvider
-      // Enable proactive refresh_token silent renew. `oidc-client-ts` uses
-      // the refresh_token grant when one is present in the stored User and
-      // throws "No silent_redirect_uri configured" otherwise — we
-      // intentionally do not pass `silent_redirect_uri`, so the iframe
-      // fallback is structurally disabled (cookie-based silent auth is
-      // broken-by-default on Safari ITP and Firefox Total Cookie
-      // Protection). When the silent renew throws or never fires (suspended
-      // tab, clock skew), `UserProvider`'s `renewOrSignout` handler tries
-      // one more `signinSilent()` on the next 401 before signing out.
-      automaticSilentRenew
+      // The library's proactive timer-based silent renew is disabled. The
+      // 401-driven `renewOrSignout` handler in `UserProvider` is the only
+      // renewal path, so we get a single, single-flighted refresh per
+      // expiry rather than racing the library's timer against the handler
+      // (which can cause concurrent refresh-token grants and a spurious
+      // logout against IdPs that rotate refresh tokens).
+      automaticSilentRenew={false}
       userStore={new WebStorageStateStore({ store: window.localStorage })}
       onSigninCallback={user => {
         const redirectTo = extractRedirectToFromUser(user);

--- a/apps/common/frontend/src/config/schema/auth.ts
+++ b/apps/common/frontend/src/config/schema/auth.ts
@@ -17,6 +17,13 @@ const rs256Schema = tokenRequestSchema
     algorithm: z.literal(Algorithm.RS256),
     authority: z.string().url(),
     client_id: z.string(),
+    // Opt-in: include the OIDC `offline_access` scope in the authorization
+    // request. Required by some Auth0 configurations to obtain a refresh
+    // token at all; unnecessary for Keycloak (which issues a session-bound
+    // refresh token without it). Default false because Keycloak treats
+    // `offline_access` as a request for a long-lived offline refresh token,
+    // a larger XSS surface for browser-based clients.
+    enable_offline_scope: z.boolean().optional(),
   })
   .strict();
 

--- a/apps/common/frontend/src/contexts/UserContext.tsx
+++ b/apps/common/frontend/src/contexts/UserContext.tsx
@@ -102,6 +102,7 @@ export const UserProvider: React.FC<{
 
   const signoutInFlight = useRef(false);
   const renewInFlight = useRef(false);
+  const pendingInvalidation = useRef(false);
 
   const signoutFromIdp = useCallback(() => {
     if (auth === undefined || !auth.isAuthenticated) return;
@@ -110,19 +111,13 @@ export const UserProvider: React.FC<{
     });
   }, [auth]);
 
-  // On a 401 (which fires `splice:auth-expired` from BaseApiMiddleware /
-  // LedgerApiContext), attempt one refresh_token grant before giving up and
-  // signing the user out. Recovers two scenarios:
-  //   1. The proactive `automaticSilentRenew` timer never fired (suspended
-  //      tab, clock skew, or the access token expired before the
-  //      `accessTokenExpiring` notification window).
-  //   2. A request was sent with a valid token but reached the server after
-  //      the token expired, producing a 401 concurrent with an in-flight
-  //      silent renew.
-  // Single-flighted via `renewInFlight` so concurrent 401s from a fan-out
-  // collapse into one signinSilent call. On successful refresh we
-  // `invalidateQueries` to retry queries that already failed (react-query's
-  // retryQuery short-circuits on 401, so they will not retry themselves).
+  // On a 401 (`splice:auth-expired`, fired from BaseApiMiddleware /
+  // LedgerApiContext), try one `signinSilent` before signing out. Single-
+  // flighted via `renewInFlight` so concurrent 401s collapse into one
+  // grant. Invalidation of the react-query cache is deferred until the
+  // refreshed access token has propagated into `userAccessToken` (see
+  // effect below); invalidating immediately would refetch through clients
+  // still holding the stale token and produce a second 401.
   const renewOrSignout = useCallback(async () => {
     if (signoutInFlight.current) return;
     if (renewInFlight.current) return;
@@ -132,7 +127,7 @@ export const UserProvider: React.FC<{
       renewInFlight.current = true;
       try {
         await auth.signinSilent();
-        await queryClient.invalidateQueries();
+        pendingInvalidation.current = true;
         return;
       } catch (err) {
         console.debug('renewOrSignout: silent renew failed, signing out', err);
@@ -143,7 +138,7 @@ export const UserProvider: React.FC<{
 
     signoutInFlight.current = true;
     signoutFromIdp();
-  }, [auth, queryClient, signoutFromIdp]);
+  }, [auth, signoutFromIdp]);
 
   useEffect(() => onAuthExpired(renewOrSignout), [renewOrSignout]);
 
@@ -176,6 +171,18 @@ export const UserProvider: React.FC<{
       }
     }
   }, [auth, authConf, authMethod, loginWithSst, testAuthConf]);
+
+  // After a successful renewOrSignout, the access-token state above
+  // updates on a subsequent render. Once it does, invalidate the
+  // react-query cache so failed-with-401 queries refetch with the new
+  // token (`retryQuery` returns false on 401, so they will not retry
+  // themselves).
+  useEffect(() => {
+    if (pendingInvalidation.current && userAccessToken) {
+      pendingInvalidation.current = false;
+      void queryClient.invalidateQueries();
+    }
+  }, [userAccessToken, queryClient]);
 
   return (
     <UserContext.Provider

--- a/apps/common/frontend/src/contexts/UserContext.tsx
+++ b/apps/common/frontend/src/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { onAuthExpired } from '@lfdecentralizedtrust/splice-common-frontend-utils';
+import { useQueryClient } from '@tanstack/react-query';
 import { User } from 'oidc-client-ts';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { AuthState, useAuth } from 'react-oidc-context';
@@ -55,6 +56,7 @@ export const UserProvider: React.FC<{
   const [userAccessToken, setUserAccessToken] = useState<string>();
 
   const auth = useAuthSafe();
+  const queryClient = useQueryClient();
 
   const isAuthenticated =
     userId !== undefined &&
@@ -99,6 +101,7 @@ export const UserProvider: React.FC<{
   };
 
   const signoutInFlight = useRef(false);
+  const renewInFlight = useRef(false);
 
   const signoutFromIdp = useCallback(() => {
     if (auth === undefined || !auth.isAuthenticated) return;
@@ -107,13 +110,42 @@ export const UserProvider: React.FC<{
     });
   }, [auth]);
 
-  const signoutOnExpiry = useCallback(() => {
+  // On a 401 (which fires `splice:auth-expired` from BaseApiMiddleware /
+  // LedgerApiContext), attempt one refresh_token grant before giving up and
+  // signing the user out. Recovers two scenarios:
+  //   1. The proactive `automaticSilentRenew` timer never fired (suspended
+  //      tab, clock skew, or the access token expired before the
+  //      `accessTokenExpiring` notification window).
+  //   2. A request was sent with a valid token but reached the server after
+  //      the token expired, producing a 401 concurrent with an in-flight
+  //      silent renew.
+  // Single-flighted via `renewInFlight` so concurrent 401s from a fan-out
+  // collapse into one signinSilent call. On successful refresh we
+  // `invalidateQueries` to retry queries that already failed (react-query's
+  // retryQuery short-circuits on 401, so they will not retry themselves).
+  const renewOrSignout = useCallback(async () => {
     if (signoutInFlight.current) return;
+    if (renewInFlight.current) return;
+    if (auth === undefined || !auth.isAuthenticated) return;
+
+    if (auth.user?.refresh_token) {
+      renewInFlight.current = true;
+      try {
+        await auth.signinSilent();
+        await queryClient.invalidateQueries();
+        return;
+      } catch (err) {
+        console.debug('renewOrSignout: silent renew failed, signing out', err);
+      } finally {
+        renewInFlight.current = false;
+      }
+    }
+
     signoutInFlight.current = true;
     signoutFromIdp();
-  }, [signoutFromIdp]);
+  }, [auth, queryClient, signoutFromIdp]);
 
-  useEffect(() => onAuthExpired(signoutOnExpiry), [signoutOnExpiry]);
+  useEffect(() => onAuthExpired(renewOrSignout), [renewOrSignout]);
 
   useEffect(() => {
     async function f(user: User) {

--- a/apps/common/frontend/src/utils/auth.ts
+++ b/apps/common/frontend/src/utils/auth.ts
@@ -7,14 +7,15 @@ import { AuthConfig, isHs256UnsafeAuthConfig } from '../config/schema';
 
 export const oidcAuthToProviderProps = (config: AuthConfig): AuthProviderProps => {
   if (!isHs256UnsafeAuthConfig(config)) {
-    const { token_audience, token_scope, ...props } = config;
+    const { token_audience, token_scope, enable_offline_scope, ...props } = config;
 
     // We include the `openid` scope to comply with the OIDC spec, which requires this scope to be present:
     // see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest.
     // TODO(DACH-NY/canton-network-node#16509): we don't do that for tokens that access the Ledger API server as the Ledger API server does not like the multiple audiences returned by Auth0 when also requesting the openid scope.
     const openid_scope = token_scope !== 'daml_ledger_api' ? 'openid' : null;
+    const offline_scope = enable_offline_scope ? 'offline_access' : null;
 
-    const scope = [token_scope, openid_scope].filter(s => !!s).join(' ');
+    const scope = [token_scope, openid_scope, offline_scope].filter(s => !!s).join(' ');
 
     const extraQueryParams = { audience: token_audience };
     const redirect_uri = window.location.origin;

--- a/apps/sv/frontend/package.json
+++ b/apps/sv/frontend/package.json
@@ -23,6 +23,7 @@
     "@mui/x-data-grid": "^8.14.1",
     "@mui/x-date-pickers": "^8.14.1",
     "@tanstack/react-form": "^1.23.0",
+    "@tanstack/react-query": "5.90.20",
     "dayjs": "^1.11.9",
     "dompurify": "^3.4.2",
     "jose": "^4.15.9",

--- a/apps/sv/frontend/src/__tests__/auth/redirect.test.tsx
+++ b/apps/sv/frontend/src/__tests__/auth/redirect.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Algorithm, AuthConfig, UserProvider } from '@lfdecentralizedtrust/splice-common-frontend';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React, { useEffect } from 'react';
@@ -74,14 +75,18 @@ afterEach(() => {
   removeUser.mockClear();
 });
 
-const renderWithProviders = () =>
-  render(
-    <UserProvider authConf={rs256Config}>
-      <SvAdminClientProvider url={svUrl}>
-        <Caller />
-      </SvAdminClientProvider>
-    </UserProvider>
+const renderWithProviders = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UserProvider authConf={rs256Config}>
+        <SvAdminClientProvider url={svUrl}>
+          <Caller />
+        </SvAdminClientProvider>
+      </UserProvider>
+    </QueryClientProvider>
   );
+};
 
 describe('401 from SV API logs the user out', () => {
   test('on 401: clears the local user and navigates to origin', async () => {


### PR DESCRIPTION
Alternative to #5683 — same bug, different design. Posting both so maintainers can pick.

PR #5545 set `automaticSilentRenew={false}` on the `react-oidc-context` provider and removed `offline_access` from the scope request. Either change on its own would have been fine; together they leave the UIs with no refresh-token mechanism at all, so every access-token expiry forces a full re-login (5 minutes on a default Keycloak deployment).

This PR restores token renewal for both Keycloak and Auth0 without re-enabling the library's timer-based silent renew (which races the new 401 handler under refresh-token rotation, see "Why a single renewal path" below).

## What changes

**1. `renewOrSignout` in `UserProvider`** (`UserContext.tsx`). On `splice:auth-expired` (fired from `BaseApiMiddleware` / `LedgerApiContext` on any 401), try one `auth.signinSilent()` before signing the user out. Single-flighted via a `renewInFlight` ref so concurrent 401s collapse to one grant. On success, react-query cache invalidation is deferred until the refreshed access token has propagated into `userAccessToken` state — a separate effect watches that state and fires `queryClient.invalidateQueries()` so the deferred invalidation doesn't race the state update.

**2. Library's `automaticSilentRenew` stays `false`** (matches what #5545 set). With Splice owning the renewal path, there is no need for the library's proactive timer — and re-enabling it would race the 401 handler (next section).

**3. Optional `enable_offline_scope: boolean` on the rs256 `AuthConfig`** for Auth0 deployments where the IdP only returns a refresh token when `offline_access` is in the scope. Default false: Keycloak issues a session-bound refresh token without it, and on Keycloak `offline_access` produces a long-lived offline refresh token (larger XSS surface in a browser-based SPA).

## Why a single renewal path

An earlier revision of this PR re-enabled `automaticSilentRenew={true}` alongside `renewOrSignout`, on the theory that the proactive timer would cover normal expiry and the 401 handler would cover edge cases (suspended tabs, clock skew). Adversarial review surfaced a race: the library timer fires `signinSilent` at exp - 60s using the stored refresh token; a near-simultaneous user request 401s and the handler fires its own `signinSilent`. With IdPs that rotate refresh tokens (Auth0 by default, Keycloak when configured), one of the two concurrent grants is rejected — the refresh token was already exchanged. The handler's catch block then signs the user out even though the other renewal succeeded.

Dropping `automaticSilentRenew` to `false` and routing all renewal through the single-flighted handler eliminates the race. Trade: one extra 401 round-trip per token expiry per active session (the user's first request after expiry takes a renewal + retry instead of using a pre-refreshed token). That cost is bounded and the net UX is far better than the forced re-login this PR replaces.

## How this compares to #5683

#5683 takes a different approach: keep `automaticSilentRenew={true}` and make `enable_offline_scope` a mandatory operator-set boolean. That forces the Auth0-vs-Keycloak decision at configuration time but leaves two cases open:

- Auth0 without `offline_access` opt-in: no refresh token, silent renew has nothing to use, user is logged out at access-token TTL.
- The same silent-renew vs concurrent-401 race documented above.

This PR keeps the schema field optional (no breaking config change) and uses the `renewOrSignout` design to handle both cases at runtime. Pick whichever shape fits.

## Testing

New tests under `apps/common/frontend/src/__tests__/auth/`:

- `UserContextRenewOrSignout.test.tsx`: signinSilent called when a refresh token is present; `invalidateQueries` fires after token state propagates (deferred path); removeUser called when no refresh token; failure path falls through to signout; `invalidateQueries` not called on the signout path; single-flight under concurrent expired events; listener removed on unmount.
- `AuthProvider.test.tsx`: asserts `automaticSilentRenew=false` (the design intent).
- `authSchema.test.ts`: parse behaviour of optional `enable_offline_scope`.
- `oidcAuthToProviderProps.test.ts`: scope construction with and without the opt-in.

Existing 401-fallback coverage in `BaseApiMiddleware.test.ts` and `LedgerApiClient.test.ts` is untouched — the handler still fires `splice:auth-expired` on 401, only the handler's response changes.

`apps/sv/frontend/src/__tests__/auth/redirect.test.tsx` is updated to wrap `UserProvider` in `QueryClientProvider` (now required because `UserProvider` calls `useQueryClient`). `apps/sv/frontend/package.json` pins `@tanstack/react-query: 5.90.20` directly to match the other apps and prevent singleton-resolution drift.

## References

- Refresh-token path: `oidc-client-ts.js:2533` (`if (user?.refresh_token) return this._useRefreshToken(state)`).
- Iframe fallback gate: `oidc-client-ts.js:2540` (throws "No silent_redirect_uri configured" when no refresh token and no `silent_redirect_uri` — Splice never sets `silent_redirect_uri`, so the iframe path is unreachable).
- Auth0 docs require `offline_access` to receive a refresh token: https://auth0.com/docs/secure/tokens/refresh-tokens/get-refresh-tokens

Fixes #5682
