### PR TITLE
Set template id filters in acs queries

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AutoIgnoreUnresponsivePartiesIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/AutoIgnoreUnresponsivePartiesIntegrationTest.scala
@@ -170,6 +170,8 @@ class AutoIgnoreUnresponsivePartiesIntegrationTest
       )
 
       clue("Disconnect alice's participant from the synchronizer") {
+        // stop to avoid log noise.
+        aliceValidatorBackend.stop()
         aliceValidatorBackend.participantClient.synchronizers.disconnect_all()
         aliceValidatorBackend.participantClient.synchronizers.is_connected(
           synchronizerId
@@ -192,9 +194,12 @@ class AutoIgnoreUnresponsivePartiesIntegrationTest
           sv1Backend.dsoDelegateBasedAutomation.expiredAmuletIgnoredPartiesStore.getAll should contain(
             aliceParty
           )
-          aliceWalletClient.list().amulets should have length numAmulets.toLong
-          aliceWalletClient.list().lockedAmulets should have length numAmulets.toLong
         },
       )
+
+      // reconnect or other tests might get unhappy, in particular `withNoVettedPackages` gets confused if the nodes is disconnected.
+      clue("Reconnect alice's participant") {
+        aliceValidatorBackend.participantClient.synchronizers.reconnect_all()
+      }
   }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SpliceAppAutomationService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SpliceAppAutomationService.scala
@@ -6,6 +6,7 @@ package org.lfdecentralizedtrust.splice.automation
 import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.config.{AutomationConfig, SpliceParametersConfig}
 import org.lfdecentralizedtrust.splice.environment.{
+  PackageVersionSupport,
   RetryProvider,
   SpliceLedgerClient,
   SpliceLedgerConnection,
@@ -36,6 +37,7 @@ abstract class SpliceAppAutomationService[Store <: AppStore](
     ledgerClient: SpliceLedgerClient,
     retryProvider: RetryProvider,
     parametersConfig: SpliceParametersConfig,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -102,8 +104,10 @@ abstract class SpliceAppAutomationService[Store <: AppStore](
         updateHistory.ingestionSink,
         connection(SpliceLedgerConnectionPriority.High),
         automationConfig,
+        triggerContext.clock,
         backoffClock = triggerContext.pollingClock,
         triggerContext.retryProvider,
+        packageVersionSupport,
         triggerContext.loggerFactory,
       )
     )
@@ -118,8 +122,10 @@ abstract class SpliceAppAutomationService[Store <: AppStore](
       store.multiDomainAcsStore.ingestionSink,
       connection(SpliceLedgerConnectionPriority.High),
       automationConfig,
+      triggerContext.clock,
       backoffClock = triggerContext.pollingClock,
       triggerContext.retryProvider,
+      packageVersionSupport,
       triggerContext.loggerFactory,
     )
   )

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/UpdateIngestionService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/UpdateIngestionService.scala
@@ -14,6 +14,7 @@ import org.apache.pekko.stream.scaladsl.Source
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
 import org.lfdecentralizedtrust.splice.environment.ledger.api.LedgerClient.GetTreeUpdatesResponse
 import org.lfdecentralizedtrust.splice.environment.{
+  PackageVersionSupport,
   RetryProvider,
   ServiceWithGuaranteedShutdown,
   SpliceLedgerConnection,
@@ -33,8 +34,10 @@ class UpdateIngestionService(
     ingestionSink: MultiDomainAcsStore.IngestionSink,
     connection: SpliceLedgerConnection,
     config: AutomationConfig,
+    clock: Clock,
     backoffClock: Clock,
     override protected val retryProvider: RetryProvider,
+    packageVersionSupport: PackageVersionSupport,
     baseLoggerFactory: NamedLoggerFactory,
 )(implicit
     ec: ExecutionContext,
@@ -122,6 +125,8 @@ class UpdateIngestionService(
             config.ingestion.activeContractsMaxBackoff.underlying,
             config.ingestion.activeContractsRandomFactor,
           ),
+          clock,
+          packageVersionSupport,
         )
       ),
       offset,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/PackageVersionSupport.scala
@@ -143,6 +143,28 @@ trait PackageVersionSupport extends NamedLogging {
     )
   }
 
