### PR TITLE
[static] shorten more release names for gha

### DIFF
--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -305,7 +305,7 @@ function installDockerRunnerScaleSets(
     .filter(spec => spec.docker)
     .forEach(spec => {
       installDockerRunnerScaleSet(
-        `self-hosted-docker-${spec.name}`,
+        (repo == 'splice' ? `self-hosted-docker-${spec.name}` : `docker-${spec.name}`),
         runnersNamespace,
         controller,
         tokenSecret,
@@ -673,7 +673,7 @@ function installK8sRunnerScaleSets(
     .forEach(spec => {
       installK8sRunnerScaleSet(
         runnersNamespace,
-        `self-hosted-k8s-${spec.name}`,
+        (repo == 'splice' ? `self-hosted-k8s-${spec.name}` : `k8s-${spec.name}`),
         tokenSecret,
         cachePvcName,
         spec.resources,

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -305,7 +305,7 @@ function installDockerRunnerScaleSets(
     .filter(spec => spec.docker)
     .forEach(spec => {
       installDockerRunnerScaleSet(
-        (repo == 'splice' ? `self-hosted-docker-${spec.name}` : `docker-${spec.name}`),
+        repo == 'splice' ? `self-hosted-docker-${spec.name}` : `docker-${spec.name}`,
         runnersNamespace,
         controller,
         tokenSecret,
@@ -673,7 +673,7 @@ function installK8sRunnerScaleSets(
     .forEach(spec => {
       installK8sRunnerScaleSet(
         runnersNamespace,
-        (repo == 'splice' ? `self-hosted-k8s-${spec.name}` : `k8s-${spec.name}`),
+        repo == 'splice' ? `self-hosted-k8s-${spec.name}` : `k8s-${spec.name}`,
         tokenSecret,
         cachePvcName,
         spec.resources,


### PR DESCRIPTION
To support longer feature fork names.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
