### PR TITLE
fix runner names for feature forks

### DIFF
--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -72,8 +72,9 @@ function installDockerRunnerScaleSet(
   repo: string,
   dependsOn: Resource[]
 ): k8s.helm.v3.Release {
+  const shortName = repo == 'splice' ? name : name.replace('self-hosted-', '');
   return new k8s.helm.v3.Release(
-    `${name}-${repo}`,
+    `${shortName}-${repo}`,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,
@@ -305,7 +306,7 @@ function installDockerRunnerScaleSets(
     .filter(spec => spec.docker)
     .forEach(spec => {
       installDockerRunnerScaleSet(
-        repo == 'splice' ? `self-hosted-docker-${spec.name}` : `docker-${spec.name}`,
+        `self-hosted-docker-${spec.name}`,
         runnersNamespace,
         controller,
         tokenSecret,
@@ -337,7 +338,8 @@ function installK8sRunnerScaleSet(
   dependsOn: Resource[],
   performanceTestsDb?: PerformanceTestDb
 ): Release {
-  const podConfigMapName = `${name}-pod-config-${repo}`;
+  const shortName = repo == 'splice' ? name : name.replace('self-hosted-', '');
+  const podConfigMapName = `${shortName}-pod-config-${repo}`;
   // A configMap that will be mounted to runner pods and provide additional pod spec for the workflow pods
   const workflowPodConfigMap = cachePvcName.apply(
     cachePvcName =>
@@ -425,7 +427,7 @@ function installK8sRunnerScaleSet(
   const runnerImage = `${DOCKER_REPO}/splice-test-runner-hook:${ghaConfig.runnerHookVersion}`;
 
   return new k8s.helm.v3.Release(
-    `${name}-${repo}`,
+    `${shortName}-${repo}`,
     {
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,
@@ -673,7 +675,7 @@ function installK8sRunnerScaleSets(
     .forEach(spec => {
       installK8sRunnerScaleSet(
         runnersNamespace,
-        repo == 'splice' ? `self-hosted-k8s-${spec.name}` : `k8s-${spec.name}`,
+        `self-hosted-k8s-${spec.name}`,
         tokenSecret,
         cachePvcName,
         spec.resources,


### PR DESCRIPTION
The name used for the runner names must match those defined in the gha workflows. We broke that for forks with the shortening. This PR applies the shortening only to the resource, but reverts it for the runner names in order to fix that.

Applied manually by bumping splice locally and running `pulumi up`, and confirmed to work.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
