### PR TITLE
port 0.6.9 - Move cometbft preflights in their own file (#6056)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2231,7 +2231,13 @@ updateTestConfigForParallelRuns := {
     (
       "Preflight tests against core nodes",
       "test-full-class-names-core-preflight.log",
-      (t: String) => isCoreDeploymentPreflightIntegrationTest(t) && !isNonDevNetTest(t),
+      (t: String) =>
+        isCoreDeploymentPreflightIntegrationTest(t) && !isNonDevNetTest(t) && !isCometBftTest(t),
+    ),
+    (
+      "Preflight tests against core nodes for cometBft",
+      "test-full-class-names-core-preflight-cometbft.log",
+      (t: String) => isCoreDeploymentPreflightIntegrationTest(t) && isCometBftTest(t),
     ),
     (
       "Preflight tests against validator1",
@@ -2246,7 +2252,13 @@ updateTestConfigForParallelRuns := {
     (
       "Preflight tests against runbook SV",
       "test-full-class-names-sv-preflight.log",
-      (t: String) => isRunbookSvPreflightIntegrationTest(t) && !isNonDevNetTest(t),
+      (t: String) =>
+        isRunbookSvPreflightIntegrationTest(t) && !isNonDevNetTest(t) && !isCometBftTest(t),
+    ),
+    (
+      "Preflight tests against runbook SV for cometBft",
+      "test-full-class-names-sv-preflight-cometbft.log",
+      (t: String) => isRunbookSvPreflightIntegrationTest(t) && isCometBftTest(t),
     ),
     (
       "Non-DevNet Preflight tests against runbook SV",

--- a/test-full-class-names-core-preflight-cometbft.log
+++ b/test-full-class-names-core-preflight-cometbft.log
@@ -1,0 +1,1 @@
+org.lfdecentralizedtrust.splice.integration.tests.runbook.CometBftPreflightIntegrationTest

--- a/test-full-class-names-core-preflight.log
+++ b/test-full-class-names-core-preflight.log
@@ -1,3 +1,2 @@
-org.lfdecentralizedtrust.splice.integration.tests.runbook.CometBftPreflightIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.runbook.DsoPreflightIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.runbook.RateLimitPreflightIntegrationTest

--- a/test-full-class-names-sv-preflight-cometbft.log
+++ b/test-full-class-names-sv-preflight-cometbft.log
@@ -1,0 +1,1 @@
+org.lfdecentralizedtrust.splice.integration.tests.runbook.RunbookSvCometBftPreflightIntegrationTest

--- a/test-full-class-names-sv-preflight.log
+++ b/test-full-class-names-sv-preflight.log
@@ -1,3 +1,2 @@
-org.lfdecentralizedtrust.splice.integration.tests.runbook.RunbookSvCometBftPreflightIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.runbook.RunbookSvPreflightIntegrationTest
 org.lfdecentralizedtrust.splice.integration.tests.runbook.RunbookSvSequencerInfoPreflightIntegrationTest


### PR DESCRIPTION
this will allow us to easily not run them on dabft cluster tests

[static]


(cherry picked from commit fcdadce8d8e26d25a60b0e35544aca0f2a060ec5)

fixes https://github.com/DACH-NY/cn-test-failures/issues/8878

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
