### PR TITLE
Traffic-Based App Rewards: do not use the round when filtering RewardCouponsV2

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -70,6 +70,9 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
           )
         )(config)
       )
+      // Prevent wallets from minting RewardCouponV2 before the test
+      // can observe them on the DSO store.
+      .withoutAutomaticRewardsCollectionAndAmuletMerging
 
   "Enable, disable of dryRunVersion/mintingVersion take effect at round closure" in {
     implicit env =>

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -574,7 +574,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
               .listDevelopmentFundCoupons()
               .futureValue shouldBe empty withClue "DevelopmentFundCoupon"
             externalPartyWallet.store
-              .listSortedMintableRewardCouponV2s(issuingRoundsMap, includeUnassigned = true)
+              .listSortedMintableRewardCouponV2s(includeUnassigned = true)
               .futureValue shouldBe empty withClue "RewardCouponV2"
           }
         }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletRewardsTimeBasedIntegrationTest.scala
@@ -97,18 +97,7 @@ class WalletRewardsTimeBasedIntegrationTest
         validatorRewards = Seq((bob, 0.33)),
       )
 
-      // Create unassigned V2 coupons for both validators.
-      // Bob (no sharing config) → treasury mints unassigned coupons.
-      // Alice (has sharing config) → treasury does NOT mint unassigned coupons.
       val rewardCouponV2Amount = BigDecimal(1000.0)
