### PR TITLE
Fix ExternalPartyWalletStore to ingest beneficiary AppRewardCoupons

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletMintingDelegationTimeBasedIntegrationTest.scala
@@ -4,6 +4,7 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import org.lfdecentralizedtrust.splice.codegen.java.splice.types.Round
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.{
   Amulet,
   AppRewardCoupon,
@@ -465,6 +466,7 @@ class WalletMintingDelegationTimeBasedIntegrationTest
       balanceBefore shouldBe BigDecimal(0)
 
       val appRewardAmount = BigDecimal(100.0)
+      val appRewardBeneficiaryAmount = BigDecimal(150.0)
       val unclaimedActivityAmount = BigDecimal(200.0)
       val validatorRewardAmount = BigDecimal(500.0)
       val developmentFundAmount = BigDecimal(300.0)
@@ -497,21 +499,20 @@ class WalletMintingDelegationTimeBasedIntegrationTest
 
         // Pause minting delegation trigger to ensure we mint them together
         setTriggersWithin(triggersToPauseAtStart = Seq(externalPartyMintingDelegationTrigger)) {
-          // Create AppRewardCoupon
-          sv1Backend.participantClientWithAdminToken.ledger_api_extensions.commands
-            .submitWithResult(
-              userId = sv1Backend.config.ledgerApiUser,
-              actAs = Seq(dsoParty),
-              readAs = Seq.empty,
-              update = new AppRewardCoupon(
-                dsoParty.toProtoPrimitive,
-                beneficiaryParty.party.toProtoPrimitive,
-                false,
-                appRewardAmount.bigDecimal,
-                issuingRound.round,
-                java.util.Optional.empty(),
-              ).create,
-            )
+          // Create AppRewardCoupon where external party is the provider
+          createAppRewardCoupon(
+            provider = beneficiaryParty.party,
+            amount = appRewardAmount,
+            round = issuingRound.round,
+          )
+
+          // Create AppRewardCoupon where external party is the beneficiary (not the provider)
+          createAppRewardCoupon(
+            provider = aliceParty,
+            amount = appRewardBeneficiaryAmount,
+            round = issuingRound.round,
+            beneficiary = Some(beneficiaryParty.party),
+          )
 
           // Create UnclaimedActivityRecord
           sv1Backend.participantClientWithAdminToken.ledger_api_extensions.commands
@@ -614,7 +615,9 @@ class WalletMintingDelegationTimeBasedIntegrationTest
       val actualIncrease = balanceAfter - balanceBefore
 
       val expectedTotalReward =
-        (appRewardAmount * BigDecimal(issuingRound.issuancePerUnfeaturedAppRewardCoupon)) +
+        ((appRewardAmount + appRewardBeneficiaryAmount) * BigDecimal(
+          issuingRound.issuancePerUnfeaturedAppRewardCoupon
+        )) +
           (BigDecimal(
             issuingRound.optIssuancePerValidatorFaucetCoupon.orElse(java.math.BigDecimal.ZERO)
           )) +
@@ -814,4 +817,27 @@ class WalletMintingDelegationTimeBasedIntegrationTest
         commands = proposal.create.commands.asScala.toSeq,
       )
   }
+
+  private def createAppRewardCoupon(
+      provider: PartyId,
+      amount: BigDecimal,
+      round: Round,
+      beneficiary: Option[PartyId] = None,
+  )(implicit env: SpliceTestConsoleEnvironment): Unit =
+    sv1Backend.participantClientWithAdminToken.ledger_api_extensions.commands
+      .submitWithResult(
+        userId = sv1Backend.config.ledgerApiUser,
+        actAs = Seq(dsoParty),
+        readAs = Seq.empty,
+        update = new AppRewardCoupon(
+          dsoParty.toProtoPrimitive,
+          provider.toProtoPrimitive,
+          false,
+          amount.bigDecimal,
+          round,
+          beneficiary.fold(java.util.Optional.empty[String]())(b =>
+            java.util.Optional.of(b.toProtoPrimitive)
+          ),
+        ).create,
+      )
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
@@ -503,6 +503,7 @@ abstract class StoreTestBase
       provider: PartyId,
       featured: Boolean = false,
       amount: Numeric.Numeric = numeric(1.0),
