### PR TITLE
Don't install cometbft ingress when not using cometbft

### DIFF
--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -527,7 +527,7 @@ function configureGatewayService(
 function configureGateway(
   ingressNs: ExactNamespace,
   gwSvc: k8s.helm.v3.Release,
-  cometBftSvc: k8s.helm.v3.Release,
+  cometBftSvc: k8s.helm.v3.Release | undefined,
   withSeparateGcpGateway: boolean
 ): k8s.apiextensions.CustomResource[] {
   const hosts = [
@@ -637,7 +637,7 @@ function configureGateway(
       },
     },
     {
-      dependsOn: [cometBftSvc],
+      dependsOn: cometBftSvc ? [cometBftSvc] : [],
     }
   );
   return [httpGw, appsGw];
@@ -926,7 +926,9 @@ export function configureIstio(
     expectGKEL7Gateway ? { viaGKEL7: true } : { viaGKEL7: false, ip: ingressIp },
     istiod
   );
-  const cometBftSvc = configureCometBFTGatewayService(ingressNs.ns, cometBftIngressIp, istiod);
+  const cometBftSvc = DecentralizedSynchronizerUpgradeConfig.usesCometbft()
+    ? configureCometBFTGatewayService(ingressNs.ns, cometBftIngressIp, istiod)
+    : undefined;
   const gateways = configureGateway(ingressNs, gwSvc, cometBftSvc, expectGKEL7Gateway);
   const docsAndReleases = configureDocsAndReleases(true, gateways);
   const publicInfo = configurePublicInfo(ingressNs.ns);


### PR DESCRIPTION
I cannot be bothered to figure out the issues around port configs there.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
