### PR TITLE
make auto upgrade test workflow directly request the test and refactor pr_cluster_test

### DIFF
--- a/.github/workflows/pr_auto_upgrade_test.yml
+++ b/.github/workflows/pr_auto_upgrade_test.yml
@@ -1,27 +1,21 @@
 name: Automatically trigger an upgrade test on PRs
 on:
-  pull_request_target:
+  pull_request:
     # This is only triggered on PR creation to avoid spamming the PR with comments on every update.
     # It is up to the author to decided if subsequent changes require another upgrade test.
     types: [ opened ]
     paths:
       - 'cluster/pulumi/**/package.json'
       - 'nix/**'
-permissions:
+permissions: # permissions have to match pr_cluster_test permissions as called workflows cannot escalate their own permissions
   contents: read
   issues: read
-  pull-requests: write # To comment back on the PR
+  pull-requests: write
+  id-token: write
 jobs:
   request_upgrade_test:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Add a comment to the PR to request an upgrade test
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script : |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: "Requesting an /upgrade_test due to changes in Pulumi or Nix package versions."
-            });
+    uses: ./.github/workflows/pr_cluster_test.yml
+    secrets: inherit
+    with:
+      workflow: upgrade_test
+      pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr_auto_upgrade_test.yml
+++ b/.github/workflows/pr_auto_upgrade_test.yml
@@ -1,6 +1,6 @@
 name: Automatically trigger an upgrade test on PRs
 on:
-  pull_request:
+  pull_request_target:
     # This is only triggered on PR creation to avoid spamming the PR with comments on every update.
     # It is up to the author to decided if subsequent changes require another upgrade test.
     types: [ opened ]

--- a/.github/workflows/pr_cluster_test.yml
+++ b/.github/workflows/pr_cluster_test.yml
@@ -2,6 +2,14 @@ name: Trigger a cluster test on a PR
 on:
   issue_comment:
     types: [created]
+  workflow_call:
+    inputs:
+      workflow:
+        type: string
+        required: true
+      pr_number:
+        type: number
+        required: true
 permissions:
   contents: read
   issues: read
@@ -12,7 +20,7 @@ jobs:
 
   get_head:
     runs-on: ubuntu-24.04
-    if: github.event.issue.pull_request
+    if: github.event.issue.pull_request || github.event_name == 'workflow_call'
     outputs:
       sha: ${{ steps.get_head.outputs.sha }}
       repo: ${{ steps.get_head.outputs.repo }}
@@ -21,7 +29,8 @@ jobs:
         id: get_head
         run: |
           set -euo pipefail
-          query='query pullRequestDetails { repository(name: \"${{ github.event.repository.name }}\", owner: \"${{ github.repository_owner }}\") { pullRequest(number: ${{ github.event.issue.number }}) { headRef { target { oid } } } } }'
+          pr_number="${{ github.event.issue.number }}${{ inputs.pr_number }}"
+          query="query pullRequestDetails { repository(name: \"${{ github.event.repository.name }}\", owner: \"${{ github.repository_owner }}\") { pullRequest(number: $pr_number) { headRef { target { oid } } } } }"
           result=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -X POST -d " { \"query\": \"$query\" } " https://api.github.com/graphql)
           if ! echo "$result" | jq empty > /dev/null 2>&1; then
             echo "GitHub API did not return valid JSON. Response: $result"
@@ -34,25 +43,63 @@ jobs:
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
-  trigger_cluster_test_basic:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/cluster_test')
-    needs: get_head
+  determine_test_type:
+    runs-on: ubuntu-24.04
+    outputs:
+      workflow: ${{ steps.determine_test_type.outputs.workflow }}
+    steps:
+      - name: Determine test type
+        id: determine_test_type
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUTS_WORKFLOW: ${{ inputs.workflow }}
+        with:
+          script: |
+            let workflow = '';
+
+            switch (context.eventName) {
+              case 'workflow_call':
+                workflow = process.env.INPUTS_WORKFLOW;
+                break;
+              case 'issue_comment':
+                const body = context.payload.comment.body || '';
+                
+                if (body.includes('/cluster_test')) {
+                  workflow = 'cluster_test';
+                } else if (body.includes('/hdm_test')) {
+                  workflow = 'hdm_test';
+                } else if (body.includes('/lsu_test')) {
+                  workflow = 'lsu_test';
+                } else if (body.includes('/upgrade_test')) {
+                  workflow = 'upgrade_test';
+                }
+                break;
+            }
+
+            core.setOutput('workflow', workflow);
+
+  trigger_test:
+    needs:
+      - get_head
+      - determine_test_type
     uses: ./.github/workflows/cluster_tests.yml
     secrets: inherit
     with:
