### PR TITLE
Traffic-Based App Rewards: add reward sharing config and mint unshared, unassigned RewardCouponV2

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -815,7 +815,9 @@ object SpliceConfig {
               s"domains.global.url must not be set for an SV unless disableSvValidatorBftSequencerConnection is also set"
             ),
           )
-          _ <- conf.rewardSharingByParty.foldLeft(Right(()): Either[ConfigValidationFailed, Unit]) {
+          _ <- conf.rewardSharingConfigByParty.foldLeft(
+            Right(()): Either[ConfigValidationFailed, Unit]
+          ) {
             case (Left(err), _) => Left(err)
             case (Right(()), (party, sharingConfig)) =>
               for {

--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/SpliceConfig.scala
@@ -35,7 +35,9 @@ import org.lfdecentralizedtrust.splice.sv.config.SvOnboardingConfig.FoundDso
 import org.lfdecentralizedtrust.splice.util.{Codec, SpliceRateLimitConfig}
 import org.lfdecentralizedtrust.splice.validator.config.*
 import org.lfdecentralizedtrust.splice.wallet.config.{
+  AppRewardBeneficiaryConfig,
   AutoAcceptTransfersConfig,
+  RewardSharingConfig,
   TransferPreapprovalConfig,
   TreasuryConfig,
   WalletAppClientConfig,
@@ -685,6 +687,10 @@ object SpliceConfig {
       deriveReader[WalletSweepConfig]
     implicit val autoAcceptTransfersConfigReader: ConfigReader[AutoAcceptTransfersConfig] =
       deriveReader[AutoAcceptTransfersConfig]
+    implicit val appRewardBeneficiaryConfigReader: ConfigReader[AppRewardBeneficiaryConfig] =
+      deriveReader[AppRewardBeneficiaryConfig]
+    implicit val rewardSharingConfigReader: ConfigReader[RewardSharingConfig] =
+      deriveReader[RewardSharingConfig]
     implicit val validatorDecentralizedSynchronizerConfigReader
         : ConfigReader[ValidatorDecentralizedSynchronizerConfig] =
       deriveReader[ValidatorDecentralizedSynchronizerConfig].emap(config => {
@@ -809,6 +815,28 @@ object SpliceConfig {
               s"domains.global.url must not be set for an SV unless disableSvValidatorBftSequencerConnection is also set"
             ),
           )
+          _ <- conf.rewardSharingByParty.foldLeft(Right(()): Either[ConfigValidationFailed, Unit]) {
+            case (Left(err), _) => Left(err)
+            case (Right(()), (party, sharingConfig)) =>
+              for {
+                _ <- Either.cond(
+                  sharingConfig.beneficiaries.forall(b =>
+                    b.percentage > 0 && b.percentage <= BigDecimal(1.0)
+                  ),
+                  (),
+                  ConfigValidationFailed(
+                    s"Reward sharing percentages for $party must be in (0.0, 1.0]"
+                  ),
+                )
+                _ <- Either.cond(
+                  sharingConfig.beneficiaries.map(_.percentage).sum <= BigDecimal(1.0),
+                  (),
+                  ConfigValidationFailed(
+                    s"Reward sharing percentages for $party must sum to at most 1.0"
+                  ),
+                )
+              } yield ()
+          }
         } yield conf
       }
     implicit val validatorClientConfigReader: ConfigReader[ValidatorAppClientConfig] =
@@ -1085,6 +1113,10 @@ object SpliceConfig {
       deriveWriter[WalletSweepConfig]
     implicit val autoAcceptTransfersConfigWriter: ConfigWriter[AutoAcceptTransfersConfig] =
       deriveWriter[AutoAcceptTransfersConfig]
+    implicit val appRewardBeneficiaryConfigWriter: ConfigWriter[AppRewardBeneficiaryConfig] =
+      deriveWriter[AppRewardBeneficiaryConfig]
+    implicit val rewardSharingConfigWriter: ConfigWriter[RewardSharingConfig] =
+      deriveWriter[RewardSharingConfig]
     implicit val validatorDecentralizedSynchronizerConfigWriter
         : ConfigWriter[ValidatorDecentralizedSynchronizerConfig] =
       deriveWriter[ValidatorDecentralizedSynchronizerConfig]

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
@@ -78,4 +78,79 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
       SpliceConfig.loadAndValidate(buggyConfig) shouldBe a[Right[?, ?]]
     }
   }
+
+  "rewardSharingByParty" should {
+
+    def mkSharingConfig(beneficiaries: String): String =
+      s"""
+        |canton.validator-apps.aliceValidator.reward-sharing-by-party = {
+        |  "alice::1220abc" = {
+        |    beneficiaries = [$beneficiaries]
+        |    min-ttl-after-sharing = 30h
+        |  }
+        |}
+        """.stripMargin
+
+    def mkBeneficiary(name: String, percentage: String): String =
+      s"""{ beneficiary = "$name::1220", percentage = $percentage }"""
+
+    Seq(
+      ("two beneficiaries", "0.3, 0.2"),
+      ("single beneficiary", "0.5"),
+      ("small percentage", "0.01"),
+      ("percentage exactly 1.0", "1.0"),
+      ("near-total split", "0.5, 0.49"),
+      ("exact total split", "0.6, 0.4"),
+      ("three-way even split", "0.33, 0.33, 0.33"),
+      ("high precision", "0.123456789, 0.876543210"),
+      ("ten decimal places", "0.0000000001"),
+      ("empty beneficiaries", ""),
+    ).foreach { case (desc, percentages) =>
+      val beneficiaries = percentages
+        .split(",")
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .zipWithIndex
+        .map { case (pct, i) => mkBeneficiary(s"party$i", pct) }
+        .mkString(", ")
+
+      s"accept $desc ($percentages)" in {
+        val overwrite = ConfigFactory.parseString(mkSharingConfig(beneficiaries))
+        val validConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
+        SpliceConfig.loadAndValidate(validConfig) shouldBe a[Right[?, ?]]
+      }
+    }
+
+    Seq(
+      ("percentage > 1.0", "1.5", "must be in (0.0, 1.0]"),
+      ("percentage = 0", "0.0", "must be in (0.0, 1.0]"),
+      ("negative percentage", "-0.1", "must be in (0.0, 1.0]"),
+    ).foreach { case (desc, percentage, expectedError) =>
+      s"reject $desc" in {
+        val overwrite =
+          ConfigFactory.parseString(mkSharingConfig(mkBeneficiary("charlie", percentage)))
+        val buggyConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
+        SpliceConfig.loadAndValidate(buggyConfig).left.value.toString should include(expectedError)
+      }
+    }
+
+    Seq(
+      ("sum > 1.0", "0.6, 0.5"),
+    ).foreach { case (desc, percentages) =>
+      val beneficiaries = percentages
+        .split(",")
+        .map(_.trim)
+        .zipWithIndex
+        .map { case (pct, i) => mkBeneficiary(s"party$i", pct) }
+        .mkString(", ")
+
+      s"reject percentages with $desc" in {
+        val overwrite = ConfigFactory.parseString(mkSharingConfig(beneficiaries))
+        val buggyConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
+        SpliceConfig.loadAndValidate(buggyConfig).left.value.toString should include(
+          "must sum to at most 1.0"
+        )
+      }
+    }
+  }
 }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
@@ -159,11 +159,11 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
     }
   }
 
