### PR TITLE
Improve logs splitwellfrontendintegrationtest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -69,7 +69,7 @@ class SplitwellFrontendIntegrationTest
         requestGroupMembership(invite)
       }
 
-      withFrontEndStep("aliceSplitwell", "accept-bob-membership") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "click-add-user-link") { implicit webDriver =>
         eventuallyClickOn(className("add-user-link"))
       }
 
@@ -78,7 +78,7 @@ class SplitwellFrontendIntegrationTest
         requestGroupMembership(invite)
       }
 
-      withFrontEndStep("aliceSplitwell", "accept-charlie-and-add-lunch") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") { implicit webDriver =>
         eventuallyClickOn(className("add-user-link"))
         eventually() {
           findAll(className("balances-table-row")).toSeq should have length 2
@@ -95,7 +95,7 @@ class SplitwellFrontendIntegrationTest
         eventuallyClickOn(className("enter-payment-link"))
       }
 
-      withFrontEndStep("charlieSplitwell", "add-digestivs") { implicit webDriver =>
+      withFrontEndStep("charlieSplitwell", "enter-payment-info") { implicit webDriver =>
         inside(eventuallyFind(className("enter-payment-amount-field"))) { case Some(field) =>
           field.underlying.click()
           reactTextInput(field).value = "333.0"
@@ -210,17 +210,17 @@ class SplitwellFrontendIntegrationTest
       val bobAns = expectedAns(bobUserParty, bobEntryName)
       bobWalletClient.tap(walletAmuletToUsd(510))
 
-      val invite = withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      val invite = withFrontEndStep("aliceSplitwell", "create-invite") { implicit webDriver =>
         login(aliceSplitwellUIPort, aliceDamlUser)
         createGroupAndInviteLink(groupName)
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "request-membership") { implicit webDriver =>
         login(bobSplitwellUIPort, bobDamlUser)
         requestGroupMembership(invite)
       }
 
-      withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") { implicit webDriver =>
         eventuallyClickOn(className("add-user-link"))
         eventually() {
           findAll(className("balances-table-row")).toSeq should have length 1
@@ -228,7 +228,7 @@ class SplitwellFrontendIntegrationTest
         addTeamLunch(1000)
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "enter-payment-accept-verify") { implicit webDriver =>
         enterSplitwellPayment(aliceEntryName, aliceUserParty, 500)
 
         // Bob is redirected to wallet ..
@@ -276,7 +276,7 @@ class SplitwellFrontendIntegrationTest
         )
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "error-on-unknown-party") { implicit webDriver =>
         val errorMsg = "is not part of the group"
         loggerFactory.assertLoggedWarningsAndErrorsSeq(
           enterSplitwellPayment("unknown::abc", PartyId.tryFromProtoPrimitive("unknown::abc"), 42),
@@ -297,7 +297,7 @@ class SplitwellFrontendIntegrationTest
       onboardWalletUser(charlieWalletClient, charlieValidator)
 
       // Alice creates three groups - abc, ab, ac
-      val (invite1, invite2, invite3) = withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      val (invite1, invite2, invite3) = withFrontEndStep("aliceSplitwell", "create-three-groups") { implicit webDriver =>
         login(aliceSplitwellUIPort, aliceDamlUser)
 
         val invite1 = createGroupAndInviteLink("group-abc")
@@ -308,21 +308,21 @@ class SplitwellFrontendIntegrationTest
       }
 
       // Bob requests to join groups abc and ab
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "request-membership-abc-ab") { implicit webDriver =>
         login(bobSplitwellUIPort, bobDamlUser)
         requestGroupMembership(invite1)
         requestGroupMembership(invite2)
       }
 
       // Charlie requests to join groups abc and ac
-      withFrontEnd("charlieSplitwell") { implicit webDriver =>
+      withFrontEndStep("charlieSplitwell", "request-membership-abc-ac") { implicit webDriver =>
         login(charlieSplitwellUIPort, charlieDamlUser)
         requestGroupMembership(invite1)
         requestGroupMembership(invite3)
       }
 
       // Alice accepts all requests
-      withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "accept-all-membership-requests") { implicit webDriver =>
         eventually(timeUntilSuccess = 20.minute) {
           findAll(
             className("add-user-link")
@@ -347,7 +347,7 @@ class SplitwellFrontendIntegrationTest
         }
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "verify-bob-groups") { implicit webDriver =>
         eventually() {
           findAll(className("group-entry")) should have length 2
           val groups = findAll(className("group-entry")).toSeq
@@ -361,7 +361,7 @@ class SplitwellFrontendIntegrationTest
           )
         }
       }
-      withFrontEnd("charlieSplitwell") { implicit webDriver =>
+      withFrontEndStep("charlieSplitwell", "verify-charlie-groups") { implicit webDriver =>
         eventually() {
           findAll(className("group-entry")) should have length 2
           val groups = findAll(className("group-entry")).toSeq

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -78,21 +78,22 @@ class SplitwellFrontendIntegrationTest
         requestGroupMembership(invite)
       }
 
-      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") { implicit webDriver =>
-        eventuallyClickOn(className("add-user-link"))
-        eventually() {
-          findAll(className("balances-table-row")).toSeq should have length 2
-        }
+      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") {
+        implicit webDriver =>
+          eventuallyClickOn(className("add-user-link"))
+          eventually() {
+            findAll(className("balances-table-row")).toSeq should have length 2
+          }
 
-        inside(eventuallyFind(className("enter-payment-amount-field"))) { case Some(field) =>
-          field.underlying.click()
-          reactTextInput(field).value = "1200.0"
-        }
-        inside(eventuallyFind(className("enter-payment-description-field"))) { case Some(field) =>
-          field.underlying.click()
-          reactTextInput(field).value = "Team lunch"
-        }
-        eventuallyClickOn(className("enter-payment-link"))
+          inside(eventuallyFind(className("enter-payment-amount-field"))) { case Some(field) =>
+            field.underlying.click()
+            reactTextInput(field).value = "1200.0"
+          }
+          inside(eventuallyFind(className("enter-payment-description-field"))) { case Some(field) =>
+            field.underlying.click()
+            reactTextInput(field).value = "Team lunch"
+          }
+          eventuallyClickOn(className("enter-payment-link"))
       }
 
       withFrontEndStep("charlieSplitwell", "enter-payment-info") { implicit webDriver =>
@@ -220,12 +221,13 @@ class SplitwellFrontendIntegrationTest
         requestGroupMembership(invite)
       }
 
-      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") { implicit webDriver =>
-        eventuallyClickOn(className("add-user-link"))
-        eventually() {
-          findAll(className("balances-table-row")).toSeq should have length 1
-        }
-        addTeamLunch(1000)
+      withFrontEndStep("aliceSplitwell", "click-add-user-link-and-check-balance-table-length") {
+        implicit webDriver =>
+          eventuallyClickOn(className("add-user-link"))
+          eventually() {
+            findAll(className("balances-table-row")).toSeq should have length 1
+          }
+          addTeamLunch(1000)
       }
 
       withFrontEndStep("bobSplitwell", "enter-payment-accept-verify") { implicit webDriver =>
@@ -297,14 +299,15 @@ class SplitwellFrontendIntegrationTest
       onboardWalletUser(charlieWalletClient, charlieValidator)
 
       // Alice creates three groups - abc, ab, ac
-      val (invite1, invite2, invite3) = withFrontEndStep("aliceSplitwell", "create-three-groups") { implicit webDriver =>
-        login(aliceSplitwellUIPort, aliceDamlUser)
+      val (invite1, invite2, invite3) = withFrontEndStep("aliceSplitwell", "create-three-groups") {
+        implicit webDriver =>
+          login(aliceSplitwellUIPort, aliceDamlUser)
 
-        val invite1 = createGroupAndInviteLink("group-abc")
-        val invite2 = createGroupAndInviteLink("group-ab")
-        val invite3 = createGroupAndInviteLink("group-ac")
+          val invite1 = createGroupAndInviteLink("group-abc")
+          val invite2 = createGroupAndInviteLink("group-ab")
+          val invite3 = createGroupAndInviteLink("group-ac")
 
-        (invite1, invite2, invite3)
+          (invite1, invite2, invite3)
       }
 
       // Bob requests to join groups abc and ab

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -22,6 +22,11 @@ class SplitwellFrontendIntegrationTest
     with SplitwellFrontendTestUtil
     with FrontendLoginUtil {
 
+  private def withFrontEndStep[A](frontend: String, step: String)(body: WebDriverType => A): A =
+    withClue(s"[frontend=$frontend step=$step]") {
+      withFrontEnd(frontend)(body)
+    }
+
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology1Sv(this.getClass.getSimpleName)
@@ -54,26 +59,26 @@ class SplitwellFrontendIntegrationTest
 
       bobWalletClient.tap(walletAmuletToUsd(550))
 
-      val invite = withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      val invite = withFrontEndStep("aliceSplitwell", "create-invite") { implicit webDriver =>
         login(aliceSplitwellUIPort, aliceDamlUser)
         createGroupAndInviteLink(groupName)
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "request-membership") { implicit webDriver =>
         login(bobSplitwellUIPort, bobDamlUser)
         requestGroupMembership(invite)
       }
 
-      withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "accept-bob-membership") { implicit webDriver =>
         eventuallyClickOn(className("add-user-link"))
       }
 
-      withFrontEnd("charlieSplitwell") { implicit webDriver =>
+      withFrontEndStep("charlieSplitwell", "request-membership") { implicit webDriver =>
         login(charlieSplitwellUIPort, charlieDamlUser)
         requestGroupMembership(invite)
       }
 
-      withFrontEnd("aliceSplitwell") { implicit webDriver =>
+      withFrontEndStep("aliceSplitwell", "accept-charlie-and-add-lunch") { implicit webDriver =>
         eventuallyClickOn(className("add-user-link"))
         eventually() {
           findAll(className("balances-table-row")).toSeq should have length 2
@@ -90,7 +95,7 @@ class SplitwellFrontendIntegrationTest
         eventuallyClickOn(className("enter-payment-link"))
       }
 
-      withFrontEnd("charlieSplitwell") { implicit webDriver =>
+      withFrontEndStep("charlieSplitwell", "add-digestivs") { implicit webDriver =>
         inside(eventuallyFind(className("enter-payment-amount-field"))) { case Some(field) =>
           field.underlying.click()
           reactTextInput(field).value = "333.0"
@@ -102,7 +107,7 @@ class SplitwellFrontendIntegrationTest
         eventuallyClickOn(className("enter-payment-link"))
       }
 
-      withFrontEnd("bobSplitwell") { implicit webDriver =>
+      withFrontEndStep("bobSplitwell", "settle-debts-and-verify") { implicit webDriver =>
         eventually() {
           inside(findAll(className("balances-table-row")).toSeq) {
             case Seq(r1, r2) => // Need to sync here on the actual values (size not enough)


### PR DESCRIPTION
https://github.com/DACH-NY/cn-test-failures/issues/8733

Debugging the above issue was difficult w/o granular logs. e.g. we have multiple `aliceSplitwell` clues (`SplitwellFrontendIntegrationTest/web-frontend=aliceSplitwell`), we don't know which one failed. This PR adds granular clues for each step. 