### PR TITLE
Use real Scan server in OpenAPI specs

### DIFF
--- a/apps/scan/src/main/openapi/scan-stream-server.yaml
+++ b/apps/scan/src/main/openapi/scan-stream-server.yaml
@@ -19,7 +19,7 @@ tags:
     description: |
       Still under active development, highly unstable. Do not use in production.
 servers:
-  - url: https://example.com/api/scan
+  - url: https://scan.sv-1.global.canton.network.sync.global/api/scan
 paths:
 
   # Note for developers working on this openAPI spec: we generate only server-side code from this file,
@@ -50,4 +50,3 @@ paths:
                   x-scala-type: org.apache.pekko.http.scaladsl.model.ResponseEntity
         "404":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
-

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -19,7 +19,7 @@ tags:
     description: |
       Still under active development, highly unstable. Do not use in production.
 servers:
-  - url: https://example.com/api/scan
+  - url: https://scan.sv-1.global.canton.network.sync.global/api/scan
 paths:
   /readyz:
     $ref: "../../../../common/src/main/openapi/common-external.yaml#/paths/~1readyz"


### PR DESCRIPTION
## Summary
- replace the Scan OpenAPI placeholder server with the requested public Scan target

Upstream fix for https://github.com/canton-network/cf-docs/issues/649. The generated cf-docs curl for `/v0/scans` should become:

```bash
curl https://scan.sv-1.global.canton.network.sync.global/api/scan/v0/scans
```