### PR TITLE
helm, splice-info: Switch to unprivileged NGINX image

### DIFF
--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -168,7 +168,7 @@ scan_get_status() {
             '
         )
 
-        # Use an exlusive lock to make sure we don't mix up the outputs
+        # Use an exclusive lock to make sure we don't mix up the outputs
         exec {LOCK_FD}<>"$lockfile"
         flock "$LOCK_FD"
 

--- a/cluster/helm/splice-info/templates/deployment.yaml
+++ b/cluster/helm/splice-info/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         imagePullPolicy: {{ . }}
         {{- end }}
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         volumeMounts:
         - name: config
           mountPath: /etc/nginx/conf.d/staticfile.conf

--- a/cluster/helm/splice-info/templates/service.yaml
+++ b/cluster/helm/splice-info/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 80
+    targetPort: 8080

--- a/cluster/helm/splice-info/values-template.yaml
+++ b/cluster/helm/splice-info/values-template.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-nginxImage: nginx:1.31.0@sha256:06aa3d7be10bc6307990c81bdca075793132e9163391abc370c015e344e23128
+nginxImage: nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:762e8e4e5e103817c4158400fc3753c8e713ff8153b8c3afbb458ae4572bc9a3
 updaterImage: registry.gitlab.com/gitlab-ci-utils/curl-jq:4.0.3@sha256:bd2cc4f9c880d277f8a42d87102d46e67ebce0f1d3a19b21b0125da9a4a44aa0
 contentType: "application/json"
 


### PR DESCRIPTION
Before: Standard Debian-based NGINX docker image.
After: Unprivileged Alpine-based (slim variant) NGINX docker image.