### PR TITLE
Re-enable automaticSilentRenew on OidcAuthProvider

### DIFF
--- a/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockOidcAuthProvider = vi.fn(({ children }: React.PropsWithChildren) => <>{children}</>);
 
@@ -31,8 +31,11 @@ const rs256Config: AuthConfig = {
 };
 
 describe('AuthProvider', () => {
-  test('passes automaticSilentRenew=true to the OIDC provider', () => {
+  beforeEach(() => {
     mockOidcAuthProvider.mockClear();
+  });
+
+  test('passes automaticSilentRenew=true to the OIDC provider', () => {
     render(
       <AuthProvider authConf={rs256Config}>
         <div />
@@ -44,7 +47,6 @@ describe('AuthProvider', () => {
   });
 
   test('hs256-unsafe config short-circuits without rendering the OIDC provider', () => {
-    mockOidcAuthProvider.mockClear();
     render(
       <AuthProvider
         authConf={{

--- a/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
+++ b/apps/common/frontend/src/__tests__/auth/AuthProvider.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+const mockOidcAuthProvider = vi.fn(({ children }: React.PropsWithChildren) => <>{children}</>);
+
+vi.mock('react-oidc-context', () => ({
+  AuthProvider: (props: React.PropsWithChildren<Record<string, unknown>>) =>
+    mockOidcAuthProvider(props),
+}));
+
+// `apps/common/frontend/src/utils/index.ts` is a barrel that re-exports
+// voteRequests, which transitively depends on `@daml.js/splice-amulet`
+// codegen. Mock the barrel to keep this test focused on AuthProvider props.
+vi.mock('../../utils', async () => {
+  const auth = await vi.importActual<typeof import('../../utils/auth')>('../../utils/auth');
+  return { ...auth };
+});
+
+import AuthProvider from '../../components/AuthProvider';
+import { Algorithm, AuthConfig } from '../../config/schema';
+
+const rs256Config: AuthConfig = {
+  algorithm: Algorithm.RS256,
+  authority: 'https://idp.example.com/',
+  client_id: 'test-client',
+  token_audience: 'https://api.example.com',
+  token_scope: 'wallet',
+};
+
+describe('AuthProvider', () => {
+  test('passes automaticSilentRenew=true to the OIDC provider', () => {
+    mockOidcAuthProvider.mockClear();
+    render(
+      <AuthProvider authConf={rs256Config}>
+        <div />
+      </AuthProvider>
+    );
+    expect(mockOidcAuthProvider).toHaveBeenCalled();
+    const props = mockOidcAuthProvider.mock.calls[0][0] as Record<string, unknown>;
+    expect(props.automaticSilentRenew).toBe(true);
+  });
+
+  test('hs256-unsafe config short-circuits without rendering the OIDC provider', () => {
+    mockOidcAuthProvider.mockClear();
+    render(
+      <AuthProvider
+        authConf={{
+          algorithm: Algorithm.HS256UNSAFE,
+          secret: 'shh',
+          token_audience: 'https://api.example.com',
+        }}
+      >
+        <div />
+      </AuthProvider>
+    );
+    expect(mockOidcAuthProvider).not.toHaveBeenCalled();
+  });
+});

--- a/apps/common/frontend/src/components/AuthProvider.tsx
+++ b/apps/common/frontend/src/components/AuthProvider.tsx
@@ -38,7 +38,7 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
 
   return (
     <OidcAuthProvider
-      automaticSilentRenew={false}
+      automaticSilentRenew
       userStore={new WebStorageStateStore({ store: window.localStorage })}
       onSigninCallback={user => {
         const redirectTo = extractRedirectToFromUser(user);


### PR DESCRIPTION
PR #5545 disabled `automaticSilentRenew` when removing the global `offline_access` scope. Keycloak still issues a session-bound refresh token without that scope, so silent renew can use the refresh_token grant and users are no longer forced back to the IdP on every short access-token expiry (default 5 minutes).

Fixes #5682

## Change

Re-enable `automaticSilentRenew` on `OidcAuthProvider`.

## Testing

`AuthProvider.test.tsx` mocks `react-oidc-context` and asserts `automaticSilentRenew: true` is passed through. Also covers the hs256-unsafe short-circuit path.

## Note

This is the minimal fix Pawel asked for in lieu of #5683, which adds per-IdP `enable_offline_scope` configuration and operator docs. Auth0 deployments that require `offline_access` to receive a refresh token may still need a follow-up if silent renew does not work there without that scope.
