### PR TITLE
Extract the synchronizer methods from the participant admin connection

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminConnection.scala
@@ -3,19 +3,14 @@
 
 package org.lfdecentralizedtrust.splice.environment
 
-import cats.data.{EitherT, OptionT}
+import cats.data.EitherT
 import cats.implicits.catsSyntaxOptionId
-import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.commands.{
   GrpcAdminCommand,
   ParticipantAdminCommands,
   PruningSchedulerCommands,
 }
-import com.digitalasset.canton.admin.api.client.data.{
-  ListConnectedSynchronizersResult,
-  NodeStatus,
-  ParticipantStatus,
-}
+import com.digitalasset.canton.admin.api.client.data.{NodeStatus, ParticipantStatus}
 import com.digitalasset.canton.admin.participant.v30.PruningServiceGrpc.PruningServiceStub
 import com.digitalasset.canton.admin.participant.v30.{
   ExportAcsResponse,
@@ -35,12 +30,8 @@ import com.digitalasset.canton.sequencing.{
   GrpcSequencerConnection,
   SequencerConnection,
   SequencerConnections,
-  SequencerConnectionValidation,
 }
-import com.digitalasset.canton.sequencing.protocol.TrafficState
 import com.digitalasset.canton.topology.{
-  ConfiguredPhysicalSynchronizerId,
-  KnownPhysicalSynchronizerId,
   NodeIdentity,
   ParticipantId,
   PartyId,
@@ -50,16 +41,15 @@ import com.digitalasset.canton.topology.{
 }
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.transaction.{
+  GrpcConnection,
   HostingParticipant,
   ParticipantPermission,
   PartyToParticipant,
   SignedTopologyTransaction,
   TopologyChangeOp,
 }
-import com.digitalasset.canton.topology.transaction.GrpcConnection
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.ShowUtil.*
-import com.github.blemale.scaffeine.Scaffeine
 import com.google.protobuf.ByteString
 import io.grpc.{Status, StatusRuntimeException}
 import io.opentelemetry.api.trace.Tracer
@@ -77,7 +67,6 @@ import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
 
 /** Connection to the subset of the Canton admin API that we rely
@@ -99,6 +88,7 @@ class ParticipantAdminConnection(
     )
     with HasParticipantId
     with ParticipantAdminDarsConnection
+    with ParticipantAdminSynchronizerConnection
     with StatusAdminConnection
     with PruningAdminConnection {
   override val serviceName = "Canton Participant Admin API"
@@ -114,22 +104,10 @@ class ParticipantAdminConnection(
       _.getSchedule(_),
     )
 
-  private val synchronizerIdAliasCache =
-    Scaffeine()
-      .expireAfterWrite(1.minutes)
-      .maximumSize(100)
-      .buildAsync[SynchronizerAlias, SynchronizerId]()
-
   override type Status = ParticipantStatus
 
   override protected def getStatusRequest: GrpcAdminCommand[?, ?, NodeStatus[ParticipantStatus]] =
     ParticipantAdminCommands.Health.ParticipantStatusCommand()
-
-  def listConnectedDomains()(implicit
-      traceContext: TraceContext
-  ): Future[Seq[ListConnectedSynchronizersResult]] = {
-    runCmd(ParticipantAdminCommands.SynchronizerConnectivity.ListConnectedSynchronizers())
-  }
 
   def isNodeInitialized()(implicit traceContext: TraceContext): Future[Boolean] =
     runCmd(getStatusRequest).map {
@@ -137,224 +115,6 @@ class ParticipantAdminConnection(
       case NodeStatus.NotInitialized(_, _) => false
       case NodeStatus.Success(_) => true
     }
-
-  def getSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[SynchronizerId] = {
-    synchronizerIdAliasCache.getFuture(
-      synchronizerAlias,
-      alias => getPhysicalSynchronizerId(alias).map(_.logical),
-    )
-  }
-
-  def lookupPhysicalSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[Option[PhysicalSynchronizerId]] =
-    OptionT(for {
-      configuredDomains <- listRegisteredSynchronizers()
-    } yield configuredDomains.collectFirst {
-      case (configuredSynchronizer, psid, _)
-          if configuredSynchronizer.synchronizerAlias == synchronizerAlias =>
-        psid.toOption
-    }.flatten)
-      .orElseF(
-        runCmd(
-          ParticipantAdminCommands.SynchronizerConnectivity.GetSynchronizerId(synchronizerAlias)
-        ).map(Some(_)).recover {
-          case ex: StatusRuntimeException if ex.getStatus.getCode == Status.Code.NOT_FOUND => None
-        }
-      )
-      .value
-
-  def listRegisteredSynchronizers()(implicit
-      tc: TraceContext
-  ): Future[Seq[(SynchronizerConnectionConfig, ConfiguredPhysicalSynchronizerId, Boolean)]] = {
-    runCmd(
-      ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
-    )
-  }
-
-  def getPhysicalSynchronizerId(synchronizerId: SynchronizerId)(implicit
-      traceContext: TraceContext
-  ): Future[PhysicalSynchronizerId] = listRegisteredSynchronizers().map(
-    _.collectFirst {
-      case (_, KnownPhysicalSynchronizerId(psid), _) if psid.logical == synchronizerId => psid
-    }.getOrElse(
-      throw Status.NOT_FOUND
-        .withDescription(
-          s"No synchronizer registered and handshaked for id $synchronizerId"
-        )
-        .asRuntimeException()
-    )
-  )
-  def getPhysicalSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[PhysicalSynchronizerId] = lookupPhysicalSynchronizerId(synchronizerAlias).map(
-    _.getOrElse(
-      throw Status.NOT_FOUND
-        .withDescription(
-          s"No synchronizer registered and handshaked for $synchronizerAlias"
-        )
-        .asRuntimeException()
-    )
-  )
-
-  def reconnectAllDomains()(implicit
-      traceContext: TraceContext
-  ): Future[Unit] = {
-    runCmd(
-      ParticipantAdminCommands.SynchronizerConnectivity.ReconnectSynchronizers(ignoreFailures =
-        false
-      )
-    )
-  }
-
-  def disconnectFromAllDomains()(implicit
-      traceContext: TraceContext
-  ): Future[Unit] = for {
-    domains <- listConnectedDomains()
-    _ <- Future.sequence(
-      domains.map(domain =>
-        runCmd(
-          ParticipantAdminCommands.SynchronizerConnectivity.DisconnectSynchronizer(
-            domain.synchronizerAlias
-          )
-        )
-      )
-    )
-  } yield ()
-
-  private def registerDomain(config: SynchronizerConnectionConfig, handshakeOnly: Boolean)(implicit
-      traceContext: TraceContext
-  ): Future[Unit] =
-    runCmd(
-      ParticipantAdminCommands.SynchronizerConnectivity.RegisterSynchronizer(
-        config,
-        handshakeOnly,
-        SequencerConnectionValidation.ThresholdActive,
-      )
-    )
-
-  def connectDomain(alias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[Unit] =
-    retryProvider.retryForClientCalls(
-      "connect_domain",
-      s"participant is connected to $alias",
-      runCmd(
-        ParticipantAdminCommands.SynchronizerConnectivity
-          .ReconnectSynchronizer(alias, retry = false)
-      ).map(isConnected =>
-        if (!isConnected) {
-          val msg = s"failed to connect to $alias"
-          throw Status.Code.FAILED_PRECONDITION.toStatus.withDescription(msg).asRuntimeException()
-        }
-      ),
-      logger,
-    )
-
-  private def disconnectDomain(alias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[Unit] =
-    runCmd(ParticipantAdminCommands.SynchronizerConnectivity.DisconnectSynchronizer(alias))
-
-  def ensureDomainRegistered(
-      config: SynchronizerConnectionConfig,
-      retryFor: RetryFor,
-  )(implicit traceContext: TraceContext): Future[Unit] = {
-    for {
-      _ <- retryProvider
-        .ensureThat(
-          retryFor,
-          "domain_registered_handshake",
-          s"participant registered ${config.synchronizerAlias} with handshake only",
-          lookupSynchronizerConnectionConfig(config.synchronizerAlias).map(_.toRight(())),
-          (_: Unit) => registerDomain(config, handshakeOnly = true),
-          logger,
-        )
-    } yield ()
-  }
-
-  def ensureDomainRegisteredNoHandshake(
-      config: SynchronizerConnectionConfig,
-      retryFor: RetryFor,
-  )(implicit traceContext: TraceContext): Future[Unit] = {
-    require(
-      config.manualConnect,
-      "manualConnect must be true when trying to register only",
-    )
-    for {
-      _ <- retryProvider
-        .ensureThat(
-          retryFor,
-          "domain_registered_no_handshake",
-          s"participant registered ${config.synchronizerAlias}",
-          lookupSynchronizerConnectionConfig(config.synchronizerAlias).map(_.toRight(())),
-          (_: Unit) => registerDomain(config, handshakeOnly = false),
-          logger,
-        )
-    } yield ()
-  }
-
-  def ensureDomainRegisteredAndConnected(
-      config: SynchronizerConnectionConfig,
-      overwriteExistingConnection: Boolean,
-      reconnectOnSynchronizerConfigurationChange: Boolean,
-      retryFor: RetryFor,
-  )(implicit traceContext: TraceContext): Future[Unit] = for {
-    _ <- retryProvider
-      .ensureThat(
-        retryFor,
-        "domain_registered",
-        s"participant registered ${config.synchronizerAlias} with config $config",
-        lookupSynchronizerConnectionConfig(config.synchronizerAlias).map {
-          case Some(_) if !overwriteExistingConnection => Right(())
-          // We don't set the sequencer id when connecting but Canton returns it so we ignore it in the comparison here.
-          case Some(existingConfig)
-              if ParticipantAdminConnection.dropSequencerId(
-                existingConfig
-              ) == ParticipantAdminConnection.dropSequencerId(config) =>
-            Right(())
-          case Some(other) => Left(Some(other))
-          case None => Left(None)
-        },
-        (existingDomainConfig: Option[SynchronizerConnectionConfig]) =>
-          existingDomainConfig match {
-            case None =>
-              logger.info(s"Registering new domain with config $config")
-              registerDomain(config, handshakeOnly = false)
-            case Some(_) =>
-              modifySynchronizerConnectionConfigAndReconnect(
-                config.synchronizerAlias,
-                reconnectOnSynchronizerConfigurationChange,
-                _ => Some(config),
-              )
-                .map(_ => ())
-          },
-        logger,
-      )
-    _ <- connectDomain(config.synchronizerAlias)
-  } yield ()
-
-  private def reconnectDomain(alias: SynchronizerAlias)(implicit
-      traceContext: TraceContext
-  ): Future[Unit] = for {
-    _ <- retryProvider.retryForClientCalls(
-      "reconnect_domain_disconnect",
-      s"participant is disconnected from $alias",
-      disconnectDomain(alias),
-      logger,
-    )
-    _ <- connectDomain(alias)
-  } yield ()
-
-  def getParticipantTrafficState(
-      synchronizerId: SynchronizerId
-  )(implicit traceContext: TraceContext): Future[TrafficState] = {
-    runCmd(
-      ParticipantAdminCommands.TrafficControl.GetTrafficControlState(synchronizerId)
-    )
-  }
 
   def offsetByTimestamp(synchronizerId: SynchronizerId, timestamp: Instant, force: Boolean)(implicit
       tc: TraceContext
@@ -508,129 +268,6 @@ class ParticipantAdminConnection(
 
   def getParticipantId()(implicit traceContext: TraceContext): Future[ParticipantId] =
     getId().map(ParticipantId(_))
-
-  def lookupSynchronizerConnectionConfig(
-      domain: SynchronizerAlias
-  )(implicit traceContext: TraceContext): Future[Option[SynchronizerConnectionConfig]] =
-    for {
-      configuredDomains <- listRegisteredSynchronizers()
-    } yield configuredDomains
-      .collectFirst {
-        case (configuredDomain, _, _) if configuredDomain.synchronizerAlias == domain =>
-          configuredDomain
-      }
-
-  def getSynchronizerConnectionConfig(
-      domain: SynchronizerAlias
-  )(implicit traceContext: TraceContext): Future[SynchronizerConnectionConfig] =
-    lookupSynchronizerConnectionConfig(domain).map(
-      _.getOrElse(
-        throw Status.NOT_FOUND
-          .withDescription(s"Domain $domain is not configured on the participant")
-          .asRuntimeException()
-      )
-    )
-
-  private def setSynchronizerConnectionConfig(config: SynchronizerConnectionConfig)(implicit
-      traceContext: TraceContext
-  ): Future[Unit] =
-    runCmd(
-      ParticipantAdminCommands.SynchronizerConnectivity.ModifySynchronizerConnection(
-        None,
-        config,
-        SequencerConnectionValidation.ThresholdActive,
-      )
-    )
-
-  def modifySynchronizerConnectionConfig(
-      synchronizer: SynchronizerAlias,
-      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
-  )(implicit traceContext: TraceContext): Future[Boolean] = {
-    retryProvider.retryForClientCalls(
-      "modify_synchronizer_connection",
-      "Set the new synchronizer connection if required",
-      for {
-        oldConfig <- getSynchronizerConnectionConfig(synchronizer)
-        newConfig = f(oldConfig)
-        configModified <- newConfig match {
-          case None =>
-            logger.trace("No update to synchronizer connection config required")
-            Future.successful(false)
-          case Some(config) =>
-            logger.info(
-              s"Updating to new synchronizer connection config for synchronizer $synchronizer. Old config: $oldConfig, new config: $config"
-            )
-            for {
-              _ <- setSynchronizerConnectionConfig(config)
-            } yield true
-        }
-      } yield configModified,
-      logger,
-    )
-  }
-
-  private def modifyOrRegisterSynchronizerConnectionConfig(
-      config: SynchronizerConnectionConfig,
-      reconnectOnSynchronizerConfigurationChange: Boolean,
-      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
-      retryFor: RetryFor,
-  )(implicit traceContext: TraceContext): Future[Boolean] =
-    for {
-      configO <- lookupSynchronizerConnectionConfig(config.synchronizerAlias)
-      needsReconnect <- configO match {
-        case Some(config) =>
-          modifySynchronizerConnectionConfig(
-            config.synchronizerAlias,
-            f,
-          )
-        case None =>
-          logger.info(s"Domain ${config.synchronizerAlias} is new, registering")
-          ensureDomainRegisteredAndConnected(
-            config,
-            overwriteExistingConnection = true,
-            reconnectOnSynchronizerConfigurationChange = reconnectOnSynchronizerConfigurationChange,
-            retryFor = retryFor,
-          ).map(_ => false)
-      }
-    } yield needsReconnect
-
-  def modifySynchronizerConnectionConfigAndReconnect(
-      domain: SynchronizerAlias,
-      reconnectOnSynchronizerConfigurationChange: Boolean,
-      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
-  )(implicit traceContext: TraceContext): Future[Unit] =
-    for {
-      configModified <- modifySynchronizerConnectionConfig(domain, f)
-      _ <-
-        if (configModified && reconnectOnSynchronizerConfigurationChange) {
-          logger.info(
-            s"reconnect to the domain $domain for new sequencer configuration to take effect"
-          )
-          reconnectDomain(domain)
-        } else Future.unit
-    } yield ()
-
-  def modifyOrRegisterSynchronizerConnectionConfigAndReconnect(
-      config: SynchronizerConnectionConfig,
-      reconnectOnSynchronizerConfigurationChange: Boolean,
-      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
-      retryFor: RetryFor,
-  )(implicit traceContext: TraceContext): Future[Unit] =
-    for {
-      configModified <- modifyOrRegisterSynchronizerConnectionConfig(
-        config,
-        reconnectOnSynchronizerConfigurationChange,
-        f,
-        retryFor,
-      )
-      _ <-
-        if (configModified && reconnectOnSynchronizerConfigurationChange) {
-          logger.info(
-            s"reconnect to the domain ${config.synchronizerAlias} for new sequencer configuration to take effect"
-          )
-          reconnectDomain(config.synchronizerAlias)
-        } else Future.unit
-    } yield ()
 
   def ensureInitialPartyToParticipant(
       store: TopologyStoreId,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminDarsConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminDarsConnection.scala
@@ -60,7 +60,7 @@ trait ParticipantAdminDarsConnection {
         Seq(UploadablePackage.fromByteString(path.getFileName.toString, darFile)),
         retryFor,
       )
-      domains <- listConnectedDomains().map(_.map(_.synchronizerId))
+      domains <- listConnectedSynchronizers().map(_.map(_.synchronizerId))
       darResource = DarResource(path)
       _ <- MonadUtil.sequentialTraverse(domains) { domainId =>
         vetDars(domainId.logical, Seq(darResource), None, maxVettingDelay = None)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ParticipantAdminSynchronizerConnection.scala
@@ -1,0 +1,384 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.environment
+
+import cats.data.OptionT
+import com.digitalasset.canton.admin.api.client.commands.ParticipantAdminCommands
+import com.digitalasset.canton.admin.api.client.data.ListConnectedSynchronizersResult
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.SynchronizerAlias
+import com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig
+import com.digitalasset.canton.sequencing.SequencerConnectionValidation
+import com.digitalasset.canton.sequencing.protocol.TrafficState
+import com.digitalasset.canton.topology.{
+  ConfiguredPhysicalSynchronizerId,
+  KnownPhysicalSynchronizerId,
+  PhysicalSynchronizerId,
+  SynchronizerId,
+}
+import com.github.blemale.scaffeine.Scaffeine
+import io.grpc.{Status, StatusRuntimeException}
+import org.lfdecentralizedtrust.splice.environment.ParticipantAdminConnection.HasParticipantId
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+trait ParticipantAdminSynchronizerConnection {
+  this: ParticipantAdminConnection & HasParticipantId =>
+
+  private val synchronizerIdAliasCache =
+    Scaffeine()
+      .expireAfterWrite(1.minutes)
+      .maximumSize(100)
+      .buildAsync[SynchronizerAlias, SynchronizerId]()
+
+  def listConnectedSynchronizers()(implicit
+      traceContext: TraceContext
+  ): Future[Seq[ListConnectedSynchronizersResult]] = {
+    runCmd(ParticipantAdminCommands.SynchronizerConnectivity.ListConnectedSynchronizers())
+  }
+
+  def getSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[SynchronizerId] = {
+    synchronizerIdAliasCache.getFuture(
+      synchronizerAlias,
+      alias => getPhysicalSynchronizerId(alias).map(_.logical),
+    )
+  }
+
+  def lookupPhysicalSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[Option[PhysicalSynchronizerId]] =
+    OptionT(for {
+      configuredSynchronziers <- listRegisteredSynchronizers()
+    } yield configuredSynchronziers.collectFirst {
+      case (configuredSynchronizer, psid, _)
+          if configuredSynchronizer.synchronizerAlias == synchronizerAlias =>
+        psid.toOption
+    }.flatten)
+      .orElseF(
+        runCmd(
+          ParticipantAdminCommands.SynchronizerConnectivity.GetSynchronizerId(synchronizerAlias)
+        ).map(Some(_)).recover {
+          case ex: StatusRuntimeException if ex.getStatus.getCode == Status.Code.NOT_FOUND => None
+        }
+      )
+      .value
+
+  def listRegisteredSynchronizers()(implicit
+      tc: TraceContext
+  ): Future[Seq[(SynchronizerConnectionConfig, ConfiguredPhysicalSynchronizerId, Boolean)]] = {
+    runCmd(
+      ParticipantAdminCommands.SynchronizerConnectivity.ListRegisteredSynchronizers
+    )
+  }
+
+  def getPhysicalSynchronizerId(synchronizerId: SynchronizerId)(implicit
+      traceContext: TraceContext
+  ): Future[PhysicalSynchronizerId] = listRegisteredSynchronizers().map(
+    _.collectFirst {
+      case (_, KnownPhysicalSynchronizerId(psid), _) if psid.logical == synchronizerId => psid
+    }.getOrElse(
+      throw Status.NOT_FOUND
+        .withDescription(
+          s"No synchronizer registered and handshaked for id $synchronizerId"
+        )
+        .asRuntimeException()
+    )
+  )
+  def getPhysicalSynchronizerId(synchronizerAlias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[PhysicalSynchronizerId] = lookupPhysicalSynchronizerId(synchronizerAlias).map(
+    _.getOrElse(
+      throw Status.NOT_FOUND
+        .withDescription(
+          s"No synchronizer registered and handshaked for $synchronizerAlias"
+        )
+        .asRuntimeException()
+    )
+  )
+
+  def reconnectAllSynchronizers()(implicit
+      traceContext: TraceContext
+  ): Future[Unit] = {
+    runCmd(
+      ParticipantAdminCommands.SynchronizerConnectivity.ReconnectSynchronizers(ignoreFailures =
+        false
+      )
+    )
+  }
+
+  def disconnectFromAllSynchronizers()(implicit
+      traceContext: TraceContext
+  ): Future[Unit] = for {
+    synchronizers <- listConnectedSynchronizers()
+    _ <- Future.sequence(
+      synchronizers.map(synchronizer =>
+        runCmd(
+          ParticipantAdminCommands.SynchronizerConnectivity.DisconnectSynchronizer(
+            synchronizer.synchronizerAlias
+          )
+        )
+      )
+    )
+  } yield ()
+
+  private def registerSynchronizer(config: SynchronizerConnectionConfig, handshakeOnly: Boolean)(
+      implicit traceContext: TraceContext
+  ): Future[Unit] =
+    runCmd(
+      ParticipantAdminCommands.SynchronizerConnectivity.RegisterSynchronizer(
+        config,
+        handshakeOnly,
+        SequencerConnectionValidation.ThresholdActive,
+      )
+    )
+
+  def connectSynchronizer(alias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[Unit] =
+    retryProvider.retryForClientCalls(
+      "connect_synchronizer",
+      s"participant is connected to $alias",
+      runCmd(
+        ParticipantAdminCommands.SynchronizerConnectivity
+          .ReconnectSynchronizer(alias, retry = false)
+      ).map(isConnected =>
+        if (!isConnected) {
+          val msg = s"failed to connect to $alias"
+          throw Status.Code.FAILED_PRECONDITION.toStatus.withDescription(msg).asRuntimeException()
+        }
+      ),
+      logger,
+    )
+
+  private def disconnectSynchronizer(alias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[Unit] =
+    runCmd(ParticipantAdminCommands.SynchronizerConnectivity.DisconnectSynchronizer(alias))
+
+  def ensureSynchronizerRegistered(
+      config: SynchronizerConnectionConfig,
+      retryFor: RetryFor,
+  )(implicit traceContext: TraceContext): Future[Unit] = {
+    for {
+      _ <- retryProvider
+        .ensureThat(
+          retryFor,
+          "synchronizer_registered_handshake",
+          s"participant registered ${config.synchronizerAlias} with handshake only",
+          lookupSynchronizerConnectionConfig(config.synchronizerAlias).map(_.toRight(())),
+          (_: Unit) => registerSynchronizer(config, handshakeOnly = true),
+          logger,
+        )
+    } yield ()
+  }
+
+  def ensureSynchronizerRegisteredNoHandshake(
+      config: SynchronizerConnectionConfig,
+      retryFor: RetryFor,
+  )(implicit traceContext: TraceContext): Future[Unit] = {
+    require(
+      config.manualConnect,
+      "manualConnect must be true when trying to register only",
+    )
+    for {
+      _ <- retryProvider
+        .ensureThat(
+          retryFor,
+          "synchronizer_registered_no_handshake",
+          s"participant registered ${config.synchronizerAlias}",
+          lookupSynchronizerConnectionConfig(config.synchronizerAlias).map(_.toRight(())),
+          (_: Unit) => registerSynchronizer(config, handshakeOnly = false),
+          logger,
+        )
+    } yield ()
+  }
+
+  def ensureSynchronizerRegisteredAndConnected(
+      config: SynchronizerConnectionConfig,
+      overwriteExistingConnection: Boolean,
+      reconnectOnSynchronizerConfigurationChange: Boolean,
+      retryFor: RetryFor,
+  )(implicit traceContext: TraceContext): Future[Unit] = for {
+    _ <- retryProvider
+      .ensureThat(
+        retryFor,
+        "synchronizer_registered",
+        s"participant registered ${config.synchronizerAlias} with config $config",
+        lookupSynchronizerConnectionConfig(config.synchronizerAlias).map {
+          case Some(_) if !overwriteExistingConnection => Right(())
+          // We don't set the sequencer id when connecting but Canton returns it so we ignore it in the comparison here.
+          case Some(existingConfig)
+              if ParticipantAdminConnection.dropSequencerId(
+                existingConfig
+              ) == ParticipantAdminConnection.dropSequencerId(config) =>
+            Right(())
+          case Some(other) => Left(Some(other))
+          case None => Left(None)
+        },
+        (existingConfig: Option[SynchronizerConnectionConfig]) =>
+          existingConfig match {
+            case None =>
+              logger.info(s"Registering new synchronizer with config $config")
+              registerSynchronizer(config, handshakeOnly = false)
+            case Some(_) =>
+              modifySynchronizerConnectionConfigAndReconnect(
+                config.synchronizerAlias,
+                reconnectOnSynchronizerConfigurationChange,
+                _ => Some(config),
+              )
+                .map(_ => ())
+          },
+        logger,
+      )
+    _ <- connectSynchronizer(config.synchronizerAlias)
+  } yield ()
+
+  private def reconnectSynchronizer(alias: SynchronizerAlias)(implicit
+      traceContext: TraceContext
+  ): Future[Unit] = for {
+    _ <- retryProvider.retryForClientCalls(
+      "reconnect_synchronizer_disconnect",
+      s"participant is disconnected from $alias",
+      disconnectSynchronizer(alias),
+      logger,
+    )
+    _ <- connectSynchronizer(alias)
+  } yield ()
+
+  def getParticipantTrafficState(
+      synchronizerId: SynchronizerId
+  )(implicit traceContext: TraceContext): Future[TrafficState] = {
+    runCmd(
+      ParticipantAdminCommands.TrafficControl.GetTrafficControlState(synchronizerId)
+    )
+  }
+
+  def lookupSynchronizerConnectionConfig(
+      synchronizerAlias: SynchronizerAlias
+  )(implicit traceContext: TraceContext): Future[Option[SynchronizerConnectionConfig]] =
+    for {
+      registeredSynchronizers <- listRegisteredSynchronizers()
+    } yield registeredSynchronizers
+      .collectFirst {
+        case (registeredSynchronizer, _, _)
+            if registeredSynchronizer.synchronizerAlias == synchronizerAlias =>
+          registeredSynchronizer
+      }
+
+  def getSynchronizerConnectionConfig(
+      synchronizerAlias: SynchronizerAlias
+  )(implicit traceContext: TraceContext): Future[SynchronizerConnectionConfig] =
+    lookupSynchronizerConnectionConfig(synchronizerAlias).map(
+      _.getOrElse(
+        throw Status.NOT_FOUND
+          .withDescription(s"Synchronizer $synchronizerAlias is not configured on the participant")
+          .asRuntimeException()
+      )
+    )
+
+  private def setSynchronizerConnectionConfig(config: SynchronizerConnectionConfig)(implicit
+      traceContext: TraceContext
+  ): Future[Unit] =
+    runCmd(
+      ParticipantAdminCommands.SynchronizerConnectivity.ModifySynchronizerConnection(
+        None,
+        config,
+        SequencerConnectionValidation.ThresholdActive,
+      )
+    )
+
+  def modifySynchronizerConnectionConfig(
+      synchronizer: SynchronizerAlias,
+      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
+  )(implicit traceContext: TraceContext): Future[Boolean] = {
+    retryProvider.retryForClientCalls(
+      "modify_synchronizer_connection",
+      "Set the new synchronizer connection if required",
+      for {
+        oldConfig <- getSynchronizerConnectionConfig(synchronizer)
+        newConfig = f(oldConfig)
+        configModified <- newConfig match {
+          case None =>
+            logger.trace("No update to synchronizer connection config required")
+            Future.successful(false)
+          case Some(config) =>
+            logger.info(
+              s"Updating to new synchronizer connection config for synchronizer $synchronizer. Old config: $oldConfig, new config: $config"
+            )
+            for {
+              _ <- setSynchronizerConnectionConfig(config)
+            } yield true
+        }
+      } yield configModified,
+      logger,
+    )
+  }
+
+  private def modifyOrRegisterSynchronizerConnectionConfig(
+      config: SynchronizerConnectionConfig,
+      reconnectOnSynchronizerConfigurationChange: Boolean,
+      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
+      retryFor: RetryFor,
+  )(implicit traceContext: TraceContext): Future[Boolean] =
+    for {
+      configO <- lookupSynchronizerConnectionConfig(config.synchronizerAlias)
+      needsReconnect <- configO match {
+        case Some(config) =>
+          modifySynchronizerConnectionConfig(
+            config.synchronizerAlias,
+            f,
+          )
+        case None =>
+          logger.info(s"Synchronizer ${config.synchronizerAlias} is new, registering")
+          ensureSynchronizerRegisteredAndConnected(
+            config,
+            overwriteExistingConnection = true,
+            reconnectOnSynchronizerConfigurationChange = reconnectOnSynchronizerConfigurationChange,
+            retryFor = retryFor,
+          ).map(_ => false)
+      }
+    } yield needsReconnect
+
+  def modifySynchronizerConnectionConfigAndReconnect(
+      synchronizerAlias: SynchronizerAlias,
+      reconnectOnSynchronizerConfigurationChange: Boolean,
+      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
+  )(implicit traceContext: TraceContext): Future[Unit] =
+    for {
+      configModified <- modifySynchronizerConnectionConfig(synchronizerAlias, f)
+      _ <-
+        if (configModified && reconnectOnSynchronizerConfigurationChange) {
+          logger.info(
+            s"reconnect to the synchronizer $synchronizerAlias for new sequencer configuration to take effect"
+          )
+          reconnectSynchronizer(synchronizerAlias)
+        } else Future.unit
+    } yield ()
+
+  def modifyOrRegisterSynchronizerConnectionConfigAndReconnect(
+      config: SynchronizerConnectionConfig,
+      reconnectOnSynchronizerConfigurationChange: Boolean,
+      f: SynchronizerConnectionConfig => Option[SynchronizerConnectionConfig],
+      retryFor: RetryFor,
+  )(implicit traceContext: TraceContext): Future[Unit] =
+    for {
+      configModified <- modifyOrRegisterSynchronizerConnectionConfig(
+        config,
+        reconnectOnSynchronizerConfigurationChange,
+        f,
+        retryFor,
+      )
+      _ <-
+        if (configModified && reconnectOnSynchronizerConfigurationChange) {
+          logger.info(
+            s"reconnect to the synchronizer ${config.synchronizerAlias} for new sequencer configuration to take effect"
+          )
+          reconnectSynchronizer(config.synchronizerAlias)
+        } else Future.unit
+    } yield ()
+
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -665,7 +665,7 @@ class HttpScanHandler(
         synchronizerId <- store
           .lookupAmuletRules()
           .map(_.flatMap(_.state.fold(_.some, None)))
-        connectedDomains <- participantAdminConnection.listConnectedDomains()
+        connectedDomains <- participantAdminConnection.listConnectedSynchronizers()
       } yield {
         synchronizerId.fold(
           ScanResource.GetActivePhysicalSynchronizerSerialResponse.NotFound(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SvTopologyStateReconciler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SvTopologyStateReconciler.scala
@@ -105,7 +105,7 @@ abstract class SvTopologyStatePollingAndAssignedTrigger[Task](
     for {
       noDsoRules <- store.lookupDsoRules().map(_.isEmpty)
       // required to prevent bogus topology transactions from being created during LSUs
-      connectedSyncs <- participantAdminConnection.traverse(_.listConnectedDomains())
+      connectedSyncs <- participantAdminConnection.traverse(_.listConnectedSynchronizers())
     } yield noDsoRules || connectedSyncs.exists(_.isEmpty)
 
   }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SyncConnectionStalenessCheck.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/singlesv/SyncConnectionStalenessCheck.scala
@@ -13,5 +13,5 @@ trait SyncConnectionStalenessCheck {
   def participantAdminConnection: ParticipantAdminConnection
 
   def isNotConnectedToSync()(implicit tc: TraceContext, ec: ExecutionContext): Future[Boolean] =
-    participantAdminConnection.listConnectedDomains().map(_.isEmpty)
+    participantAdminConnection.listConnectedSynchronizers().map(_.isEmpty)
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeDsoPartyHosting.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeDsoPartyHosting.scala
@@ -71,7 +71,7 @@ class JoiningNodeDsoPartyHosting(
                     participantId,
                   )
                 _ = logger.info("Disconnecting from all domains")
-                _ <- participantAdminConnection.disconnectFromAllDomains()
+                _ <- participantAdminConnection.disconnectFromAllSynchronizers()
                 _ = logger.info("candidate SV participant disconnected from global domain")
                 response <- retryProvider
                   .retry(
@@ -111,7 +111,7 @@ class JoiningNodeDsoPartyHosting(
                         "Reconnecting to global domain so that the proposal can be recreated from the latest base."
                       )
                       for {
-                        _ <- participantAdminConnection.connectDomain(synchronizerAlias)
+                        _ <- participantAdminConnection.connectSynchronizer(synchronizerAlias)
                         _ <- retryProvider.waitUntil(
                           RetryFor.WaitingOnInitDependency,
                           "party_hosting_serial_observed",
@@ -158,9 +158,9 @@ class JoiningNodeDsoPartyHosting(
           _ = logger.info(
             "Imported Acs snapshot from sponsor SV participant to candidate participant"
           )
-          _ <- participantAdminConnection.reconnectAllDomains()
+          _ <- participantAdminConnection.reconnectAllSynchronizers()
           // Explicitly connect to global domain as that has manualConnect=false
-          _ <- participantAdminConnection.connectDomain(synchronizerAlias)
+          _ <- participantAdminConnection.connectSynchronizer(synchronizerAlias)
           _ = logger.info("candidate SV participant reconnected to global domain")
           _ <- dsoPartyHosting.waitForDsoPartyToParticipantAuthorization(
             synchronizerId,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -165,7 +165,7 @@ class JoiningNodeInitializer(
         // If the url is unset, we skip this step. This is fine if the node has already initialized its
         // own sequencer.
         domainConfigO.traverse_(
-          participantAdminConnection.ensureDomainRegisteredNoHandshake(
+          participantAdminConnection.ensureSynchronizerRegisteredNoHandshake(
             _,
             RetryFor.WaitingOnInitDependency,
           )
@@ -523,7 +523,7 @@ class JoiningNodeInitializer(
             dsoPartyToParticipantMapping.nonEmpty || activeDsoPartyToParticipantProposals.isEmpty
           ) {
             logger.info("Reconnecting all domains.")
-            participantAdminConnection.reconnectAllDomains()
+            participantAdminConnection.reconnectAllSynchronizers()
           } else {
             Future.unit
           }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -167,7 +167,7 @@ class SV1Initializer(
           bootstrapDomain(synchronizerNodeService.nodes.current)
         }
       _ = logger.info("Domain is bootstrapped, connecting sv1 participant to domain")
-      _ <- participantAdminConnection.ensureDomainRegisteredAndConnected(
+      _ <- participantAdminConnection.ensureSynchronizerRegisteredAndConnected(
         SynchronizerConnectionConfig(
           config.domains.global.alias,
           sequencerConnections = SequencerConnections.tryMany(

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -244,7 +244,7 @@ class ValidatorApp(
                 extraSynchronizerAliases: Set[SynchronizerAlias] = config.domains.extra
                   .map(_.alias)
                   .toSet
-                allConnectedSynchronizers <- participantAdminConnection.listConnectedDomains()
+                allConnectedSynchronizers <- participantAdminConnection.listConnectedSynchronizers()
                 extraSynchronizerIds: Seq[SynchronizerId] = allConnectedSynchronizers
                   .filter(result => extraSynchronizerAliases.contains(result.synchronizerAlias))
                   .map(_.physicalSynchronizerId.logical)

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/domain/DomainConnector.scala
@@ -54,7 +54,7 @@ class DomainConnector(
         .flatMap {
           case Some(_) =>
             participantAdminConnection
-              .listConnectedDomains()
+              .listConnectedSynchronizers()
               .map(
                 _.find(_.synchronizerAlias == config.domains.global.alias).fold(
                   throw Status.FAILED_PRECONDITION
@@ -166,7 +166,7 @@ class DomainConnector(
       ),
     )
     logger.info(s"Ensuring domain $alias registered with config $domainConfig")
-    participantAdminConnection.ensureDomainRegisteredAndConnected(
+    participantAdminConnection.ensureSynchronizerRegisteredAndConnected(
       domainConfig,
       overwriteExistingConnection = true,
       reconnectOnSynchronizerConfigurationChange =

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/lsu/RollForwardLsuTrigger.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/lsu/RollForwardLsuTrigger.scala
@@ -38,7 +38,7 @@ final case class RollForwardLsuTrigger(
     scanConnection.lookupRollForwardLsu().flatMap {
       case None => Future.successful(Seq.empty)
       case Some(rollForward) =>
-        participantAdminConnection.listConnectedDomains().flatMap { connections =>
+        participantAdminConnection.listConnectedSynchronizers().flatMap { connections =>
           connections
             .find(_.physicalSynchronizerId == rollForward.currentPhysicalSynchronizerId) match {
             case None => Future.successful(Seq.empty)
@@ -72,7 +72,7 @@ final case class RollForwardLsuTrigger(
       task: RollForwardLsu
   )(implicit tc: TraceContext): Future[Boolean] =
     for {
-      connections <- participantAdminConnection.listConnectedDomains()
+      connections <- participantAdminConnection.listConnectedSynchronizers()
     } yield connections.find(_.physicalSynchronizerId == task.currentPhysicalSynchronizerId).isEmpty
 
   private def getUsableNewSequencers(alias: SynchronizerAlias, rollForward: RollForwardLsu)(implicit

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/migration/ParticipantPartyMigrator.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/migration/ParticipantPartyMigrator.scala
@@ -387,7 +387,7 @@ class ParticipantPartyMigrator(
       getAcsSnapshot: PartyId => Future[ByteString],
   ): Future[Unit] = {
     for {
-      _ <- participantAdminConnection.disconnectFromAllDomains()
+      _ <- participantAdminConnection.disconnectFromAllSynchronizers()
       // ACS exports are expensive so do not change this to be parallel.
       _ <- MonadUtil.sequentialTraverse(partyIds.toSeq) { partyId =>
         for {
@@ -395,8 +395,8 @@ class ParticipantPartyMigrator(
           _ <- participantAdminConnection.uploadAcsSnapshot(Seq(acsSnapshot), synchronizerId)
         } yield ()
       }
-      _ <- participantAdminConnection.reconnectAllDomains()
-      _ <- participantAdminConnection.connectDomain(decentralizedSynchronizerAlias)
+      _ <- participantAdminConnection.reconnectAllSynchronizers()
+      _ <- participantAdminConnection.connectSynchronizer(decentralizedSynchronizerAlias)
       _ = logger.info("ACS import complete")
     } yield ()
   }


### PR DESCRIPTION
and rename everything to synchronzier

[ci]

no actual changes done 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