-      workflow: cluster_test
+      workflow: ${{ needs.determine_test_type.outputs.workflow }}
       sha: ${{ needs.get_head.outputs.sha }}
 
   result:
     runs-on: ubuntu-24.04
     needs:
-      - trigger_cluster_test_basic
       - get_head
+      - determine_test_type
+      - trigger_test
+    if: needs.determine_test_type.outputs.workflow == 'cluster_test'
     steps:
       - name: parse the result
         id: parse
         run: |
-          number=$(echo '${{ needs.trigger_cluster_test_basic.outputs.result }}' | jq -r '.number')
+          number=$(echo '${{ needs.trigger_test.outputs.result }}' | jq -r '.number')
           echo "Deploy scratchnet pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${number}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
       - name: Comment on the PR
@@ -66,26 +113,18 @@ jobs:
               body: "Deploy cluster test triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please contact a Contributor to approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${{ steps.parse.outputs.number }}"
             });
 
-
-  trigger_cluster_test_hdm:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/hdm_test')
-    needs: get_head
-    uses: ./.github/workflows/cluster_tests.yml
-    secrets: inherit
-    with:
-      workflow: hdm_test
-      sha: ${{ needs.get_head.outputs.sha }}
-
   result_hdm:
     runs-on: ubuntu-24.04
     needs:
-      - trigger_cluster_test_hdm
       - get_head
+      - determine_test_type
+      - trigger_test
+    if: needs.determine_test_type.outputs.workflow == 'hdm_test'
     steps:
       - name: parse the result
         id: parse
         run: |
-          number=$(echo '${{ needs.trigger_cluster_test_hdm.outputs.result }}' | jq -r '.number')
+          number=$(echo '${{ needs.trigger_test.outputs.result }}' | jq -r '.number')
           echo "Deploy scratchnet HDM pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${number}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
       - name: Comment on the PR
@@ -99,25 +138,18 @@ jobs:
               body: "Deploy HDM pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please contact a Contributor to approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${{ steps.parse.outputs.number }}"
             });
 
-  trigger_cluster_test_lsu:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/lsu_test')
-    needs: get_head
-    uses: ./.github/workflows/cluster_tests.yml
-    secrets: inherit
-    with:
-      workflow: lsu_test
-      sha: ${{ needs.get_head.outputs.sha }}
-
   result_lsu:
     runs-on: ubuntu-24.04
     needs:
-      - trigger_cluster_test_lsu
       - get_head
+      - determine_test_type
+      - trigger_test
+    if: needs.determine_test_type.outputs.workflow == 'lsu_test'
     steps:
       - name: parse the result
         id: parse
         run: |
-          number=$(echo '${{ needs.trigger_cluster_test_lsu.outputs.result }}' | jq -r '.number')
+          number=$(echo '${{ needs.trigger_test.outputs.result }}' | jq -r '.number')
           echo "Deploy scratchnet LSU pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${number}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
       - name: Comment on the PR
@@ -131,25 +163,18 @@ jobs:
               body: "Deploy LSU pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please contact a Contributor to approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${{ steps.parse.outputs.number }}"
             });
 
-  trigger_cluster_test_upgrade:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/upgrade_test')
-    needs: get_head
-    uses: ./.github/workflows/cluster_tests.yml
-    secrets: inherit
-    with:
-      workflow: upgrade_test
-      sha: ${{ needs.get_head.outputs.sha }}
-
   result_upgrade:
     runs-on: ubuntu-24.04
     needs:
-      - trigger_cluster_test_upgrade
       - get_head
+      - determine_test_type
+      - trigger_test
+    if: needs.determine_test_type.outputs.workflow == 'upgrade_test'
     steps:
       - name: parse the result
         id: parse
         run: |
