### PR TITLE
Refactor jdbc types tests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/store/db/AcsJdbcTypesTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/store/db/AcsJdbcTypesTest.scala
@@ -11,11 +11,11 @@ import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import io.circe.Json
+import org.scalatest.Assertion
 import org.scalatest.wordspec.AsyncWordSpec
-import slick.jdbc.{JdbcProfile, PostgresProfile}
+import slick.jdbc.{GetResult, JdbcProfile, PostgresProfile, SetParameter}
 
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.Await
+import scala.concurrent.Future
 
 class AcsJdbcTypesTest
     extends AsyncWordSpec
@@ -28,92 +28,157 @@ class AcsJdbcTypesTest
   import org.lfdecentralizedtrust.splice.util.FutureUnlessShutdownUtil.futureUnlessShutdownToFuture
   import storage.api.jdbcProfile.api.*
 
-  val TestTable = new TableQuery(tag => new TestTableDef(tag))
+  private def writeAndRead[T](value: T, dbType: String)(implicit
+      get: GetResult[T],
+      set: SetParameter[T],
+  ): Future[Assertion] = {
+    for {
+      _ <- storage.underlying.update(
+        sqlu"""
+        create table jdbc_types_test_table (
+          val #$dbType
+        )
+        """,
+        "create test table",
+      )(implicitly, implicitly, _ => false)
+      _ <- storage.underlying.update(
+        sqlu" insert into jdbc_types_test_table values (${value})",
+        "insert",
+      )
+      fetched <- storage.underlying
+        .querySingle(
+          sql"select val from jdbc_types_test_table".as[T].headOption,
+          "fetch",
+        )
+        .value
+        .map(_.value)
+    } yield fetched match {
+      case arr: Array[?] => arr should contain theSameElementsAs value.asInstanceOf[Array[?]]
+      case _ => fetched should be(value)
+    }
+  }
+
+  private def readNull[T](dbType: String)(implicit
+      get: GetResult[Option[T]]
+  ): Future[Assertion] = {
+    for {
+      _ <- storage.underlying.update(
+        sqlu"""
+        create table jdbc_types_test_table (
+          val #$dbType
+        )
+        """,
+        "create test table",
+      )(implicitly, implicitly, _ => false)
+      _ <- storage.underlying.update(
+        sqlu" insert into jdbc_types_test_table values (null)",
+        "insert",
+      )
+      fetched <- storage.underlying
+        .querySingle(
+          sql"select val from jdbc_types_test_table".as[Option[T]].headOption,
+          "fetch",
+        )
+        .value
+        .map(_.value)
+    } yield {
+      fetched shouldBe None
+    }
+  }
 
   "AcsJdbcTypes" should {
-    "be symmetric write-read" in {
-      val row = TestRow(
-        Timestamp.now(),
-        new ContractId[Any](
-          "003daad4665efc696dfb505d8ca794034a18f264cda4ebd3f0549f03c0f1f4ef42ca011220df05a9d3d5a4180cec940aeed16e1f080e6f81ee3867ff433e4a37ce2a9769c1"
-        ),
-        Offset.tryFromLong(64),
-        "bf196cb0db2637fd30850500c50984c3b2dc23c2f89b42d9a673c5dcad3649a2",
-        QualifiedName(
-          "Splice.Directory",
-          "DirectoryEntry",
-        ),
-        SynchronizerId.tryFromString(
-          "domain_007c100515333195029920502::122083332c56ac1568312ccdccc7ebae45cb93005da7c4ff58c333588403efee5901"
-        ),
-        PartyId.tryFromProtoPrimitive("aaaa::bbbb"),
-        Json.obj(
-          "a" -> Json.fromInt(1),
-          "b" -> Json.arr(Json.fromString("c"), Json.fromString("d")),
-        ),
+    "String" in {
+      val value = "abc"
+      writeAndRead(value, "text not null")
+    }
+
+    "Option.empty[String]" in {
+      val value = Option.empty[String]
+      writeAndRead(value, "text")
+    }
+
+    "Timestamp" in {
+      val value = Timestamp.now()
+      writeAndRead(value, "bigint not null")
+    }
+
+    "ContractId" in {
+      val value = new ContractId[Any](
+        "003daad4665efc696dfb505d8ca794034a18f264cda4ebd3f0549f03c0f1f4ef42ca011220df05a9d3d5a4180cec940aeed16e1f080e6f81ee3867ff433e4a37ce2a9769c1"
       )
-
-      (for {
-        _ <- storage.update(TestTable += row, "insert")
-        fetched <- storage.query(TestTable.result, "fetch")
-      } yield fetched.head).futureValue should be(row)
+      writeAndRead(value, "text not null")
     }
 
-    "set and get contract id arrays" in {
+    "SynchronizerId" in {
+      val value = SynchronizerId.tryFromString(
+        "domain_007c100515333195029920502::122083332c56ac1568312ccdccc7ebae45cb93005da7c4ff58c333588403efee5901"
+      )
+      writeAndRead(value, "text not null")
+    }
+
+    "Offset" in {
+      val value = Offset.tryFromLong(64)
+      writeAndRead(value, "text not null")
+    }
+
+    "QualifiedName" in {
+      val value = QualifiedName(
+        "Splice.Directory",
+        "DirectoryEntry",
+      )
+      writeAndRead(value, "text not null")
+    }
+
+    "PartyId" in {
+      val value = PartyId.tryFromProtoPrimitive("aaaa::bbbb")
+      writeAndRead(value, "text not null")
+    }
+
+    "Json.obj" in {
+      val value = Json.obj(
+        "a" -> Json.fromInt(1),
+        "b" -> Json.arr(Json.fromString("c"), Json.fromString("d")),
+      )
+      writeAndRead(value, "json")
+    }
+
+    "Array[ContractId]" in {
       val value = Array("a", "b", "c").map(new ContractId[Any](_))
-      for {
-        result <- storage.querySingle(
-          sql"select $value".as[Array[ContractId[Any]]].headOption,
-          "array",
-        )
-      } yield result should contain theSameElementsAs value
+      writeAndRead(value, "text[] not null")
     }
 
-    "set and get string arrays" in {
-      val value = Array("a", "b", "c")
-      for {
-        result <- storage.querySingle(
-          sql"select ${value.map(lengthLimited)}".as[Array[String]].headOption,
-          "array",
-        )
-      } yield result should contain theSameElementsAs value
+    "Seq[String]" in {
+      val value = Seq[String]("a", "b", "c")
+      writeAndRead(value, "text[] not null")
     }
 
-    "set and get optional string arrays" in {
-      val value = Array("a", "b", "c")
-      for {
-        resultSome <- storage.querySingle(
-          sql"select 1, ${value.map(lengthLimited)}".as[(Int, Option[Array[String]])].headOption,
-          "optional array",
-        )
-        resultNone <- storage.querySingle(
-          sql"select 1, null".as[(Int, Option[Array[String]])].headOption,
-          "optional array",
-        )
-      } yield {
-        resultSome._2.value should contain theSameElementsAs value
-        resultNone._2 shouldBe None
-      }
+    "Seq.empty[String]" in {
+      val value = Seq.empty[String]
+      writeAndRead(value, "text[] not null")
     }
 
-    "set and get string sequences" in {
-      val value = Seq("a", "b", "c")
-      for {
-        result <- storage.querySingle(
-          sql"select ${value.map(lengthLimited)}".as[Seq[String]].headOption,
-          "array",
-        )
-      } yield result should contain theSameElementsAs value
+    "Array[String]" in {
+      val value = Array[String]("a", "b", "c")
+      writeAndRead(value, "text[] not null")
     }
 
-    "set and get int arrays" in {
-      val value = Seq(1, 2, 3)
-      for {
-        result <- storage.querySingle(
-          sql"select ${value}".as[Array[Int]].headOption,
-          "int array",
-        )
-      } yield result.toSeq should contain theSameElementsAs value
+    "Option[Array[String]]" in {
+      readNull[Array[String]]("text[]")
+    }
+
+    "Seq[Long]" in {
+      val value = Seq[Long](1, 2, 3)
+      writeAndRead(value, "bigint[] not null")
+    }
+
+    "Seq.empty[Long]" in {
+      val value = Seq.empty[Long]
+      writeAndRead(value, "bigint[] not null")
+    }
+
+    "Array[Long]" in {
+      val value = Array[Long](1, 2, 3)
+      writeAndRead(value, "bigint[] not null")
     }
   }
 
@@ -126,45 +191,12 @@ class AcsJdbcTypesTest
       synchronizerId: SynchronizerId,
       partyId: PartyId,
       json: Json,
+      intArray: Seq[Int],
+      stringArray: Seq[String],
   )
-
-  class TestTableDef(_tableTag: Tag)
-      extends storage.api.jdbcProfile.Table[TestRow](_tableTag, "jdbc_types_test_table") {
-    val timestamp: Rep[Timestamp] = column[Timestamp]("timestamp")
-    val contractId: Rep[ContractId[Any]] = column[ContractId[Any]]("contract_id")
-    val offset: Rep[Offset] = column[Offset]("offset")
-    val templateIdPackageId: Rep[String] = column[String]("template_id_package_id")
-    val templateIdQualifiedName: Rep[QualifiedName] =
-      column[QualifiedName]("template_id_qualified_name")
-    val synchronizerId: Rep[SynchronizerId] = column[SynchronizerId]("domain_id")
-    val partyId: Rep[PartyId] = column[PartyId]("party_id")
-    val json: Rep[Json] = column[Json]("jayson")
-    def * = (
-      timestamp,
-      contractId,
-      offset,
-      templateIdPackageId,
-      templateIdQualifiedName,
-      synchronizerId,
-      partyId,
-      json,
-    ).<>(
-      TestRow.tupled,
-      TestRow.unapply,
-    )
-  }
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    val ddl = TestTable.schema.createIfNotExists.statements
-    Await.result(
-      storage.update(DBIO.sequence(ddl.map(s => sqlu"#$s")), "create test table")(
-        implicitly,
-        implicitly,
-        _ => false,
-      ),
-      10.seconds,
-    )
   }
 
   override def cleanDb(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/store/db/AcsJdbcTypesTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/store/db/AcsJdbcTypesTest.scala
@@ -52,9 +52,22 @@ class AcsJdbcTypesTest
         )
         .value
         .map(_.value)
-    } yield fetched match {
-      case arr: Array[?] => arr should contain theSameElementsAs value.asInstanceOf[Array[?]]
-      case _ => fetched should be(value)
+      fetchedLiteral <- storage.underlying
+        .querySingle(
+          sql"select $value".as[T].headOption,
+          "fetch literal",
+        )
+        .value
+        .map(_.value)
+    } yield {
+      value match {
+        case valueArray: Array[?] =>
+          fetched.asInstanceOf[Array[?]] should contain theSameElementsAs valueArray
+          fetchedLiteral.asInstanceOf[Array[?]] should contain theSameElementsAs valueArray
+        case _ =>
+          fetched should be(value)
+          fetchedLiteral should be(value)
+      }
     }
   }
 
@@ -81,8 +94,16 @@ class AcsJdbcTypesTest
         )
         .value
         .map(_.value)
+      fetchedLiteral <- storage.underlying
+        .querySingle(
+          sql"select null".as[Option[T]].headOption,
+          "fetch literal",
+        )
+        .value
+        .map(_.value)
     } yield {
       fetched shouldBe None
+      fetchedLiteral shouldBe None
     }
   }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsJdbcTypes.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AcsJdbcTypes.scala
@@ -186,6 +186,9 @@ trait AcsJdbcTypes {
   protected implicit lazy val longSeqSetParameter: SetParameter[Seq[Long]] =
     (longs: Seq[Long], pp: PositionedParameters) => longArraySetParameter(longs.toArray, pp)
 
+  protected implicit lazy val longSeqGetResult: GetResult[Seq[Long]] =
+    longArrayGetResult.andThen(_.toSeq)
+
   protected implicit lazy val cantonTimestampArraySetParameter
       : SetParameter[Array[CantonTimestamp]] =
     (timestamps: Array[CantonTimestamp], pp: PositionedParameters) =>


### PR DESCRIPTION
The main motivation is to have tests that show that we can handle empty arrays without an explicit type annotation, at least when using sql interpolation.

The previous tests also only used `GetResult` implicits for the individual tests; only the one test using `TestTable` actually wrote any data and used `SetParameter` implicits.

