### PR TITLE
Fix flaky MultiHostValidatorOperator topology serial race

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
@@ -116,6 +116,20 @@ class MultiHostValidatorOperatorIntegrationTest extends IntegrationTest with Wal
       bobValidatorBackend.startSync()
     }
 
+    // bobValidator's participant has just reconnected and its topology store may still lag behind,
+    // causing the propose_delta below to become racy; hence we wait a bit to avoid flakes
+    eventually() {
+      forEvery(multiHostedParties) { party =>
+        val aliceView = aliceParticipant.topology.party_to_participant_mappings
+          .list(synchronizerId, filterParty = party.toProtoPrimitive)
+          .map(result => result.context.serial -> result.item)
+        val bobView = bobParticipant.topology.party_to_participant_mappings
+          .list(synchronizerId, filterParty = party.toProtoPrimitive)
+          .map(result => result.context.serial -> result.item)
+        bobView shouldBe aliceView withClue s"bob caught up to alice's view of $party"
+      }
+    }
+
     actAndCheck(
       "Clear the onboarding flags", {
         multiHostedParties.map(party =>


### PR DESCRIPTION
Fixes DACH-NY/cn-test-failures#8444

[ci]

Theory: After bobValidator reconnects, its participant's topology store can still lag behind the party-to-participant change aliceValidator authorized while bob was disconnected. "Clear the onboarding flags" possibly races with catching up to topology and therefore gets rejected with TOPOLOGY_SERIAL_MISMATCH.

The best smoking gun I have for this from the logs is that reconnect finishes at `2026-05-18T06:52:39.586Z `, then we try the propose at `2026-05-18T06:52:39.631`. This is very short time... 

So either this really fixes it or we have better proof that somehow a topology transaction disappears again (if this is what happens).

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
