### PR TITLE
Add stable cf-docs snippet tags

### DIFF
--- a/docs/src/app_dev/overview/version_information.rst
+++ b/docs/src/app_dev/overview/version_information.rst
@@ -37,11 +37,11 @@ Follow these steps to install a recent, compatible OSS Daml SDK version:
 #. Select the most recent stable release with the same major and minor version as above.
 #. Install that release using
 
+   .. CF_DOCS_SPLICE_SNIPPET_001_START
    .. code-block:: bash
 
       curl -sSL https://get.digitalasset.com/ | sh
+   .. CF_DOCS_SPLICE_SNIPPET_001_END
 
 For more information about installing the Daml SDK, see the
 `DPM installation guide <https://docs.digitalasset.com/build/3.4/dpm/dpm.html?>`__.
-
-

--- a/docs/src/app_dev/testing/localnet.rst
+++ b/docs/src/app_dev/testing/localnet.rst
@@ -121,10 +121,12 @@ In most scenarios, the ``*.localhost`` domains (e.g., ``http://scan.localhost``)
 There are some situations where the resolution does not occur and the solution is to add entries to your ``/etc/hosts`` file.  For example,
 to resolve ``http://scan.localhost`` and ``http://wallet.localhost`` add these entry to the file:
 
+.. CF_DOCS_SPLICE_SNIPPET_007_START
 .. code-block::
 
    127.0.0.1   scan.localhost
    127.0.0.1   wallet.localhost
+.. CF_DOCS_SPLICE_SNIPPET_007_END
 
 
 Default Wallet Users
@@ -142,9 +144,11 @@ Swagger UI
 When the ``swagger-ui`` profile is enabled, the Swagger UI for the ``JSON Ledger API HTTP Endpoints`` across all running participants is available at `http://localhost:9090 <http://localhost:9090>`_.
 Note: Some endpoints require a JWT token when using the **Try it out** feature. One method to obtain this token is via the Canton Console. Start the Canton Console `make canton-console` and execute the following command:
 
+.. CF_DOCS_SPLICE_SNIPPET_008_START
 .. code-block:: none
 
      `app-provider`.adminToken
+.. CF_DOCS_SPLICE_SNIPPET_008_END
 
 For proper functionality, Swagger UI relies on a localhost nginx proxy for ``canton.localhost`` configured for each participant. For example, the ``JSON Ledger API HTTP Endpoints`` for the app-provider can be accessed at the nginx proxy URL ``http://canton.localhost:${APP_PROVIDER_UI_PORT}`` via Swagger UI, which corresponds to accessing ``localhost:3${PARTICIPANT_JSON_API_PORT}`` directly. The nginx proxy only adds additional headers to resolve CORS issues within Swagger UI.
 
@@ -157,6 +161,7 @@ Use LocalNet
 Start LocalNet nodes
 ^^^^^^^^^^^^^^^^^^^^
 
+.. CF_DOCS_SPLICE_SNIPPET_002_START
 .. code-block:: bash
 
    docker compose --env-file $LOCALNET_DIR/compose.env \
@@ -166,10 +171,12 @@ Start LocalNet nodes
                   --profile sv \
                   --profile app-provider \
                   --profile app-user up -d
+.. CF_DOCS_SPLICE_SNIPPET_002_END
 
 Stop LocalNet nodes
 ^^^^^^^^^^^^^^^^^^^
 
+.. CF_DOCS_SPLICE_SNIPPET_003_START
 .. code-block:: bash
 
    docker compose --env-file $LOCALNET_DIR/compose.env \
@@ -179,12 +186,14 @@ Stop LocalNet nodes
                   --profile sv \
                   --profile app-provider \
                   --profile app-user down -v
+.. CF_DOCS_SPLICE_SNIPPET_003_END
 
 Start nodes including a swagger-ui
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See :ref:`swagger-ui` for more information.
 
+.. CF_DOCS_SPLICE_SNIPPET_004_START
 .. code-block:: bash
 
    docker compose --env-file $LOCALNET_DIR/compose.env \
@@ -195,12 +204,14 @@ See :ref:`swagger-ui` for more information.
                   --profile app-provider \
                   --profile app-user \
                   --profile swagger-ui up -d
+.. CF_DOCS_SPLICE_SNIPPET_004_END
 
 Stop nodes including a swagger-ui
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See :ref:`swagger-ui` for more information.
 
+.. CF_DOCS_SPLICE_SNIPPET_005_START
 .. code-block:: bash
 
    docker compose --env-file $LOCALNET_DIR/compose.env \
@@ -211,6 +222,7 @@ See :ref:`swagger-ui` for more information.
                   --profile app-provider \
                   --profile app-user \
                   --profile swagger-ui down -v
+.. CF_DOCS_SPLICE_SNIPPET_005_END
 
 Access the Canton Admin Console
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,6 +235,7 @@ of the Canton sequencer, mediator, and participant nodes in your LocalNet deploy
 * `Canton Console commands <https://docs.digitalasset.com/operate/3.4/reference/console.html>`__
 
 
+.. CF_DOCS_SPLICE_SNIPPET_006_START
 .. code-block:: bash
 
    docker compose --env-file $LOCALNET_DIR/compose.env \
@@ -230,6 +243,7 @@ of the Canton sequencer, mediator, and participant nodes in your LocalNet deploy
                   -f $LOCALNET_DIR/compose.yaml \
                   -f $LOCALNET_DIR/resource-constraints.yaml \
                   run --rm console
+.. CF_DOCS_SPLICE_SNIPPET_006_END
 
 .. _multi-sync-localnet:
 

--- a/docs/src/deployment/configuration.rst
+++ b/docs/src/deployment/configuration.rst
@@ -46,11 +46,13 @@ it can be useful. To do so, you need to set the
 ``OVERRIDE_BOOTSTRAP_SCRIPT`` environment variable to the content of your bootstrap script.
 Note that the script must be wrapped in a ``main`` function, e.g.,
 
+.. CF_DOCS_SPLICE_SNIPPET_009_START
 .. code::
 
    def main() {
      logger.info(s"Participant id from bootstrap script: ${participant.id}")
    }
+.. CF_DOCS_SPLICE_SNIPPET_009_END
 
 You can set this environment variable through ``additionalEnvVars`` as described below.
 
@@ -65,8 +67,10 @@ Helm charts support
 
 The helm charts can be configured through the value ``additionalEnvVars``, which passes the values as environment variables to the apps.
 
+.. CF_DOCS_SPLICE_SNIPPET_010_START
 .. code-block:: yaml
 
     additionalEnvVars:
         - name: ADDITIONAL_CONFIG_EXAMPLE
           value: canton.example.key=value
+.. CF_DOCS_SPLICE_SNIPPET_010_END

--- a/docs/src/deployment/console_access.rst
+++ b/docs/src/deployment/console_access.rst
@@ -35,6 +35,7 @@ Participant console
 1. Obtain an authentication token as specified in `the Canton authentication docs <https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html>`_
 2. Ensure you can access the participant's ports 5001 and 5002
 3. Add the configuration to a local file `console.conf`
+    .. CF_DOCS_SPLICE_SNIPPET_015_START
     .. code-block::
 
         canton {
@@ -55,17 +56,21 @@ Participant console
           features.enable-testing-commands = yes
           features.enable-repair-commands = yes
         }
+    .. CF_DOCS_SPLICE_SNIPPET_015_END
 
 4. Run the docker command
 
+    .. CF_DOCS_SPLICE_SNIPPET_019_START
     .. parsed-literal::
 
         docker run -it --rm --network host -v $(pwd)/console.conf:/app/app.conf |docker_repo_prefix|/canton:|version_literal| --console
+    .. CF_DOCS_SPLICE_SNIPPET_019_END
 
     .. important::
         If you run the participant using the docker compose setup the docker command must be run with the docker network used by the participant.
         Adjust the configuration to connect to the participant container:
 
+            .. CF_DOCS_SPLICE_SNIPPET_016_START
             .. code-block::
 
                 canton {
@@ -86,12 +91,15 @@ Participant console
                   features.enable-testing-commands = yes
                   features.enable-repair-commands = yes
                 }
+            .. CF_DOCS_SPLICE_SNIPPET_016_END
 
         Running docker with the default network (`splice-validator`):
 
+        .. CF_DOCS_SPLICE_SNIPPET_020_START
         .. parsed-literal::
 
             docker run -it --rm --network splice-validator -v $(pwd)/console.conf:/app/app.conf |docker_repo_prefix|/canton:|version_literal| --console
+        .. CF_DOCS_SPLICE_SNIPPET_020_END
 
 Sequencer console
 +++++++++++++++++
@@ -99,6 +107,7 @@ Sequencer console
 1. Ensure you can access the sequencer's ports 5008 and 5009
 2. Add the configuration to a local file `console.conf`
 
+    .. CF_DOCS_SPLICE_SNIPPET_013_START
     .. code-block::
 
         canton {
@@ -118,12 +127,15 @@ Sequencer console
           features.enable-testing-commands = yes
           features.enable-repair-commands = yes
         }
+    .. CF_DOCS_SPLICE_SNIPPET_013_END
 
 3. Run the docker command
 
+    .. CF_DOCS_SPLICE_SNIPPET_017_START
     .. parsed-literal::
 
         docker run -it --rm --network host -v $(pwd)/console.conf:/app/app.conf |docker_repo_prefix|/canton:|version_literal| --console
+    .. CF_DOCS_SPLICE_SNIPPET_017_END
 
 Mediator console
 +++++++++++++++++
@@ -131,6 +143,7 @@ Mediator console
 1. Ensure you can access the mediator's port 5007
 2. Add the configuration to a local file `console.conf`
 
+    .. CF_DOCS_SPLICE_SNIPPET_014_START
     .. code-block::
 
         canton {
@@ -146,12 +159,15 @@ Mediator console
           features.enable-testing-commands = yes
           features.enable-repair-commands = yes
         }
+    .. CF_DOCS_SPLICE_SNIPPET_014_END
 
 3. Run the docker command
 
+    .. CF_DOCS_SPLICE_SNIPPET_018_START
     .. parsed-literal::
 
         docker run -it --rm --network host -v $(pwd)/console.conf:/app/app.conf |docker_repo_prefix|/canton:|version_literal| --console
+    .. CF_DOCS_SPLICE_SNIPPET_018_END
 
 
 Access in a K8s cluster
@@ -161,17 +177,21 @@ In a K8s cluster you can use a debug pod to access the console directly from the
 
 First you can create a pod running the right canton version using:
 
+.. CF_DOCS_SPLICE_SNIPPET_011_START
 .. code-block:: bash
 
     kubectl debug "${POD_NAME}" --image "$(kubectl get pod "${POD_NAME}" -o json | jq -re '.spec.containers[0].image')" -i -t -- bash
+.. CF_DOCS_SPLICE_SNIPPET_011_END
 
 where `POD_NAME` is the name of the participant/sequencer/mediator pod.
 
 Once you are inside the running pod you can install a text editor and create the config file `console.conf` that is described above.
 
+.. CF_DOCS_SPLICE_SNIPPET_012_START
 .. code-block:: bash
 
     $ apt-get update
     $ apt-get install -y vim
     $ vim console.conf # paste in the config from above
     $ /app/bin/canton -v -c console.conf
+.. CF_DOCS_SPLICE_SNIPPET_012_END

--- a/docs/src/deployment/traffic.rst
+++ b/docs/src/deployment/traffic.rst
@@ -83,12 +83,15 @@ The current synchronizer traffic parameters are recorded on the global ``AmuletR
 and can be obtained from Scan. You can obtain them via the Scan UI or by querying the Scan API using,
 for example, this command (requires installing `jq <https://jqlang.org/>`_):
 
+.. CF_DOCS_SPLICE_SNIPPET_023_START
 .. parsed-literal::
 
     curl -X POST --header "Content-Type: application/json" -d "{}" |gsf_scan_url|/api/scan/v0/amulet-rules | jq ".amulet_rules_update.contract.payload.configSchedule.initialValue.decentralizedSynchronizer.fees"
+.. CF_DOCS_SPLICE_SNIPPET_023_END
 
 Above command will return a JSON object similar to the following:
 
+.. CF_DOCS_SPLICE_SNIPPET_021_START
 .. code-block:: json
 
     "fees": {
@@ -102,6 +105,7 @@ Above command will return a JSON object similar to the following:
       "readVsWriteScalingFactor": "4",
       "minTopupAmount": "200000"
     }
+.. CF_DOCS_SPLICE_SNIPPET_021_END
 
 
 This represents an encoded instance of the
@@ -124,9 +128,11 @@ To give an overview here:
   For querying the current CC price in USD as per the currently open mining round,
   you can check the Scan UI or use the following command (requires installing `jq <https://jqlang.org/>`_):
 
+  .. CF_DOCS_SPLICE_SNIPPET_022_START
   .. parsed-literal::
 
      curl -X POST --header "Content-Type: application/json" -d "{\"cached_open_mining_round_contract_ids\":[], \"cached_issuing_round_contract_ids\":[]}" |gsf_scan_url|/api/scan/v0/open-and-issuing-mining-rounds | jq ".open_mining_rounds | values[] | .contract.payload | {round, amuletPrice}"
+  .. CF_DOCS_SPLICE_SNIPPET_022_END
 
 - ``readVsWriteScalingFactor``: specifies the weight of additional traffic balance subtractions (from a sender's balance)
   for delivering a synchronizer message to each of its recipients.

--- a/docs/src/deployment/troubleshooting.rst
+++ b/docs/src/deployment/troubleshooting.rst
@@ -84,9 +84,11 @@ traffic to complete a traffic purchase. Check the logs for
 If you only want to rely on free traffic and do not want to purchase any extra traffic, remove
 the validator top-up config.
 
+.. CF_DOCS_SPLICE_SNIPPET_029_START
 .. code:: text
 
     ABORTED: Traffic balance below reserved traffic amount (0 < 200000)
+.. CF_DOCS_SPLICE_SNIPPET_029_END
 
 .. _error-insufficient-funds:
 
@@ -104,9 +106,11 @@ existing node with a CC balance can transfer CC to you to increase your balance.
 If you only want to rely on free traffic and do not want to purchase any extra traffic, remove
 the validator top-up config.
 
+.. CF_DOCS_SPLICE_SNIPPET_024_START
 .. code:: text
 
     Insufficient funds to buy configured traffic amount. Please ensure that the validator’s wallet has enough amulets to purchase 1.9998 MB of traffic to continue healthy operation.
+.. CF_DOCS_SPLICE_SNIPPET_024_END
 
 Gave up getting app version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -118,9 +122,11 @@ at the end.
 
 In a docker-compose setup, verify the URL passed to ``-s`` which should be a SV URL or ``svSponsorAddress`` for the helm deployment.
 
+.. CF_DOCS_SPLICE_SNIPPET_025_START
 .. code:: text
 
     2025-02-11T10:16:13.098Z [⋮] ERROR - o.l.s.v.ValidatorSvConnection:validator=validator_backend (7427be2620676fce8a464eee769eb1d8-app_version-2d71c55f5ecd731b-793d382fa2d6ce14) - Gave up getting 'app version of https://scan.sv-2.dev.global.canton.network.digitalasset.com/api/sv' org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller$UnsupportedContentTypeException: Unsupported Content-Type [Some(text/html)], supported: application/json
+.. CF_DOCS_SPLICE_SNIPPET_025_END
 
 UNAUTHENTICATED errors in validator, sv and scan app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -130,9 +136,11 @@ indicates an authentication error on the connection to the
 participant. Check the participant logs which will contain more
 details on why the request got rejected.
 
+.. CF_DOCS_SPLICE_SNIPPET_026_START
 .. code:: text
 
     2025-02-14T11:32:00.304Z [⋮] INFO - o.l.s.v.ValidatorApp:validator=validator_backend (50836441bf579035d64a56f776566cbf) - The operation 'Get user 7D95xiEUxju4IUXFQgyUrwHMMuZO0g2F@clients' failed with a retryable error (full stack trace omitted): UNAUTHENTICATED: An error occurred. Please contact the operator and inquire about the request efd009557dec03da74dd29b723949cd6 with tid efd009557dec03da74dd29b723949cd6
+.. CF_DOCS_SPLICE_SNIPPET_026_END
 
 Node has identity X, but identifier Y was expected
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,9 +164,11 @@ again.
 If this is not a new node, change
 the values back to what you had before.
 
+.. CF_DOCS_SPLICE_SNIPPET_027_START
 .. code:: text
 
     │Caused by: io.grpc.StatusRuntimeException: INTERNAL: Node has identity a-b-c-1::122098ffcd99..., but identifier a-b-1 was expected.                │
+.. CF_DOCS_SPLICE_SNIPPET_027_END
 
 MemberDisabled error when connecting to sequencer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,8 +179,10 @@ Any attempts to connect will fail with the same error.
 You can recover your CC balance by spinning up a new node via :ref:`validator_reonboard`.
 
 
+.. CF_DOCS_SPLICE_SNIPPET_028_START
 .. code:: text
 
     2025-04-16T08:18:06.451Z [⋮] DEBUG - c.d.c.s.c.t.GrpcSequencerSubscription:participant=participant/domainId=global-domain::12206d339948/sequencerAlias=Some-Alias (---) - Completed subscription with Success(GrpcSubscriptionError(Request failed for sequencer.
       GrpcRequestRefusedByServer: FAILED_PRECONDITION/MemberDisabled(PAR::validator1::12203d9ed85f...)
       Request: subscription
+.. CF_DOCS_SPLICE_SNIPPET_028_END

--- a/docs/src/scalability/scalability.rst
+++ b/docs/src/scalability/scalability.rst
@@ -112,8 +112,10 @@ To do so, add the following :ref:`environment variables
 experiment with the batch size but batch sizes above 20 are not
 recommended as batches that are too large can cause issues.
 
+.. CF_DOCS_SPLICE_SNIPPET_030_START
 .. code::
 
     - name: ADDITIONAL_CONFIG_TOPOLOGY_BATCH_SIZE
       value: |
         canton.participants.participant.topology.broadcast-batch-size = 20
+.. CF_DOCS_SPLICE_SNIPPET_030_END

--- a/docs/src/sv_operator/sv_backup.rst
+++ b/docs/src/sv_operator/sv_backup.rst
@@ -18,9 +18,11 @@ access to your Canton Coin holdings), so must be backed up outside of the cluste
 
 Your identites may be fetched from your node through the following endpoint:
 
+.. CF_DOCS_SPLICE_SNIPPET_031_START
 .. code-block:: bash
 
     curl "https://sv.sv.YOUR_HOSTNAME/api/sv/v0/admin/domain/identities-dump" -H "authorization: Bearer <token>"
+.. CF_DOCS_SPLICE_SNIPPET_031_END
 
 where `<token>` is an OAuth2 Bearer Token obtained from your OAuth provider. For context, see the Authentication section :ref:`here <app-auth>`.
 

--- a/docs/src/sv_operator/sv_helm.rst
+++ b/docs/src/sv_operator/sv_helm.rst
@@ -34,10 +34,12 @@ Requirements
    The serial ID is 0 for the initial synchronizer deployment and is incremented by 1 for each :ref:`logical synchronizer upgrade <sv-logical-synchronizer-upgrades>`.
    The serial ID is used for helm release names, DNS entries, database names, and deployment naming.
 
+.. CF_DOCS_SPLICE_SNIPPET_037_START
 .. code-block:: bash
 
    export MIGRATION_ID=0
    export SERIAL_ID=0
+.. CF_DOCS_SPLICE_SNIPPET_037_END
 
 .. include:: ../common/backup_suggestion.rst
 
@@ -50,7 +52,10 @@ SV operators are identified by a human-readable name and an EC public key.
 This identification is stable across deployments of the Global Synchronizer.
 You are, for example, expected to reuse your SV name and public key between (test-)network resets.
 
-Use the following shell commands to generate a keypair in the format expected by the SV node software: ::
+Use the following shell commands to generate a keypair in the format expected by the SV node software:
+
+.. CF_DOCS_SPLICE_SNIPPET_039_START
+.. code-block:: bash
 
   # Generate the keypair
   openssl ecparam -name prime256v1 -genkey -noout -out sv-keys.pem
@@ -65,14 +70,19 @@ Use the following shell commands to generate a keypair in the format expected by
 
   # Clean up
   rm sv-keys.pem
+.. CF_DOCS_SPLICE_SNIPPET_039_END
 
 ..
   Based on `scripts/generate-sv-keys.sh`
 
-These commands should result in an output similar to ::
+These commands should result in an output similar to:
+
+.. CF_DOCS_SPLICE_SNIPPET_059_START
+.. code-block:: text
 
   public-key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1eb+JkH2QFRCZedO/P5cq5d2+yfdwP+jE+9w3cT6BqfHxCd/PyA0mmWMePovShmf97HlUajFuN05kZgxvjcPQw=="
   private-key = "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCBsFuFa7Eumkdg4dcf/vxIXgAje2ULVz+qTKP3s/tHqKw=="
+.. CF_DOCS_SPLICE_SNIPPET_059_END
 
 Store both keys in a safe location.
 You will be using them every time you want to deploy a new SV node, i.e., also when deploying an SV node to a different deployment of the Global Synchronizer and for redeploying an SV node after a (test-)network reset.
@@ -88,9 +98,11 @@ Preparing a Cluster for Installation
 
 Create the application namespace within Kubernetes.
 
+.. CF_DOCS_SPLICE_SNIPPET_047_START
 .. code-block:: bash
 
     kubectl create ns sv
+.. CF_DOCS_SPLICE_SNIPPET_047_END
 
 .. _helm-sv-auth:
 
@@ -297,6 +309,7 @@ We are now going to configure your SV node software based on the OIDC provider c
 
 The following kubernetes secret will instruct the participant to create a service user for your SV app (omit the scope if it is not needed in your setup).
 
+.. CF_DOCS_SPLICE_SNIPPET_033_START
 .. code-block:: bash
 
     kubectl create --namespace sv secret generic splice-app-sv-ledger-api-auth \
@@ -306,9 +319,11 @@ The following kubernetes secret will instruct the participant to create a servic
         "--from-literal=client-secret=${SV_CLIENT_SECRET}" \
         "--from-literal=audience=${OIDC_AUTHORITY_LEDGER_API_AUDIENCE}"
         "--from-literal=scope=${OIDC_AUTHORITY_LEDGER_API_SCOPE}"
+.. CF_DOCS_SPLICE_SNIPPET_033_END
 
 The validator app backend requires the following secret (omit the scope if it is not needed in your setup).
 
+.. CF_DOCS_SPLICE_SNIPPET_034_START
 .. code-block:: bash
 
     kubectl create --namespace sv secret generic splice-app-validator-ledger-api-auth \
@@ -318,9 +333,11 @@ The validator app backend requires the following secret (omit the scope if it is
         "--from-literal=client-secret=${VALIDATOR_CLIENT_SECRET}" \
         "--from-literal=audience=${OIDC_AUTHORITY_LEDGER_API_AUDIENCE}" \
         "--from-literal=scope=${OIDC_AUTHORITY_LEDGER_API_SCOPE}"
+.. CF_DOCS_SPLICE_SNIPPET_034_END
 
 To setup the wallet, CNS and SV UI, create the following two secrets.
 
+.. CF_DOCS_SPLICE_SNIPPET_035_START
 .. code-block:: bash
 
     kubectl create --namespace sv secret generic splice-app-wallet-ui-auth \
@@ -334,6 +351,7 @@ To setup the wallet, CNS and SV UI, create the following two secrets.
     kubectl create --namespace sv secret generic splice-app-cns-ui-auth \
         "--from-literal=url=${OIDC_AUTHORITY_URL}" \
         "--from-literal=client-id=${CNS_UI_CLIENT_ID}"
+.. CF_DOCS_SPLICE_SNIPPET_035_END
 
 Configuring your CometBFT node
 ------------------------------
@@ -349,6 +367,7 @@ To generate the node config you use the CometBFT docker image provided through G
 
 Use the following shell commands to generate the proper keys:
 
+.. CF_DOCS_SPLICE_SNIPPET_051_START
 .. parsed-literal::
 
   # Create a folder to store the config
@@ -358,13 +377,18 @@ Use the following shell commands to generate the proper keys:
   docker run --rm -v "$(pwd):/init" |docker_repo_prefix|/cometbft:|version| init --home /init
   # Read the node id and keep a note of it for the deployment
   docker run --rm -v "$(pwd):/init" |docker_repo_prefix|/cometbft:|version| show-node-id --home /init
+.. CF_DOCS_SPLICE_SNIPPET_051_END
 
 Please keep a note of the node ID printed out above.
 
-In addition, please retain some of the configuration files generated, as follows (you might need to change the permissions/ownership for them as they are accessible only by the root user): ::
+In addition, please retain some of the configuration files generated, as follows (you might need to change the permissions/ownership for them as they are accessible only by the root user):
+
+.. CF_DOCS_SPLICE_SNIPPET_058_START
+.. code-block:: text
 
   cometbft/config/node_key.json
   cometbft/config/priv_validator_key.json
+.. CF_DOCS_SPLICE_SNIPPET_058_END
 
 Any other files can be ignored.
 
@@ -376,11 +400,13 @@ Configuring your CometBFT node keys
 The CometBFT node is configured with a secret, based on the output from :ref:`Generating the CometBFT node identity <cometbft-identity>`
 The secret is created as follows, with the `node_key.json` and `priv_validator_key.json` files representing the files generated as part of the node identity:
 
+.. CF_DOCS_SPLICE_SNIPPET_036_START
 .. code-block:: bash
 
     kubectl create --namespace sv secret generic cometbft-keys \
         "--from-file=node_key.json=node_key.json" \
         "--from-file=priv_validator_key.json=priv_validator_key.json"
+.. CF_DOCS_SPLICE_SNIPPET_036_END
 
 .. _helm-cometbft-state-sync:
 
@@ -435,27 +461,33 @@ To do so, SV operators must perform the following steps.
 
 Step 1. In ``sv-validator-values.yaml``, add the following ``synchronizer`` config.
 
+.. CF_DOCS_SPLICE_SNIPPET_060_START
 .. code-block:: yaml
 
     synchronizer:
       connectionType: "trust-single"
       url: "SEQUENCER_PUBLIC_URI" # synchronizers.current.sequencerPublicUrl from sv-values.yaml
+.. CF_DOCS_SPLICE_SNIPPET_060_END
 
 Step 2. In ``validator-values.yaml``, add the following or an equivalent :ref:`config override <configuration_ad_hoc>`:
 
+.. CF_DOCS_SPLICE_SNIPPET_061_START
 .. code-block:: yaml
 
     additionalEnvVars:
         - name: ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION
           value: "canton.validator-apps.validator_backend.disable-sv-validator-bft-sequencer-connection = true"
+.. CF_DOCS_SPLICE_SNIPPET_061_END
 
 Step 3. In ``sv-values.yaml``, add the following or an equivalent :ref:`config override <configuration_ad_hoc>`:
 
+.. CF_DOCS_SPLICE_SNIPPET_062_START
 .. code-block:: yaml
 
     additionalEnvVars:
         - name: ADDITIONAL_CONFIG_NO_BFT_SEQUENCER_CONNECTION
           value: "canton.sv-apps.sv.bft-sequencer-connection = false"
+.. CF_DOCS_SPLICE_SNIPPET_062_END
 
 The default behavior is restored by undoing above changes.
 
@@ -463,6 +495,7 @@ To confirm the current configuration of your SV participant,
 open a :ref:`Canton console <console_access>` to it and execute ``participant.synchronizers.config("global")``.
 In case BFT sequencer connections are disabled, this should return a single sequencer connection in an output similar to the following:
 
+.. CF_DOCS_SPLICE_SNIPPET_052_START
 .. parsed-literal::
 
     @ participant.synchronizers.config("global")
@@ -478,6 +511,7 @@ In case BFT sequencer connections are disabled, this should return a single sequ
         timeTracker = SynchronizerTimeTrackerConfig(minObservationDuration = 30m)
       )
     )
+.. CF_DOCS_SPLICE_SNIPPET_052_END
 
 Alternatively, you can also search your participant logs for a ``DEBUG``-level entry such as
 ``Connecting to synchronizer with config: SynchronizerConnectionConfig(...)``,
@@ -502,6 +536,7 @@ All apps support reading the Postgres password from a Kubernetes secret.
 Currently, all apps use the Postgres user ``cnadmin``.
 The password can be setup with the following command, assuming you set the environment variables ``POSTGRES_PASSWORD_XXX`` to secure values:
 
+.. CF_DOCS_SPLICE_SNIPPET_038_START
 .. code-block:: bash
 
     kubectl create secret generic sequencer-pg-secret \
@@ -516,6 +551,7 @@ The password can be setup with the following command, assuming you set the envir
     kubectl create secret generic apps-pg-secret \
         --from-literal=postgresPassword=${POSTGRES_PASSWORD_APPS} \
         -n sv
+.. CF_DOCS_SPLICE_SNIPPET_038_END
 
 
 Postgres in the Cluster
@@ -523,12 +559,14 @@ Postgres in the Cluster
 
 If you wish to run the Postgres instances as pods in your cluster, you can use the `splice-postgres` Helm chart to install them:
 
+.. CF_DOCS_SPLICE_SNIPPET_053_START
 .. parsed-literal::
 
     helm install sequencer-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-sequencer.yaml --wait
     helm install mediator-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-mediator.yaml --wait
     helm install participant-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-participant.yaml --wait
     helm install apps-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-apps.yaml --wait
+.. CF_DOCS_SPLICE_SNIPPET_053_END
 
 Cloud-Hosted Postgres
 +++++++++++++++++++++
@@ -622,11 +660,13 @@ and register a name and keypair for your SV. Replace
 and ``private-key`` values obtained as part of generating your SV
 identity.
 
+.. CF_DOCS_SPLICE_SNIPPET_040_START
 .. code-block:: bash
 
     kubectl create secret --namespace sv generic splice-app-sv-key \
         --from-literal=public=YOUR_PUBLIC_KEY \
         --from-literal=private=YOUR_PRIVATE_KEY
+.. CF_DOCS_SPLICE_SNIPPET_040_END
 
 For configuring your sv app, please modify the file ``splice-node/examples/sv-helm/sv-values.yaml`` as follows:
 
@@ -686,33 +726,41 @@ reaches a stable state prior to moving on to the next step.
 
 Install the Canton and CometBFT components:
 
+.. CF_DOCS_SPLICE_SNIPPET_054_START
 .. parsed-literal::
 
     helm install global-domain-${SERIAL_ID}-cometbft |helm_repo_prefix|/splice-cometbft -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/cometbft-values.yaml --wait
     helm install global-domain-${SERIAL_ID} |helm_repo_prefix|/splice-global-domain -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/global-domain-values.yaml --wait
+.. CF_DOCS_SPLICE_SNIPPET_054_END
 
 Note that we use the serial ID when naming Canton synchronizer components.
 This is to support operating multiple instances of these components side by side as part of a :ref:`logical synchronizer upgrade <sv-logical-synchronizer-upgrades>`.
 
 Install the participant:
 
+.. CF_DOCS_SPLICE_SNIPPET_055_START
 .. parsed-literal::
 
     helm install participant |helm_repo_prefix|/splice-participant -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/participant-values.yaml --wait
+.. CF_DOCS_SPLICE_SNIPPET_055_END
 
 Install the SV node apps:
 
+.. CF_DOCS_SPLICE_SNIPPET_056_START
 .. parsed-literal::
 
     helm install sv |helm_repo_prefix|/splice-sv-node -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/sv-values.yaml -f ${SV_IDENTITIES_FILE} -f ${UI_CONFIG_VALUES_FILE} --wait
     helm install scan |helm_repo_prefix|/splice-scan -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/scan-values.yaml -f ${UI_CONFIG_VALUES_FILE} --wait
     helm install validator |helm_repo_prefix|/splice-validator -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/validator-values.yaml -f splice-node/examples/sv-helm/sv-validator-values.yaml -f ${UI_CONFIG_VALUES_FILE} --wait
+.. CF_DOCS_SPLICE_SNIPPET_056_END
 
 Install the INFO app, which is used to provide information about the SV node and its configuration:
 
+.. CF_DOCS_SPLICE_SNIPPET_057_START
 .. parsed-literal::
 
     helm install info |helm_repo_prefix|/splice-info -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/info-values.yaml
+.. CF_DOCS_SPLICE_SNIPPET_057_END
 
 
 
@@ -720,6 +768,7 @@ Once everything is running, you should be able to inspect the state of the
 cluster and observe pods running in the new
 namespace. A typical query might look as follows:
 
+.. CF_DOCS_SPLICE_SNIPPET_041_START
 .. code-block:: bash
 
     $ kubectl get pods -n sv
@@ -740,6 +789,7 @@ namespace. A typical query might look as follows:
     sv-web-ui-67bfbdfc77-wwvp9                   2/2     Running   0             13m
     validator-app-667445fdfc-rcztx               2/2     Running   0             10m
     wallet-web-ui-648f86f9f9-lffz5               2/2     Running   0             10m
+.. CF_DOCS_SPLICE_SNIPPET_041_END
 
 
 Note also that ``Pod`` restarts may happen during bringup,
@@ -830,20 +880,24 @@ Your SV node should be configured with a url to your ``global-domain-sequencer``
 Make sure your cluster's ingress is correctly configured for the sequencer service and can be accessed through the provided URL.
 To check whether the sequencer is accessible, we can use the command below with the `grpcurl tool <https://github.com/fullstorydev/grpcurl>`_ :
 
+.. CF_DOCS_SPLICE_SNIPPET_042_START
 .. code-block:: bash
 
     grpcurl <sequencer host>:<sequencer port> grpc.health.v1.Health/Check
+.. CF_DOCS_SPLICE_SNIPPET_042_END
 
 If you are using the ingress configuration of this runbook, the ``<sequencer host>:<sequencer port>`` should be ``sequencer-SERIAL_ID.sv.YOUR_HOSTNAME:443``
 Please replace ``YOUR_HOSTNAME`` with your host name and ``SERIAL_ID`` with the serial ID of the synchronizer that the sequencer is part of.
 
 If you see the response below, it means the sequencer is up and accessible through the URL.
 
+.. CF_DOCS_SPLICE_SNIPPET_043_START
 .. code-block:: bash
 
     {
       "status": "SERVING"
     }
+.. CF_DOCS_SPLICE_SNIPPET_043_END
 
 
 Requirements
@@ -856,27 +910,32 @@ In order to install the reference charts, the following must be satisfied in you
 
 **Example of Istio installation:**
 
+.. CF_DOCS_SPLICE_SNIPPET_044_START
 .. code-block:: bash
 
     helm repo add istio https://istio-release.storage.googleapis.com/charts
     helm repo update
     helm install istio-base istio/base -n istio-system --set defaults.global.istioNamespace=cluster-ingress --wait
     helm install istiod istio/istiod -n cluster-ingress --set global.istioNamespace="cluster-ingress" --set meshConfig.accessLogFile="/dev/stdout"  --wait
+.. CF_DOCS_SPLICE_SNIPPET_044_END
 
 Installation Instructions
 +++++++++++++++++++++++++
 
 Create a `cluster-ingress` namespace:
 
+.. CF_DOCS_SPLICE_SNIPPET_045_START
 .. code-block:: bash
 
     kubectl create ns cluster-ingress
+.. CF_DOCS_SPLICE_SNIPPET_045_END
 
 
 Ensure that there is a cert-manager certificate available in a secret
 named ``cn-net-tls``.  An example of a suitable certificate
 definition:
 
+.. CF_DOCS_SPLICE_SNIPPET_063_START
 .. code-block:: yaml
 
     apiVersion: cert-manager.io/v1
@@ -890,11 +949,13 @@ definition:
         issuerRef:
             name: letsencrypt-production
         secretName: cn-net-tls
+.. CF_DOCS_SPLICE_SNIPPET_063_END
 
 
 Create a file named ``istio-gateway-values.yaml`` with the following content
 (Tip: on GCP you can get the cluster IP from ``gcloud compute addresses list``):
 
+.. CF_DOCS_SPLICE_SNIPPET_064_START
 .. code-block:: yaml
 
     service:
@@ -904,14 +965,17 @@ Create a file named ``istio-gateway-values.yaml`` with the following content
             - "35.198.147.95/32"
             - "35.189.40.124/32"
             - "34.132.91.75/32"
+.. CF_DOCS_SPLICE_SNIPPET_064_END
 
 
 
 And install it to your cluster:
 
+.. CF_DOCS_SPLICE_SNIPPET_046_START
 .. code-block:: bash
 
     helm install istio-ingress istio/gateway -n cluster-ingress -f istio-gateway-values.yaml
+.. CF_DOCS_SPLICE_SNIPPET_046_END
 
 
 Create Istio Gateway resources in the `cluster-ingress` namespace. Save the following to a file named `gateways.yaml`,
@@ -921,6 +985,7 @@ with the following modifications:
 - The second gateway (cn-apps-gateway) exposes ports for three migration IDs (0, 1, and 2) for the CometBFT apps of the SV node.
   If a higher migration ID is reached, expand that list using the same pattern.
 
+.. CF_DOCS_SPLICE_SNIPPET_065_START
 .. code-block:: yaml
 
     apiVersion: networking.istio.io/v1alpha3
@@ -982,12 +1047,15 @@ with the following modifications:
           protocol: TCP
         hosts:
           - "*"
+.. CF_DOCS_SPLICE_SNIPPET_065_END
 
 And apply them to your cluster:
 
+.. CF_DOCS_SPLICE_SNIPPET_048_START
 .. code-block:: bash
 
     kubectl apply -f gateways.yaml -n cluster-ingress
+.. CF_DOCS_SPLICE_SNIPPET_048_END
 
 
 The http gateway terminates tls using the secret that you configured above, and exposes raw http traffic in its outbound port 443.
@@ -1000,9 +1068,11 @@ A reference Helm chart is provided for that, which can be installed after
 using:
 
 
+.. CF_DOCS_SPLICE_SNIPPET_050_START
 .. parsed-literal::
 
     helm install cluster-ingress-sv |helm_repo_prefix|/splice-cluster-ingress-runbook -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/sv-cluster-ingress-values.yaml
+.. CF_DOCS_SPLICE_SNIPPET_050_END
 
 
 
@@ -1028,9 +1098,11 @@ It might also be required in the future to support the operation of the ordering
 To get a list of all current scan instances, you can query the ``/api/scan/v0/scans`` endpoint on any scan instances known to you.
 For example using the sponsor's scan instance (and with some optional post-processing using `jq <https://jqlang.org/>`_):
 
+.. CF_DOCS_SPLICE_SNIPPET_032_START
 .. code-block:: bash
 
     curl https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans | jq -r '.scans.[].scans.[].publicUrl'
+.. CF_DOCS_SPLICE_SNIPPET_032_END
 
 .. _helm-sv-wallet-ui:
 
@@ -1130,6 +1202,7 @@ Note that SVs must wait ``voteCooldownTime`` (a governance parameter
 that defaults to 1min) between updates to their rate. Therefore updates made
 by the publisher will not propagate immediately.
 
+.. CF_DOCS_SPLICE_SNIPPET_049_START
 .. code::
 
   - name: ADDITIONAL_CONFIG_FOLLOW_AMULET_CONVERSION_RATE_FEED
@@ -1141,3 +1214,4 @@ by the publisher will not propagate immediately.
           max = 100.0
         }
       }
+.. CF_DOCS_SPLICE_SNIPPET_049_END

--- a/docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst
+++ b/docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst
@@ -82,11 +82,13 @@ Concretely, the procedure is as follows:
 1. The old physical synchronizer is deemed broken and the last sequenced message was at record time R.
 2. Super validators configure this as the max sequencing time on the old sequencer to guarantee that nothing accidentally gets sequenced after that time. This is done by applying the following environment variable to the existing sequencer:
 
+.. CF_DOCS_SPLICE_SNIPPET_068_START
 .. code::
 
     - name: ADDITIONAL_CONFIG_SEQUENCER_LSU_MAX_SEQUENCING_TIME
       value: |
         canton.sequencers.sequencer.parameters.lsu-repair.global-max-sequencing-time-exclusive=MAX_SEQUENCING_TIME
+.. CF_DOCS_SPLICE_SNIPPET_068_END
 
 2. Super validators deploy successor nodes. Depending on the issue,
    the successor nodes may be configured with older image and protocol
@@ -113,6 +115,7 @@ Concretely, the procedure is as follows:
 4. Super validators configure their SV app app to transfer the topology and traffic state from the old physical synchronizer to the successor nodes.
    To do so, add the following helm values to the SV app:
 
+.. CF_DOCS_SPLICE_SNIPPET_066_START
 .. code::
 
    rollForwardLsu:
@@ -122,6 +125,7 @@ Concretely, the procedure is as follows:
        topologyExportTime: TOPOLOGY_EXPORT_TIME # Must be agreed between SVs
        trafficExportTime: TRAFFIC_EXPORT_TIME # Must be agreed between SVs
        upgradeTime: UPGRADE_TIME # Must be agreed between SVs
+.. CF_DOCS_SPLICE_SNIPPET_066_END
 
 5. Validators initiate the :ref:`procedure <validator_roll_forward_lsu>` on their side.
 
@@ -137,11 +141,13 @@ To do so, use the following steps:
 
 1. Super validators configure the manual LSU in their scan.
 
+.. CF_DOCS_SPLICE_SNIPPET_067_START
 .. code::
 
   rollForwardLsu:
      enabled: true
      upgradeTime: UPGRADE_TIME # Must be agreed between SVs, optional, if not specified it is taken from an existing LSU announcement which should usually be sufficient.
+.. CF_DOCS_SPLICE_SNIPPET_067_END
 
 2. Validator app automation picks up that configuration and initiates a manual roll-forward LSU to the new synchronizer.
 
@@ -167,6 +173,6 @@ LSU requires deployment changes for super validators. Concretely:
    should be configured to the successor physical synchronizer when that is deployed. After the upgrade, ``synchronizers.current`` becomes ``synchronizers.legacy`` and ``synchronizers.successor`` becomes ``synchronizers.current``. The legacy configuration should be removed together with removing the old physical synchronizer after 30 days. If you already have a node in ``legacy`` and it should not yet be
    decomissioned move it to ``additionalLegacy`` which accepts an array of synchronizers.
    The CometBFT configuration also moves under ``synchronizers.(current|successor|legacy)``.
-3. The ``sequencerAddress`` and ``mediatorAddress``values in scan should be replaced by ``synchronizers.current.sequencer`` and ``synchronizers.current.mediator``. The corresponding values under ``synchronizers.successor`` should be set together with
+3. The ``sequencerAddress`` and ``mediatorAddress`` values in scan should be replaced by ``synchronizers.current.sequencer`` and ``synchronizers.current.mediator``. The corresponding values under ``synchronizers.successor`` should be set together with
    the deployment of the successor physical synchronizer. After the upgrade ``successor`` becomes ``current`` and ``current`` is removed.
 4. When using DABFT as the successor node, further changes will be required. Most notably the cometbft node goes away as DABFT runs as part of the sequencer pod. The sequencer pod and SV app will require some additional configuration. Details of this will be added later.

--- a/docs/src/sv_operator/sv_network_resets.rst
+++ b/docs/src/sv_operator/sv_network_resets.rst
@@ -70,26 +70,32 @@ To complete the reset, go through the following steps:
     a. Confirm that the reset did not change the dso rules
        by repeating step 1.a and comparing the result:
 
+       .. CF_DOCS_SPLICE_SNIPPET_069_START
        .. code-block:: bash
 
            curl -sSL --fail-with-body https://YOUR_SCAN_URL/api/scan/v0/dso > current_state.json
+       .. CF_DOCS_SPLICE_SNIPPET_069_END
 
        The reset should preserve SV reward weights, i.e., the following diff should be empty:
 
+       .. CF_DOCS_SPLICE_SNIPPET_070_START
        .. code-block:: bash
 
            jq '.dso_rules.contract.payload.svs.[] | [.[1].name, .[1].svRewardWeight]' backup.json > weights_backup.json
            jq '.dso_rules.contract.payload.svs.[] | [.[1].name, .[1].svRewardWeight]' current_state.json > weights_current.json
            diff -C2 weights_backup.json weights_current.json
+       .. CF_DOCS_SPLICE_SNIPPET_070_END
 
        The reset should also preserve the amulet rules modulo cryptographic keys, i.e., the following diff should
        only show changes to the dso and synchronizer namespaces:
 
+       .. CF_DOCS_SPLICE_SNIPPET_071_START
        .. code-block:: bash
 
            jq '.amulet_rules.contract.payload' backup.json > amulet_backup.json
            jq '.amulet_rules.contract.payload' current_state.json > amulet_current.json
            diff amulet_backup.json amulet_current.json
+       .. CF_DOCS_SPLICE_SNIPPET_071_END
 
     b. Check your desired coin price in the SV UI, and verify that it matches
        the value from before the reset (see step 1.b.)

--- a/docs/src/sv_operator/sv_operations.rst
+++ b/docs/src/sv_operator/sv_operations.rst
@@ -166,6 +166,7 @@ The suggested specific steps are as follows:
    (b) had a single coin input.
    You can confirm both of these conditions by looking at the matching log entry of the form:
 
+   .. CF_DOCS_SPLICE_SNIPPET_077_START
    .. parsed-literal::
 
      executing batch AmuletOperationBatch(
@@ -176,6 +177,7 @@ The suggested specific steps are as follows:
        ),
        priority = Low
      ) with inputs Vector(InputAmulet(ContractId(002ace5687dc7f82cb0ca80d2b349a39b1127ffd01db2cd7172053fef88308e6faca1012202646cd3cbb31c78314c3ef22657d4ba6f7f096e90167dcd0d71eba565fa35844)))
+   .. CF_DOCS_SPLICE_SNIPPET_077_END
 
    Use  the ``trace-id`` from this log enty's metadata
    (**not** the ``tid`` in view here but from the dedicated ``trace-id`` field on the log entry JSON)
@@ -188,9 +190,11 @@ The suggested specific steps are as follows:
    The goal is to tie the action here to a ``trace-id`` on the Canton side.
    Search for a log entry of the following form:
 
+   .. CF_DOCS_SPLICE_SNIPPET_078_START
    .. parsed-literal::
 
      Request (tid:43fd8ad332ca637b0c7c1509b2bdf715) com.daml.ledger.api.v2.CommandService/SubmitAndWaitForTransactionTree to participant-1:5001: sending request
+   .. CF_DOCS_SPLICE_SNIPPET_078_END
 
    The ``tid`` in this log entry is the ``trace-id`` that you're looking for.
    It will be different from the ``trace-id`` in the log entry metadata
@@ -199,11 +203,13 @@ The suggested specific steps are as follows:
 5. Search your SV's `sequencer` logs for the ``trace-id`` from the previous step.
    You want to use a log filter along the lines of (all rules here should be concatenated with logical "AND"s):
 
+   .. CF_DOCS_SPLICE_SNIPPET_079_START
    .. parsed-literal::
 
      resource.labels.container_name="sequencer"
      jsonPayload.logger_name="c.d.c.s.t.TrafficConsumedManager:sequencer=sequencer"
      jsonPayload."trace-id"="43fd8ad332ca637b0c7c1509b2bdf715"
+   .. CF_DOCS_SPLICE_SNIPPET_079_END
 
 
 6. The resulting log lines contain traffic consumption information about the sender and receiver participants,
@@ -217,11 +223,13 @@ The suggested specific steps are as follows:
    Filtering the resulting log lines for the participant IDs corresponding to the sender and receiver,
    you should get log lines similar to the following:
 
+   .. CF_DOCS_SPLICE_SNIPPET_080_START
    .. parsed-literal::
 
      Consumed 16147 for PAR::sender::...
      Consumed 711 for PAR::receiver::...
      Consumed 1450 for PAR::sender::...
+   .. CF_DOCS_SPLICE_SNIPPET_080_END
 
 7. Sum up the numbers in the log lines to get the total traffic consumed for the last leg of a CC transfer.
    In this example, the total traffic consumed would be 17597 bytes for the sender and 711 bytes for the receiver.
@@ -291,12 +299,14 @@ To resolve this issue, **each** SV operator is currently asked to follow the fol
 1. Shortly before the Daml upgrade becomes effective:
    Each SV pauses their ``ExpireRewardCouponsTrigger`` trigger by extending ``.additionalEnvVars`` in ``sv-values.yaml`` in the following way:
 
+   .. CF_DOCS_SPLICE_SNIPPET_083_START
    .. code-block:: yaml
 
       additionalEnvVars:
         - name: ADDITIONAL_CONFIG_PAUSED_EXPIRY_TRIGGER
           value: |
             canton.sv-apps.sv.automation.paused-triggers += "org.lfdecentralizedtrust.splice.sv.automation.delegatebased.ExpireRewardCouponsTrigger"
+   .. CF_DOCS_SPLICE_SNIPPET_083_END
 
 2. Shortly after the Daml upgrade becomes effective:
    One SV operator :ref:`constructs a party exclusion config <sv_ops_ignored_rewards_party_ids_determine>`,
@@ -304,6 +314,7 @@ To resolve this issue, **each** SV operator is currently asked to follow the fol
 3. Each SV operator adopts the party exclusion config and resume the ``ExpireRewardCouponsTrigger`` trigger by reverting the change from step 1.
    If ``.additionalEnvVars`` in ``sv-values.yaml`` was empty before step 1, it is now expected to look similar to the following:
 
+   .. CF_DOCS_SPLICE_SNIPPET_084_START
    .. code-block:: yaml
 
       additionalEnvVars:
@@ -312,6 +323,7 @@ To resolve this issue, **each** SV operator is currently asked to follow the fol
             canton.sv-apps.sv {
               automation.ignored-expired-rewards-party-ids = [ "party1::12345", "party2:57890" ]
             }
+   .. CF_DOCS_SPLICE_SNIPPET_084_END
 
 Updates to the party exclusion config are possible at future points in time,
 e.g., in case validators that were previously outdated eventually upgrade to a sufficiently recent Splice version.
@@ -339,9 +351,11 @@ Based on that:
 - For a more quick feedback loop, you can attempt queries against the SV app (postgres) database.
   For example, you can list receivers of rewards that were not expired since the Daml upgrade:
 
+  .. CF_DOCS_SPLICE_SNIPPET_081_START
   .. code-block:: sql
 
       select distinct(reward_party) from dso_acs_store where reward_round < UPGRADE_ROUND;
+  .. CF_DOCS_SPLICE_SNIPPET_081_END
 
   Note however that this query overapproximates the set of parties to ignore, so you might need to remove some parties again later.
 
@@ -354,6 +368,7 @@ Based on that:
   The following database query shows expired rewards that were generated *after* the Daml upgrade,
   which is an indicator that the hosting validator has upgraded and so these parties should not be ignored anymore:
 
+  .. CF_DOCS_SPLICE_SNIPPET_082_START
   .. code-block:: sql
 
      select m.template_id_qualified_name, m.reward_party, min(m.reward_round) from (
@@ -363,6 +378,7 @@ Based on that:
        and r.mining_round > UPGRADE_ROUND
        and r.template_id_qualified_name = 'Splice.Round:ClosedMiningRound'
      ) as m group by (template_id_qualified_name, reward_party);
+  .. CF_DOCS_SPLICE_SNIPPET_082_END
 
 .. _sv_unclaimed_sv_rewards_script:
 
@@ -477,6 +493,7 @@ The ``unclaimed_sv_rewards.py`` script is executed as a standalone Python progra
 
 Example using default optional parameters:
 
+.. CF_DOCS_SPLICE_SNIPPET_072_START
 .. code-block:: bash
 
   python3 unclaimed_sv_rewards.py \
@@ -499,9 +516,11 @@ Example using default optional parameters:
       --begin-migration-id 3 \
       --weight 5000 \
       --already-minted-weight 0
+.. CF_DOCS_SPLICE_SNIPPET_072_END
 
 Example with optional parameters:
 
+.. CF_DOCS_SPLICE_SNIPPET_073_START
 .. code-block:: bash
 
   python3 unclaimed_sv_rewards.py \
@@ -530,9 +549,11 @@ Example with optional parameters:
       --begin-migration-id 3 \
       --weight 5000 \
       --already-minted-weight 0
+.. CF_DOCS_SPLICE_SNIPPET_073_END
 
 Using a cache:
 
+.. CF_DOCS_SPLICE_SNIPPET_074_START
 .. code-block:: bash
 
   python3 unclaimed_sv_rewards.py \
@@ -556,9 +577,11 @@ Using a cache:
       --begin-migration-id 3 \
       --weight 5000 \
       --already-minted-weight 0
+.. CF_DOCS_SPLICE_SNIPPET_074_END
 
 To rebuild the cache:
 
+.. CF_DOCS_SPLICE_SNIPPET_075_START
 .. code-block:: bash
 
   python3 unclaimed_sv_rewards.py \
@@ -583,6 +606,7 @@ To rebuild the cache:
       --weight 5000 \
       --already-minted-weight 0 \
       --rebuild-cache
+.. CF_DOCS_SPLICE_SNIPPET_075_END
 
 
 For operational details regarding cache behavior, see
@@ -678,10 +702,12 @@ The beneficiary’s escrowed reward weight evolves as follows:
   - GSF sets weight = 30K.
   - GSF runs the script once for ``(t0, t1]``:
 
+  .. CF_DOCS_SPLICE_SNIPPET_076_START
   .. code-block:: bash
 
      --begin-record-time=t0 --end-record-time=t1 \
      --weight=10000 --already-minted-weight=0
+  .. CF_DOCS_SPLICE_SNIPPET_076_END
 
   - A vote is initiated for **m₁**.
 
@@ -816,36 +842,44 @@ The `ScanAppBackendConfig` has a field for both the ACS store and the TxLog stor
 The helm chart value `acsStoreDescriptorUserVersion` sets the `user version` of the
 ACS store, which is shown in the example below:
 
+   .. CF_DOCS_SPLICE_SNIPPET_085_START
    .. code-block:: yaml
 
       # Example to trigger re-ingestion of the ACS store for the first time
       persistence:
         acsStoreDescriptorUserVersion: 1
+   .. CF_DOCS_SPLICE_SNIPPET_085_END
 
 A subsequent re-ingestion can be triggered by incrementing the value, as shown in the example below:
 
+   .. CF_DOCS_SPLICE_SNIPPET_086_START
    .. code-block:: yaml
 
       # Example to trigger re-ingestion of the ACS store for the second time
       persistence:
         acsStoreDescriptorUserVersion: 2
+   .. CF_DOCS_SPLICE_SNIPPET_086_END
 
 The helm chart value `txLogStoreDescriptorUserVersion` sets the `user version` of the
 TxLog store, which is shown in the example below:
 
+   .. CF_DOCS_SPLICE_SNIPPET_087_START
    .. code-block:: yaml
 
       # Example to trigger re-ingestion of the TxLog store for the first time
       persistence:
         txLogStoreDescriptorUserVersion: 1
+   .. CF_DOCS_SPLICE_SNIPPET_087_END
 
 A subsequent re-ingestion can be triggered by incrementing the value, as shown in the example below:
 
+   .. CF_DOCS_SPLICE_SNIPPET_088_START
    .. code-block:: yaml
 
       # Example to trigger re-ingestion of the TxLog store for the second time
       persistence:
         txLogStoreDescriptorUserVersion: 2
+   .. CF_DOCS_SPLICE_SNIPPET_088_END
 
 The ``activityIngestionUserVersion`` field controls the activity record ingestion version. Incrementing this value causes the scan app to record a new app activity record completeness lower bound. Reward accounting excludes rounds before this boundary, even though their activity records are retained. Thus bumping the user version has the same effect as reinitializing the app activity record computation from the time of the bump onwards.
 
@@ -860,12 +894,14 @@ The user version must never decrease. A lower value than previously stored will 
 
 The HOCON configuration key is ``canton.scan-apps.scan-app.activity-ingestion-user-version``. It can be set via an ``ADDITIONAL_CONFIG`` environment variable:
 
+   .. CF_DOCS_SPLICE_SNIPPET_089_START
    .. code-block:: yaml
 
       # Example to reset the activity ingestion completeness boundary
       additionalEnvVars:
         - name: ADDITIONAL_CONFIG_ACTIVITY_INGESTION_USER_VERSION
           value: canton.scan-apps.scan-app.activity-ingestion-user-version = 1
+   .. CF_DOCS_SPLICE_SNIPPET_089_END
 
 .. _sv-unvet_insecure_package_versions:
 
@@ -884,6 +920,7 @@ To unvet supported packages, SVs (but not regular validators) must set the follo
 
 Here an example of how to unvet specific versions of a package:
 
+  .. CF_DOCS_SPLICE_SNIPPET_090_START
   .. code-block:: yaml
 
      additionalEnvVars:
@@ -891,6 +928,7 @@ Here an example of how to unvet specific versions of a package:
          value: |
            canton.sv-apps.sv.additional-packages-to-unvet.splice-wallet = ["0.1.16"]
            canton.sv-apps.sv.additional-packages-to-unvet.splice-amulet = ["0.1.16", "0.1.17"]
+  .. CF_DOCS_SPLICE_SNIPPET_090_END
 
 .. note::
 

--- a/docs/src/sv_operator/sv_pruning.rst
+++ b/docs/src/sv_operator/sv_pruning.rst
@@ -57,9 +57,11 @@ You also need to tell the participant to continue pruning even if it has not rec
 in the last 30 days. Without this pruning will essentially never run on mainnet as validators get shut down relatively frequently:
 To do so, set the following through the ``additionalEnvVars`` on your participant:
 
+.. CF_DOCS_SPLICE_SNIPPET_091_START
 .. code-block:: yaml
 
     additionalEnvVars:
         - name: ADDITIONAL_CONFIG_PRUNING_ACS_COMMITMENTS
           value: |
             canton.participants.participant.parameters.stores.safe-to-prune-commitment-state = "all"
+.. CF_DOCS_SPLICE_SNIPPET_091_END

--- a/docs/src/sv_operator/sv_restore.rst
+++ b/docs/src/sv_operator/sv_restore.rst
@@ -52,6 +52,7 @@ to restore the node:
 Scale down all components in the SV node to 0 replicas
 (replace ``-0`` with the correct serial ID in case a :ref:`logical synchronizer upgrade <sv-logical-synchronizer-upgrades>` has already been performed):
 
+.. CF_DOCS_SPLICE_SNIPPET_093_START
 .. code-block:: bash
 
     kubectl scale deployment --replicas=0 -n sv \
@@ -62,6 +63,7 @@ Scale down all components in the SV node to 0 replicas
       scan-app \
       sv-app \
       validator-app
+.. CF_DOCS_SPLICE_SNIPPET_093_END
 
 Restore the storage and DBs of all components from the backups. The exact process for this
 depends on the storage and DBs used by the components, and is not documented here.
@@ -69,6 +71,7 @@ depends on the storage and DBs used by the components, and is not documented her
 Once all storage has been restored, scale up all components in the SV node back to 1 replica
 (replace ``-0`` with the correct serial ID in case a :ref:`logical synchronizer upgrade <sv-logical-synchronizer-upgrades>` has already been performed):
 
+.. CF_DOCS_SPLICE_SNIPPET_094_START
 .. code-block:: bash
 
     kubectl scale deployment --replicas=1 -n sv \
@@ -79,6 +82,7 @@ Once all storage has been restored, scale up all components in the SV node back 
       scan-app \
       sv-app \
       validator-app
+.. CF_DOCS_SPLICE_SNIPPET_094_END
 
 Once all components are healthy again, they should start catching up their state from peer
 SVs, and eventually become functional again.
@@ -97,9 +101,11 @@ The details of fetching the identities are provided in the :ref:`Backup of Node 
 From the backup of Node Identities, copy the content of the field ``identities.participant`` and save it as a separate JSON file.
 This file will be used as identities bootstrap dump for the validator runbook.
 
+.. CF_DOCS_SPLICE_SNIPPET_092_START
 .. code-block:: bash
 
     jq '.identities.participant' backup.json > dump.json
+.. CF_DOCS_SPLICE_SNIPPET_092_END
 
 
 Once the failed SV node is offboarded by a majority of SVs (via a governance vote on a ``OffboardMember`` action), we can deploy a standalone validator node for recovering the SV's amulets.

--- a/docs/src/sv_operator/sv_security.rst
+++ b/docs/src/sv_operator/sv_security.rst
@@ -68,7 +68,10 @@ This involves the following steps:
 Generating a CometBFT governance key
 ====================================
 
-Use the following shell commands to generate a keypair in the expected format: ::
+Use the following shell commands to generate a keypair in the expected format:
+
+.. CF_DOCS_SPLICE_SNIPPET_096_START
+.. code-block:: bash
 
   # Generate the private key
   openssl genpkey -algorithm ed25519 -out cometbft-governance-keys.pem
@@ -85,16 +88,21 @@ Use the following shell commands to generate a keypair in the expected format: :
 
   # Clean up
   rm cometbft-governance-keys.pem
+.. CF_DOCS_SPLICE_SNIPPET_096_END
 
 ..
   Based on `scripts/generate-cometbft-governance-keys.sh`
 
-These commands should result in an output similar to ::
+These commands should result in an output similar to:
+
+.. CF_DOCS_SPLICE_SNIPPET_097_START
+.. code-block:: json
 
   {
     "public": "A9tWyYq/HIJ3B73ym1eIUV8yqnDBligGJUE8463CBUM=",
     "private": "FDG16PaSh9hGLu2fXzEHmTECMjSyQuZnEg+w5HKCEtg="
   }
+.. CF_DOCS_SPLICE_SNIPPET_097_END
 
 Save this output to a file, e.g., ``cometbft-governance-keys.json``.
 
@@ -105,11 +113,15 @@ You inject the externally generated CometBFT governance key into the SV app via
 storing it in a k8s secret named ``splice-app-sv-cometbft-governance-key``.
 
 Assuming that your SV deployment resides in the ``sv`` namespace,
-use the following command to create the secret from the JSON file generated above: ::
+use the following command to create the secret from the JSON file generated above:
+
+.. CF_DOCS_SPLICE_SNIPPET_095_START
+.. code-block:: bash
 
   kubectl create secret --namespace sv generic splice-app-sv-cometbft-governance-key \
     --from-literal=publicKey="$(jq -r .public cometbft-governance-keys.json)" \
     --from-literal=privateKey="$(jq -r .private cometbft-governance-keys.json)"
+.. CF_DOCS_SPLICE_SNIPPET_095_END
 
 To instruct the SV app to use the externally managed CometBFT governance key instead of generating a fresh one itself,
 set the ``cometBFT.externalGovernanceKey`` value in the ``splice-sv-node`` Helm chart to ``true``.

--- a/docs/src/validator_operator/required_network_parameters.rst
+++ b/docs/src/validator_operator/required_network_parameters.rst
@@ -6,6 +6,8 @@
 Required Network Parameters
 +++++++++++++++++++++++++++
 
+.. CF_DOCS_SPLICE_SNIPPET_135_START
+
 To initialize your validator node, you need the following parameters
 that define the network you're onboarding to and the secret
 required for doing so.
@@ -33,3 +35,5 @@ ONBOARDING_SECRET
      Make sure to use the **SV app URL** (starting with ``sv.``), not the Scan URL (starting with ``scan.``).
 
      Note that this self-served secret is only valid for 1 hour.
+
+.. CF_DOCS_SPLICE_SNIPPET_135_END

--- a/docs/src/validator_operator/validator_backups.rst
+++ b/docs/src/validator_operator/validator_backups.rst
@@ -31,9 +31,11 @@ access to your Canton Coin holdings), so must be backed up outside of the cluste
 
 Your identites may be fetched from your node through the following endpoint:
 
+.. CF_DOCS_SPLICE_SNIPPET_098_START
 .. code-block:: bash
 
     curl "https://wallet.validator.YOUR_HOSTNAME/api/validator/v0/admin/participant/identities" -H "authorization: Bearer <token>"
+.. CF_DOCS_SPLICE_SNIPPET_098_END
 
 where `<token>` is an OAuth2 Bearer Token with enough claims to access the Validator app,
 as obtained from your OAuth provider. For context, see the Authentication section :ref:`here <app-auth>`.
@@ -62,11 +64,13 @@ If you are running a docker-compose deployment, you can run the following comman
 the Postgres databases. This will create two dump files, one for the participant and one for
 the validator app.
 
+.. CF_DOCS_SPLICE_SNIPPET_099_START
 .. code-block:: bash
 
   docker exec -i splice-validator-postgres-splice-1 pg_dump -U cnadmin validator > "${backup_dir}"/validator-"$(date -u +"%Y-%m-%dT%H:%M:%S%:z")".dump
   active_participant_db=$(docker exec splice-validator-participant-1 bash -c 'echo $CANTON_PARTICIPANT_POSTGRES_DB')
   docker exec splice-validator-postgres-splice-1 pg_dump -U cnadmin "${active_participant_db}" > "${backup_dir}"/"${active_participant_db}"-"$(date -u +"%Y-%m-%dT%H:%M:%S%:z")".dump
+.. CF_DOCS_SPLICE_SNIPPET_099_END
 
 Historical backups
 ^^^^^^^^^^^^^^^^^^

--- a/docs/src/validator_operator/validator_compose.rst
+++ b/docs/src/validator_operator/validator_compose.rst
@@ -53,6 +53,7 @@ following commands. All commands should succeed and print out the
 version. Note that the exact versions you see may be different from
 the example here. As long as you have docker-compose 2.26.0 or newer you should be fine.
 
+.. CF_DOCS_SPLICE_SNIPPET_104_START
 .. code-block:: bash
 
    > docker compose version
@@ -64,6 +65,7 @@ the example here. As long as you have docker-compose 2.26.0 or newer you should 
    Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd
    > jq --version
    jq-1.7.1
+.. CF_DOCS_SPLICE_SNIPPET_104_END
 
 2) Your machine should either be connected to a VPN that is whitelisted on the network
    (contact your sponsor SV to obtain access), or have a static egress IP address.
@@ -91,6 +93,7 @@ If you need to use an HTTP forward proxy for egress in your environment, you nee
 in `JAVA_TOOL_OPTIONS` in ``splice-node/docker-compose/validator/compose.yaml`` to use the HTTP proxy for outgoing connections.
 You need to do this for both the validator and the participant services:
 
+.. CF_DOCS_SPLICE_SNIPPET_108_START
 .. code-block:: yaml
 
   services:
@@ -99,7 +102,9 @@ You need to do this for both the validator and the participant services:
         JAVA_TOOL_OPTIONS: >-
           -Dhttps.proxyHost=your.proxy.host
           -Dhttps.proxyPort=your_proxy_port
+.. CF_DOCS_SPLICE_SNIPPET_108_END
 
+.. CF_DOCS_SPLICE_SNIPPET_105_START
 .. code-block:: yaml
 
   services:
@@ -108,6 +113,7 @@ You need to do this for both the validator and the participant services:
         JAVA_TOOL_OPTIONS: >-
           -Dhttps.proxyHost=your.proxy.host
           -Dhttps.proxyPort=your_proxy_port
+.. CF_DOCS_SPLICE_SNIPPET_105_END
 
 Replace ``your.proxy.host`` and ``your_proxy_port`` with the actual host and port of your HTTP proxy.
 Proxy authentication is currently not supported.
@@ -147,6 +153,7 @@ Example that proxies external traffic from the ``validator`` service but bypasse
 ``localhost`` / ``127.0.0.1``, any host in the ``.internal`` domain, and any IPv4 address whose
 literal string representation starts with ``10.``:
 
+.. CF_DOCS_SPLICE_SNIPPET_106_START
 .. code-block:: yaml
 
   services:
@@ -156,23 +163,28 @@ literal string representation starts with ``10.``:
           -Dhttps.proxyHost=your.proxy.host
           -Dhttps.proxyPort=your_proxy_port
           -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.internal|10.*
+.. CF_DOCS_SPLICE_SNIPPET_106_END
 
 Deployment
 ++++++++++
 
 1) Change to the `docker-compose` directory inside the extracted bundle:
 
+.. CF_DOCS_SPLICE_SNIPPET_100_START
 .. code-block:: bash
 
    cd splice-node/docker-compose/validator
+.. CF_DOCS_SPLICE_SNIPPET_100_END
 
 2) Export the current version to an environment variable: |image_tag_set|
 
 3) Run the following command to start the validator node, and wait for it to become ready (could take a few minutes):
 
+  .. CF_DOCS_SPLICE_SNIPPET_101_START
   .. code-block:: bash
 
     ./start.sh -s "<SPONSOR_SV_URL>" -o "<ONBOARDING_SECRET>" -p "<party_hint>" -m "<MIGRATION_ID>" -w
+  .. CF_DOCS_SPLICE_SNIPPET_101_END
 
   Where:
 
@@ -276,9 +288,11 @@ CONTACT_POINT                 The contact point for your validator node that can
 In order to enable auth in the deployment, add the `-a` flag to the `start.sh`
 command, as follows:
 
+.. CF_DOCS_SPLICE_SNIPPET_102_START
 .. code-block:: bash
 
     ./start.sh -s "<SPONSOR_SV_URL>" -o "<ONBOARDING_SECRET>" -p "<party_hint>" -m "<MIGRATION_ID>" -w -a
+.. CF_DOCS_SPLICE_SNIPPET_102_END
 
 If you have already deployed a non-authenticated validator on your machine, you can migrate it to an
 authenticated one by stopping the validator with `./stop.sh` and restarting it with the `-a` flag
@@ -301,10 +315,12 @@ Your node is configured to automatically purchase :ref:`traffic <traffic>` on a 
 (see :ref:`automatically purchase traffic <traffic_topup>`).
 To tune to your needs, you can set environment variables, for example:
 
+.. CF_DOCS_SPLICE_SNIPPET_103_START
 .. code-block:: bash
 
    export TARGET_TRAFFIC_THROUGHPUT=20000 # target throughput in bytes/second
    export MIN_TRAFFIC_TOPUP_INTERVAL="1m" # minimum interval between top-ups
+.. CF_DOCS_SPLICE_SNIPPET_103_END
 
 .. include:: ../common/traffic_topups.rst
 
@@ -342,6 +358,7 @@ To do so, fill the following section and add the following additional config to 
 Similarly, you can configure the validator to automatically accept transfer offers
 from certain parties on the network. To do so, add the following additional config:
 
+.. CF_DOCS_SPLICE_SNIPPET_107_START
 .. code-block:: yaml
 
    services:
@@ -354,6 +371,7 @@ from certain parties on the network. To do so, add the following additional conf
                    from-parties = ["<senderPartyId1>", "<senderPartyId2>"]
                  }
                }
+.. CF_DOCS_SPLICE_SNIPPET_107_END
 
 Integration with systemd and other init systems
 +++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/src/validator_operator/validator_delegations.rst
+++ b/docs/src/validator_operator/validator_delegations.rst
@@ -196,6 +196,7 @@ To create the proposal, submit a ``create`` command via the Ledger API
 
 First, set up the required environment variables:
 
+.. CF_DOCS_SPLICE_SNIPPET_109_START
 .. code-block:: bash
 
    export LEDGER_API_URL="https://validator.example.com:5003"
@@ -207,9 +208,11 @@ First, set up the required environment variables:
    # This could be created by
    # export EXPIRES_AT="$(date -u -d '+1 year' '+%Y-%m-%dT%H:%M:%SZ')"
    export AMULET_MERGE_LIMIT=10
+.. CF_DOCS_SPLICE_SNIPPET_109_END
 
 Then create the proposal using curl:
 
+.. CF_DOCS_SPLICE_SNIPPET_110_START
 .. code-block:: bash
 
    curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -232,6 +235,7 @@ Then create the proposal using curl:
      ]
    }' \
    "$LEDGER_API_URL/v2/commands"
+.. CF_DOCS_SPLICE_SNIPPET_110_END
 
 See the `MintingDelegationProposal template source code
 <https://github.com/canton-network/splice/blob/main/daml/splice-wallet/daml/Splice/Wallet/MintingDelegation.daml>`_
@@ -246,6 +250,7 @@ The beneficiary can monitor their proposal status by querying for active
 
 To query for pending proposals:
 
+.. CF_DOCS_SPLICE_SNIPPET_111_START
 .. code-block:: bash
 
    curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -267,10 +272,12 @@ To query for pending proposals:
      }
    }' \
    "$LEDGER_API_URL/v2/state/active-contracts"
