### PR TITLE
Add NOT_CONNECTED_TO_ANY_SYNCHRONIZER to conflict error codes

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
@@ -26,6 +26,7 @@ import com.digitalasset.canton.ledger.error.groups.CommandExecutionErrors.Interp
 import org.lfdecentralizedtrust.splice.http.v0.definitions as d0
 import com.digitalasset.canton.error.{ErrorCodeUtils, TransactionRoutingError}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
+import com.digitalasset.canton.participant.sync.SyncServiceInjectionError
 import com.digitalasset.canton.tracing.TraceContext
 import io.circe.Printer
 import io.circe.syntax.*
@@ -113,6 +114,7 @@ final class HttpErrorHandler(
           Interpreter.UnhandledException,
           Interpreter.InterpretationUserError,
           Interpreter.TemplatePreconditionViolated,
+          SyncServiceInjectionError.NotConnectedToAnySynchronizer,
           TransactionRoutingError.TopologyErrors.UnknownContractSynchronizers,
         )
         if (conflictErrorCodes.exists(ErrorCodeUtils.isError(grpcDesc, _)))

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
@@ -108,6 +108,7 @@ final class HttpErrorHandler(
       case Status.Code.UNAVAILABLE => StatusCodes.ServiceUnavailable
       case Status.Code.INTERNAL => StatusCodes.InternalServerError
       case Status.Code.FAILED_PRECONDITION =>
+
         val grpcDesc = grpcStatus.getDescription
         val conflictErrorCodes = Seq(
           Interpreter.GenericInterpretationError,

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
@@ -108,7 +108,6 @@ final class HttpErrorHandler(
       case Status.Code.UNAVAILABLE => StatusCodes.ServiceUnavailable
       case Status.Code.INTERNAL => StatusCodes.InternalServerError
       case Status.Code.FAILED_PRECONDITION =>
-
         val grpcDesc = grpcStatus.getDescription
         val conflictErrorCodes = Seq(
           Interpreter.GenericInterpretationError,


### PR DESCRIPTION
https://github.com/DACH-NY/cn-test-failures/issues/8779

```
bobValidator App ---(onboard)--> SV App--(onboardRequest)-->Participant
bobValidator App <---(HTTP 400)-- SV App<--(FAILED_PRECONDITION/NOT_CONNECTED_TO_SYNCHRONIZER)---Participant

So the participant is complaining about NOT_CONNECTED_TO_SYNCHRONIZER. The error is commuincated as a FAILED_PRECONDITION grpc code. This grpc code is converted to a HTTP 400 error. That avoids bobValidator retrying the onboarding process.

The participant error: NOT_CONNECTED_TO_SYNCHRONIZER should not be a client error. It should actually be converted to a retryable error.
```
