### PR TITLE
Support http basic auth in oauth client credential requests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/http/HttpClientProxyTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/unit/http/HttpClientProxyTest.scala
@@ -169,6 +169,7 @@ class HttpClientProxyTest
               new OAuthApi(
                 NonNegativeDuration.ofSeconds(20),
                 HttpClientMetrics(metricsFactory),
+                httpBasicAuth = false,
                 loggerFactory,
               )
             api.getWellKnown(wellKnownUrlString).futureValue shouldBe an[WellKnownResponse]

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/auth/AuthTokenSource.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/auth/AuthTokenSource.scala
@@ -89,11 +89,12 @@ case class AuthTokenSourceOAuthClientCredentials(
     scope: Option[String],
     requestTimeout: NonNegativeDuration,
     httpClientMetrics: HttpClientMetrics,
+    httpBasicAuth: Boolean,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit ec: ExecutionContext, ac: ActorSystem)
     extends AuthTokenSource
     with NamedLogging {
-  private val oauth = new OAuthApi(requestTimeout, httpClientMetrics, loggerFactory)
+  private val oauth = new OAuthApi(requestTimeout, httpClientMetrics, httpBasicAuth, loggerFactory)
 
   override def getToken(implicit tc: TraceContext): Future[Option[AuthToken]] = {
     for {
@@ -130,6 +131,7 @@ object AuthTokenSource {
           audience,
           scope,
           requestTimeout,
+          httpBasicAuth,
           _,
         ) =>
       new AuthTokenSourceOAuthClientCredentials(
@@ -141,6 +143,7 @@ object AuthTokenSource {
         audience = audience,
         scope = scope,
         requestTimeout = requestTimeout,
+        httpBasicAuth = httpBasicAuth,
       )
   }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/auth/OAuthApi.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/auth/OAuthApi.scala
@@ -7,6 +7,7 @@ import com.digitalasset.canton.config.{ApiLoggingConfig, NonNegativeDuration}
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import org.apache.pekko.http.scaladsl.model.{FormData, HttpMethods, HttpRequest, HttpResponse}
+import org.apache.pekko.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import org.apache.pekko.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.tracing.TraceContext
@@ -26,15 +27,25 @@ object OAuthApi {
       scope: Option[String],
       grant_type: String = "client_credentials",
   ) {
-    def toFormData = FormData(
-      Map(
-        "client_id" -> client_id,
-        "client_secret" -> client_secret,
+    def toFormDataAndHeaders(httpBasicAuth: Boolean) = {
+      val formParams = Map(
         "audience" -> audience,
         "grant_type" -> grant_type,
-      )
-        ++ scope.filter(_.nonEmpty).map("scope" -> _)
-    )
+      ) ++ scope.filter(_.nonEmpty).map("scope" -> _)
+      if (httpBasicAuth) {
+        (
+          FormData(formParams),
+          Seq(Authorization(BasicHttpCredentials(client_id, client_secret))),
+        )
+      } else {
+        (
+          FormData(
+            formParams ++ Seq("client_id" -> client_id, "client_secret" -> client_secret)
+          ),
+          Seq.empty,
+        )
+      }
+    }
   }
 
   /** expires_in is in seconds */
@@ -66,6 +77,7 @@ trait OAuthApiJson extends SprayJsonSupport with DefaultJsonProtocol {
 class OAuthApi(
     requestTimeout: NonNegativeDuration,
     httpClientMetrics: HttpClientMetrics,
+    httpBasicAuth: Boolean,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit actorSystem: ActorSystem)
     extends OAuthApiJson
@@ -126,14 +138,17 @@ class OAuthApi(
 
     val payload = ClientCredentialRequest(clientId, clientSecret, audience, scope)
 
-    val responseFuture: Future[HttpResponse] =
+    val responseFuture: Future[HttpResponse] = {
+      val (formData, headers) = payload.toFormDataAndHeaders(httpBasicAuth)
       httpClient.executeRequest(clientName, "requestToken")(
         HttpRequest(
           method = HttpMethods.POST,
           uri = tokenUrl,
-          entity = payload.toFormData.toEntity,
+          entity = formData.toEntity,
+          headers = headers,
         )
       )
+    }
 
     for {
       res <- responseFuture

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AuthTokenSourceConfig.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/config/AuthTokenSourceConfig.scala
@@ -39,6 +39,8 @@ object AuthTokenSourceConfig {
       audience: String,
       scope: Option[String],
       requestTimeout: NonNegativeDuration = NonNegativeDuration.ofSeconds(30),
+      httpBasicAuth: Boolean =
+        false, // Authenticate using http basic auth instead of passing client_id/secret in the request body.
       adminToken: Option[String],
   ) extends AuthTokenSourceConfig
 
@@ -57,6 +59,7 @@ object AuthTokenSourceConfig {
             audience,
             scope,
             requestTimeout,
+            basicAuth,
             adminToken,
           ) =>
         ClientCredentials(
@@ -66,6 +69,7 @@ object AuthTokenSourceConfig {
           audience,
           scope,
           requestTimeout,
+          basicAuth,
           hide(adminToken),
         )
     }

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,7 +7,6 @@
 
 .. release-notes:: Upcoming
 
-
       - PostgreSQL Data Checksums
 
           - `PostgreSQL data checksums <https://www.postgresql.org/docs/14/checksums.html>`_ are now
@@ -29,3 +28,8 @@
 
           - Splice nodes now perform a best-effort check at startup and log a ``WARN`` if PostgreSQL
             data checksums are not enabled on their backing database. This check never fails startup.
+
+      - Validator, sv and scan app
+
+          - Support passing client-id and secret through Http Basic Authentication instead of in the request body. For backwards compatibility this is disabled by default.
+            To enable it set an environment variable ``ADDITIONAL_CONFIG_HTTP_BASIC_AUTH=canton.validator-apps.sv.participant-client.ledger-api.auth-config.http-basic-auth = true``.


### PR DESCRIPTION
Testing is a bit tricky, we don't actually have integration tests against auth0 afaict for backends (we do have some for frontends).

Most cluster tests also don't work as we use fixed tokens so this does nothing.

So what I did for now is a manual scratch test with basic-auth = true and fixed-tokens = false which works fine.

In terms of keeping it tested, I think the best in our current setup is to set validator1 on devnet (cilr has fixed tokens) to enable this. Obviously can only do this after a release.

fixes #6031

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
