### PR TITLE
test(wallet): make TransferPreapproval failure test robust to validator timeout

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -27,6 +27,7 @@ import org.lfdecentralizedtrust.splice.wallet.store.{
 import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.console.CommandFailure
 import com.digitalasset.canton.data.CantonTimestamp
+import com.digitalasset.canton.logging.SuppressingLogger.LogEntryOptionality
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 import com.digitalasset.canton.{HasExecutionContext, SynchronizerAlias}
@@ -693,6 +694,23 @@ class WalletIntegrationTest
         aliceValidatorBackend.lookupTransferPreapprovalByParty(aliceUserParty) shouldBe None
         aliceTransferPreapprovalProposals should be(empty)
 
+        // Once validator automation is paused the request cannot complete. The intended outcome is
+        // a 429 once the server-side retry loop gives up. Under load the validator's HTTP request
+        // timeout can fire first, in which case the server logs a WARN "resulted in a timeout" and
+        // returns a 503 instead. Accept either failure (both surface the request as a logged ERROR)
+        // and tolerate the optional timeout WARN, so a slow CI host does not flake the assertion.
+        def assertCreateTransferPreapprovalFails(): Unit =
+          loggerFactory.assertThrowsAndLogsUnorderedOptional[CommandFailure](
+            aliceWalletClient.createTransferPreapproval(),
+            LogEntryOptionality.Required -> { entry =>
+              entry.errorMessage should (include("429 Too Many Requests") or
+                include("503 Service Unavailable"))
+            },
+            LogEntryOptionality.Optional -> { entry =>
+              entry.warningMessage should include("resulted in a timeout")
+            },
+          )
+
         // Disable validator automation to create the TransferPreapproval.
         // This implies the request from alice will not succeed and time out.
         bracket(
@@ -700,19 +718,13 @@ class WalletIntegrationTest
           acceptTransferPreapprovalProposalTrigger.resume(),
         ) {
           val proposalCid =
-            clue("createTransferPreapproval fails with HTTP 429 if validator automation fails") {
-              assertThrowsAndLogsCommandFailures(
-                aliceWalletClient.createTransferPreapproval(),
-                _.errorMessage should include("429 Too Many Requests"),
-              )
+            clue("createTransferPreapproval fails if validator automation fails") {
+              assertCreateTransferPreapprovalFails()
               aliceTransferPreapprovalProposals should have length 1
               aliceTransferPreapprovalProposals.head.id
             }
           clue("TransferPreapprovalProposals created via the wallet API are deduplicated") {
-            assertThrowsAndLogsCommandFailures(
-              aliceWalletClient.createTransferPreapproval(),
-              _.errorMessage should include("429 Too Many Requests"),
-            )
+            assertCreateTransferPreapprovalFails()
             aliceTransferPreapprovalProposals should have length 1
             aliceTransferPreapprovalProposals.head.id shouldBe proposalCid
           }


### PR DESCRIPTION
Make the "Failure to complete TransferPreapproval creation should be handled correctly" wallet test robust to a transient validator HTTP timeout that flakes the log assertion under CI load.

### Flake

Observed on the `wall-clock-time (0)` job: https://github.com/canton-network/splice/actions/runs/27450544466 (job: https://github.com/canton-network/splice/actions/runs/27450544466/job/81436663390)

```
forEvery failed, because:
  at index 0, Incorrect log level WARN. Expected: ERROR.
  Message: Request to .../api/validator/v0/wallet/transfer-preapproval (POST) resulted in a timeout after 38 seconds.
  Remaining log entries:
  ## ERROR ... HttpCommandException: HTTP 503 Service Unavailable POST at '/api/validator/v0/wallet/transfer-preapproval' ... The server is taking too long to respond
```

The test pauses validator automation so `createTransferPreapproval` cannot complete. The intended outcome is an HTTP 429 once the server-side `RetryFor.ClientCalls` loop in `HttpWalletHandler` gives up (`ABORTED` -> `TooManyRequests`). Under load the validator's HTTP request timeout fired first: `HttpErrorHandler.timeoutHandler` logged a WARN "resulted in a timeout after 38 seconds" and returned 503 instead. The strict ordered assertion in `assertThrowsAndLogsCommandFailures` then matched the unexpected WARN entry at index 0 with `errorMessage`, which requires ERROR level, and failed.

### Fix

Assert the failure via `assertThrowsAndLogsUnorderedOptional[CommandFailure]`: a required ERROR entry matching either "429 Too Many Requests" or "503 Service Unavailable", plus an optional WARN entry matching the server-side "resulted in a timeout". This keeps the requirement that a genuine failure is surfaced and logged as ERROR, while tolerating the transient timeout WARN/503 on a slow host. Mirrors the existing pattern in `ScanIntegrationTest` and `SplitwellUpgradeIntegrationTest`.

Observed on PR #5937's CI run. The fix is by inspection; the integration test was not run locally.