+      beneficiary: Option[PartyId] = None,
       contractId: String = nextCid(),
   ): Contract[amuletCodegen.AppRewardCoupon.ContractId, amuletCodegen.AppRewardCoupon] =
     contract(
@@ -514,7 +515,7 @@ abstract class StoreTestBase
         featured,
         amount,
         new Round(round),
-        Optional.empty(),
+        beneficiary.map(_.toProtoPrimitive).fold(Optional.empty[String]())(Optional.of),
       ),
     )
 

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/store/ExternalPartyWalletStore.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/store/ExternalPartyWalletStore.scala
@@ -173,7 +173,8 @@ object ExternalPartyWalletStore {
       Map(
         mkFilter(AppRewardCoupon.COMPANION) { co =>
           co.payload.dso == dso &&
-          co.payload.provider == externalParty
+          (co.payload.provider == externalParty && co.payload.beneficiary.isEmpty ||
+            co.payload.beneficiary == java.util.Optional.of(externalParty))
         }(co =>
           ExternalPartyWalletAcsStoreRowData(co, rewardCouponRound = Some(co.payload.round.number))
         ),

--- a/apps/wallet/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ExternalPartyWalletStoreTest.scala
+++ b/apps/wallet/src/test/scala/org/lfdecentralizedtrust/splice/store/db/ExternalPartyWalletStoreTest.scala
@@ -1,6 +1,7 @@
 package org.lfdecentralizedtrust.splice.store.db
 
 import com.daml.metrics.api.noop.NoOpMetricsFactory
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.AppRewardCoupon
 import com.digitalasset.canton.concurrent.FutureSupervisor
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.resource.DbStorage
@@ -99,6 +100,44 @@ abstract class ExternalPartyWalletStoreTest
         } yield {
           store1.lookupTransferCommandCounter().futureValue.value shouldBe transferCommandCtr1
           store2.lookupTransferCommandCounter().futureValue shouldBe None
+        }
+      }
+
+    }
+
+    "AppRewardCoupon ingestion" should {
+
+      "ingest coupons where external party is provider or beneficiary" in {
+        for {
+          store <- mkStore(externalParty1)
+          // external party is the provider, no beneficiary
+          couponAsProvider = appRewardCoupon(round = 1, provider = externalParty1)
+          // external party is the beneficiary, different provider
+          couponAsBeneficiary = appRewardCoupon(
+            round = 1,
+            provider = externalParty2,
+            beneficiary = Some(externalParty1),
+          )
+          // neither provider nor beneficiary — should not be ingested
+          couponForOther = appRewardCoupon(round = 1, provider = externalParty2)
+          _ <- dummyDomain.create(
+            couponAsProvider,
+            createdEventSignatories = Seq(dsoParty, externalParty1),
+          )(store.multiDomainAcsStore)
+          _ <- dummyDomain.create(
+            couponAsBeneficiary,
+            createdEventSignatories = Seq(dsoParty, externalParty1),
+          )(store.multiDomainAcsStore)
+          _ <- dummyDomain.create(
+            couponForOther,
+            createdEventSignatories = Seq(dsoParty, externalParty2),
+          )(store.multiDomainAcsStore)
+        } yield {
+          val coupons = store.multiDomainAcsStore
+            .listContracts(AppRewardCoupon.COMPANION, HardLimit.tryCreate(Limit.DefaultMaxPageSize))
+            .futureValue
+          coupons.map(_.contractId) should contain theSameElementsAs
+            Seq(couponAsProvider, couponAsBeneficiary).map(_.contractId)
         }
       }
 


### PR DESCRIPTION
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
