### PR TITLE
Retry the transfer preapproval

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -340,16 +340,13 @@ class LsuIntegrationTest
       walletClient.tap(50.0)
       createTransferPreapprovalEnsuringItExists(walletClient, validatorBackend)
       createAndAcceptExternalPartySetupProposal(validatorBackend, onboarding)
-      eventually() {
-        validatorBackend.lookupTransferPreapprovalByParty(externalParty) should not be empty
-        validatorBackend.scanProxy.lookupTransferPreapprovalByParty(
-          externalParty
-        ) should not be empty
-      }
       validatorBackend
         .getExternalPartyBalance(externalParty)
         .totalUnlockedCoin shouldBe "0.0000000000"
-      walletClient.transferPreapprovalSend(externalParty, 40.0, UUID.randomUUID.toString)
+      // can still fail with no preapproval depending on what scan subset is used
+      eventuallySucceeds() {
+        walletClient.transferPreapprovalSend(externalParty, 40.0, UUID.randomUUID.toString)
+      }
       eventually() {
         validatorBackend
           .getExternalPartyBalance(externalParty)


### PR DESCRIPTION
Even if we check that preapprovals exists, we would need to check all the scans to ensure it will always succeed, so we just retry the transfer on failures

[ci]

failure here https://github.com/canton-network/splice/actions/runs/26876616620/attempts/1?pr=5798

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
