### PR TITLE
Bump actAndCheck timeout to 90s to have enough time for the AdvanceOpenMiningRoundTrigger to get triggered after Domain time is caught up

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/TimeTestUtil.scala
@@ -178,7 +178,7 @@ trait TimeTestUtil extends TestCommon {
 
     // not exactly 150s because of the skew parameter.
     val (_, lowestRound) =
-      actAndCheck(timeUntilSuccess = 30.seconds)("advancing time", advanceTime(duration))(
+      actAndCheck(timeUntilSuccess = 90.seconds)("advancing time", advanceTime(duration))(
         s"waiting for open and issuing round automation (should create OpenMiningRound ${highestOpen + 1}, should advance IssuingMiningRounds $previousIssuingRounds",
         _ => {
 


### PR DESCRIPTION
Fix https://github.com/DACH-NY/cn-test-failures/issues/8423

`ValidatorLicenseMetadataTimeBasedIntegrationTest` times out in `advanceTimeAndWaitForRoundAutomation` because the `AdvanceOpenMiningRoundTrigger` fails to bump round.

```
actAndCheck(timeUntilSuccess = 30.seconds)("advancing time", advanceTime(duration))(
        s"waiting for open and issuing round automation (should create OpenMiningRound ${highestOpen + 1}, should advance IssuingMiningRounds $previousIssuingRounds",
        _ => {

            (
            newLowestOpen,
            newLowestOpen,
            newMiddleOpen,
            newHighestOpen,
          ) shouldBe (lowestOpen + 1, middleOpen, highestOpen, highestOpen + 1)
```

When `advanceTime` artificially jumps in sim time, the SV apps's Local time instantly jumps, but not it's Domain Time. Because this gap exceeds Canton's strict 2-minute safety threshold, `AdvanceOpenMiningRoundTrigger` aborts.

` 2026-05-13T13:11:02.173Z [⋮] INFO - o.l.s.s.DomainTimeStore:ValidatorLicenseMetadataTimeBasedIntegrationTest/config=e89ef596/SV=sv1 (243895e5f8aec9d354a683464f8463ca-AdvanceOpenMiningRoundTrigger--03ec674478bb450c) - Domain time delay is currently 10m 9.999086s (1970-03-04T09:05:20.999Z - 1970-03-04T08:55:10.999914Z), waiting until delay is below 2 minutes. This is expected if the node restored from backup`

The `actAndCheck` initially had a 30s window, which occasionally is insufficient for the Domain time to update in SV app.

Hence, the trigger was never completed -> no rounds progressed, and hence the original error `(4, 4, 5, 6) was not equal to (5, 5, 6, 7) ` 

Although increasing timeouts is not preferred, 3 number of flakes in 2 weeks justifies increasing the `actAndCheck` timeout to 90 seconds (in logs i didn't see domain time updating always at 60s)