### PR TITLE
helm, splice-info: Add runtime/info.json with active synchronizer serial

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/runbook/DsoPreflightIntegrationTest.scala
@@ -43,6 +43,7 @@ class DsoPreflightIntegrationTest
         s"${infoUrl}",
         s"${infoUrl}/runtime/",
         s"${infoUrl}/runtime/dso.json",
+        s"${infoUrl}/runtime/info.json",
         s"${infoUrl}/runtime/status.json",
       )
 
@@ -63,7 +64,7 @@ class DsoPreflightIntegrationTest
             assert(json.isObject, s"Response body must be a JSON object, but got: $body")
             if (url == s"${infoUrl}/runtime/") {
               val expected = parse(
-                """{"dso":"/runtime/dso.json","status":"/runtime/status.json"}"""
+                """{"dso":"/runtime/dso.json","info":"/runtime/info.json","status":"/runtime/status.json"}"""
               ).getOrElse(fail("Hardcoded JSON invalid"))
               assert(json == expected, s"Expected $expected but got $json")
             }

--- a/cluster/helm/splice-info/scripts/get-info.sh
+++ b/cluster/helm/splice-info/scripts/get-info.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCAN_URL="${SCAN_URL:-http://scan-app:5012}"
+
+CURL_TIMEOUT="${CURL_TIMEOUT:-15}"
+
+TLS_SKIP_VERIFY="${TLS_SKIP_VERIFY:-false}"
+CURL_CMD=(curl -fs -m "$CURL_TIMEOUT")
+[[ $TLS_SKIP_VERIFY == true ]] && CURL_CMD+=(-k)
+
+get_serial_id() {
+  local fetched_serial_id; fetched_serial_id=$("${CURL_CMD[@]}" "$SCAN_URL/api/scan/v0/active-synchronizer-serial" | jq -r '.serial') || true
+
+  if [[ -n "$fetched_serial_id" ]]; then
+    echo "$fetched_serial_id"
+  else
+    echo null
+  fi
+}
+
+main() {
+  local active_synchronizer_serial; active_synchronizer_serial=$(get_serial_id)
+
+  jq -n \
+    --argjson active_synchronizer_serial "$active_synchronizer_serial" \
+    '
+      {
+        runtimeInfo: {
+          activeSynchronizerSerial: {
+            value: $active_synchronizer_serial,
+            description: "The current physical synchronizer serial as reported by the SV participant. This value is fetched from Scan and is null if it cannot be fetched.",
+          },
+        },
+        generatedAt: (now | todate),
+      }
+    '
+}
+
+main "$@"

--- a/cluster/helm/splice-info/scripts/updater.sh
+++ b/cluster/helm/splice-info/scripts/updater.sh
@@ -16,12 +16,17 @@ dso_json_file="$html_dir/$dso_json_path"
 status_json_path=runtime/status.json
 status_json_file="$html_dir/$status_json_path"
 
+info_json_path=runtime/info.json
+info_json_file="$html_dir/$info_json_path"
+
 jq -n \
   --arg dso "/$dso_json_path" \
   --arg status "/$status_json_path" \
+  --arg info "/$info_json_path" \
   '
     {
       $dso,
+      $info,
       $status,
     }
   ' > "$runtime_index_file"
@@ -37,6 +42,12 @@ while true; do
 
   if result=$(/scripts/get-status.sh); then
     dest="$status_json_file"
+    echo "$result" > "$dest.new"
+    mv "$dest.new" "$dest"
+  fi &
+
+  if result=$(/scripts/get-info.sh); then
+    dest="$info_json_file"
     echo "$result" > "$dest.new"
     mv "$dest.new" "$dest"
   fi &


### PR DESCRIPTION
The root of the info endpoint exposes only configured values. `info.json` will show the actual runtime values.