-  "rewardSharingByParty" should {
+  "rewardSharingConfigByParty" should {
 
     def mkHoconConfig(beneficiaries: String): String =
       s"""
-        |canton.validator-apps.aliceValidator.reward-sharing-by-party = {
+        |canton.validator-apps.aliceValidator.reward-sharing-config-by-party = {
         |  "alice::1220abc" = {
         |    beneficiaries = [$beneficiaries]
         |    min-ttl-after-sharing = 30h

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
@@ -5,6 +5,13 @@ import com.digitalasset.canton.config.CantonConfig
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AsyncWordSpec
 
+import org.lfdecentralizedtrust.splice.wallet.config.{
+  AppRewardBeneficiaryConfig,
+  RewardSharingConfig,
+}
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import com.digitalasset.canton.topology.PartyId
+
 class SpliceConfigTest extends AsyncWordSpec with BaseTest {
   private implicit val elc: com.digitalasset.canton.logging.ErrorLoggingContext = SpliceConfig.elc
   val config = ConfigFactory.parseFile(
@@ -79,6 +86,103 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
     }
   }
 
+  "RewardSharingConfig.providerRemainder" should {
+    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
+      RewardSharingConfig(
+        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
+        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
+          AppRewardBeneficiaryConfig(
+            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
+            pct,
+          )
+        },
+      )
+
+    Seq(
+      ("no beneficiaries", Seq.empty[BigDecimal], BigDecimal(1.0)),
+      ("single beneficiary", Seq(BigDecimal(0.3)), BigDecimal(0.7)),
+      ("two beneficiaries", Seq(BigDecimal(0.3), BigDecimal(0.2)), BigDecimal(0.5)),
+      ("full allocation", Seq(BigDecimal(1.0)), BigDecimal(0.0)),
+      ("near-total", Seq(BigDecimal(0.5), BigDecimal(0.49)), BigDecimal(0.01)),
+    ).foreach { case (desc, percentages, expected) =>
+      s"return $expected for $desc" in {
+        mkConfig(percentages*).providerRemainder shouldBe expected
+      }
+    }
+  }
+
+  "RewardSharingConfig.allBeneficiaries" should {
+    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
+      RewardSharingConfig(
+        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
+        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
+          AppRewardBeneficiaryConfig(
+            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
+            pct,
+          )
+        },
+      )
+
+    val provider = PartyId.tryFromProtoPrimitive("provider::1220")
+
+    "include provider with remainder" in {
+      val all = mkConfig(BigDecimal(0.3), BigDecimal(0.2)).allBeneficiaries(provider)
+      all should have size 3
+      all.last.beneficiary shouldBe provider
+      all.last.percentage shouldBe BigDecimal(0.5)
+    }
+
+    "exclude provider when fully allocated" in {
+      val all = mkConfig(BigDecimal(1.0)).allBeneficiaries(provider)
+      all should have size 1
+      all.headOption.value.beneficiary shouldBe PartyId.tryFromProtoPrimitive("party0::1220")
+    }
+
+    "return only provider when no beneficiaries" in {
+      val all = mkConfig().allBeneficiaries(provider)
+      all should have size 1
+      all.headOption.value.beneficiary shouldBe provider
+      all.headOption.value.percentage shouldBe BigDecimal(1.0)
+    }
+  }
+
+  "RewardSharingConfig.allDamlBeneficiaries" should {
+    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
+      RewardSharingConfig(
+        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
+        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
+          AppRewardBeneficiaryConfig(
+            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
+            pct,
+          )
+        },
+      )
+
+    val provider = PartyId.tryFromProtoPrimitive("provider::1220")
+
+    "convert percentages to Daml Decimal scale 10" in {
+      val all = mkConfig(BigDecimal(0.3), BigDecimal(0.2)).allDamlBeneficiaries(provider)
+      all should have size 3
+      all.map(_._2.scale()) shouldBe Seq(10, 10, 10)
+    }
+
+    Seq(
+      ("two-way split", Seq(BigDecimal(0.3), BigDecimal(0.2))),
+      ("three-way split", Seq(BigDecimal(0.33), BigDecimal(0.33), BigDecimal(0.33))),
+      ("high precision", Seq(BigDecimal(0.123456789), BigDecimal(0.876543210))),
+      ("single beneficiary", Seq(BigDecimal(0.5))),
+      ("full allocation", Seq(BigDecimal(1.0))),
+      ("near-total", Seq(BigDecimal(0.5), BigDecimal(0.49))),
+      ("no beneficiaries", Seq.empty[BigDecimal]),
+    ).foreach { case (desc, percentages) =>
+      s"$desc sums to exactly 1.0 at Daml precision" in {
+        val all = mkConfig(percentages*).allDamlBeneficiaries(provider)
+        val sum = all.map(_._2).foldLeft(java.math.BigDecimal.ZERO)(_.add(_))
+        sum.compareTo(java.math.BigDecimal.ONE) shouldBe 0
+      }
+    }
+  }
+
   "rewardSharingByParty" should {
 
     def mkSharingConfig(beneficiaries: String): String =
@@ -135,7 +239,7 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
     }
 
     Seq(
-      ("sum > 1.0", "0.6, 0.5"),
+      ("sum > 1.0", "0.6, 0.5")
     ).foreach { case (desc, percentages) =>
       val beneficiaries = percentages
         .split(",")

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/config/SpliceConfigTest.scala
@@ -86,18 +86,21 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
     }
   }
 
-  "RewardSharingConfig.providerRemainder" should {
-    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
-      RewardSharingConfig(
-        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
-        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
-          AppRewardBeneficiaryConfig(
-            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
-            pct,
-          )
-        },
-      )
+  // Shared helper for RewardSharingConfig tests
+  private def mkSharingCfg(percentages: BigDecimal*): RewardSharingConfig =
+    RewardSharingConfig(
+      minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
+      beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
+        AppRewardBeneficiaryConfig(
+          PartyId.tryFromProtoPrimitive(s"party$i::1220"),
+          pct,
+        )
+      },
+    )
 
+  private val provider = PartyId.tryFromProtoPrimitive("provider::1220")
+
+  "RewardSharingConfig.providerRemainder" should {
     Seq(
       ("no beneficiaries", Seq.empty[BigDecimal], BigDecimal(1.0)),
       ("single beneficiary", Seq(BigDecimal(0.3)), BigDecimal(0.7)),
@@ -106,40 +109,27 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
       ("near-total", Seq(BigDecimal(0.5), BigDecimal(0.49)), BigDecimal(0.01)),
     ).foreach { case (desc, percentages, expected) =>
       s"return $expected for $desc" in {
-        mkConfig(percentages*).providerRemainder shouldBe expected
+        mkSharingCfg(percentages*).providerRemainder shouldBe expected
       }
     }
   }
 
   "RewardSharingConfig.allBeneficiaries" should {
-    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
-      RewardSharingConfig(
-        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
-        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
-          AppRewardBeneficiaryConfig(
-            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
-            pct,
-          )
-        },
-      )
-
-    val provider = PartyId.tryFromProtoPrimitive("provider::1220")
-
     "include provider with remainder" in {
-      val all = mkConfig(BigDecimal(0.3), BigDecimal(0.2)).allBeneficiaries(provider)
+      val all = mkSharingCfg(BigDecimal(0.3), BigDecimal(0.2)).allBeneficiaries(provider)
       all should have size 3
       all.last.beneficiary shouldBe provider
       all.last.percentage shouldBe BigDecimal(0.5)
     }
 
     "exclude provider when fully allocated" in {
-      val all = mkConfig(BigDecimal(1.0)).allBeneficiaries(provider)
+      val all = mkSharingCfg(BigDecimal(1.0)).allBeneficiaries(provider)
       all should have size 1
       all.headOption.value.beneficiary shouldBe PartyId.tryFromProtoPrimitive("party0::1220")
     }
 
     "return only provider when no beneficiaries" in {
-      val all = mkConfig().allBeneficiaries(provider)
+      val all = mkSharingCfg().allBeneficiaries(provider)
       all should have size 1
       all.headOption.value.beneficiary shouldBe provider
       all.headOption.value.percentage shouldBe BigDecimal(1.0)
@@ -147,21 +137,8 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
   }
 
   "RewardSharingConfig.allDamlBeneficiaries" should {
-    def mkConfig(percentages: BigDecimal*): RewardSharingConfig =
-      RewardSharingConfig(
-        minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
-        beneficiaries = percentages.zipWithIndex.map { case (pct, i) =>
-          AppRewardBeneficiaryConfig(
-            PartyId.tryFromProtoPrimitive(s"party$i::1220"),
-            pct,
-          )
-        },
-      )
-
-    val provider = PartyId.tryFromProtoPrimitive("provider::1220")
-
     "convert percentages to Daml Decimal scale 10" in {
-      val all = mkConfig(BigDecimal(0.3), BigDecimal(0.2)).allDamlBeneficiaries(provider)
+      val all = mkSharingCfg(BigDecimal(0.3), BigDecimal(0.2)).allDamlBeneficiaries(provider)
       all should have size 3
       all.map(_._2.scale()) shouldBe Seq(10, 10, 10)
     }
@@ -172,11 +149,10 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
       ("high precision", Seq(BigDecimal(0.123456789), BigDecimal(0.876543210))),
       ("single beneficiary", Seq(BigDecimal(0.5))),
       ("full allocation", Seq(BigDecimal(1.0))),
-      ("near-total", Seq(BigDecimal(0.5), BigDecimal(0.49))),
       ("no beneficiaries", Seq.empty[BigDecimal]),
     ).foreach { case (desc, percentages) =>
       s"$desc sums to exactly 1.0 at Daml precision" in {
-        val all = mkConfig(percentages*).allDamlBeneficiaries(provider)
+        val all = mkSharingCfg(percentages*).allDamlBeneficiaries(provider)
         val sum = all.map(_._2).foldLeft(java.math.BigDecimal.ZERO)(_.add(_))
         sum.compareTo(java.math.BigDecimal.ONE) shouldBe 0
       }
@@ -185,7 +161,7 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
 
   "rewardSharingByParty" should {
 
-    def mkSharingConfig(beneficiaries: String): String =
+    def mkHoconConfig(beneficiaries: String): String =
       s"""
         |canton.validator-apps.aliceValidator.reward-sharing-by-party = {
         |  "alice::1220abc" = {
@@ -198,19 +174,8 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
     def mkBeneficiary(name: String, percentage: String): String =
       s"""{ beneficiary = "$name::1220", percentage = $percentage }"""
 
-    Seq(
-      ("two beneficiaries", "0.3, 0.2"),
-      ("single beneficiary", "0.5"),
-      ("small percentage", "0.01"),
-      ("percentage exactly 1.0", "1.0"),
-      ("near-total split", "0.5, 0.49"),
-      ("exact total split", "0.6, 0.4"),
-      ("three-way even split", "0.33, 0.33, 0.33"),
-      ("high precision", "0.123456789, 0.876543210"),
-      ("ten decimal places", "0.0000000001"),
-      ("empty beneficiaries", ""),
-    ).foreach { case (desc, percentages) =>
-      val beneficiaries = percentages
+    def beneficiariesFromPcts(percentages: String): String =
+      percentages
         .split(",")
         .map(_.trim)
         .filter(_.nonEmpty)
@@ -218,8 +183,19 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
         .map { case (pct, i) => mkBeneficiary(s"party$i", pct) }
         .mkString(", ")
 
+    Seq(
+      ("two beneficiaries", "0.3, 0.2"),
+      ("single beneficiary", "0.5"),
+      ("small percentage", "0.01"),
+      ("percentage exactly 1.0", "1.0"),
+      ("exact total split", "0.6, 0.4"),
+      ("three-way even split", "0.33, 0.33, 0.33"),
+      ("high precision", "0.123456789, 0.876543210"),
+      ("empty beneficiaries", ""),
+    ).foreach { case (desc, percentages) =>
       s"accept $desc ($percentages)" in {
-        val overwrite = ConfigFactory.parseString(mkSharingConfig(beneficiaries))
+        val overwrite =
+          ConfigFactory.parseString(mkHoconConfig(beneficiariesFromPcts(percentages)))
         val validConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
         SpliceConfig.loadAndValidate(validConfig) shouldBe a[Right[?, ?]]
       }
@@ -229,31 +205,15 @@ class SpliceConfigTest extends AsyncWordSpec with BaseTest {
       ("percentage > 1.0", "1.5", "must be in (0.0, 1.0]"),
       ("percentage = 0", "0.0", "must be in (0.0, 1.0]"),
       ("negative percentage", "-0.1", "must be in (0.0, 1.0]"),
+      ("sum > 1.0", "0.6, 0.5", "must sum to at most 1.0"),
     ).foreach { case (desc, percentage, expectedError) =>
       s"reject $desc" in {
-        val overwrite =
-          ConfigFactory.parseString(mkSharingConfig(mkBeneficiary("charlie", percentage)))
+        val beneficiaries =
+          if (percentage.contains(",")) beneficiariesFromPcts(percentage)
+          else mkBeneficiary("charlie", percentage)
+        val overwrite = ConfigFactory.parseString(mkHoconConfig(beneficiaries))
         val buggyConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
         SpliceConfig.loadAndValidate(buggyConfig).left.value.toString should include(expectedError)
-      }
-    }
-
-    Seq(
-      ("sum > 1.0", "0.6, 0.5")
-    ).foreach { case (desc, percentages) =>
-      val beneficiaries = percentages
-        .split(",")
-        .map(_.trim)
-        .zipWithIndex
-        .map { case (pct, i) => mkBeneficiary(s"party$i", pct) }
-        .mkString(", ")
-
-      s"reject percentages with $desc" in {
-        val overwrite = ConfigFactory.parseString(mkSharingConfig(beneficiaries))
-        val buggyConfig = CantonConfig.mergeConfigs(config, Seq(overwrite))
-        SpliceConfig.loadAndValidate(buggyConfig).left.value.toString should include(
-          "must sum to at most 1.0"
-        )
       }
     }
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -544,7 +544,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
 
           // Create RewardCouponV2 (assigned to beneficiary)
           createRewardCouponsV2(
-            Seq((beneficiaryParty.party, rewardCouponV2Amount, beneficiaryParty.party)),
+            Seq((beneficiaryParty.party, rewardCouponV2Amount, Some(beneficiaryParty.party))),
             round = Some(issuingRound.round),
           )
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -574,7 +574,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
               .listDevelopmentFundCoupons()
               .futureValue shouldBe empty withClue "DevelopmentFundCoupon"
             externalPartyWallet.store
-              .listSortedAssignedRewardCouponV2s(issuingRoundsMap)
+              .listSortedMintableRewardCouponV2s(issuingRoundsMap, includeUnassigned = true)
               .futureValue shouldBe empty withClue "RewardCouponV2"
           }
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
@@ -1,13 +1,22 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
-import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
-import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
-import org.lfdecentralizedtrust.splice.util.{SpliceUtil, TimeTestUtil, WalletTestUtil}
-import org.lfdecentralizedtrust.splice.validator.automation.ReceiveFaucetCouponTrigger
+import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import com.digitalasset.canton.topology.PartyId
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.{
   AppRewardCoupon,
   RewardCouponV2,
   ValidatorRewardCoupon,
+}
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms.updateAllValidatorConfigs
+import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
+import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
+import org.lfdecentralizedtrust.splice.util.{SpliceUtil, TimeTestUtil, WalletTestUtil}
+import org.lfdecentralizedtrust.splice.validator.automation.ReceiveFaucetCouponTrigger
+import org.lfdecentralizedtrust.splice.wallet.config.{
+  AppRewardBeneficiaryConfig,
+  RewardSharingConfig,
 }
 
 import scala.concurrent.duration.DurationInt
@@ -22,6 +31,33 @@ class WalletRewardsTimeBasedIntegrationTest
       .simpleTopology1SvWithSimTime(this.getClass.getSimpleName)
       // TODO (#965) remove and fix test failures
       .withAmuletPrice(walletAmuletPrice)
+      .addConfigTransforms((_, config) => {
+        def validatorPartyId(validatorUser: String, validatorName: String): PartyId = {
+          val participant =
+            ConfigTransforms.getParticipantIds(config.parameters.clock)(validatorUser)
+          val partyHint =
+            config.validatorApps(InstanceName.tryCreate(validatorName)).validatorPartyHint.value
+          PartyId.tryFromProtoPrimitive(s"${partyHint}::${participant.split("::").last}")
+        }
+        val aliceValidatorPartyId = validatorPartyId("alice_validator_user", "aliceValidator")
+        val bobPartyId = validatorPartyId("bob_validator_user", "bobValidator")
+        updateAllValidatorConfigs { case (name, c) =>
+          if (name == "aliceValidator") {
+            // Specify a RewardConfig for Alice's validator,
+            // so that unassigned RewardCouponV2 should not get minted
+            c.copy(
+              rewardSharingByParty = Map(
+                aliceValidatorPartyId.toProtoPrimitive -> RewardSharingConfig(
+                  minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
+                  beneficiaries = Seq(
+                    AppRewardBeneficiaryConfig(bobPartyId, BigDecimal(0.4))
+                  ),
+                )
+              )
+            )
+          } else c
+        }(config)
+      })
 
   // TODO (#965) remove and fix test failures
   override def walletAmuletPrice = SpliceUtil.damlDecimal(1.0)
@@ -61,10 +97,16 @@ class WalletRewardsTimeBasedIntegrationTest
         validatorRewards = Seq((bob, 0.33)),
       )
 
+      // Create unassigned V2 coupons for both validators.
+      // Bob (no sharing config) → treasury mints unassigned coupons.
+      // Alice (has sharing config) → treasury does NOT mint unassigned coupons.
       val rewardCouponV2Amount = BigDecimal(1000.0)
-      clue("Create assigned RewardCouponV2 for bob's validator") {
+      clue("Create unassigned RewardCouponV2 for both validators") {
         createRewardCouponsV2(
-          Seq((bobValidatorParty, rewardCouponV2Amount, Some(bobValidatorParty)))
+          Seq(
+            (bobValidatorParty, rewardCouponV2Amount, None),
+            (aliceValidatorParty, rewardCouponV2Amount, None),
+          )
         )
       }
 
@@ -131,6 +173,22 @@ class WalletRewardsTimeBasedIntegrationTest
             walletUsdToAmulet(0.5 + faucetCouponAmountUsd) + rewardCouponV2Amount,
           ),
         )
+      }
+
+      clue("Alice's unassigned V2 coupon is NOT minted (sharing config present)") {
+        val aliceWallet = aliceValidatorBackend.appState.walletManager
+          .valueOrFail("WalletManager is expected to be defined")
+          .lookupEndUserPartyWallet(aliceValidatorParty)
+          .valueOrFail("Expected alice to have a wallet")
+        val unassigned = aliceWallet.store.multiDomainAcsStore
+          .listContracts(RewardCouponV2.COMPANION)
+          .futureValue
+          .filter(c =>
+            c.payload.provider == aliceValidatorParty.toProtoPrimitive &&
+              c.payload.beneficiary.isEmpty
+          )
+        unassigned should have size 1 withClue
+          "Unassigned V2 coupon should remain (not minted) because sharing config is present"
       }
     }
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
@@ -64,7 +64,7 @@ class WalletRewardsTimeBasedIntegrationTest
       val rewardCouponV2Amount = BigDecimal(1000.0)
       clue("Create assigned RewardCouponV2 for bob's validator") {
         createRewardCouponsV2(
-          Seq((bobValidatorParty, rewardCouponV2Amount, bobValidatorParty))
+          Seq((bobValidatorParty, rewardCouponV2Amount, Some(bobValidatorParty)))
         )
       }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
@@ -46,7 +46,7 @@ class WalletRewardsTimeBasedIntegrationTest
             // Specify a RewardConfig for Alice's validator,
             // so that unassigned RewardCouponV2 should not get minted
             c.copy(
-              rewardSharingByParty = Map(
+              rewardSharingConfigByParty = Map(
                 aliceValidatorPartyId.toProtoPrimitive -> RewardSharingConfig(
                   minTtlAfterSharing = NonNegativeFiniteDuration.ofHours(30),
                   beneficiaries = Seq(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -1439,14 +1439,14 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
   }
 
   def createRewardCouponsV2(
-      coupons: Seq[(PartyId, BigDecimal, PartyId)],
+      coupons: Seq[(PartyId, BigDecimal, Option[PartyId])],
       round: Option[splice.types.Round] = None,
   )(implicit env: SpliceTestConsoleEnvironment): Unit = {
     val now = env.environment.clock.now
     val couponRound = round.getOrElse(sv1ScanBackend.getLatestOpenMiningRound(now).payload.round)
     sv1Backend.participantClientWithAdminToken.ledger_api_extensions.commands.submitJava(
       actAs = Seq(dsoParty),
-      commands = coupons.flatMap { case (provider, amount, beneficiary) =>
+      commands = coupons.flatMap { case (provider, amount, beneficiaryO) =>
         new splice.amulet.RewardCouponV2(
           dsoParty.toProtoPrimitive,
           provider.toProtoPrimitive,
@@ -1454,7 +1454,9 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
           amount.bigDecimal,
           now.plus(java.time.Duration.ofDays(1)).toInstant,
           true,
-          java.util.Optional.of(beneficiary.toProtoPrimitive),
+          beneficiaryO.fold(java.util.Optional.empty[String]())(b =>
+            java.util.Optional.of(b.toProtoPrimitive)
+          ),
         ).create.commands.asScala
       },
     )

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/WalletTestUtil.scala
@@ -1454,9 +1454,7 @@ trait WalletTestUtil extends TestCommon with AnsTestUtil {
           amount.bigDecimal,
           now.plus(java.time.Duration.ofDays(1)).toInstant,
           true,
-          beneficiaryO.fold(java.util.Optional.empty[String]())(b =>
-            java.util.Optional.of(b.toProtoPrimitive)
-          ),
+          beneficiaryO.map(_.toProtoPrimitive).toJava,
         ).create.commands.asScala
       },
     )

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
@@ -118,9 +118,7 @@ trait TransferInputStore extends AppStore with LimitHelpers {
 
   /** Returns mintable RewardCouponV2 sorted by round ascending, amount descending.
     * When `includeUnassigned` is true, includes coupons where the party is provider
-    * with no beneficiary (for providers without sharing config).
-    * Always includes coupons where the party is the assigned beneficiary.
-    * Always excludes coupons assigned to a different party.
+    * with no beneficiary
     */
   def listSortedMintableRewardCouponV2s(
       issuingRoundsMap: Map[Round, IssuingMiningRound],

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
@@ -116,11 +116,15 @@ trait TransferInputStore extends AppStore with LimitHelpers {
         ),
     )
 
-  /** Returns assigned RewardCouponV2 sorted by round ascending, amount descending.
-    * Only includes coupons with an assigned beneficiary from the given `activeIssuingRounds`.
+  /** Returns mintable RewardCouponV2 sorted by round ascending, amount descending.
+    * When `includeUnassigned` is true, includes coupons where the party is provider
+    * with no beneficiary (for providers without sharing config).
+    * Always includes coupons where the party is the assigned beneficiary.
+    * Always excludes coupons assigned to a different party.
     */
-  def listSortedAssignedRewardCouponV2s(
+  def listSortedMintableRewardCouponV2s(
       issuingRoundsMap: Map[Round, IssuingMiningRound],
+      includeUnassigned: Boolean,
       limit: Limit = defaultLimit,
   )(implicit tc: TraceContext): Future[Seq[
     (Contract[RewardCouponV2.ContractId, RewardCouponV2], BigDecimal)
@@ -130,12 +134,13 @@ trait TransferInputStore extends AppStore with LimitHelpers {
         RewardCouponV2.COMPANION
       )
     } yield applyLimit(
-      "listSortedAssignedRewardCouponV2s",
+      "listSortedMintableRewardCouponV2s",
       limit,
       rewards
         .filter { rw =>
-          rw.payload.beneficiary.isPresent &&
-          issuingRoundsMap.contains(rw.payload.round)
+          issuingRoundsMap.contains(rw.payload.round) &&
+          (rw.payload.beneficiary.isPresent ||
+            (includeUnassigned && rw.payload.beneficiary.isEmpty))
         }
         .map(rw => (rw.contract, BigDecimal(rw.payload.amount)))
         .sorted(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/TransferInputStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/TransferInputStoreTest.scala
@@ -102,7 +102,7 @@ abstract class TransferInputStoreTest extends StoreTestBase {
     }
   }
 
-  "listSortedAssignedRewardCouponV2s" should {
+  "listSortedMintableRewardCouponV2s" should {
     "return correct results" in {
       for {
         store <- mkTransferInputStore(user)
@@ -131,24 +131,34 @@ abstract class TransferInputStoreTest extends StoreTestBase {
             )(store.multiDomainAcsStore)
           } yield ()
         )
-        // unassigned coupon in round 2 — should be excluded from results
+        // unassigned coupon in round 2 — should be excluded when includeUnassigned is false
         _ <- dummyDomain.create(
           rewardCouponV2(round = 2, provider = user, amount = numeric(20), beneficiary = None),
           createdEventSignatories = Seq(dsoParty),
           createdEventObservers = Seq(user),
         )(store.multiDomainAcsStore)
       } yield {
-        store.listSortedAssignedRewardCouponV2s(Map.empty).futureValue shouldBe empty
+        store
+          .listSortedMintableRewardCouponV2s(Map.empty, includeUnassigned = false)
+          .futureValue shouldBe empty
         val roundsToFilter = (2 to 4).map(n => issuingMiningRound(dsoParty, n.toLong))
+        val issuingMap = roundsToFilter.map(r => r.payload.round -> r.payload).toMap
         // assigned coupons listed in ascending round order, descending amount per round;
         // the unassigned coupon (amount=20) in round 2 is excluded
         store
-          .listSortedAssignedRewardCouponV2s(
-            roundsToFilter.map(r => r.payload.round -> r.payload).toMap
-          )
+          .listSortedMintableRewardCouponV2s(issuingMap, includeUnassigned = false)
           .futureValue
           .map(_._1.payload.amount.doubleValue()) should contain theSameElementsInOrderAs Seq(
           4.0, 2.0, // round 2 (unassigned 20.0 excluded)
+          6.0, 3.0, // round 3
+          8.0, 4.0, // round 4
+        )
+        // with includeUnassigned, the unassigned coupon (20.0) appears in round 2
+        store
+          .listSortedMintableRewardCouponV2s(issuingMap, includeUnassigned = true)
+          .futureValue
+          .map(_._1.payload.amount.doubleValue()) should contain theSameElementsInOrderAs Seq(
+          20.0, 4.0, 2.0, // round 2 (unassigned 20.0 included)
           6.0, 3.0, // round 3
           8.0, 4.0, // round 4
         )

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -734,6 +734,7 @@ class ValidatorApp(
             validatorTopupConfig,
             config.walletSweep,
             config.autoAcceptTransfers,
+            config.rewardSharingByParty,
             dedupDuration,
             config.parameters,
           )

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -714,6 +714,7 @@ class ValidatorApp(
             config.parameters,
             scanConnection,
             packageVersionSupport,
+            config.rewardSharingByParty,
           )
           val walletManager = new UserWalletManager(
             ledgerClient,

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/ValidatorApp.scala
@@ -714,7 +714,7 @@ class ValidatorApp(
             config.parameters,
             scanConnection,
             packageVersionSupport,
-            config.rewardSharingByParty,
+            config.rewardSharingConfigByParty,
           )
           val walletManager = new UserWalletManager(
             ledgerClient,
@@ -735,7 +735,7 @@ class ValidatorApp(
             validatorTopupConfig,
             config.walletSweep,
             config.autoAcceptTransfers,
-            config.rewardSharingByParty,
+            config.rewardSharingConfigByParty,
             dedupDuration,
             config.parameters,
           )

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -186,7 +186,7 @@ case class ValidatorAppBackendConfig(
       */
     autoAcceptTransfers: Map[String, AutoAcceptTransfersConfig] = Map.empty,
 
-    /** The configuration for sharing reward coupons with beneficiaries
+    /** The configuration for sharing app reward coupons from traffic-based app rewards with beneficiaries
       */
     rewardSharingByParty: Map[String, RewardSharingConfig] = Map.empty,
     // We don't make this optional to encourage users to think about it at least. They

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -12,6 +12,7 @@ import org.lfdecentralizedtrust.splice.scan.config.ScanAppClientConfig
 import org.lfdecentralizedtrust.splice.sv.SvAppClientConfig
 import org.lfdecentralizedtrust.splice.wallet.config.{
   AutoAcceptTransfersConfig,
+  RewardSharingConfig,
   TransferPreapprovalConfig,
   TreasuryConfig,
   WalletSweepConfig,
@@ -184,6 +185,10 @@ case class ValidatorAppBackendConfig(
     /** The configuration for auto-accepting transfers from other parties
       */
     autoAcceptTransfers: Map[String, AutoAcceptTransfersConfig] = Map.empty,
+
+    /** The configuration for sharing reward coupons with beneficiaries
+      */
+    rewardSharingByParty: Map[String, RewardSharingConfig] = Map.empty,
     // We don't make this optional to encourage users to think about it at least. They
     // can always set it to an empty string.
     contactPoint: String,

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/config/ValidatorAppConfig.scala
@@ -188,7 +188,7 @@ case class ValidatorAppBackendConfig(
 
     /** The configuration for sharing app reward coupons from traffic-based app rewards with beneficiaries
       */
-    rewardSharingByParty: Map[String, RewardSharingConfig] = Map.empty,
+    rewardSharingConfigByParty: Map[String, RewardSharingConfig] = Map.empty,
     // We don't make this optional to encourage users to think about it at least. They
     // can always set it to an empty string.
     contactPoint: String,

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
@@ -22,6 +22,7 @@ import org.lfdecentralizedtrust.splice.environment.{
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.{DomainTimeSynchronization, LimitHelpers}
 import org.lfdecentralizedtrust.splice.util.TemplateJsonDecoder
+import org.lfdecentralizedtrust.splice.wallet.config.RewardSharingConfig
 import org.lfdecentralizedtrust.splice.wallet.store.{ExternalPartyWalletStore, WalletStore}
 
 import scala.collection.concurrent.TrieMap
@@ -43,6 +44,7 @@ class ExternalPartyWalletManager(
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
     packageVersionSupport: PackageVersionSupport,
+    rewardSharingByParty: Map[String, RewardSharingConfig],
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -172,6 +174,7 @@ class ExternalPartyWalletManager(
       params,
       scanConnection,
       packageVersionSupport,
+      rewardSharingByParty.get(externalParty.toProtoPrimitive),
     )
     (externalPartyRetryProvider, walletService)
   }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletManager.scala
@@ -44,7 +44,7 @@ class ExternalPartyWalletManager(
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
     packageVersionSupport: PackageVersionSupport,
-    rewardSharingByParty: Map[String, RewardSharingConfig],
+    rewardSharingConfigByParty: Map[String, RewardSharingConfig],
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -174,7 +174,7 @@ class ExternalPartyWalletManager(
       params,
       scanConnection,
       packageVersionSupport,
-      rewardSharingByParty.get(externalParty.toProtoPrimitive),
+      rewardSharingConfigByParty.getOrElse(externalParty.toProtoPrimitive, RewardSharingConfig()),
     )
     (externalPartyRetryProvider, walletService)
   }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
@@ -36,7 +36,7 @@ class ExternalPartyWalletService(
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
     packageVersionSupport: PackageVersionSupport,
-    rewardSharingO: Option[RewardSharingConfig],
+    rewardSharingConfig: RewardSharingConfig,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -70,7 +70,7 @@ class ExternalPartyWalletService(
     scanConnection,
     loggerFactory,
     packageVersionSupport,
-    rewardSharingO,
+    rewardSharingConfig,
   )
 
   override def onClosed(): Unit = {

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/ExternalPartyWalletService.scala
@@ -16,6 +16,7 @@ import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.DomainTimeSynchronization
 import org.lfdecentralizedtrust.splice.util.TemplateJsonDecoder
 import org.lfdecentralizedtrust.splice.wallet.automation.ExternalPartyWalletAutomationService
+import org.lfdecentralizedtrust.splice.wallet.config.RewardSharingConfig
 import org.lfdecentralizedtrust.splice.wallet.store.ExternalPartyWalletStore
 
 import scala.concurrent.ExecutionContext
@@ -35,6 +36,7 @@ class ExternalPartyWalletService(
     params: SpliceParametersConfig,
     scanConnection: BftScanConnection,
     packageVersionSupport: PackageVersionSupport,
+    rewardSharingO: Option[RewardSharingConfig],
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -68,6 +70,7 @@ class ExternalPartyWalletService(
     scanConnection,
     loggerFactory,
     packageVersionSupport,
+    rewardSharingO,
   )
 
   override def onClosed(): Unit = {

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletManager.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletManager.scala
@@ -18,6 +18,7 @@ import org.lfdecentralizedtrust.splice.store.{DomainTimeSynchronization, Limit, 
 import org.lfdecentralizedtrust.splice.util.{Contract, HasHealth, TemplateJsonDecoder}
 import org.lfdecentralizedtrust.splice.wallet.config.{
   AutoAcceptTransfersConfig,
+  RewardSharingConfig,
   TreasuryConfig,
   WalletSweepConfig,
 }
@@ -57,6 +58,7 @@ class UserWalletManager(
     validatorTopupConfig: ValidatorTopupConfig,
     walletSweep: Map[String, WalletSweepConfig],
     autoAcceptTransfers: Map[String, AutoAcceptTransfersConfig],
+    rewardSharingByParty: Map[String, RewardSharingConfig],
     dedupDuration: DedupDuration,
     params: SpliceParametersConfig,
 )(implicit
@@ -230,6 +232,7 @@ class UserWalletManager(
       // TODO(DACH-NY/canton-network-node#12554): make it easier to configure the sweep functionality and guard better against operator errors (typos, etc.)
       walletSweep.get(endUserParty.toProtoPrimitive),
       autoAcceptTransfers.get(endUserParty.toProtoPrimitive),
+      rewardSharingByParty.get(endUserParty.toProtoPrimitive),
       dedupDuration,
       params,
     )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletManager.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletManager.scala
@@ -58,7 +58,7 @@ class UserWalletManager(
     validatorTopupConfig: ValidatorTopupConfig,
     walletSweep: Map[String, WalletSweepConfig],
     autoAcceptTransfers: Map[String, AutoAcceptTransfersConfig],
-    rewardSharingByParty: Map[String, RewardSharingConfig],
+    rewardSharingConfigByParty: Map[String, RewardSharingConfig],
     dedupDuration: DedupDuration,
     params: SpliceParametersConfig,
 )(implicit
@@ -232,7 +232,7 @@ class UserWalletManager(
       // TODO(DACH-NY/canton-network-node#12554): make it easier to configure the sweep functionality and guard better against operator errors (typos, etc.)
       walletSweep.get(endUserParty.toProtoPrimitive),
       autoAcceptTransfers.get(endUserParty.toProtoPrimitive),
-      rewardSharingByParty.get(endUserParty.toProtoPrimitive),
+      rewardSharingConfigByParty.getOrElse(endUserParty.toProtoPrimitive, RewardSharingConfig()),
       dedupDuration,
       params,
     )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
@@ -114,7 +114,6 @@ class UserWalletService(
     validatorTopupConfigO,
     walletSweep,
     autoAcceptTransfers,
-    rewardSharingConfig,
     dedupDuration,
     params,
   )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
@@ -12,6 +12,7 @@ import org.lfdecentralizedtrust.splice.util.{HasHealth, SpliceCircuitBreaker, Te
 import org.lfdecentralizedtrust.splice.wallet.automation.UserWalletAutomationService
 import org.lfdecentralizedtrust.splice.wallet.config.{
   AutoAcceptTransfersConfig,
+  RewardSharingConfig,
   TreasuryConfig,
   WalletSweepConfig,
 }
@@ -49,6 +50,7 @@ class UserWalletService(
     validatorTopupConfigO: Option[ValidatorTopupConfig],
     walletSweep: Option[WalletSweepConfig],
     autoAcceptTransfers: Option[AutoAcceptTransfersConfig],
+    rewardSharing: Option[RewardSharingConfig],
     dedupDuration: DedupDuration,
     params: SpliceParametersConfig,
 )(implicit
@@ -111,6 +113,7 @@ class UserWalletService(
     validatorTopupConfigO,
     walletSweep,
     autoAcceptTransfers,
+    rewardSharing,
     dedupDuration,
     params,
   )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
@@ -96,7 +96,7 @@ class UserWalletService(
     walletManager,
     retryProvider,
     scanConnection,
-    hasRewardSharing = rewardSharing.isDefined,
+    mintUnassignedRewardCouponsV2 = rewardSharing.isEmpty,
     loggerFactory,
   )
 

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
@@ -50,7 +50,7 @@ class UserWalletService(
     validatorTopupConfigO: Option[ValidatorTopupConfig],
     walletSweep: Option[WalletSweepConfig],
     autoAcceptTransfers: Option[AutoAcceptTransfersConfig],
-    rewardSharing: Option[RewardSharingConfig],
+    rewardSharingConfig: RewardSharingConfig,
     dedupDuration: DedupDuration,
     params: SpliceParametersConfig,
 )(implicit
@@ -96,7 +96,7 @@ class UserWalletService(
     walletManager,
     retryProvider,
     scanConnection,
-    mintUnassignedRewardCouponsV2 = rewardSharing.isEmpty,
+    mintUnassignedRewardCouponsV2 = rewardSharingConfig.beneficiaries.isEmpty,
     loggerFactory,
   )
 
@@ -114,7 +114,7 @@ class UserWalletService(
     validatorTopupConfigO,
     walletSweep,
     autoAcceptTransfers,
-    rewardSharing,
+    rewardSharingConfig,
     dedupDuration,
     params,
   )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/UserWalletService.scala
@@ -96,6 +96,7 @@ class UserWalletService(
     walletManager,
     retryProvider,
     scanConnection,
+    hasRewardSharing = rewardSharing.isDefined,
     loggerFactory,
   )
 

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
@@ -18,6 +18,7 @@ import org.lfdecentralizedtrust.splice.environment.*
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
 import org.lfdecentralizedtrust.splice.store.DomainTimeSynchronization
+import org.lfdecentralizedtrust.splice.wallet.config.RewardSharingConfig
 import org.lfdecentralizedtrust.splice.wallet.store.ExternalPartyWalletStore
 
 import scala.concurrent.ExecutionContext
@@ -33,6 +34,7 @@ class ExternalPartyWalletAutomationService(
     scanConnection: BftScanConnection,
     override protected val loggerFactory: NamedLoggerFactory,
     packageVersionSupport: PackageVersionSupport,
+    rewardSharingO: Option[RewardSharingConfig],
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -64,6 +66,7 @@ class ExternalPartyWalletAutomationService(
       store,
       scanConnection,
       connection(SpliceLedgerConnectionPriority.Low),
+      rewardSharingO,
     )
   )
 }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/ExternalPartyWalletAutomationService.scala
@@ -34,7 +34,7 @@ class ExternalPartyWalletAutomationService(
     scanConnection: BftScanConnection,
     override protected val loggerFactory: NamedLoggerFactory,
     packageVersionSupport: PackageVersionSupport,
-    rewardSharingO: Option[RewardSharingConfig],
+    rewardSharingConfig: RewardSharingConfig,
 )(implicit
     ec: ExecutionContext,
     mat: Materializer,
@@ -66,7 +66,7 @@ class ExternalPartyWalletAutomationService(
       store,
       scanConnection,
       connection(SpliceLedgerConnectionPriority.Low),
-      rewardSharingO,
+      rewardSharingConfig,
     )
   )
 }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
@@ -43,6 +43,7 @@ import org.lfdecentralizedtrust.splice.util.{
   ContractWithState,
   SpliceUtil,
 }
+import org.lfdecentralizedtrust.splice.wallet.config.RewardSharingConfig
 import org.lfdecentralizedtrust.splice.wallet.store.ExternalPartyWalletStore
 import com.digitalasset.canton.topology.PartyId
 import com.digitalasset.canton.tracing.TraceContext
@@ -60,6 +61,7 @@ class MintingDelegationCollectRewardsTrigger(
     store: ExternalPartyWalletStore,
     scanConnection: BftScanConnection,
     spliceLedgerConnection: SpliceLedgerConnection,
+    rewardSharingO: Option[RewardSharingConfig],
 )(implicit
     override val ec: ExecutionContext,
     override val tracer: Tracer,
@@ -284,10 +286,9 @@ class MintingDelegationCollectRewardsTrigger(
         Some(issuingRoundsMap.keySet.map(_.number))
       )
       appRewardCouponsWithQuantity <- store.listSortedAppRewards(issuingRoundsMap)
-      // TODO(#5787): use sharing config to decide includeUnassigned
       rewardCouponsV2WithQuantity <- store.listSortedMintableRewardCouponV2s(
         issuingRoundsMap,
-        includeUnassigned = true,
+        includeUnassigned = rewardSharingO.isEmpty,
       )
       unclaimedActivityRecords <- store.listUnclaimedActivityRecords()
       developmentFundCoupons <- store.listDevelopmentFundCoupons()

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
@@ -284,7 +284,11 @@ class MintingDelegationCollectRewardsTrigger(
         Some(issuingRoundsMap.keySet.map(_.number))
       )
       appRewardCouponsWithQuantity <- store.listSortedAppRewards(issuingRoundsMap)
-      rewardCouponsV2WithQuantity <- store.listSortedAssignedRewardCouponV2s(issuingRoundsMap)
+      // TODO(#5787): use sharing config to decide includeUnassigned
+      rewardCouponsV2WithQuantity <- store.listSortedMintableRewardCouponV2s(
+        issuingRoundsMap,
+        includeUnassigned = true,
+      )
       unclaimedActivityRecords <- store.listUnclaimedActivityRecords()
       developmentFundCoupons <- store.listDevelopmentFundCoupons()
     } yield CouponsData(

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
@@ -61,7 +61,7 @@ class MintingDelegationCollectRewardsTrigger(
     store: ExternalPartyWalletStore,
     scanConnection: BftScanConnection,
     spliceLedgerConnection: SpliceLedgerConnection,
-    rewardSharingO: Option[RewardSharingConfig],
+    rewardSharingConfig: RewardSharingConfig,
 )(implicit
     override val ec: ExecutionContext,
     override val tracer: Tracer,
@@ -288,7 +288,7 @@ class MintingDelegationCollectRewardsTrigger(
       appRewardCouponsWithQuantity <- store.listSortedAppRewards(issuingRoundsMap)
       rewardCouponsV2WithQuantity <- store.listSortedMintableRewardCouponV2s(
         issuingRoundsMap,
-        includeUnassigned = rewardSharingO.isEmpty,
+        includeUnassigned = rewardSharingConfig.beneficiaries.isEmpty,
       )
       unclaimedActivityRecords <- store.listUnclaimedActivityRecords()
       developmentFundCoupons <- store.listDevelopmentFundCoupons()

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
@@ -50,7 +50,7 @@ class UserWalletAutomationService(
     validatorTopupConfigO: Option[ValidatorTopupConfig],
     walletSweep: Option[WalletSweepConfig],
     autoAcceptTransfers: Option[AutoAcceptTransfersConfig],
-    rewardSharing: Option[RewardSharingConfig],
+    rewardSharingConfig: RewardSharingConfig,
     dedupDuration: DedupDuration,
     paramsConfig: SpliceParametersConfig,
 )(implicit
@@ -178,8 +178,8 @@ class UserWalletAutomationService(
   }
 
   // TODO(#5787): replace with RewardSharingTrigger registration;
-  // foreach suppresses the unused parameter warning until then.
-  rewardSharing.foreach { _ => () }
+  // suppresses the unused parameter warning until then.
+  locally { val _ = rewardSharingConfig }
 
   registerTrigger(
     new AmuletMetricsTrigger(triggerContext, store, scanConnection)

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
@@ -177,7 +177,8 @@ class UserWalletAutomationService(
     )
   }
 
-  // TODO(#5787): register RewardSharingTrigger when implemented
+  // TODO(#5787): replace with RewardSharingTrigger registration;
+  // foreach suppresses the unused parameter warning until then.
   rewardSharing.foreach { _ => () }
 
   registerTrigger(

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
@@ -25,11 +25,7 @@ import org.lfdecentralizedtrust.splice.environment.ledger.api.DedupDuration
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
 import org.lfdecentralizedtrust.splice.store.DomainTimeSynchronization
-import org.lfdecentralizedtrust.splice.wallet.config.{
-  AutoAcceptTransfersConfig,
-  RewardSharingConfig,
-  WalletSweepConfig,
-}
+import org.lfdecentralizedtrust.splice.wallet.config.{AutoAcceptTransfersConfig, WalletSweepConfig}
 import org.lfdecentralizedtrust.splice.wallet.store.UserWalletStore
 import org.lfdecentralizedtrust.splice.wallet.treasury.TreasuryService
 import org.lfdecentralizedtrust.splice.wallet.util.ValidatorTopupConfig
@@ -50,7 +46,6 @@ class UserWalletAutomationService(
     validatorTopupConfigO: Option[ValidatorTopupConfig],
     walletSweep: Option[WalletSweepConfig],
     autoAcceptTransfers: Option[AutoAcceptTransfersConfig],
-    rewardSharingConfig: RewardSharingConfig,
     dedupDuration: DedupDuration,
     paramsConfig: SpliceParametersConfig,
 )(implicit
@@ -176,10 +171,6 @@ class UserWalletAutomationService(
       )
     )
   }
-
-  // TODO(#5787): replace with RewardSharingTrigger registration;
-  // suppresses the unused parameter warning until then.
-  locally { val _ = rewardSharingConfig }
 
   registerTrigger(
     new AmuletMetricsTrigger(triggerContext, store, scanConnection)

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/UserWalletAutomationService.scala
@@ -25,7 +25,11 @@ import org.lfdecentralizedtrust.splice.environment.ledger.api.DedupDuration
 import org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnection
 import org.lfdecentralizedtrust.splice.store.AppStoreWithIngestion.SpliceLedgerConnectionPriority
 import org.lfdecentralizedtrust.splice.store.DomainTimeSynchronization
-import org.lfdecentralizedtrust.splice.wallet.config.{AutoAcceptTransfersConfig, WalletSweepConfig}
+import org.lfdecentralizedtrust.splice.wallet.config.{
+  AutoAcceptTransfersConfig,
+  RewardSharingConfig,
+  WalletSweepConfig,
+}
 import org.lfdecentralizedtrust.splice.wallet.store.UserWalletStore
 import org.lfdecentralizedtrust.splice.wallet.treasury.TreasuryService
 import org.lfdecentralizedtrust.splice.wallet.util.ValidatorTopupConfig
@@ -46,6 +50,7 @@ class UserWalletAutomationService(
     validatorTopupConfigO: Option[ValidatorTopupConfig],
     walletSweep: Option[WalletSweepConfig],
     autoAcceptTransfers: Option[AutoAcceptTransfersConfig],
+    rewardSharing: Option[RewardSharingConfig],
     dedupDuration: DedupDuration,
     paramsConfig: SpliceParametersConfig,
 )(implicit
@@ -171,6 +176,9 @@ class UserWalletAutomationService(
       )
     )
   }
+
+  // TODO(#5787): register RewardSharingTrigger when implemented
+  rewardSharing.foreach { _ => () }
 
   registerTrigger(
     new AmuletMetricsTrigger(triggerContext, store, scanConnection)

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.wallet.config
 
 import org.lfdecentralizedtrust.splice.config.{HttpClientConfig, NetworkAppClientConfig}
+import org.lfdecentralizedtrust.splice.util.SpliceUtil
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.config.RequireTypes.NonNegativeNumeric
@@ -52,4 +53,16 @@ final case class AppRewardBeneficiaryConfig(
 final case class RewardSharingConfig(
     minTtlAfterSharing: NonNegativeFiniteDuration,
     beneficiaries: Seq[AppRewardBeneficiaryConfig],
-)
+) {
+  def providerRemainder: BigDecimal = BigDecimal(1.0) - beneficiaries.map(_.percentage).sum
+
+  def allBeneficiaries(provider: PartyId): Seq[AppRewardBeneficiaryConfig] = {
+    val remainder = providerRemainder
+    beneficiaries ++
+      (if (remainder > 0) Seq(AppRewardBeneficiaryConfig(provider, remainder))
+       else Seq.empty)
+  }
+
+  def allDamlBeneficiaries(provider: PartyId): Seq[(PartyId, java.math.BigDecimal)] =
+    allBeneficiaries(provider).map(b => (b.beneficiary, SpliceUtil.damlDecimal(b.percentage)))
+}

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.wallet.config
 
+import com.google.common.annotations.VisibleForTesting
 import org.lfdecentralizedtrust.splice.config.{HttpClientConfig, NetworkAppClientConfig}
 import org.lfdecentralizedtrust.splice.util.SpliceUtil
 import com.digitalasset.canton.SynchronizerAlias
@@ -56,6 +57,7 @@ final case class RewardSharingConfig(
 ) {
   def providerRemainder: BigDecimal = BigDecimal(1.0) - beneficiaries.map(_.percentage).sum
 
+  @VisibleForTesting
   def allBeneficiaries(provider: PartyId): Seq[AppRewardBeneficiaryConfig] = {
     val remainder = providerRemainder
     beneficiaries ++

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
@@ -5,6 +5,7 @@ package org.lfdecentralizedtrust.splice.wallet.config
 
 import org.lfdecentralizedtrust.splice.config.{HttpClientConfig, NetworkAppClientConfig}
 import com.digitalasset.canton.SynchronizerAlias
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.config.RequireTypes.NonNegativeNumeric
 import com.digitalasset.canton.topology.PartyId
 
@@ -41,4 +42,14 @@ final case class WalletSweepConfig(
 
 final case class AutoAcceptTransfersConfig(
     fromParties: Seq[PartyId] = Seq()
+)
+
+final case class AppRewardBeneficiaryConfig(
+    beneficiary: PartyId,
+    percentage: BigDecimal,
+)
+
+final case class RewardSharingConfig(
+    minTtlAfterSharing: NonNegativeFiniteDuration,
+    beneficiaries: Seq[AppRewardBeneficiaryConfig],
 )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
@@ -62,8 +62,8 @@ final case class AppRewardBeneficiaryConfig(
   *   the provider keeps the remainder (1.0 - sum of percentages)
   */
 final case class RewardSharingConfig(
-    minTtlAfterSharing: NonNegativeFiniteDuration,
-    beneficiaries: Seq[AppRewardBeneficiaryConfig],
+    minTtlAfterSharing: NonNegativeFiniteDuration = NonNegativeFiniteDuration.ofHours(30),
+    beneficiaries: Seq[AppRewardBeneficiaryConfig] = Seq.empty,
 ) {
   def providerRemainder: BigDecimal = BigDecimal(1.0) - beneficiaries.map(_.percentage).sum
 

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/config/WalletAppConfig.scala
@@ -46,11 +46,21 @@ final case class AutoAcceptTransfersConfig(
     fromParties: Seq[PartyId] = Seq()
 )
 
+/** A beneficiary that receives a share of the provider's app reward coupons.
+  * @param beneficiary the party receiving the share
+  * @param percentage fraction of the reward in (0.0, 1.0]; per-party percentages must sum to at most 1.0
+  */
 final case class AppRewardBeneficiaryConfig(
     beneficiary: PartyId,
     percentage: BigDecimal,
 )
 
+/** Configuration for sharing traffic-based app reward coupons with beneficiaries.
+  * @param minTtlAfterSharing minimum remaining coupon TTL before sharing is triggered;
+  *   e.g., 30h means share when 30h of coupon lifetime remains (6h after creation for 36h coupons)
+  * @param beneficiaries parties to share rewards with and their percentages;
+  *   the provider keeps the remainder (1.0 - sum of percentages)
+  */
 final case class RewardSharingConfig(
     minTtlAfterSharing: NonNegativeFiniteDuration,
     beneficiaries: Seq[AppRewardBeneficiaryConfig],

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
@@ -123,7 +123,7 @@ class TreasuryService(
     walletManager: UserWalletManager,
     override protected[this] val retryProvider: RetryProvider,
     scanConnection: BftScanConnection,
-    hasRewardSharing: Boolean,
+    mintUnassignedRewardCouponsV2: Boolean,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit ec: ExecutionContext, mat: Materializer)
     extends NamedLogging
@@ -1094,7 +1094,7 @@ class TreasuryService(
     for {
       rewardCouponV2Inputs <- userStore.listSortedMintableRewardCouponV2s(
         issuingRoundsMap,
-        includeUnassigned = !hasRewardSharing,
+        includeUnassigned = mintUnassignedRewardCouponsV2,
         PageLimit.tryCreate(maxNumInputs),
       )
       rewardCouponV2AmuletQuantity = rewardCouponV2Inputs.map(_._2).sum

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
@@ -123,6 +123,7 @@ class TreasuryService(
     walletManager: UserWalletManager,
     override protected[this] val retryProvider: RetryProvider,
     scanConnection: BftScanConnection,
+    hasRewardSharing: Boolean,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit ec: ExecutionContext, mat: Materializer)
     extends NamedLogging
@@ -1091,9 +1092,9 @@ class TreasuryService(
       tc: TraceContext
   ): Future[(BigDecimal, Seq[(Round, BigDecimal, InputRewardCouponV2)])] =
     for {
-      // TODO(#5787): eventually support mint of unassigned, unshared RewardCouponV2
-      rewardCouponV2Inputs <- userStore.listSortedAssignedRewardCouponV2s(
+      rewardCouponV2Inputs <- userStore.listSortedMintableRewardCouponV2s(
         issuingRoundsMap,
+        includeUnassigned = !hasRewardSharing,
         PageLimit.tryCreate(maxNumInputs),
       )
       rewardCouponV2AmuletQuantity = rewardCouponV2Inputs.map(_._2).sum


### PR DESCRIPTION
### Pull Request Checklist
Fixes #5816 

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