+.. CF_DOCS_SPLICE_SNIPPET_111_END
 
 Once accepted, query for the active ``MintingDelegation`` contract to confirm the
 delegation is active:
 
+.. CF_DOCS_SPLICE_SNIPPET_112_START
 .. code-block:: bash
 
    curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -292,6 +299,7 @@ delegation is active:
      }
    }' \
    "$LEDGER_API_URL/v2/state/active-contracts"
+.. CF_DOCS_SPLICE_SNIPPET_112_END
 
 Withdrawing a Proposal
 """"""""""""""""""""""
@@ -304,6 +312,7 @@ contract via the Ledger API's
 First, obtain the contract ID of the proposal from the active contracts query above,
 then exercise the withdrawal choice:
 
+.. CF_DOCS_SPLICE_SNIPPET_113_START
 .. code-block:: bash
 
    export PROPOSAL_CONTRACT_ID="00abcd1234..."
@@ -322,6 +331,7 @@ then exercise the withdrawal choice:
      ]
    }' \
    "$LEDGER_API_URL/v2/commands"
+.. CF_DOCS_SPLICE_SNIPPET_113_END
 
 
 Security Considerations

--- a/docs/src/validator_operator/validator_disaster_recovery.rst
+++ b/docs/src/validator_operator/validator_disaster_recovery.rst
@@ -180,11 +180,13 @@ Here is one possible way to do so:
    * You only need to restore and scale up the participant, i.e., you can ignore the validator app and its database.
    * In case the restored participant shuts down immediately due to failures, add the following :ref:`additional configuration <configuration_ad_hoc>`:
 
+    .. CF_DOCS_SPLICE_SNIPPET_122_START
     .. code-block:: yaml
 
         additionalEnvVars:
             - name: ADDITIONAL_CONFIG_EXIT_ON_FATAL_FAILURES
               value: canton.parameters.exit-on-fatal-failures = false
+    .. CF_DOCS_SPLICE_SNIPPET_122_END
 
 #. Open a :ref:`Canton console <console_access>` to the temporary participant.
 #. Run below commands in the opened console. This will store the backup into a *local* file
@@ -235,18 +237,22 @@ To address a failed :term:`ACS` import, you can usually:
    <console_access>` to any participant on the network (i.e., you can also ask another validator or SV operator for this information) and running the
    following query where <namespace> is the part after the ``::`` in, for example, your validator party ID.
 
+   .. CF_DOCS_SPLICE_SNIPPET_114_START
    .. code::
 
       val syncId = participant.synchronizers.list_connected().head.synchronizerId
       participant.topology.party_to_participant_mappings.list(syncId, filterParticipant = <namespace>)
+   .. CF_DOCS_SPLICE_SNIPPET_114_END
 
    If all parties are on the same node, proceed to the next step. If some are on the old node and some are on the new node, migrate the ones on the old node to the new node by opening a console to the new node and running the following command
    (adjust the parameters as required for your parties):
 
+   .. CF_DOCS_SPLICE_SNIPPET_115_START
    .. code::
 
       val participantId = participant.id // ID of the new participant
       participant.topology.party_to_participant_mappings.propose(<party-id>, Seq((participantId, <participant-permission>)), store = syncId)
+   .. CF_DOCS_SPLICE_SNIPPET_115_END
 
 2. If all parties are on the new node already, you can attempt to (re-)import the ACS for those parties manually.
    The following steps concern your new validator node:
@@ -255,17 +261,21 @@ To address a failed :term:`ACS` import, you can usually:
    b. Open a :ref:`participant console <console_access>` to that new validator and keep it open for the next steps.
    c. From the Canton console, run:
 
+      .. CF_DOCS_SPLICE_SNIPPET_116_START
       .. code::
 
          participant.synchronizers.disconnect_all()
+      .. CF_DOCS_SPLICE_SNIPPET_116_END
 
    d. For each ``PARTY_ID`` you want to migrate / re-import the ACS for:
 
       Run from a regular shell (same working directory like the one you started your Canton console from):
 
+      .. CF_DOCS_SPLICE_SNIPPET_120_START
       .. parsed-literal::
 
          curl -sSL --fail-with-body '|gsf_scan_url|/api/scan/v0/acs/YOUR_PARTY_ID' -H 'Content-Type: application/json' | jq -r .acs_snapshot | base64 -d > acs_snapshot
+      .. CF_DOCS_SPLICE_SNIPPET_120_END
 
       From the Canton console:
 
@@ -294,10 +304,12 @@ onboarded on Splice 0.4.1 or earlier, which used a Canton version that did not r
 the mapped keys to co-sign ``OwnerToKeyMapping`` transactions.
 You can identify this issue by looking for the following messages in your participant logs:
 
+.. CF_DOCS_SPLICE_SNIPPET_117_START
 .. code::
 
    Missing authorizers: ReferencedAuthorizations(extraKeys = <key-id>...)
    Rejected transaction ... OwnerToKeyMapping(...) ... due to Not authorized
+.. CF_DOCS_SPLICE_SNIPPET_117_END
 
 To work around this, follow these steps:
 
@@ -309,6 +321,7 @@ To work around this, follow these steps:
    those from the rejected ``OwnerToKeyMapping`` in your participant logs, and replace the
    old participant ID with your actual old participant ID:
 
+   .. CF_DOCS_SPLICE_SNIPPET_118_START
    .. code::
 
       val keys = Seq("<signing-key-id-prefix>", "<encryption-key-id-prefix>").map(prefix =>
@@ -317,6 +330,7 @@ To work around this, follow these steps:
       val oldParticipantId = ParticipantId.fromProtoPrimitive("<old-participant-id>", "participant").toOption.get
       val otk = OwnerToKeyMapping(member = oldParticipantId, keys = NonEmpty.from(keys).get)
       participant.topology.owner_to_key_mappings.propose(otk, force = ForceFlag.AlienMember)
+   .. CF_DOCS_SPLICE_SNIPPET_118_END
 
 3. Start the validator app using your original identities dump configuration.
 
@@ -438,10 +452,12 @@ In this example, the validFrom time is ``2025-05-14T10:19:33.534074Z``.
 
 We can now query CC Scan to get the active contract set (ACS) for a party and write it to the file ``acs_snapshot``:
 
+.. CF_DOCS_SPLICE_SNIPPET_121_START
 .. parsed-literal::
 
     // Make sure to adjust YOUR_VALID_FROM to the time you got from the previous query and YOUR_PARY_ID
     curl -sSL --fail-with-body '|gsf_scan_url|/api/scan/v0/acs/YOUR_PARTY_ID?record_time=YOUR_VALID_FROM' -H 'Content-Type: application/json' | jq -r .acs_snapshot | base64 -d > acs_snapshot
+.. CF_DOCS_SPLICE_SNIPPET_121_END
 
 
 Lastly, we can import the ACS:
@@ -480,6 +496,7 @@ Validators then need to:
 
 2. Initiate the roll forward LSU through a :ref:`Canton console <console_access>`:
 
+.. CF_DOCS_SPLICE_SNIPPET_119_START
 .. code::
 
     val existingPhysicalSynchronizerId = participant.synchronizers.list_connected().find(_.synchronizerAlias == "global").head.physicalSynchronizerId
@@ -489,6 +506,7 @@ Validators then need to:
       upgradeTime = None,
       sequencerSuccessors,
     )
+.. CF_DOCS_SPLICE_SNIPPET_119_END
 
 .. _validator_acs_mismatches:
 

--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -60,9 +60,11 @@ Preparing a Cluster for Installation
 
 Create the application namespace within Kubernetes.
 
+.. CF_DOCS_SPLICE_SNIPPET_123_START
 .. code-block:: bash
 
     kubectl create ns validator
+.. CF_DOCS_SPLICE_SNIPPET_123_END
 
 .. note::
 
@@ -77,11 +79,13 @@ HTTP Proxy configuration
 If you need to use an HTTP forward proxy for egress in your environment, you need to set ``https.proxyHost`` and ``https.proxyPort``
 in ``additionalJvmOptions`` in the validator and participant helm charts to use the HTTP proxy for outgoing connections:
 
+.. CF_DOCS_SPLICE_SNIPPET_127_START
 .. code-block:: yaml
 
   additionalJvmOptions: |
     -Dhttps.proxyHost=your.proxy.host
     -Dhttps.proxyPort=your_proxy_port
+.. CF_DOCS_SPLICE_SNIPPET_127_END
 
 Replace ``your.proxy.host`` and ``your_proxy_port`` with the actual host and port of your HTTP proxy.
 Proxy authentication is currently not supported.
@@ -122,12 +126,14 @@ external traffic but bypasses the proxy for ``localhost`` / ``127.0.0.1``, any
 host in the ``.internal`` domain, and any IPv4 address whose literal string
 representation starts with ``10.``:
 
+.. CF_DOCS_SPLICE_SNIPPET_126_START
 .. code-block:: yaml
 
   additionalJvmOptions: |
     -Dhttps.proxyHost=your.proxy.host
     -Dhttps.proxyPort=your_proxy_port
     -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.internal|10.*
+.. CF_DOCS_SPLICE_SNIPPET_126_END
 
 .. _validator-postgres-auth:
 
@@ -467,11 +473,13 @@ With these files in place, you can execute the following helm commands
 in sequence. It's generally a good idea to wait until each deployment
 reaches a stable state prior to moving on to the next step.
 
+.. CF_DOCS_SPLICE_SNIPPET_124_START
 .. parsed-literal::
 
     helm install postgres |helm_repo_prefix|/splice-postgres -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-validator-participant.yaml --wait
     helm install participant |helm_repo_prefix|/splice-participant -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/participant-values.yaml -f splice-node/examples/sv-helm/standalone-participant-values.yaml --wait
     helm install validator |helm_repo_prefix|/splice-validator -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/validator-values.yaml -f splice-node/examples/sv-helm/standalone-validator-values.yaml --wait
+.. CF_DOCS_SPLICE_SNIPPET_124_END
 
 Once this is running, you should be able to inspect the state of the
 cluster and observe pods running in the new
@@ -652,9 +660,11 @@ A reference Helm chart is provided for that, which can be installed after
 using:
 
 
+.. CF_DOCS_SPLICE_SNIPPET_125_START
 .. parsed-literal::
 
     helm install cluster-ingress-validator |helm_repo_prefix|/splice-cluster-ingress-runbook -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/validator-cluster-ingress-values.yaml
+.. CF_DOCS_SPLICE_SNIPPET_125_END
 
 
 .. _helm-validator-wallet-ui:

--- a/docs/src/validator_operator/validator_onboarding.rst
+++ b/docs/src/validator_operator/validator_onboarding.rst
@@ -81,15 +81,18 @@ or from within your Kubernetes cluster.
 First, please confirm that your egress IP in the terminal in which you are
 running the command is indeed the one you provided for whitelisting by running:
 
+.. CF_DOCS_SPLICE_SNIPPET_131_START
 .. parsed-literal::
 
    curl -sSL http://checkip.amazonaws.com
+.. CF_DOCS_SPLICE_SNIPPET_131_END
 
 and confirming that the IP matches what you have provided for whitelisting. If it does,
 run the following command to check to which instance of Scan you can connect.
 
 Note that the following snippet requires installing `jq <https://jqlang.org/>`_.
 
+.. CF_DOCS_SPLICE_SNIPPET_132_START
 .. parsed-literal::
 
    (set -o pipefail
@@ -98,10 +101,12 @@ Note that the following snippet requires installing `jq <https://jqlang.org/>`_.
      echo -n "$url: "
      $CURL "$url"/api/scan/version | jq -r '.version'
    done)
+.. CF_DOCS_SPLICE_SNIPPET_132_END
 
 You should see output in the form shown below, where each line indicates one SV and the version it is on. If you see timeouts that SV has not yet added you to their allowlist,
 if you do not get any errors, then all SVs have added you. Note that the URLs and versions will vary over time so don't try to compare exactly.
 
+.. CF_DOCS_SPLICE_SNIPPET_128_START
 .. code-block:: bash
 
    https://scan.sv-2.test.global.canton.network.digitalasset.com: 0.3.6
@@ -114,6 +119,7 @@ if you do not get any errors, then all SVs have added you. Note that the URLs an
    https://scan.sv-2.test.global.canton.network.cumberland.io: 0.3.6
    https://scan.sv-1.test.global.canton.network.c7.digital: 0.3.6
    https://scan.sv-1.test.global.canton.network.digitalasset.com: 0.3.6
+.. CF_DOCS_SPLICE_SNIPPET_128_END
 
 Apart from connectivity to Scan, your validator must also be able to connect to the sequencer endpoints of the SVs.
 If you are encountering issues related to connecting to the synchronizer,
@@ -121,6 +127,7 @@ you can use the following snippet to confirm that you are able to reach those en
 (i.e., that SVs have whitelisted your IP for those endpoints as well).
 Note that the following snippet requires installing `jq <https://jqlang.org/>`_ and `grpcurl <https://github.com/fullstorydev/grpcurl>`_.
 
+.. CF_DOCS_SPLICE_SNIPPET_130_START
 .. parsed-literal::
 
    (set -o pipefail
@@ -128,9 +135,11 @@ Note that the following snippet requires installing `jq <https://jqlang.org/>`_ 
      echo -n "$url: "
      grpcurl --max-time 10 "$url":443 grpc.health.v1.Health/Check
    done)
+.. CF_DOCS_SPLICE_SNIPPET_130_END
 
 Sequencers that are functional and have whitelisted your IP correctly will return ``"status": "SERVING"`` in the ``grpcurl`` output.
 
+.. CF_DOCS_SPLICE_SNIPPET_129_START
 .. code-block:: bash
 
    sequencer-1.sv-2.test.global.canton.network.digitalasset.com: {
@@ -163,6 +172,7 @@ Sequencers that are functional and have whitelisted your IP correctly will retur
    sequencer-1.sv-1.test.global.canton.network.digitalasset.com: {
      "status": "SERVING"
    }
+.. CF_DOCS_SPLICE_SNIPPET_129_END
 
 The default configuration for both of these requires access to at least 2/3 of the SVs for each of scans and sequencers.
 You may, at your option and own risk, configure connection to a single trusted scan and sequencer as described under :ref:`validator helm chart configuration <helm-validator-install>`, at the cost of losing BFT integrity guarantees.

--- a/docs/src/validator_operator/validator_users.rst
+++ b/docs/src/validator_operator/validator_users.rst
@@ -43,11 +43,13 @@ In order to associate a user with the party of the validator operator, the follo
    Save it in a PARTY_ID environment variable: ``export PARTY_ID=<PartyID of the operator>``
 5. Run the following command to associate the user with the party of the validator operator:
 
+.. CF_DOCS_SPLICE_SNIPPET_133_START
 .. code-block:: bash
 
     curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
     --data-raw "{\"party_id\":\"$PARTY_ID\",\"name\":\"$USER\"}" \
     https://<URL of your wallet>/api/validator/v0/admin/users
+.. CF_DOCS_SPLICE_SNIPPET_133_END
 
 6. The user can now login to the wallet UI, and will be accessing the wallet of the validator operator.
    Note that the user should not be greeted with the "Onboard yourself" button, as the user is already
@@ -61,11 +63,13 @@ This is used to create parties with descriptive hints (e.g., treasury_dept::...)
 2. Determine the desired, full PartyID ``(Hint::Namespace)``, e.g., ``alice::f3d917....``. Use the namespace of an existing party (like the validator operator's) for the namespace part. Save the full ID in a ``PARTY_ID`` environment variable: ``export PARTY_ID=alice::f3d917...``.
 3. Run the following command to create the new party and associate the user:
 
+.. CF_DOCS_SPLICE_SNIPPET_134_START
 .. code-block:: bash
 
     curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
     --data-raw "{\"party_id\":\"$PARTY_ID\",\"name\":\"$USER\",\"createPartyIfMissing\":true}" \
     https://<URL of your wallet>/api/validator/v0/admin/users
+.. CF_DOCS_SPLICE_SNIPPET_134_END
 
 Disable wallet and wallet automation
 -----------------------------------------------


### PR DESCRIPTION
## Summary

Adds stable `CF_DOCS_SPLICE_SNIPPET_*` RST comment tags around the Splice documentation ranges consumed by cf-docs external snippet generation. This lets cf-docs extract snippets by source tags instead of brittle line numbers.

Six implicit literal blocks are converted to explicit `code-block` directives so the tag comments can wrap the exact snippet body cleanly without changing the rendered intent. I also fixed one adjacent inline-literal spacing typo caught by `sphinx-lint`.

Confirmed that existing docs generation still works.