-      clue("Create unassigned RewardCouponV2 for both validators") {
-        createRewardCouponsV2(
-          Seq(
-            (bobValidatorParty, rewardCouponV2Amount, None),
-            (aliceValidatorParty, rewardCouponV2Amount, None),
-          )
-        )
-      }
 
       val openRounds = eventually() {
         import math.Ordering.Implicits.*
@@ -144,6 +133,19 @@ class WalletRewardsTimeBasedIntegrationTest
         .futureValue
 
       val prevBalance = bobValidatorWalletClient.balance().unlockedQty
+
+      // Create unassigned V2 coupons after capturing prevBalance, so the
+      // minted V2 amount is reflected in the balance delta.
+      // Bob (no sharing config) → treasury mints unassigned coupons.
+      // Alice (has sharing config) → treasury does NOT mint unassigned coupons.
+      clue("Create unassigned RewardCouponV2 for both validators") {
+        createRewardCouponsV2(
+          Seq(
+            (bobValidatorParty, rewardCouponV2Amount, None),
+            (aliceValidatorParty, rewardCouponV2Amount, None),
+          )
+        )
+      }
 
       // Bob's validator collects rewards
       // it takes 3 ticks for the IssuingMiningRound 1 to be created and open.

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/TransferInputStore.scala
@@ -118,10 +118,9 @@ trait TransferInputStore extends AppStore with LimitHelpers {
 
   /** Returns mintable RewardCouponV2 sorted by round ascending, amount descending.
     * When `includeUnassigned` is true, includes coupons where the party is provider
-    * with no beneficiary
+    * with no beneficiary.
     */
   def listSortedMintableRewardCouponV2s(
-      issuingRoundsMap: Map[Round, IssuingMiningRound],
       includeUnassigned: Boolean,
       limit: Limit = defaultLimit,
   )(implicit tc: TraceContext): Future[Seq[
@@ -136,9 +135,8 @@ trait TransferInputStore extends AppStore with LimitHelpers {
       limit,
       rewards
         .filter { rw =>
-          issuingRoundsMap.contains(rw.payload.round) &&
-          (rw.payload.beneficiary.isPresent ||
-            (includeUnassigned && rw.payload.beneficiary.isEmpty))
+          rw.payload.beneficiary.isPresent ||
+          (includeUnassigned && rw.payload.beneficiary.isEmpty)
         }
         .map(rw => (rw.contract, BigDecimal(rw.payload.amount)))
         .sorted(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/TransferInputStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/TransferInputStoreTest.scala
@@ -138,26 +138,23 @@ abstract class TransferInputStoreTest extends StoreTestBase {
           createdEventObservers = Seq(user),
         )(store.multiDomainAcsStore)
       } yield {
-        store
-          .listSortedMintableRewardCouponV2s(Map.empty, includeUnassigned = false)
-          .futureValue shouldBe empty
-        val roundsToFilter = (2 to 4).map(n => issuingMiningRound(dsoParty, n.toLong))
-        val issuingMap = roundsToFilter.map(r => r.payload.round -> r.payload).toMap
         // assigned coupons listed in ascending round order, descending amount per round;
         // the unassigned coupon (amount=20) in round 2 is excluded
         store
-          .listSortedMintableRewardCouponV2s(issuingMap, includeUnassigned = false)
+          .listSortedMintableRewardCouponV2s(includeUnassigned = false)
           .futureValue
           .map(_._1.payload.amount.doubleValue()) should contain theSameElementsInOrderAs Seq(
+          2.0, 1.0, // round 1
           4.0, 2.0, // round 2 (unassigned 20.0 excluded)
           6.0, 3.0, // round 3
           8.0, 4.0, // round 4
         )
         // with includeUnassigned, the unassigned coupon (20.0) appears in round 2
         store
-          .listSortedMintableRewardCouponV2s(issuingMap, includeUnassigned = true)
+          .listSortedMintableRewardCouponV2s(includeUnassigned = true)
           .futureValue
           .map(_._1.payload.amount.doubleValue()) should contain theSameElementsInOrderAs Seq(
+          2.0, 1.0, // round 1
           20.0, 4.0, 2.0, // round 2 (unassigned 20.0 included)
           6.0, 3.0, // round 3
           8.0, 4.0, // round 4

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/automation/MintingDelegationCollectRewardsTrigger.scala
@@ -287,8 +287,7 @@ class MintingDelegationCollectRewardsTrigger(
       )
       appRewardCouponsWithQuantity <- store.listSortedAppRewards(issuingRoundsMap)
       rewardCouponsV2WithQuantity <- store.listSortedMintableRewardCouponV2s(
-        issuingRoundsMap,
-        includeUnassigned = rewardSharingConfig.beneficiaries.isEmpty,
+        includeUnassigned = rewardSharingConfig.beneficiaries.isEmpty
       )
       unclaimedActivityRecords <- store.listUnclaimedActivityRecords()
       developmentFundCoupons <- store.listDevelopmentFundCoupons()

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
@@ -812,10 +812,7 @@ class TreasuryService(
         issuingRoundsMap,
       )
       (rewardCouponV2TotalAmuletQuantity, rewardCouponV2Inputs) <-
-        getRewardCouponV2AndQuantity(
-          maxNumInputs,
-          issuingRoundsMap,
-        )
+        getRewardCouponV2AndQuantity(maxNumInputs)
       (svRewardsTotalAmuletQuantity, svRewardInputs) <- getSvRewardCouponsAndQuantity(
         maxNumInputs,
         issuingRoundsMap,
@@ -1086,14 +1083,12 @@ class TreasuryService(
     } yield (appRewardsAmuletQuantity, appRewardInputs)
 
   private def getRewardCouponV2AndQuantity(
-      maxNumInputs: Int,
-      issuingRoundsMap: Map[Round, IssuingMiningRound],
+      maxNumInputs: Int
   )(implicit
       tc: TraceContext
   ): Future[(BigDecimal, Seq[(Round, BigDecimal, InputRewardCouponV2)])] =
     for {
       rewardCouponV2Inputs <- userStore.listSortedMintableRewardCouponV2s(
-        issuingRoundsMap,
         includeUnassigned = mintUnassignedRewardCouponsV2,
         PageLimit.tryCreate(maxNumInputs),
       )


### PR DESCRIPTION
Addresses [this comment](https://github.com/canton-network/splice/pull/5786#discussion_r3379510995)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
