### PR TITLE
Add metric and log for NO_EVENT_AT_TIMESTAMPS sequencer errors

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
@@ -299,7 +299,6 @@ class ScanVerdictIngestionService(
       // Recover from NO_EVENT_AT_TIMESTAMPS by returning an empty result.
       // See ensureVerdictsHaveTrafficSummaries for when missing summaries are
       // tolerated vs treated as errors.
-      // TODO(#5460): Add a metric recording missed timestamps for alerting.
       .recoverWith { case ex @ GrpcException(status, trailers) =>
         val statusProto = StatusProto.fromStatusAndTrailers(status, trailers)
         val errorDetails = ErrorDetails.from(statusProto)
@@ -311,9 +310,14 @@ class ScanVerdictIngestionService(
           }
           .headOption
           .getOrElse("none")
-        if (errorCodeId == TrafficControlErrors.NoEventAtTimestamps.id)
+        if (errorCodeId == TrafficControlErrors.NoEventAtTimestamps.id) {
+          ingestionMetrics.noEventAtTimestampsCount.mark()(MetricsContext.Empty)
+          logger.info(
+            s"Sequencer returned NO_EVENT_AT_TIMESTAMPS for ${sequencingTimes.size} timestamps" +
+              s" (first=${sequencingTimes.headOption}, last=${sequencingTimes.lastOption})"
+          )
           Future.successful(Seq.empty)
-        else
+        } else
           Future.failed(ex)
       }
   }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanMediatorVerdictIngestionMetrics.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanMediatorVerdictIngestionMetrics.scala
@@ -5,7 +5,7 @@ package org.lfdecentralizedtrust.splice.scan.metrics
 
 import com.daml.metrics.api.MetricHandle.{Gauge, Histogram, LabeledMetricsFactory, Meter, Timer}
 import com.daml.metrics.api.{MetricInfo, MetricName, MetricsContext}
-import com.daml.metrics.api.MetricQualification.{Latency, Saturation, Traffic}
+import com.daml.metrics.api.MetricQualification.{Errors, Latency, Saturation, Traffic}
 import com.digitalasset.canton.data.CantonTimestamp
 import org.lfdecentralizedtrust.splice.environment.SpliceMetrics
 
@@ -53,7 +53,7 @@ class ScanMediatorVerdictIngestionMetrics(metricsFactory: LabeledMetricsFactory)
     MetricInfo(
       name = prefix :+ "no_event_at_timestamps_count",
       summary = "Number of NO_EVENT_AT_TIMESTAMPS errors from the sequencer",
-      qualification = Traffic,
+      qualification = Errors,
     )
   )(MetricsContext.Empty)
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanMediatorVerdictIngestionMetrics.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/metrics/ScanMediatorVerdictIngestionMetrics.scala
@@ -49,6 +49,14 @@ class ScanMediatorVerdictIngestionMetrics(metricsFactory: LabeledMetricsFactory)
       )
     )(MetricsContext.Empty)
 
+  val noEventAtTimestampsCount: Meter = metricsFactory.meter(
+    MetricInfo(
+      name = prefix :+ "no_event_at_timestamps_count",
+      summary = "Number of NO_EVENT_AT_TIMESTAMPS errors from the sequencer",
+      qualification = Traffic,
+    )
+  )(MetricsContext.Empty)
+
   override def close(): Unit = {
     lastIngestedRecordTime.close()
   }


### PR DESCRIPTION
Fixes #5460
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
