### PR TITLE
Allow for bigger overhead for rate limiter test

### DIFF
--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/SpliceRateLimiterTest.scala
@@ -22,13 +22,12 @@ class SpliceRateLimiterTest
     with HasExecutionContext
     with MetricValues {
 
-  private val elementsToRun = 100
-
   "the rate limiter" should {
 
     "accept requests under limit" in {
+      val elementsToRun = 100
       withRateLimiter { case (rateLimitMetrics, rateLimiter) =>
-        runThroughRateLimiter(rateLimiter, 9).reduce(_ && _) shouldBe true
+        runThroughRateLimiter(rateLimiter, 9, elementsToRun).reduce(_ && _) shouldBe true
 
         rateLimitMetrics.meter.valueFilteredOnLabels(
           LabelFilter(
@@ -45,12 +44,12 @@ class SpliceRateLimiterTest
 
     "reject requests that are over the limit" in {
       withRateLimiter { case (rateLimitMetrics, rateLimiter) =>
-        val results = runThroughRateLimiter(rateLimiter, 11)
+        val results = runThroughRateLimiter(rateLimiter, 100, 1000)
 
         val (accepted, rejected) = results.partition(identity)
 
-        // estimate for running 9 seconds
-        accepted.length should (be > 85 and be < 95)
+        // estimate for running 10 seconds, with some overhead for slower execution
+        accepted.length should (be > 85 and be < 150)
 
         rateLimitMetrics.meter.valueFilteredOnLabels(
           LabelFilter(
@@ -79,10 +78,14 @@ class SpliceRateLimiterTest
 
   }
 
-  private def runThroughRateLimiter(rateLimiter: SpliceRateLimiter, runsPerSecond: Int) = {
+  private def runThroughRateLimiter(
+      rateLimiter: SpliceRateLimiter,
+      runsPerSecond: Int,
+      runFor: Int,
+  ) = {
     runRateLimited(
       runsPerSecond,
-      elementsToRun,
+      runFor,
     ) {
       rateLimiter
         .runWithLimit(Future.successful(true))


### PR DESCRIPTION
[ci]

fixes https://github.com/DACH-NY/cn-test-failures/issues/8859


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
