### PR TITLE
Bft read: ignore consensus on failure response from single scan

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -858,7 +858,13 @@ object BftScanConnection {
               (_, scans) => scan.url :: Option(scans).getOrElse(List.empty),
             )
 
-          if (agreements.size == nTargetSuccess) { // consensus has been reached
+          // Only a quorum of matching successful responses should decide the call; failures
+          // fall through to ConsensusNotReached.
+          val isSuccessfulResponse = key match {
+            case _: SuccessfulResponse[?] => true
+            case _ => false
+          }
+          if (isSuccessfulResponse && agreements.size == nTargetSuccess) { // consensus has been reached
             finalResponse.tryComplete(response): Unit
           }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -858,13 +858,13 @@ object BftScanConnection {
               (_, scans) => scan.url :: Option(scans).getOrElse(List.empty),
             )
 
-          // Only a quorum of matching successful responses should decide the call; failures
-          // fall through to ConsensusNotReached.
-          val isSuccessfulResponse = key match {
+          // In the special case of nTargetSuccess == 1, consider the response only if it is a success
+          // Otherwise a single HTTP error or network failure would prevent reading the responses from others
+          val considerResponseForQuorum = key match {
             case _: SuccessfulResponse[?] => true
-            case _ => false
+            case _ => !(nTargetSuccess == 1 && requestFrom.size != 1)
           }
-          if (isSuccessfulResponse && agreements.size == nTargetSuccess) { // consensus has been reached
+          if (considerResponseForQuorum && agreements.size == nTargetSuccess) { // consensus has been reached
             finalResponse.tryComplete(response): Unit
           }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -858,11 +858,11 @@ object BftScanConnection {
               (_, scans) => scan.url :: Option(scans).getOrElse(List.empty),
             )
 
-          // In the special case of nTargetSuccess == 1, consider the response only if it is a success
+          // In the special case of nTargetSuccess == 1, ignore error responses
           // Otherwise a single HTTP error or network failure would prevent reading the responses from others
           val considerResponseForQuorum = key match {
-            case _: SuccessfulResponse[?] => true
-            case _ => !(nTargetSuccess == 1 && requestFrom.size != 1)
+            case _: ExceptionFailureResponse[?] => !(nTargetSuccess == 1 && requestFrom.size != 1)
+            case _ => true
           }
           if (considerResponseForQuorum && agreements.size == nTargetSuccess) { // consensus has been reached
             finalResponse.tryComplete(response): Unit

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
@@ -13,6 +13,7 @@ import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.{BaseTest, HasActorSystem, HasExecutionContext}
 import com.google.protobuf.ByteString
 import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.stream.StreamTcpException
 import org.lfdecentralizedtrust.splice.admin.api.client.commands.HttpCommandException
 import org.lfdecentralizedtrust.splice.admin.http.HttpErrorWithHttpCode
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amuletrules as amuletrulesCodegen
@@ -233,6 +234,8 @@ class BftScanConnectionTest
     StatusCodes.NotFound,
     HttpCommandException.ErrorResponseBody(ErrorResponse("Whatever thing was not found")),
   )
+  val tcpFailure = new StreamTcpException("Connection reset by peer")
+
   val partyIdA = PartyId.tryFromProtoPrimitive("whatever::a")
   val partyIdB = PartyId.tryFromProtoPrimitive("whatever::b")
 
@@ -908,9 +911,9 @@ class BftScanConnectionTest
 
     val call: SingleScanConnection => Future[PartyId] = _.getDsoPartyId()
 
-    "not let a single failure decide the call when n == 2" in {
+    "not let a single error response decide the call when n == 2" in {
       val connections = getMockedConnections(n = 2)
-      makeMockFail(connections.head, notFoundFailure)
+      makeMockFail(connections.head, tcpFailure)
       val delayedSuccess =
         org.apache.pekko.pattern.after(200.millis, actorSystem.scheduler)(
           Future.successful(partyIdA)
@@ -922,9 +925,17 @@ class BftScanConnectionTest
       } yield result should be(partyIdA)
     }
 
-    "Forward the failure when n == 1" in {
-      val connections = getMockedConnections(n = 1)
-      connections.foreach(makeMockFail(_, notFoundFailure))
+    // Unlike a transport exception, an http failure still counts towards the quorum.
+    // Although this behaviour is mostly a result of the tech-debt of the
+    // inability for the scan endpoints to specify what responses are expected (like 404)
+    "but let a single http failure decide the call when n == 2" in {
+      val connections = getMockedConnections(n = 2)
+      makeMockFail(connections.head, notFoundFailure)
+      val delayedSuccess =
+        org.apache.pekko.pattern.after(200.millis, actorSystem.scheduler)(
+          Future.successful(partyIdA)
+        )
+      connections.tail.foreach(c => when(c.getDsoPartyId()).thenReturn(delayedSuccess))
 
       for {
         failure <- BftScanConnection
@@ -933,9 +944,20 @@ class BftScanConnectionTest
       } yield failure should be(notFoundFailure)
     }
 
-    "fall through to ConsensusNotReached when all scans fail" in {
+    "Forward the error response when n == 1" in {
+      val connections = getMockedConnections(n = 1)
+      connections.foreach(makeMockFail(_, tcpFailure))
+
+      for {
+        failure <- BftScanConnection
+          .executeCall(call, connections, nTargetSuccess = 1, logger)
+          .failed
+      } yield failure should be(tcpFailure)
+    }
+
+    "fall through to ConsensusNotReached when all scans throw  error response" in {
       val connections = getMockedConnections(n = 3)
-      connections.foreach(makeMockFail(_, notFoundFailure))
+      connections.foreach(makeMockFail(_, tcpFailure))
 
       for {
         failure <- BftScanConnection

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
@@ -54,6 +54,7 @@ import org.slf4j.event.Level
 
 import java.time.{Duration, Instant}
 import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 // mock verification triggers this
@@ -900,6 +901,47 @@ class BftScanConnectionTest
         code should be(StatusCodes.BadGateway)
         message should include("Failed to reach consensus from 5 Scan nodes")
       }
+    }
+  }
+
+  "When targetSuccess is 1, BftScanConnection.executeCall" should {
+
+    val call: SingleScanConnection => Future[PartyId] = _.getDsoPartyId()
+
+    "not let a single failure decide the call when n == 2" in {
+      val connections = getMockedConnections(n = 2)
+      makeMockFail(connections.head, notFoundFailure)
+      val delayedSuccess =
+        org.apache.pekko.pattern.after(200.millis, actorSystem.scheduler)(
+          Future.successful(partyIdA)
+        )
+      connections.tail.foreach(c => when(c.getDsoPartyId()).thenReturn(delayedSuccess))
+
+      for {
+        result <- BftScanConnection.executeCall(call, connections, nTargetSuccess = 1, logger)
+      } yield result should be(partyIdA)
+    }
+
+    "Forward the failure when n == 1" in {
+      val connections = getMockedConnections(n = 1)
+      connections.foreach(makeMockFail(_, notFoundFailure))
+
+      for {
+        failure <- BftScanConnection
+          .executeCall(call, connections, nTargetSuccess = 1, logger)
+          .failed
+      } yield failure should be(notFoundFailure)
+    }
+
+    "fall through to ConsensusNotReached when all scans fail" in {
+      val connections = getMockedConnections(n = 3)
+      connections.foreach(makeMockFail(_, notFoundFailure))
+
+      for {
+        failure <- BftScanConnection
+          .executeCall(call, connections, nTargetSuccess = 1, logger)
+          .failed
+      } yield failure shouldBe a[BftScanConnection.ConsensusNotReached]
     }
   }
 


### PR DESCRIPTION
The `BftScanConnection.executeCall` can currently form a consensus on failure responses, like the `StreamTcpException` if the scan is temporarily unavailable.

This is particularly problematic if `nTargetSuccess` == 1, as the failure from an offline scan would happen quicker than the response received from online scans, and the `executeCall` thus would always ignore the success responses.

Note: the  `BftScanConnection.executeCall` can still form a consensus on  `StreamTcpException` for `nTargetSuccess` > 1, if a number of scans are offline.


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
