### PR TITLE
Fix flake; reduce vetting cache TTL and run trigger manually

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -628,7 +628,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       withClue(
         s"$cluePrefix sum of weights should be within [totalTrafficCost - numFeaturedAppParties, totalTrafficCost]"
       ) {
-        weightSum should be > (totalTrafficCost - numFeaturedAppParties)
+        weightSum should be >= (totalTrafficCost - numFeaturedAppParties)
         weightSum should be <= totalTrafficCost
       }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -2,6 +2,7 @@ package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.HasExecutionContext
 import com.digitalasset.canton.config.CantonRequireTypes.InstanceName
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.transaction.VettedPackage
 import com.digitalasset.canton.topology.{ForceFlag, ForceFlags, ParticipantId, PartyId}
@@ -25,6 +26,7 @@ import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
   IntegrationTestWithIsolatedEnvironment,
   SpliceTestConsoleEnvironment,
 }
+import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.ExpireRewardCouponV2Trigger
 import org.lfdecentralizedtrust.splice.sv.config.InitialRewardConfig
 import org.lfdecentralizedtrust.splice.util.{
   ChoiceContextWithDisclosures,
@@ -114,6 +116,15 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
       .addConfigTransform((_, config) =>
         updateAutomationConfig(ConfigurableApp.Validator)(
           _.withPausedTrigger[AcceptedTransferOfferTrigger]
+        )(config)
+      )
+      .addConfigTransform((_, config) =>
+        ConfigTransforms.updateAllSvAppConfigs_(svConfig =>
+          svConfig.copy(
+            packageVettingCache = svConfig.packageVettingCache.copy(
+              ttl = NonNegativeFiniteDuration.ofMillis(1)
+            )
+          )
         )(config)
       )
       .withoutAutomaticRewardsCollectionAndAmuletMerging
@@ -294,12 +305,16 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
       )(
         "ExpireRewardCouponV2Trigger ignores Alice coupons",
         _ => {
+          sv1Backend.dsoDelegateBasedAutomation
+            .trigger[ExpireRewardCouponV2Trigger]
+            .runOnce()
+            .futureValue
           val remaining = sv1Backend.appState.dsoStore
             .listRewardCouponsV2()
             .futureValue
             .map(_.contractId.contractId)
             .toSet
-          aliceObservedCoupons.subsetOf(remaining) shouldBe true
+          remaining shouldBe aliceObservedCoupons
         },
       )
 
@@ -308,7 +323,13 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
         revetV2AmuletOnAlice(aliceParticipantId),
       )(
         "ExpireRewardCouponV2Trigger archives once Alice is re-vetted",
-        _ => sv1Backend.appState.dsoStore.listRewardCouponsV2().futureValue shouldBe empty,
+        _ => {
+          sv1Backend.dsoDelegateBasedAutomation
+            .trigger[ExpireRewardCouponV2Trigger]
+            .runOnce()
+            .futureValue
+          sv1Backend.appState.dsoStore.listRewardCouponsV2().futureValue shouldBe empty
+        },
       )
     }
   }


### PR DESCRIPTION
Also harden the assertion to confirm bob's coupons are expired

The test failed here
 https://github.com/canton-network/splice/actions/runs/27752255332/job/82105479067
https://github.com/canton-network/splice/actions/runs/27751689161/job/82103636974
And
https://github.com/canton-network/splice/actions/runs/27761311824/job/82136332956
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
