### PR TITLE
[static] pulumi: support transfer preapprovals in sweeps

### DIFF
--- a/cluster/pulumi/common-validator/src/sweep.ts
+++ b/cluster/pulumi/common-validator/src/sweep.ts
@@ -5,4 +5,5 @@ export type SweepConfig = {
   toParty: string;
   maxBalance: number;
   minBalance: number;
+  useTransferPreapproval?: boolean;
 };

--- a/cluster/pulumi/common-validator/src/validator.ts
+++ b/cluster/pulumi/common-validator/src/validator.ts
@@ -164,6 +164,7 @@ export async function installValidatorApp(
       maxBalanceUSD: config.sweep.maxBalance,
       minBalanceUSD: config.sweep.minBalance,
       receiver: config.sweep.toParty,
+      useTransferPreapproval: config.sweep.useTransferPreapproval,
     },
   };
 


### PR DESCRIPTION
In https://github.com/DACH-NY/canton-network-internal/pull/5716, I missed the fact that my config change was actually ignored in the expected file (and in actual deployment of course) because apparently we parse that json in pulumi, and were thus ignoring the useTransferPreapproval field. 

Confirmed that in canton-network-internal, if I checkout splice to this: 
- the TestNet expected file updates to add the `useTransferPreapproval: true` as expected
- devnet and mainnet expected files do not change

[cluster test for sanity](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/70473/workflows/38cec187-6d0e-4f17-bbda-4c974f6cdae2/jobs/419085)


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