+  def supportsTrafficBasedAppRewards(parties: Seq[PartyId], now: CantonTimestamp)(implicit
+      tc: TraceContext
+  ): Future[FeatureSupport] =
+    isDarSupported(
+      parties,
+      PackageIdResolver.Package.SpliceAmulet,
+      now,
+      DarResources.amulet,
+      DarResources.amulet_0_1_19,
+    )
+
+  def supportsMintingDelegation(parties: Seq[PartyId], now: CantonTimestamp)(implicit
+      tc: TraceContext
+  ): Future[FeatureSupport] =
+    isDarSupported(
+      parties,
+      PackageIdResolver.Package.SpliceWallet,
+      now,
+      DarResources.wallet,
+      DarResources.wallet_0_1_16,
+    )
+
   private def isDarSupported(
       parties: Seq[PartyId],
       packageId: PackageIdResolver.Package,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -22,6 +22,7 @@ import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.protocol.LocalRejectError.ConsistencyRejections.InactiveContracts
+import com.digitalasset.canton.time.Clock
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.{Namespace, PartyId, SynchronizerId, UniqueIdentifier}
 import com.digitalasset.canton.tracing.TraceContext
@@ -157,10 +158,18 @@ class BaseLedgerConnection(
       filter: IngestionFilter,
       offset: Long,
       restartSettings: RestartSettings,
+      clock: Clock,
+      packageVersionSupport: PackageVersionSupport,
   )(implicit
       tc: TraceContext
   ): Source[BaseLedgerConnection.ActiveContractsItem, NotUsed] =
-    activeContracts(filter.toEventFormat, offset, restartSettings)
+    Source
+      .futureSource {
+        filter
+          .toAcsEventFormat(packageVersionSupport, clock)
+          .map(activeContracts(_, offset, restartSettings))
+      }
+      .mapMaterializedValue(_ => NotUsed)
 
   def getContract(
       contractId: ContractId[?],

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ledger/api/LedgerClient.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ledger/api/LedgerClient.scala
@@ -779,7 +779,7 @@ object LedgerClient {
       filter: IngestionFilter,
   ) {
     private[LedgerClient] def toProto: lapi.update_service.GetUpdatesRequest = {
-      val eventFormat = filter.toEventFormat
+      val eventFormat = filter.toUpdatesEventFormat
       lapi.update_service.GetUpdatesRequest(
         beginExclusive = begin,
         endInclusive = end,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
@@ -589,6 +589,8 @@ object MultiDomainAcsStore extends StoreErrors {
     // The way we parse transaction trees currently requires no filtering.
     // We may want to consider filtering for stores that just use the ACS
     // and don't care about tx trees but the extra overhead has not been an issue so far.
+    // Note that the version guards are also not going to work for updates as filtering out
+    // when we start the stream is going to miss contracts for templates when they get vetted later.
     def toUpdatesEventFormat: EventFormat = toEventFormat(
       Seq(
         CumulativeFilter(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
@@ -21,6 +21,7 @@ import org.lfdecentralizedtrust.splice.environment.ledger.api.{
   ReassignmentEvent,
   TreeUpdateOrOffsetCheckpoint,
 }
+import org.lfdecentralizedtrust.splice.environment.PackageVersionSupport
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.HasIngestionSink
 import org.lfdecentralizedtrust.splice.store.db.{AcsInterfaceViewRowData, AcsJdbcTypes, AcsRowData}
 import org.lfdecentralizedtrust.splice.util.Contract.Companion
@@ -38,9 +39,12 @@ import com.digitalasset.canton.ProtoDeserializationError
 import com.digitalasset.canton.logging.{ErrorLoggingContext, NamedLogging}
 import com.digitalasset.canton.logging.pretty.{Pretty, PrettyPrinting}
 import com.daml.metrics.api.MetricHandle.LabeledMetricsFactory
+import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.participant.pretty.Implicits.prettyContractId
+import com.digitalasset.canton.time.Clock
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.canton.util.ShowUtil.*
 import com.google.common.annotations.VisibleForTesting
 import com.google.protobuf.ByteString
@@ -324,6 +328,10 @@ object MultiDomainAcsStore extends StoreErrors {
       evPredicate: CreatedEvent => Boolean,
       decodeFromCreatedEvent: DecodeFromCreatedEvent[TCid, T],
       encodeToRow: EncodeToRow[TCid, T, R],
+      versionGuard: (
+          PackageVersionSupport,
+          CantonTimestamp,
+      ) => TraceContext => Future[PackageVersionSupport.FeatureSupport],
   ) {
     def matchingContractToRow(
         ev: CreatedEvent
@@ -370,6 +378,7 @@ object MultiDomainAcsStore extends StoreErrors {
     override val ingestionFilter =
       IngestionFilter(
         primaryParty,
+        templateFilters.view.map { case (k, filter) => (k, filter.versionGuard) }.toSeq,
         // In interface filters the ledger API warns when using a package id so we convert to a package name here.
         interfaceFilters.keys.map(PackageQualifiedName.getFromResources(_)).toSeq,
       )
@@ -474,7 +483,13 @@ object MultiDomainAcsStore extends StoreErrors {
   def mkFilter[TCid <: ContractId[T], T <: Template, R <: AcsRowData](
       templateCompanion: Contract.Companion.Template[TCid, T]
   )(
-      p: Contract[TCid, T] => Boolean
+      p: Contract[TCid, T] => Boolean,
+      versionGuard: (
+          PackageVersionSupport,
+          CantonTimestamp,
+      ) => TraceContext => Future[PackageVersionSupport.FeatureSupport] = { case _ =>
+        _ => Future.successful(PackageVersionSupport.FeatureSupport(true, Seq.empty))
+      },
   )(
       encode: EncodeToRow[TCid, T, R]
   ): (
@@ -490,6 +505,7 @@ object MultiDomainAcsStore extends StoreErrors {
         },
         ev => Contract.fromCreatedEvent(templateCompanion)(ev),
         encode,
+        versionGuard,
       ),
     )
 
@@ -524,19 +540,71 @@ object MultiDomainAcsStore extends StoreErrors {
     */
   final case class IngestionFilter(
       primaryParty: PartyId,
+      includeTemplates: Seq[
+        (
+            PackageQualifiedName,
+            (PackageVersionSupport, CantonTimestamp) => (
+                TraceContext
+            ) => Future[PackageVersionSupport.FeatureSupport],
+        )
+      ],
       includeInterfaces: Seq[PackageQualifiedName],
       includeCreatedEventBlob: Boolean = true,
   ) {
 
-    def toEventFormat: EventFormat =
+    def toAcsEventFormat(
+        packageVersionSupport: PackageVersionSupport,
+        clock: Clock,
+    )(implicit tc: TraceContext, ec: ExecutionContext): Future[EventFormat] = {
+      val now = clock.now
+      for {
+        templates <- MonadUtil.sequentialTraverse(includeTemplates) { case (id, versionGuard) =>
+          versionGuard(packageVersionSupport, now)(tc).map(keep => (id, keep))
+        }
+      } yield {
+        val filteredTemplates = templates.collect {
+          case (id, feature) if feature.supported => id
+        }
+        val templateFilters = filteredTemplates
+          .map { templateId =>
+            CumulativeFilter(
+              CumulativeFilter.IdentifierFilter.TemplateFilter(
+                com.daml.ledger.api.v2.transaction_filter.TemplateFilter(
+                  Some(
+                    com.daml.ledger.api.v2.value.Identifier(
+                      packageId = s"#${templateId.packageName}",
+                      moduleName = templateId.qualifiedName.moduleName,
+                      entityName = templateId.qualifiedName.entityName,
+                    )
+                  ),
+                  includeCreatedEventBlob = includeCreatedEventBlob,
+                )
+              )
+            )
+          }
+        toEventFormat(templateFilters)
+      }
+    }
+
+    // The way we parse transaction trees currently requires no filtering.
+    // We may want to consider filtering for stores that just use the ACS
+    // and don't care about tx trees but the extra overhead has not been an issue so far.
+    def toUpdatesEventFormat: EventFormat = toEventFormat(
+      Seq(
+        CumulativeFilter(
+          CumulativeFilter.IdentifierFilter.WildcardFilter(
+            com.daml.ledger.api.v2.transaction_filter
+              .WildcardFilter(includeCreatedEventBlob)
+          )
+        )
+      )
+    )
+
+    private def toEventFormat(nonInterfaceFilters: Seq[CumulativeFilter]): EventFormat =
       EventFormat(
         filtersByParty = Map(
           primaryParty.toProtoPrimitive -> com.daml.ledger.api.v2.transaction_filter.Filters(
-            CumulativeFilter(
-              CumulativeFilter.IdentifierFilter.WildcardFilter(
-                com.daml.ledger.api.v2.transaction_filter.WildcardFilter(includeCreatedEventBlob)
-              )
-            ) +: includeInterfaces.map { interfaceId =>
+            nonInterfaceFilters ++ includeInterfaces.map { interfaceId =>
               CumulativeFilter(
                 CumulativeFilter.IdentifierFilter.InterfaceFilter(
                   com.daml.ledger.api.v2.transaction_filter.InterfaceFilter(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
@@ -328,10 +328,7 @@ object MultiDomainAcsStore extends StoreErrors {
       evPredicate: CreatedEvent => Boolean,
       decodeFromCreatedEvent: DecodeFromCreatedEvent[TCid, T],
       encodeToRow: EncodeToRow[TCid, T, R],
-      versionGuard: (
-          PackageVersionSupport,
-          CantonTimestamp,
-      ) => TraceContext => Future[PackageVersionSupport.FeatureSupport],
+      versionGuard: VersionGuard,
   ) {
     def matchingContractToRow(
         ev: CreatedEvent
@@ -484,10 +481,7 @@ object MultiDomainAcsStore extends StoreErrors {
       templateCompanion: Contract.Companion.Template[TCid, T]
   )(
       p: Contract[TCid, T] => Boolean,
-      versionGuard: (
-          PackageVersionSupport,
-          CantonTimestamp,
-      ) => TraceContext => Future[PackageVersionSupport.FeatureSupport] = { case _ =>
+      versionGuard: VersionGuard = { case _ =>
         _ => Future.successful(PackageVersionSupport.FeatureSupport(true, Seq.empty))
       },
   )(
@@ -971,4 +965,6 @@ object MultiDomainAcsStore extends StoreErrors {
     * chosen to be "reasonable".
     */
   val notOnDomainsTotalLimit: PageLimit = PageLimit tryCreate 1000
+
+  type VersionGuard = (PackageVersionSupport, CantonTimestamp) => (TraceContext) => Future[PackageVersionSupport.FeatureSupport]
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStore.scala
@@ -966,5 +966,7 @@ object MultiDomainAcsStore extends StoreErrors {
     */
   val notOnDomainsTotalLimit: PageLimit = PageLimit tryCreate 1000
 
-  type VersionGuard = (PackageVersionSupport, CantonTimestamp) => (TraceContext) => Future[PackageVersionSupport.FeatureSupport]
+  type VersionGuard = (PackageVersionSupport, CantonTimestamp) => (
+      TraceContext
+  ) => Future[PackageVersionSupport.FeatureSupport]
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/UpdateHistory.scala
@@ -144,6 +144,7 @@ class UpdateHistory(
     new MultiDomainAcsStore.IngestionSink {
       override def ingestionFilter: IngestionFilter = IngestionFilter(
         primaryParty = updateStreamParty,
+        includeTemplates = Seq.empty,
         includeInterfaces = Seq.empty,
         includeCreatedEventBlob = false,
       )

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/MultiDomainAcsStoreTest.scala
@@ -9,6 +9,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.splitwell.*
 import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.payment.AppPaymentRequest
 import org.lfdecentralizedtrust.splice.codegen.java.da.time.types.RelTime
 import org.lfdecentralizedtrust.splice.environment.ledger.api.ReassignmentEvent
+import org.lfdecentralizedtrust.splice.environment.{PackageIdResolver, PackageVersionSupport}
 import org.lfdecentralizedtrust.splice.store.db.{
   AcsInterfaceViewRowData,
   AcsRowData,
@@ -16,8 +17,12 @@ import org.lfdecentralizedtrust.splice.store.db.{
 }
 import org.lfdecentralizedtrust.splice.util.{AssignedContract, Contract, ContractWithState}
 import com.daml.nonempty.NonEmpty
+import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.canton.HasActorSystem
+import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.topology.{ParticipantId, PartyId, SynchronizerId}
+import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.FutureInstances.parallelFuture
 import com.digitalasset.canton.util.MonadUtil
 import org.lfdecentralizedtrust.splice.codegen.java.splice.api.token.{
@@ -1663,6 +1668,51 @@ abstract class MultiDomainAcsStoreTest[
         resultAmulet.map(_.contractId.contractId) should contain theSameElementsAs Seq(
           goodContract.contractId.contractId
         )
+      }
+    }
+
+    "toAcsEventFormat respects version guards" in {
+      def filter(supported: Boolean) =
+        MultiDomainAcsStore.SimpleContractFilter[GenericAcsRowData, GenericInterfaceRowData](
+          dsoParty,
+          templateFilters = Map(
+            mkFilter(AppRewardCoupon.COMPANION)(
+              _ => true,
+              versionGuard = { case _ =>
+                _ => Future.successful(PackageVersionSupport.FeatureSupport(supported, Seq.empty))
+              },
+            ) { contract =>
+              GenericAcsRowData(contract)
+            },
+            mkFilter(Amulet.COMPANION)(_ => true) { contract =>
+              GenericAcsRowData(contract)
+            },
+          ),
+          interfaceFilters = Map.empty,
+        )
+      val clock = new com.digitalasset.canton.time.SimClock(loggerFactory = loggerFactory)
+      val outerLoggerFactory = loggerFactory
+      val versionSupport = new PackageVersionSupport {
+        override def loggerFactory: NamedLoggerFactory = outerLoggerFactory
+        // Not actually relevant, but required by the trait
+        override def isPackageSupported(
+            packageRequirements: Seq[(PackageIdResolver.Package, Seq[PartyId])],
+            at: CantonTimestamp,
+            metadata: Ast.PackageMetadata,
+        )(implicit
+            tc: TraceContext
+        ): Future[PackageVersionSupport.FeatureSupport] =
+          Future.successful(PackageVersionSupport.FeatureSupport(true, Seq.empty))
+      }
+      for {
+        unfiltered <- filter(true).ingestionFilter.toAcsEventFormat(versionSupport, clock)
+        filtered <- filter(false).ingestionFilter.toAcsEventFormat(versionSupport, clock)
+      } yield {
+        unfiltered.filtersByParty.head._2.cumulative.map(
+          _.getTemplateFilter.getTemplateId.entityName
+        ) should contain theSameElementsAs Seq("AppRewardCoupon", "Amulet")
+        filtered.filtersByParty.head._2.cumulative
+          .map(_.getTemplateFilter.getTemplateId.entityName) shouldBe Seq("Amulet")
       }
     }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -284,6 +284,19 @@ class ScanApp(
       appRewardsStoreO = appActivityRecordStoreO.map(appActivityRecordStore =>
         new DbScanAppRewardsStore(storage, updateHistory, appActivityRecordStore, loggerFactory)
       )
+      synchronizerId <-
+        retryProvider.getValueWithRetries(
+          RetryFor.WaitingOnInitDependency,
+          "synchronizer id",
+          "synchronizer id from participant",
+          participantAdminConnection.getSynchronizerId(config.globalSynchronizerAlias),
+          logger,
+        )
+      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
+        synchronizerId,
+        appInitConnection,
+        loggerFactory,
+      )
       automation = new ScanAutomationService(
         config,
         clock,
@@ -299,6 +312,7 @@ class ScanApp(
         serviceUserPrimaryParty,
         svName,
         amuletAppParameters.upgradesConfig,
+        packageVersionSupport,
       )
       scanVerdictStore = DbScanVerdictStore(
         storage,
@@ -364,11 +378,6 @@ class ScanApp(
         case None =>
           Future.unit
       }
-      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
-        synchronizerId,
-        appInitConnection,
-        loggerFactory,
-      )
       rewardsReferenceStoreO =
         if (config.enableAppActivityRecordAndTrafficIngestion) {
           val rewardsStore = ScanRewardsReferenceStore(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -346,22 +346,6 @@ class ScanApp(
         dsoParty,
         config.spliceInstanceNames.nameServiceNameAcronym.toLowerCase(),
       )
-      synchronizerId <- appInitStep("Get synchronizer id") {
-        retryProvider.getValueWithRetries(
-          RetryFor.WaitingOnInitDependency,
-          "amulet synchronizer id",
-          "amulet rules synchronizer id",
-          store.getAmuletRulesWithState().map {
-            _.state.fold(
-              identity,
-              throw Status.FAILED_PRECONDITION
-                .withDescription("Amulet rules in fllight")
-                .asRuntimeException(),
-            )
-          },
-          logger,
-        )
-      }
       _ <- config.domainMigrationId match {
         case Some(configuredMigrationId) =>
           appInitStep("Verifying configured domain migration id is in sync with other scans") {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
@@ -12,7 +12,11 @@ import org.lfdecentralizedtrust.splice.automation.{
   UpdateIngestionService,
 }
 import org.lfdecentralizedtrust.splice.config.UpgradesConfig
-import org.lfdecentralizedtrust.splice.environment.{RetryProvider, SpliceLedgerClient}
+import org.lfdecentralizedtrust.splice.environment.{
+  PackageVersionSupport,
+  RetryProvider,
+  SpliceLedgerClient,
+}
 import org.lfdecentralizedtrust.splice.http.HttpClient
 import org.lfdecentralizedtrust.splice.scan.config.ScanAppBackendConfig
 import org.lfdecentralizedtrust.splice.store.{DomainTimeSynchronization, UpdateHistory}
@@ -50,6 +54,7 @@ class ScanAutomationService(
     svParty: PartyId,
     svName: String,
     upgradesConfig: UpgradesConfig,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContextExecutor,
     mat: Materializer,
@@ -65,6 +70,7 @@ class ScanAutomationService(
       ledgerClient,
       retryProvider,
       config.parameters,
+      packageVersionSupport,
     ) {
   override def companion
       : org.lfdecentralizedtrust.splice.scan.automation.ScanAutomationService.type =
@@ -97,8 +103,10 @@ class ScanAutomationService(
         rewardsReferenceStore.multiDomainAcsStore.ingestionSink,
         connection(SpliceLedgerConnectionPriority.High),
         config.automation,
+        triggerContext.clock,
         backoffClock = triggerContext.pollingClock,
         triggerContext.retryProvider,
+        packageVersionSupport,
         triggerContext.loggerFactory,
       )
     )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -168,8 +168,11 @@ object ScanRewardsReferenceStore {
         mkFilter(splice.dsorules.DsoRules.COMPANION)(co => co.payload.dso == dso) { contract =>
           ScanRewardsReferenceStoreRowData(contract = contract)
         },
-        mkFilter(splice.amulet.rewardaccountingv2.CalculateRewardsV2.COMPANION)(co =>
-          co.payload.dso == dso
+        mkFilter(splice.amulet.rewardaccountingv2.CalculateRewardsV2.COMPANION)(
+          co => co.payload.dso == dso,
+          versionGuard = { case (pkgVersionSupport, now) =>
+            (tc) => pkgVersionSupport.supportsTrafficBasedAppRewards(Seq(key.dsoParty), now)(tc)
+          },
         ) { contract =>
           ScanRewardsReferenceStoreRowData(
             contract = contract,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanStore.scala
@@ -467,8 +467,13 @@ object ScanStore {
               Some(Timestamp.assertFromInstant(contract.payload.transfer.executeBefore)),
           )
         },
-        mkFilter(splice.externalpartyconfigstate.ExternalPartyConfigState.COMPANION)(co =>
-          co.payload.dso == dso
+        mkFilter(splice.externalpartyconfigstate.ExternalPartyConfigState.COMPANION)(
+          co => co.payload.dso == dso,
+          versionGuard = { case (pkgVersionSupport, now) =>
+            (tc) =>
+              pkgVersionSupport
+                .supports24hSubmissionDelay(Seq(key.dsoParty), Seq(key.dsoParty), now)(tc)
+          },
         ) { contract =>
           ScanAcsStoreRowData(
             contract = contract

--- a/apps/splitwell/src/main/scala/org/lfdecentralizedtrust/splice/splitwell/SplitwellApp.scala
+++ b/apps/splitwell/src/main/scala/org/lfdecentralizedtrust/splice/splitwell/SplitwellApp.scala
@@ -29,6 +29,7 @@ import org.lfdecentralizedtrust.splice.environment.{
   DarResource,
   DarResources,
   Node,
+  PackageVersionSupport,
   ParticipantAdminConnection,
   RetryFor,
   SpliceLedgerClient,
@@ -134,6 +135,20 @@ class SplitwellApp(
       config.automation.ingestion,
       config.parameters.defaultLimit,
     )
+    amuletRules <- scanConnection.getAmuletRules()
+    synchronizerId = SynchronizerId.tryFromString(
+      amuletRules.payload.configSchedule.initialValue.decentralizedSynchronizer.activeSynchronizer
+    )
+    readOnlyLedgerConnection = ledgerClient
+      .readOnlyConnection(
+        this.getClass.getSimpleName,
+        loggerFactory,
+      )
+    packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
+      synchronizerId,
+      readOnlyLedgerConnection,
+      loggerFactory,
+    )
     // splitwell does not need to have UpdateHistory
     automation = new SplitwellAutomationService(
       config.automation,
@@ -145,6 +160,7 @@ class SplitwellApp(
       retryProvider,
       config.parameters,
       loggerFactory,
+      packageVersionSupport,
     )
     preferred <- appInitStep(s"Wait for preferred domain connection") {
       store.domains.waitForDomainConnection(config.domains.splitwell.preferred.alias)

--- a/apps/splitwell/src/main/scala/org/lfdecentralizedtrust/splice/splitwell/automation/SplitwellAutomationService.scala
+++ b/apps/splitwell/src/main/scala/org/lfdecentralizedtrust/splice/splitwell/automation/SplitwellAutomationService.scala
@@ -21,6 +21,7 @@ import org.lfdecentralizedtrust.splice.environment.{
   DarResource,
   DarResources,
   PackageIdResolver,
+  PackageVersionSupport,
   RetryProvider,
   SpliceLedgerClient,
 }
@@ -47,6 +48,7 @@ class SplitwellAutomationService(
     retryProvider: RetryProvider,
     params: SpliceParametersConfig,
     protected val loggerFactory: NamedLoggerFactory,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContextExecutor,
     mat: Materializer,
@@ -61,6 +63,7 @@ class SplitwellAutomationService(
       ledgerClient,
       retryProvider,
       params,
+      packageVersionSupport,
     ) {
 
   override def companion

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvDsoAutomationService.scala
@@ -97,6 +97,7 @@ class SvDsoAutomationService(
       ledgerClient,
       retryProvider,
       config.parameters,
+      packageVersionSupport,
     ) {
 
   override def companion

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvSvAutomationService.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/SvSvAutomationService.scala
@@ -11,6 +11,7 @@ import org.lfdecentralizedtrust.splice.automation.{
   SqlIndexInitializationTrigger,
 }
 import org.lfdecentralizedtrust.splice.environment.{
+  PackageVersionSupport,
   ParticipantAdminConnection,
   RetryProvider,
   SpliceLedgerClient,
@@ -43,6 +44,7 @@ class SvSvAutomationService(
     synchronizerNodeService: SynchronizerNodeService[LocalSynchronizerNode],
     retryProvider: RetryProvider,
     topologySnapshotConfig: Option[PeriodicBackupDumpConfig],
+    packageVersionSupport: PackageVersionSupport,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit
     ec: ExecutionContextExecutor,
@@ -58,6 +60,7 @@ class SvSvAutomationService(
       ledgerClient,
       retryProvider,
       config.parameters,
+      packageVersionSupport,
     ) {
   override def companion: org.lfdecentralizedtrust.splice.sv.automation.SvSvAutomationService.type =
     SvSvAutomationService

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/NodeInitializerUtil.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/NodeInitializerUtil.scala
@@ -103,6 +103,7 @@ trait NodeInitializerUtil extends NamedLogging with Spanning with SynchronizerNo
       ledgerClient: SpliceLedgerClient,
       participantAdminConnection: ParticipantAdminConnection,
       synchronizerNodeService: SynchronizerNodeService[LocalSynchronizerNode],
+      packageVersionSupport: PackageVersionSupport,
   )(implicit
       ec: ExecutionContextExecutor,
       mat: Materializer,
@@ -122,6 +123,7 @@ trait NodeInitializerUtil extends NamedLogging with Spanning with SynchronizerNo
       synchronizerNodeService,
       retryProvider,
       config.topologySnapshotConfig,
+      packageVersionSupport,
       loggerFactory,
     )
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/joining/JoiningNodeInitializer.scala
@@ -97,16 +97,17 @@ class JoiningNodeInitializer(
     actorSystem: ActorSystem,
 ) extends NodeInitializerUtil {
 
-  private lazy val svConnection = OptionT(joiningConfig.traverse { conf =>
-    SvConnection(conf.svClient.adminApi, upgradesConfig, retryProvider, loggerFactory).map {
-      connection =>
-        (conf, connection)
-    }
-  }).getOrElse(
-    sys.error(
-      "An onboarding config is required."
+  private lazy val svConnection: Future[(SvOnboardingConfig.JoinWithKey, SvConnection)] =
+    OptionT(joiningConfig.traverse { conf =>
+      SvConnection(conf.svClient.adminApi, upgradesConfig, retryProvider, loggerFactory).map {
+        connection =>
+          (conf, connection)
+      }
+    }).getOrElse(
+      sys.error(
+        "An onboarding config is required."
+      )
     )
-  )
 
   private def migrationIdFromSponsorSv(): Future[Long] =
     svConnection.flatMap { case (_, connection) =>
@@ -203,6 +204,15 @@ class JoiningNodeInitializer(
         participantAdminConnection,
       )
       storeKey = SvStore.Key(svParty, dsoPartyId)
+      // We need to vet early so the packages are uploaded when we try to use template
+      // filters in the ACS queries in the store.
+      _ <- joiningConfig.traverse_ { _ =>
+        if (!dsoPartyIsAuthorized) {
+          // If the DSO party has already been authorized we should be far enough to not need this step and deliberately avoid it
+          // to make sure we don't introduce a dependency on the sponsoring SV.
+          svConnection.flatMap { case (_, c) => vetThroughSponsor(c) }
+        } else Future.unit
+      }
       domainMigrationId <- resolveDomainMigrationId(migrationIdFromSponsorSv())
       svStore = newSvStore(
         storeKey,
@@ -216,12 +226,18 @@ class JoiningNodeInitializer(
         participantId,
         dsoAcsStoreDescriptorUserVersion,
       )
+      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
+        decentralizedSynchronizerId,
+        initConnection,
+        loggerFactory,
+      )
       svAutomation = newSvSvAutomationService(
         svStore,
         dsoStore,
         ledgerClient,
         participantAdminConnection,
         synchronizerNodeService,
+        packageVersionSupport,
       )
       connection = svAutomation.connection(SpliceLedgerConnectionPriority.Low)
       _ <- joiningConfig.fold(Future.unit)(onboardingConfig =>
@@ -230,11 +246,6 @@ class JoiningNodeInitializer(
           config,
           onboardingConfig.name,
         )
-      )
-      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
-        decentralizedSynchronizerId,
-        connection,
-        loggerFactory,
       )
       currentNode <- synchronizerNodeService.activeSynchronizerNode()
       // We need to first wait to ensure the CometBFT node is caught up
@@ -389,6 +400,34 @@ class JoiningNodeInitializer(
         dsoAutomation,
       )
     }
+  }
+
+  private def vetThroughSponsor(svConnection: SvConnection): Future[Unit] = {
+    logger.info("Vetting packages based on state from sponsor")
+    for {
+      // This is not a BFT read: That's acceptable because
+      // we will only vet packages that have been statically compiled into the app.
+      // At most, we can be tricked into vetting a package a bit too early.
+      dsoInfo <- svConnection.getDsoInfo()
+      amuletRules = dsoInfo.amuletRules
+      synchronizerId = SynchronizerId.tryFromString(
+        amuletRules.payload.configSchedule.initialValue.decentralizedSynchronizer.activeSynchronizer
+      )
+      vetting = new PackageVetting(
+        SvPackageVettingTrigger.packages,
+        clock,
+        participantAdminConnection,
+        loggerFactory,
+        config.latestPackagesOnly,
+        config.parameters.enabledFeatures.enableUnsupportedDarsUnvetting,
+      )
+      _ <- vetting.vetCurrentPackages(
+        synchronizerId,
+        amuletRules.contract,
+        config.additionalPackagesToUnvet,
+      )
+      _ = logger.info("Packages vetting completed")
+    } yield ()
   }
 
   // Note: This is also used for synchronizer migrations
@@ -903,31 +942,6 @@ class JoiningNodeInitializer(
       )
     }
 
-    private def vetThroughSponsor(svConnection: SvConnection): Future[Unit] = {
-      logger.info("Vetting packages based on state from sponsor")
-      for {
-        // This is not a BFT read: That's acceptable because
-        // we will only vet packages that have been statically compiled into the app.
-        // At most, we can be tricked into vetting a package a bit too early.
-        dsoInfo <- svConnection.getDsoInfo()
-        amuletRules = dsoInfo.amuletRules
-        vetting = new PackageVetting(
-          SvPackageVettingTrigger.packages,
-          clock,
-          participantAdminConnection,
-          loggerFactory,
-          config.latestPackagesOnly,
-          config.parameters.enabledFeatures.enableUnsupportedDarsUnvetting,
-        )
-        _ <- vetting.vetCurrentPackages(
-          synchronizerId,
-          amuletRules.contract,
-          config.additionalPackagesToUnvet,
-        )
-        _ = logger.info("Packages vetting completed")
-      } yield ()
-    }
-
     private def requestOnboarding(
         svConnection: SvConnection,
         name: String,
@@ -939,14 +953,8 @@ class JoiningNodeInitializer(
         privateKey
       ) match {
         case Right(token) =>
-          // startSvOnboarding creates a contract with the SV as an observer so we need to vet before.
-          // technically we can still get issues if the config changes while we are onboarding. However,
-          // we prevet so this is extremely unlikely and even if we hit it,
-          // we will just crash and retry so it doesn't seem worth the complexity
-          // to wrap everything in a giant retry.
+          logger.info(s"Requesting to be onboarded via the sponsor SV")
           for {
-            _ <- vetThroughSponsor(svConnection)
-            _ = logger.info(s"Requesting to be onboarded via the sponsor SV")
             _ <- retryProvider.retry(
               RetryFor.WaitingOnInitDependency,
               "request_onboarding",

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/sv1/SV1Initializer.scala
@@ -259,12 +259,19 @@ class SV1Initializer(
         participantId,
         dsoAcsStoreDescriptorUserVersion,
       )
+      synchronizerId <- participantAdminConnection.getSynchronizerId(config.domains.global.alias)
+      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
+        synchronizerId,
+        initConnection,
+        loggerFactory,
+      )
       svAutomation = newSvSvAutomationService(
         svStore,
         dsoStore,
         ledgerClient,
         participantAdminConnection,
         synchronizerNodeService,
+        packageVersionSupport,
       )
       connection = svAutomation.connection(SpliceLedgerConnectionPriority.Low)
       (_, decentralizedSynchronizer) <- (
@@ -277,11 +284,6 @@ class SV1Initializer(
         sv1Config.name,
       )
       dsoPartyHosting = newDsoPartyHosting(storeKey.dsoParty)
-      packageVersionSupport = PackageVersionSupport.createPackageVersionSupport(
-        decentralizedSynchronizer,
-        connection,
-        loggerFactory,
-      )
       initialRound <- establishInitialRound(
         connection,
         upgradesConfig,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
@@ -1310,7 +1310,12 @@ object SvDsoStore {
           rewardWeight = Some(contract.payload.weight),
         )
       },
-      mkFilter(splice.amulet.RewardCouponV2.COMPANION)(co => co.payload.dso == dso) { contract =>
+      mkFilter(splice.amulet.RewardCouponV2.COMPANION)(
+        co => co.payload.dso == dso,
+        versionGuard = { case (pkgVersionSupport, now) =>
+          (tc) => pkgVersionSupport.supportsTrafficBasedAppRewards(Seq(dsoParty), now)(tc)
+        },
+      ) { contract =>
         DsoAcsStoreRowData(
           contract,
           rewardRound = Some(contract.payload.round.number),
@@ -1319,16 +1324,22 @@ object SvDsoStore {
           contractExpiresAt = Some(Timestamp.assertFromInstant(contract.payload.expiresAt)),
         )
       },
-      mkFilter(splice.amulet.rewardaccountingv2.CalculateRewardsV2.COMPANION)(co =>
-        co.payload.dso == dso
+      mkFilter(splice.amulet.rewardaccountingv2.CalculateRewardsV2.COMPANION)(
+        co => co.payload.dso == dso,
+        versionGuard = { case (pkgVersionSupport, now) =>
+          (tc) => pkgVersionSupport.supportsTrafficBasedAppRewards(Seq(dsoParty), now)(tc)
+        },
       ) { contract =>
         DsoAcsStoreRowData(
           contract,
           miningRound = Some(contract.payload.round.number),
         )
       },
-      mkFilter(splice.amulet.rewardaccountingv2.ProcessRewardsV2.COMPANION)(co =>
-        co.payload.dso == dso
+      mkFilter(splice.amulet.rewardaccountingv2.ProcessRewardsV2.COMPANION)(
+        co => co.payload.dso == dso,
+        versionGuard = { case (pkgVersionSupport, now) =>
+          (tc) => pkgVersionSupport.supportsTrafficBasedAppRewards(Seq(dsoParty), now)(tc)
+        },
       ) { contract =>
         DsoAcsStoreRowData(
           contract,
@@ -1504,16 +1515,24 @@ object SvDsoStore {
             contractExpiresAt = Some(Timestamp.assertFromInstant(contract.payload.expiresAt)),
           )
       },
-      mkFilter(splice.externalpartyconfigstate.ExternalPartyConfigState.COMPANION)(co =>
-        co.payload.dso == dso
+      mkFilter(splice.externalpartyconfigstate.ExternalPartyConfigState.COMPANION)(
+        co => co.payload.dso == dso,
+        versionGuard = { case (pkgVersionSupport, now) =>
+          (tc) =>
+            pkgVersionSupport.supports24hSubmissionDelay(Seq(dsoParty), Seq(dsoParty), now)(tc)
+        },
       ) { contract =>
         DsoAcsStoreRowData(
           contract,
           miningRound = Some(contract.payload.holdingFeesOpenRoundNumber.number),
         )
       },
-      mkFilter(splice.dsorules.BootstrapExternalPartyConfigStateInstruction.COMPANION)(co =>
-        co.payload.dso == dso
+      mkFilter(splice.dsorules.BootstrapExternalPartyConfigStateInstruction.COMPANION)(
+        co => co.payload.dso == dso,
+        versionGuard = { case (pkgVersionSupport, now) =>
+          (tc) =>
+            pkgVersionSupport.supports24hSubmissionDelay(Seq(dsoParty), Seq(dsoParty), now)(tc)
+        },
       ) {
         DsoAcsStoreRowData(_)
       },

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -713,6 +713,7 @@ class ValidatorApp(
             participantId,
             config.parameters,
             scanConnection,
+            packageVersionSupport,
           )
           val walletManager = new UserWalletManager(
             ledgerClient,
@@ -780,6 +781,7 @@ class ValidatorApp(
         config.additionalPackagesToUnvet,
         config.domains.global.alias,
         loggerFactory,
+        packageVersionSupport,
       )
       _ <- MonadUtil.sequentialTraverse_(config.appInstances.toList)({ case (name, instance) =>
         appInitStep(s"Set up app instance $name") {

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/ValidatorAutomationService.scala
@@ -77,6 +77,7 @@ class ValidatorAutomationService(
     additionalPackagesToUnvet: Map[PackageName, Set[PackageVersion]],
     globalSynchronizerAlias: SynchronizerAlias,
     override protected val loggerFactory: NamedLoggerFactory,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContextExecutor,
     mat: Materializer,
@@ -89,6 +90,7 @@ class ValidatorAutomationService(
       ledgerClient,
       retryProvider,
       params,
+      packageVersionSupport,
     ) {
   override def companion
       : org.lfdecentralizedtrust.splice.validator.automation.ValidatorAutomationService.type =

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
@@ -14,7 +14,11 @@ import com.digitalasset.canton.util.ShowUtil.*
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.config.{AutomationConfig, SpliceParametersConfig}
-import org.lfdecentralizedtrust.splice.environment.{RetryProvider, SpliceLedgerClient}
+import org.lfdecentralizedtrust.splice.environment.{
+  PackageVersionSupport,
+  RetryProvider,
+  SpliceLedgerClient,
+}
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.{DomainTimeSynchronization, LimitHelpers}
 import org.lfdecentralizedtrust.splice.util.TemplateJsonDecoder
@@ -38,6 +42,7 @@ class ExternalPartyWalletManager(
     participantId: ParticipantId,
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -166,6 +171,7 @@ class ExternalPartyWalletManager(
       participantId,
       params,
       scanConnection,
+      packageVersionSupport,
     )
     (externalPartyRetryProvider, walletService)
   }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
@@ -34,6 +34,7 @@ class ExternalPartyWalletService(
     participantId: ParticipantId,
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -66,6 +67,7 @@ class ExternalPartyWalletService(
     params,
     scanConnection,
     loggerFactory,
+    packageVersionSupport,
   )
 
   override def onClosed(): Unit = {

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
@@ -32,6 +32,7 @@ class ExternalPartyWalletAutomationService(
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
     override protected val loggerFactory: NamedLoggerFactory,
+    packageVersionSupport: PackageVersionSupport,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -44,6 +45,7 @@ class ExternalPartyWalletAutomationService(
       ledgerClient,
       retryProvider,
       params,
+      packageVersionSupport,
     ) {
 
   override protected def metricsContext: MetricsContext =

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
@@ -60,6 +60,7 @@ class UserWalletAutomationService(
       ledgerClient,
       retryProvider,
       paramsConfig,
+      packageVersionSupport,
     ) {
 
   override protected def metricsContext: MetricsContext =

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/store/UserWalletStore.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/store/UserWalletStore.scala
@@ -807,9 +807,11 @@ object UserWalletStore {
           co.payload.dso == dso && (co.payload.fundManager == endUser || co.payload.beneficiary == endUser)
         )(UserWalletAcsStoreRowData(_)),
         // Minting delegations for user as the delegate
-        mkFilter(mintingDelegationCodegen.MintingDelegationProposal.COMPANION)(co =>
-          co.payload.delegation.dso == dso &&
-            co.payload.delegation.delegate == endUser
+        mkFilter(mintingDelegationCodegen.MintingDelegationProposal.COMPANION)(
+          co => co.payload.delegation.dso == dso && co.payload.delegation.delegate == endUser,
+          versionGuard = { case (pkgVersionSupport, now) =>
+            (tc) => pkgVersionSupport.supportsMintingDelegation(Seq(key.endUserParty), now)(tc)
+          },
         )(contract =>
           UserWalletAcsStoreRowData(
             contract,
@@ -817,9 +819,11 @@ object UserWalletStore {
               Some(Timestamp.assertFromInstant(contract.payload.delegation.expiresAt)),
           )
         ),
-        mkFilter(mintingDelegationCodegen.MintingDelegation.COMPANION)(co =>
-          co.payload.dso == dso &&
-            co.payload.delegate == endUser
+        mkFilter(mintingDelegationCodegen.MintingDelegation.COMPANION)(
+          co => co.payload.dso == dso && co.payload.delegate == endUser,
+          versionGuard = { case (pkgVersionSupport, now) =>
+            (tc) => pkgVersionSupport.supportsMintingDelegation(Seq(key.endUserParty), now)(tc)
+          },
         )(contract =>
           UserWalletAcsStoreRowData(
             contract,


### PR DESCRIPTION
fixes #4862

[ci]

Not sure how to test it before merging, I did confirm in the logs that it seems to set things correctly.

I also checked with the indexer team that these queries are expected to be fast even if you pass lots of templates (like we do for example for the dso stores). The real test ofc will be sv runbook reonboarding on cilr.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
