### PR TITLE
[ci] small simplification in bulk storage pipelines

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorage.scala
@@ -44,10 +44,10 @@ trait AcsSnapshotBulkStorageWriter {
       tc: TraceContext
   ): Boolean
 
-  /** Return the main Flow that processes the snapshot at the given timestamp.
-    * The Flow must emit back the same timestamp as its output once processing is complete.
+  /** Return the main Flow that processes snapshots at given timestamps.
+    * The Flow must emit back the same timestamps as its output on every processed snapshot.
     */
-  def processSnapshotAt(ts: TimestampWithMigrationId)(implicit
+  def processSnapshotsFlow(implicit
       tc: TraceContext
   ): Flow[TimestampWithMigrationId, TimestampWithMigrationId, NotUsed]
 
@@ -161,11 +161,7 @@ class AcsSnapshotBulkStorage(
             getAcsSnapshotTimestampsAfter(TimestampWithMigrationId(CantonTimestamp.MinValue, 0))
         }
         .filter { writer.shouldProcessSnapshotAt }
-        .flatMapConcat(ts =>
-          Source
-            .single(ts)
-            .via(writer.processSnapshotAt(ts))
-        )
+        .via(writer.processSnapshotsFlow)
         .mapAsync(1) { ts =>
           persistentProgress.persistLatestProcessedSnapshotTimestamp(ts).map(_ => ts)
         }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDb.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDb.scala
@@ -52,7 +52,7 @@ class AcsSnapshotBulkStorageWriterFromDb(
     ret
   }
 
-  override def processSnapshotAt(ts: TimestampWithMigrationId)(implicit
+  override def processSnapshotsFlow(implicit
       tc: TraceContext
   ): Flow[TimestampWithMigrationId, TimestampWithMigrationId, NotUsed] = {
     SingleAcsSnapshotBulkStorage
@@ -64,12 +64,12 @@ class AcsSnapshotBulkStorageWriterFromDb(
         historyMetrics,
         loggerFactory,
       )
-      .map(keys => {
+      .map { case (ts, keys) =>
         logger.debug(
           s"Successfully dumped snapshot from migration ${ts.migrationId}, timestamp ${ts.timestamp} to bulk storage, with object keys: $keys"
         )
         ts
-      })
+      }
   }
 
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
@@ -125,17 +125,17 @@ object SingleAcsSnapshotBulkStorage {
   )(implicit
       tc: TraceContext,
       ec: ExecutionContext,
-  ): Flow[TimestampWithMigrationId, Seq[String], NotUsed] =
-    Flow[TimestampWithMigrationId].flatMapConcat {
+  ): Flow[TimestampWithMigrationId, (TimestampWithMigrationId, Seq[String]), NotUsed] =
+    Flow[TimestampWithMigrationId].flatMapConcat { ts =>
       new SingleAcsSnapshotBulkStorage(
-        _,
+        ts,
         storageConfig,
         appConfig,
         acsSnapshotStore,
         s3Connection,
         historyMetrics,
         loggerFactory,
-      ).getSource
+      ).getSource.map(keys => (ts, keys))
     }
 
   /** The same flow as a source, currently used only for unit testing.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorage.scala
@@ -29,9 +29,7 @@ trait UpdateHistoryBulkStorageWriter {
   /** The main Flow that processes a given segment of updates.
     * The Flow must emit back the same segment as its output once processing is complete.
     */
-  def processSegment(segment: UpdatesSegment)(implicit
-      tc: TraceContext
-  ): Flow[UpdatesSegment, UpdatesSegment, NotUsed]
+  def processSegmentsFlow(implicit tc: TraceContext): Flow[UpdatesSegment, UpdatesSegment, NotUsed]
 }
 
 class UpdateHistoryBulkStoragePersistentProgress(
@@ -193,7 +191,7 @@ class UpdateHistoryBulkStorage(
           }
         }
         .collect { case Some(segment) => segment }
-        .flatMapConcat(segment => Source.single(segment).via(writer.processSegment(segment)))
+        .via(writer.processSegmentsFlow)
         .mapAsync(1) { segment =>
           persistentProgress.persistLatestProcessedSegment(segment).map(_ => segment)
         }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageWriterFromDb.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageWriterFromDb.scala
@@ -25,9 +25,9 @@ class UpdateHistoryBulkStorageWriterFromDb(
     with NamedLogging
     with Spanning {
 
-  override def processSegment(
-      segment: UpdatesSegment
-  )(implicit tc: TraceContext): Flow[UpdatesSegment, UpdatesSegment, NotUsed] = {
+  override def processSegmentsFlow(implicit
+      tc: TraceContext
+  ): Flow[UpdatesSegment, UpdatesSegment, NotUsed] = {
     UpdateHistorySegmentBulkStorage
       .asFlow(
         storageConfig,
@@ -37,12 +37,12 @@ class UpdateHistoryBulkStorageWriterFromDb(
         historyMetrics,
         loggerFactory,
       )
-      .map(keys => {
+      .map { case (segment, keys) =>
         logger.debug(
           s"Successfully dumped updates segment $segment to bulk storage, with object keys: $keys"
         )
         segment
-      })
+      }
   }
 
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -190,7 +190,7 @@ object UpdateHistorySegmentBulkStorage {
       tc: TraceContext,
       ec: ExecutionContext,
       actorSystem: ActorSystem,
-  ): Flow[UpdatesSegment, Seq[String], NotUsed] =
+  ): Flow[UpdatesSegment, (UpdatesSegment, Seq[String]), NotUsed] =
     Flow[UpdatesSegment].flatMapConcat { (segment: UpdatesSegment) =>
       new UpdateHistorySegmentBulkStorage(
         storageConfig,
@@ -200,7 +200,7 @@ object UpdateHistorySegmentBulkStorage {
         segment,
         historyMetrics,
         loggerFactory,
-      ).getSource
+      ).getSource.map(keys => (segment, keys))
     }
 
   def asSource(


### PR DESCRIPTION
As I was working on the staging->commit pipeline, I realized how obscure the current implementation here was, turning a flow into a source and back, rather than just using it directly as a flow...

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