-          number=$(echo '${{ needs.trigger_cluster_test_upgrade.outputs.result }}' | jq -r '.number')
+          number=$(echo '${{ needs.trigger_test.outputs.result }}' | jq -r '.number')
           echo "Deploy scratchnet upgrade pipeline triggered for [Commit ${{ needs.get_head.outputs.sha }} in ${{ needs.get_head.outputs.repo }}](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/files/${{ needs.get_head.outputs.sha }}), please approve it in CircleCI: https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/${number}"
           echo "number=$number" >> "$GITHUB_OUTPUT"
       - name: Comment on the PR

--- a/.github/workflows/pr_cluster_test.yml
+++ b/.github/workflows/pr_cluster_test.yml
@@ -30,7 +30,9 @@ jobs:
         run: |
           set -euo pipefail
           pr_number="${{ github.event.issue.number }}${{ inputs.pr_number }}"
-          query="query pullRequestDetails { repository(name: \"${{ github.event.repository.name }}\", owner: \"${{ github.repository_owner }}\") { pullRequest(number: $pr_number) { headRef { target { oid } } } } }"
+          echo "PR number: $pr_number"
+          query='query pullRequestDetails { repository(name: \"${{ github.event.repository.name }}\", owner: \"${{ github.repository_owner }}\") { pullRequest(number: '"$pr_number"') { headRef { target { oid } } } } }'
+          echo "query: $query"
           result=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -X POST -d " { \"query\": \"$query\" } " https://api.github.com/graphql)
           if ! echo "$result" | jq empty > /dev/null 2>&1; then
             echo "GitHub API did not return valid JSON. Response: $result"

--- a/.github/workflows/pr_cluster_test.yml
+++ b/.github/workflows/pr_cluster_test.yml
@@ -20,7 +20,7 @@ jobs:
 
   get_head:
     runs-on: ubuntu-24.04
-    if: github.event.issue.pull_request || github.event_name == 'workflow_call'
+    if: ${{ !github.event_name == 'issue_comment' || github.event.issue.pull_request }}
     outputs:
       sha: ${{ steps.get_head.outputs.sha }}
       repo: ${{ steps.get_head.outputs.repo }}
@@ -45,6 +45,7 @@ jobs:
 
   determine_test_type:
     runs-on: ubuntu-24.04
+    if: ${{ !github.event_name == 'issue_comment' || github.event.issue.pull_request }}
     outputs:
       workflow: ${{ steps.determine_test_type.outputs.workflow }}
     steps:
@@ -57,23 +58,20 @@ jobs:
           script: |
             let workflow = '';
 
-            switch (context.eventName) {
-              case 'workflow_call':
-                workflow = process.env.INPUTS_WORKFLOW;
-                break;
-              case 'issue_comment':
-                const body = context.payload.comment.body || '';
-                
-                if (body.includes('/cluster_test')) {
-                  workflow = 'cluster_test';
-                } else if (body.includes('/hdm_test')) {
-                  workflow = 'hdm_test';
-                } else if (body.includes('/lsu_test')) {
-                  workflow = 'lsu_test';
-                } else if (body.includes('/upgrade_test')) {
-                  workflow = 'upgrade_test';
-                }
-                break;
+            if (process.env.INPUTS_WORKFLOW !== '') {
+              workflow = process.env.INPUTS_WORKFLOW;
+            } else {
+              const body = context.payload.comment.body || '';
+              
+              if (body.includes('/cluster_test')) {
+                workflow = 'cluster_test';
+              } else if (body.includes('/hdm_test')) {
+                workflow = 'hdm_test';
+              } else if (body.includes('/lsu_test')) {
+                workflow = 'lsu_test';
+              } else if (body.includes('/upgrade_test')) {
+                workflow = 'upgrade_test';
+              }
             }
 
             core.setOutput('workflow', workflow);


### PR DESCRIPTION
The first commit contains the not-quite-working changes from https://github.com/canton-network/splice/pull/6030. The second and third commit, address the shortcomings, which are:
- incorrectly using workflow_call as an event type which doesn't exist - workflow calls inherit the parent event type
- messing up the formatting of the GH GraphQL query in `get_head`