### PR TITLE
Use a dedicated Postgres server for the DABFT db

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -302,7 +302,9 @@
             "spliceRoot": "splice"
           },
           "sequencer": {
-            "enableBftSequencer": false
+            "dedicatedBftSequencerDb": true,
+            "enableBftSequencer": false,
+            "migrateBftSequencerDbFromSharedServer": false
           },
           "version": {
             "type": "remote",
@@ -323,7 +325,9 @@
               "spliceRoot": "splice"
             },
             "sequencer": {
-              "enableBftSequencer": false
+              "dedicatedBftSequencerDb": true,
+              "enableBftSequencer": false,
+              "migrateBftSequencerDbFromSharedServer": false
             },
             "version": {
               "type": "remote",
@@ -343,7 +347,9 @@
               "spliceRoot": "splice"
             },
             "sequencer": {
-              "enableBftSequencer": false
+              "dedicatedBftSequencerDb": true,
+              "enableBftSequencer": false,
+              "migrateBftSequencerDbFromSharedServer": false
             },
             "version": {
               "type": "remote",
@@ -361,7 +367,9 @@
               "spliceRoot": "splice"
             },
             "sequencer": {
-              "enableBftSequencer": false
+              "dedicatedBftSequencerDb": true,
+              "enableBftSequencer": false,
+              "migrateBftSequencerDbFromSharedServer": false
             },
             "version": {
               "type": "remote",
@@ -383,7 +391,9 @@
             "spliceRoot": "splice"
           },
           "sequencer": {
-            "enableBftSequencer": false
+            "dedicatedBftSequencerDb": true,
+            "enableBftSequencer": false,
+            "migrateBftSequencerDbFromSharedServer": false
           },
           "version": {
             "type": "remote",
@@ -403,7 +413,9 @@
             "spliceRoot": "splice"
           },
           "sequencer": {
-            "enableBftSequencer": true
+            "dedicatedBftSequencerDb": true,
+            "enableBftSequencer": true,
+            "migrateBftSequencerDbFromSharedServer": false
           },
           "version": {
             "type": "remote",

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -276,6 +276,28 @@
       },
       "kind": "Secret",
       "metadata": {
+        "name": "sequencer-bft-10-pg-secrets",
+        "namespace": "sv-1"
+      },
+      "type": "Opaque"
+    },
+    "name": "cn-app-sv-1-sequencer-bft-10-pg-secrets",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "v1",
+      "data": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {
+          "postgresPassword": ""
+        }
+      },
+      "kind": "Secret",
+      "metadata": {
         "name": "mediator-10-pg-secrets",
         "namespace": "sv-da-1"
       },
@@ -540,6 +562,28 @@
       },
       "kind": "Secret",
       "metadata": {
+        "name": "sequencer-bft-10-pg-secrets",
+        "namespace": "sv-da-1"
+      },
+      "type": "Opaque"
+    },
+    "name": "cn-app-sv-da-1-sequencer-bft-10-pg-secrets",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "v1",
+      "data": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {
+          "postgresPassword": ""
+        }
+      },
+      "kind": "Secret",
+      "metadata": {
         "name": "mediator-10-pg-secrets",
         "namespace": "sv"
       },
@@ -788,6 +832,28 @@
       "type": "Opaque"
     },
     "name": "cn-app-sv-sequencer-9-pg-secrets",
+    "provider": "",
+    "type": "kubernetes:core/v1:Secret"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "apiVersion": "v1",
+      "data": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": {
+          "postgresPassword": ""
+        }
+      },
+      "kind": "Secret",
+      "metadata": {
+        "name": "sequencer-bft-10-pg-secrets",
+        "namespace": "sv"
+      },
+      "type": "Opaque"
+    },
+    "name": "cn-app-sv-sequencer-bft-10-pg-secrets",
     "provider": "",
     "type": "kubernetes:core/v1:Secret"
   },
@@ -1876,6 +1942,16 @@
     "type": "gcp:sql/database:Database"
   },
   {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cantonnet"
+    },
+    "name": "sv-1-db-sequencer-bft-10-pg-cantonnet",
+    "provider": "",
+    "type": "gcp:sql/database:Database"
+  },
+  {
     "custom": false,
     "id": "",
     "inputs": {},
@@ -1974,7 +2050,8 @@
             "externalAddress": "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
             "persistence": {
-              "databaseName": "sequencer_10_dabft"
+              "databaseName": "sequencer_10_dabft",
+              "secretName": "sequencer-bft-10-pg-secrets"
             },
             "type": "cantonbft"
           },
@@ -3966,6 +4043,136 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "length": 16,
+      "overrideSpecial": "_%@",
+      "special": true
+    },
+    "name": "sv-1-sequencer-bft-10-pg-cnadmin-passwd",
+    "provider": "",
+    "type": "random:index/randomPassword:RandomPassword"
+  },
+  {
+    "custom": false,
+    "id": "",
+    "inputs": {
+      "active": true,
+      "alias": "sequencer-bft-pg",
+      "cloudSqlConfig": {
+        "enabled": true,
+        "enterprisePlus": false,
+        "flags": {
+          "maintenance_work_mem": "2000000",
+          "max_wal_size": "20480",
+          "random_page_cost": "1.1",
+          "temp_file_limit": "2147483647",
+          "work_mem": "16384"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "protected": true,
+        "tier": "sequencer-override-tier"
+      },
+      "defaultUserName": "cnadmin",
+      "deletionProtection": true,
+      "instanceName": "sequencer-bft-10-pg",
+      "logicalDecoding": false,
+      "migrationId": 10,
+      "namespace": {
+        "logicalName": "sv-1",
+        "ns": {
+          "__aliases": [],
+          "__name": "sv-1",
+          "__providers": {},
+          "__pulumiCustomResource": true,
+          "__pulumiResource": true,
+          "__pulumiType": "kubernetes:core/v1:Namespace",
+          "__transformations": [],
+          "__version": "4.28.0",
+          "apiVersion": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "id": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "kind": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "metadata": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "spec": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "status": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "urn": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi."
+        }
+      },
+      "retainDbResourcesOnDelete": false,
+      "secretName": "sequencer-bft-10-pg-secrets"
+    },
+    "name": "sv-1-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "canton:cloud:postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "databaseVersion": "POSTGRES_14",
+      "deletionProtection": false,
+      "region": "europe-west6",
+      "settings": {
+        "activationPolicy": "ALWAYS",
+        "backupConfiguration": {
+          "enabled": true,
+          "pointInTimeRecoveryEnabled": true
+        },
+        "databaseFlags": [
+          {
+            "name": "random_page_cost",
+            "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
+          },
+          {
+            "name": "max_wal_size",
+            "value": "20480"
+          },
+          {
+            "name": "maintenance_work_mem",
+            "value": "2000000"
+          },
+          {
+            "name": "work_mem",
+            "value": "16384"
+          }
+        ],
+        "deletionProtectionEnabled": true,
+        "edition": "ENTERPRISE",
+        "insightsConfig": {
+          "queryInsightsEnabled": true
+        },
+        "ipConfiguration": {
+          "enablePrivatePathForGoogleCloudServices": true,
+          "ipv4Enabled": false,
+          "privateNetwork": "projects/test-project/global/networks/default"
+        },
+        "locationPreference": {
+          "zone": "europe-west6-a"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "tier": "sequencer-override-tier",
+        "userLabels": {
+          "cluster": "mock",
+          "migration_id": "10"
+        }
+      }
+    },
+    "name": "sv-1-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "gcp:sql/databaseInstance:DatabaseInstance"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "v1",
       "kind": "Secret",
       "metadata": {
@@ -5375,6 +5582,16 @@
     "type": "gcp:sql/database:Database"
   },
   {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cantonnet"
+    },
+    "name": "sv-da-1-db-sequencer-bft-10-pg-cantonnet",
+    "provider": "",
+    "type": "gcp:sql/database:Database"
+  },
+  {
     "custom": false,
     "id": "",
     "inputs": {},
@@ -5473,7 +5690,8 @@
             "externalAddress": "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
             "persistence": {
-              "databaseName": "sequencer_10_dabft"
+              "databaseName": "sequencer_10_dabft",
+              "secretName": "sequencer-bft-10-pg-secrets"
             },
             "type": "cantonbft"
           },
@@ -7465,6 +7683,136 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "length": 16,
+      "overrideSpecial": "_%@",
+      "special": true
+    },
+    "name": "sv-da-1-sequencer-bft-10-pg-cnadmin-passwd",
+    "provider": "",
+    "type": "random:index/randomPassword:RandomPassword"
+  },
+  {
+    "custom": false,
+    "id": "",
+    "inputs": {
+      "active": true,
+      "alias": "sequencer-bft-pg",
+      "cloudSqlConfig": {
+        "enabled": true,
+        "enterprisePlus": false,
+        "flags": {
+          "maintenance_work_mem": "2000000",
+          "max_wal_size": "20480",
+          "random_page_cost": "1.1",
+          "temp_file_limit": "2147483647",
+          "work_mem": "16384"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "protected": true,
+        "tier": "sequencer-override-tier"
+      },
+      "defaultUserName": "cnadmin",
+      "deletionProtection": true,
+      "instanceName": "sequencer-bft-10-pg",
+      "logicalDecoding": false,
+      "migrationId": 10,
+      "namespace": {
+        "logicalName": "sv-da-1",
+        "ns": {
+          "__aliases": [],
+          "__name": "sv-da-1",
+          "__providers": {},
+          "__pulumiCustomResource": true,
+          "__pulumiResource": true,
+          "__pulumiType": "kubernetes:core/v1:Namespace",
+          "__transformations": [],
+          "__version": "4.28.0",
+          "apiVersion": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "id": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "kind": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "metadata": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "spec": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "status": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "urn": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi."
+        }
+      },
+      "retainDbResourcesOnDelete": false,
+      "secretName": "sequencer-bft-10-pg-secrets"
+    },
+    "name": "sv-da-1-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "canton:cloud:postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "databaseVersion": "POSTGRES_14",
+      "deletionProtection": false,
+      "region": "europe-west6",
+      "settings": {
+        "activationPolicy": "ALWAYS",
+        "backupConfiguration": {
+          "enabled": true,
+          "pointInTimeRecoveryEnabled": true
+        },
+        "databaseFlags": [
+          {
+            "name": "random_page_cost",
+            "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
+          },
+          {
+            "name": "max_wal_size",
+            "value": "20480"
+          },
+          {
+            "name": "maintenance_work_mem",
+            "value": "2000000"
+          },
+          {
+            "name": "work_mem",
+            "value": "16384"
+          }
+        ],
+        "deletionProtectionEnabled": true,
+        "edition": "ENTERPRISE",
+        "insightsConfig": {
+          "queryInsightsEnabled": true
+        },
+        "ipConfiguration": {
+          "enablePrivatePathForGoogleCloudServices": true,
+          "ipv4Enabled": false,
+          "privateNetwork": "projects/test-project/global/networks/default"
+        },
+        "locationPreference": {
+          "zone": "europe-west6-a"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "tier": "sequencer-override-tier",
+        "userLabels": {
+          "cluster": "mock",
+          "migration_id": "10"
+        }
+      }
+    },
+    "name": "sv-da-1-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "gcp:sql/databaseInstance:DatabaseInstance"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "v1",
       "kind": "Secret",
       "metadata": {
@@ -7936,6 +8284,16 @@
     "type": "gcp:sql/database:Database"
   },
   {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cantonnet"
+    },
+    "name": "sv-db-sequencer-bft-10-pg-cantonnet",
+    "provider": "",
+    "type": "gcp:sql/database:Database"
+  },
+  {
     "custom": false,
     "id": "",
     "inputs": {},
@@ -8034,7 +8392,8 @@
             "externalAddress": "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
             "persistence": {
-              "databaseName": "sequencer_10_dabft"
+              "databaseName": "sequencer_10_dabft",
+              "secretName": "sequencer-bft-10-pg-secrets"
             },
             "type": "cantonbft"
           },
@@ -10038,6 +10397,137 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "length": 16,
+      "overrideSpecial": "_%@",
+      "special": true
+    },
+    "name": "sv-sequencer-bft-10-pg-cnadmin-passwd",
+    "provider": "",
+    "type": "random:index/randomPassword:RandomPassword"
+  },
+  {
+    "custom": false,
+    "id": "",
+    "inputs": {
+      "active": true,
+      "alias": "sequencer-bft-pg",
+      "cloudSqlConfig": {
+        "enabled": true,
+        "enterprisePlus": false,
+        "flags": {
+          "maintenance_work_mem": "2000000",
+          "max_wal_size": "20480",
+          "random_page_cost": "1.1",
+          "temp_file_limit": "2147483647",
+          "work_mem": "16384"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "protected": true,
+        "tier": "sequencer-override-tier"
+      },
+      "defaultUserName": "cnadmin",
+      "deletionProtection": false,
+      "disableProtection": true,
+      "instanceName": "sequencer-bft-10-pg",
+      "logicalDecoding": false,
+      "migrationId": 10,
+      "namespace": {
+        "logicalName": "sv",
+        "ns": {
+          "__aliases": [],
+          "__name": "sv",
+          "__providers": {},
+          "__pulumiCustomResource": true,
+          "__pulumiResource": true,
+          "__pulumiType": "kubernetes:core/v1:Namespace",
+          "__transformations": [],
+          "__version": "4.28.0",
+          "apiVersion": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "id": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "kind": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "metadata": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "spec": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "status": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi.",
+          "urn": "Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of @pulumi/pulumi."
+        }
+      },
+      "retainDbResourcesOnDelete": false,
+      "secretName": "sequencer-bft-10-pg-secrets"
+    },
+    "name": "sv-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "canton:cloud:postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "databaseVersion": "POSTGRES_14",
+      "deletionProtection": false,
+      "region": "europe-west6",
+      "settings": {
+        "activationPolicy": "ALWAYS",
+        "backupConfiguration": {
+          "enabled": true,
+          "pointInTimeRecoveryEnabled": true
+        },
+        "databaseFlags": [
+          {
+            "name": "random_page_cost",
+            "value": "1.1"
+          },
+          {
+            "name": "temp_file_limit",
+            "value": "2147483647"
+          },
+          {
+            "name": "max_wal_size",
+            "value": "20480"
+          },
+          {
+            "name": "maintenance_work_mem",
+            "value": "2000000"
+          },
+          {
+            "name": "work_mem",
+            "value": "16384"
+          }
+        ],
+        "deletionProtectionEnabled": false,
+        "edition": "ENTERPRISE",
+        "insightsConfig": {
+          "queryInsightsEnabled": true
+        },
+        "ipConfiguration": {
+          "enablePrivatePathForGoogleCloudServices": true,
+          "ipv4Enabled": false,
+          "privateNetwork": "projects/test-project/global/networks/default"
+        },
+        "locationPreference": {
+          "zone": "europe-west6-a"
+        },
+        "maintenanceWindow": {
+          "day": 2,
+          "hour": 8
+        },
+        "tier": "sequencer-override-tier",
+        "userLabels": {
+          "cluster": "mock",
+          "migration_id": "10"
+        }
+      }
+    },
+    "name": "sv-sequencer-bft-10-pg",
+    "provider": "",
+    "type": "gcp:sql/databaseInstance:DatabaseInstance"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "apiVersion": "v1",
       "kind": "Secret",
       "metadata": {
@@ -10566,6 +11056,20 @@
         "value": null
       }
     },
+    "name": "user-sv-1-sequencer-bft-10-pg-cnadmin",
+    "provider": "",
+    "type": "gcp:sql/user:User"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cnadmin",
+      "password": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": null
+      }
+    },
     "name": "user-sv-da-1-mediator-10-pg-cnadmin",
     "provider": "",
     "type": "gcp:sql/user:User"
@@ -10734,6 +11238,20 @@
         "value": null
       }
     },
+    "name": "user-sv-da-1-sequencer-bft-10-pg-cnadmin",
+    "provider": "",
+    "type": "gcp:sql/user:User"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cnadmin",
+      "password": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": null
+      }
+    },
     "name": "user-sv-mediator-10-pg-cnadmin",
     "provider": "",
     "type": "gcp:sql/user:User"
@@ -10889,6 +11407,20 @@
       }
     },
     "name": "user-sv-sequencer-9-pg-cnadmin",
+    "provider": "",
+    "type": "gcp:sql/user:User"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "name": "cnadmin",
+      "password": {
+        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+        "value": null
+      }
+    },
+    "name": "user-sv-sequencer-bft-10-pg-cnadmin",
     "provider": "",
     "type": "gcp:sql/user:User"
   }

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -214,31 +214,80 @@ spec:
                 sleep 2;
               done
       {{- if and (eq .Values.sequencer.driver.type "cantonbft") ((.Values.sequencer.driver).persistence) }}
+        {{- $p := .Values.sequencer.driver.persistence }}
+        {{- $targetHost := $p.host | default .Values.sequencer.persistence.host }}
+        {{- $targetPort := $p.port | default .Values.sequencer.persistence.port }}
+        {{- $targetUser := $p.user | default "cnadmin" }}
+        {{- $targetDb := $p.databaseName | default .Values.sequencer.persistence.databaseName }}
+        {{- $targetSecret := $p.secretName | default .Values.sequencer.persistence.secretName }}
         - name: pg-init-bft-driver
-          image: {{ .Values.sequencer.driver.persistence.initImageName | default "postgres:14" }}
+          image: {{ $p.initImageName | default "postgres:14" }}
           env:
-            - name: PGPASSWORD
+            - name: PGPASSWORD_TARGET
               {{- if or (and .Values.sequencer.driver ((.Values.sequencer.driver.persistence).secretOverrides).postgresPassword) ((.Values.sequencer.persistence).secretOverrides).postgresPassword }}
               value: {{ if and .Values.sequencer.driver ((.Values.sequencer.driver.persistence).secretOverrides).postgresPassword }}{{ .Values.sequencer.driver.persistence.secretOverrides.postgresPassword | quote }}{{ else }}{{ .Values.sequencer.persistence.secretOverrides.postgresPassword | quote }}{{ end }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
                   key: postgresPassword
-                  name: {{ .Values.sequencer.driver.persistence.secretName | default .Values.sequencer.persistence.secretName }}
+                  name: {{ $targetSecret }}
               {{- end }}
+               {{- with $p.migrateFrom }}
+            - name: PGPASSWORD_SOURCE
+              {{- if and $.Values.sequencer.driver.persistence.secretOverrides $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword }}
+              value: {{ $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  key: postgresPassword
+                  name: {{ .secretName }}
+              {{- end }}
+            {{- end }}
           command:
             - 'bash'
             - '-c'
             - |
-              until errmsg=$(psql -h {{ .Values.sequencer.driver.persistence.host | default .Values.sequencer.persistence.host }} -p {{ .Values.sequencer.driver.persistence.port | default .Values.sequencer.persistence.port }} --username={{ .Values.sequencer.driver.persistence.user | default "cnadmin" }} --dbname=cantonnet -c 'create database {{ .Values.sequencer.driver.persistence.databaseName | default .Values.sequencer.persistence.databaseName }}' 2>&1); do
-                if [[ $errmsg == *"already exists"* ]]; then
-                  echo "Database {{ .Values.sequencer.driver.persistence.databaseName | default .Values.sequencer.persistence.databaseName }} already exists. Done."
-                  break
-                fi
+              set -euo pipefail
+              TARGET_HOST="{{ $targetHost }}"
+              TARGET_PORT="{{ $targetPort }}"
+              TARGET_USER="{{ $targetUser }}"
+              TARGET_DB="{{ $targetDb }}"
 
-                echo "trying to create postgres database {{ .Values.sequencer.driver.persistence.databaseName | default .Values.sequencer.persistence.databaseName }}, last error: $errmsg";
+              echo "Waiting for target postgres ${TARGET_HOST}:${TARGET_PORT} to become reachable...";
+              until PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
                 sleep 2;
               done
+
+              if [ "$(PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}'")" = "1" ]; then
+                echo "Database ${TARGET_DB} already exists on ${TARGET_HOST}. Done.";
+                exit 0;
+              fi
+              {{- with $p.migrateFrom }}
+              SOURCE_HOST="{{ .host }}"
+              SOURCE_PORT="{{ .port | default $targetPort }}"
+              SOURCE_USER="{{ .user | default "cnadmin" }}"
+
+              echo "Waiting for source postgres ${SOURCE_HOST}:${SOURCE_PORT} to become reachable...";
+              until PGPASSWORD="$PGPASSWORD_SOURCE" psql -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
+                sleep 2;
+              done
+
+              if [ "$(PGPASSWORD="$PGPASSWORD_SOURCE" psql -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}'")" = "1" ]; then
+                echo "Migrating database ${TARGET_DB} from shared sequencer server ${SOURCE_HOST} to dedicated server ${TARGET_HOST}...";
+                PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "CREATE DATABASE \"${TARGET_DB}\"";
+                if ! PGPASSWORD="$PGPASSWORD_SOURCE" pg_dump --no-owner --no-acl -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" "$TARGET_DB" \
+                     | PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname="$TARGET_DB"; then
+                  echo "Migration of ${TARGET_DB} failed; dropping the partially-migrated database so the migration can be retried.";
+                  PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "DROP DATABASE IF EXISTS \"${TARGET_DB}\"";
+                  exit 1;
+                fi
+                echo "Migration of ${TARGET_DB} to ${TARGET_HOST} complete.";
+                exit 0;
+              fi
+              echo "Database ${TARGET_DB} not found on source server ${SOURCE_HOST}; creating an empty database on the dedicated server instead.";
+              {{- end }}
+              PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "CREATE DATABASE \"${TARGET_DB}\"";
+              echo "Created empty database ${TARGET_DB} on ${TARGET_HOST}.";
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -232,7 +232,7 @@ spec:
                   key: postgresPassword
                   name: {{ $targetSecret }}
               {{- end }}
-               {{- with $p.migrateFrom }}
+            {{- with $p.migrateFrom }}
             - name: PGPASSWORD_SOURCE
               {{- if and $.Values.sequencer.driver.persistence.secretOverrides $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword }}
               value: {{ $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword | quote }}

--- a/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
@@ -308,11 +308,71 @@ tests:
             name: pg-init-bft-driver
             image: postgres:14
             env:
-              - name: PGPASSWORD
+              - name: PGPASSWORD_TARGET
                 valueFrom:
                   secretKeyRef:
                     key: postgresPassword
                     name: custom-pg-secret
+      # Without migrateFrom there is no source password and no migration logic.
+      - notContains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: PGPASSWORD_SOURCE
+          any: true
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: "Migrating database"
+  - it: "cantonbft driver migrates the dabft database from the shared server when migrateFrom is set"
+    set:
+      sequencer:
+        persistence:
+          host: shared-sequencer-pg
+          secretName: sequencer-pg-secret
+        driver:
+          type: cantonbft
+          externalAddress: "sequencer.example.com"
+          externalPort: 5010
+          persistence:
+            host: dedicated-bft-pg
+            secretName: dedicated-bft-pg-secret
+            databaseName: sequencer_6_dabft
+            migrateFrom:
+              host: shared-sequencer-pg
+              secretName: sequencer-pg-secret
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - isSubset:
+          path: spec.template.spec.initContainers[1]
+          content:
+            name: pg-init-bft-driver
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: PGPASSWORD_TARGET
+            valueFrom:
+              secretKeyRef:
+                key: postgresPassword
+                name: dedicated-bft-pg-secret
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: PGPASSWORD_SOURCE
+            valueFrom:
+              secretKeyRef:
+                key: postgresPassword
+                name: sequencer-pg-secret
+      # The migration copies the dabft database from the shared sequencer server to the dedicated one.
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: 'TARGET_HOST="dedicated-bft-pg"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: 'SOURCE_HOST="shared-sequencer-pg"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: 'pg_dump .* "\$SOURCE_HOST"'
 
   - it: "allows setting cometbft sequencer image and primary initImage"
     set:
@@ -384,6 +444,9 @@ tests:
         host: "custom-driver-host"
         secretOverrides:
           postgresPassword: "vault:kv/data/sequencer/driver-password"
+          migrateFromPostgresPassword: "vault:kv/data/sequencer/migrate-from-driver-password"
+        migrateFrom:
+          host: custom-driver-host-source
     documentSelector:
       path: kind
       value: Deployment
@@ -392,8 +455,11 @@ tests:
           path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='SEQUENCER_DRIVER_BFT_POSTGRES_PASSWORD')].value
           pattern: "vault:kv/data/sequencer/driver-password"
       - matchRegex:
-          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD')].value
+          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD_TARGET')].value
           pattern: "vault:kv/data/sequencer/driver-password"
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD_SOURCE')].value
+          pattern: "vault:kv/data/sequencer/migrate-from-driver-password"
 
   - it: "injects custom serviceAccountName into Deployment when specified"
     set:

--- a/cluster/pulumi/common/src/config/migrationSchema.ts
+++ b/cluster/pulumi/common/src/config/migrationSchema.ts
@@ -32,6 +32,10 @@ export const MigrationInfoSchema = z
     sequencer: z
       .object({
         enableBftSequencer: z.boolean().default(false),
+        // Use a separate DB server for DABFT.
+        dedicatedBftSequencerDb: z.boolean().default(true),
+        // Migrate data from dedicatedBftSequencerDb: false => dedicatedBftSequencerDb: true
+        migrateBftSequencerDbFromSharedServer: z.boolean().default(false),
       })
       .strict()
       .prefault({}),

--- a/cluster/pulumi/sv-canton/pulumi.ts
+++ b/cluster/pulumi/sv-canton/pulumi.ts
@@ -87,7 +87,11 @@ export function runSvCantonForSvs<T>(
         return {
           id: id,
           version: activeVersion,
-          sequencer: { enableBftSequencer: false },
+          sequencer: {
+            enableBftSequencer: false,
+            dedicatedBftSequencerDb: true,
+            migrateBftSequencerDbFromSharedServer: false,
+          },
         };
       })
   );

--- a/cluster/pulumi/sv-canton/src/canton.ts
+++ b/cluster/pulumi/sv-canton/src/canton.ts
@@ -101,6 +101,18 @@ export async function installCantonComponents(
       true,
       { isActive: migrationStillRunning, migrationId, disableProtection }
     ));
+  const bftSequencerPostgres =
+    migrationInfo.sequencer.enableBftSequencer && migrationInfo.sequencer.dedicatedBftSequencerDb
+      ? await installPostgres(
+          xns,
+          `sequencer-bft-${migrationId}-pg`,
+          `sequencer-bft-pg`,
+          version,
+          physicalSynchronizerConfig.sequencer.cloudSql,
+          true,
+          { isActive: migrationStillRunning, migrationId, disableProtection }
+        )
+      : undefined;
   if (migrationStillRunning) {
     const decentralizedSynchronizerNode = migrationInfo.sequencer.enableBftSequencer
       ? new InStackCantonBftDecentralizedSynchronizerNode(
@@ -111,6 +123,9 @@ export async function installCantonComponents(
           {
             sequencerPostgres: sequencerPostgres,
             mediatorPostgres: mediatorPostgres,
+            bftSequencerPostgres: bftSequencerPostgres,
+            migrateBftSequencerDbFromSharedServer:
+              migrationInfo.sequencer.migrateBftSequencerDbFromSharedServer,
             setCoreDbNames: svConfig.isCoreSv,
           },
           version,

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -84,6 +84,7 @@ abstract class InStackDecentralizedSynchronizerNode
       setCoreDbNames: boolean;
       sequencerPostgres: Postgres;
       mediatorPostgres: Postgres;
+      bftSequencerPostgres?: Postgres;
     },
     driver:
       | { type: 'cometbft'; host: Output<string>; port: number }
@@ -97,6 +98,12 @@ abstract class InStackDecentralizedSynchronizerNode
             databaseName?: string;
             port?: number;
             user?: string;
+            migrateFrom?: {
+              host: Output<string>;
+              secretName: Output<string>;
+              port?: number;
+              user?: string;
+            };
           };
         },
     version: CnChartVersion,
@@ -181,7 +188,11 @@ abstract class InStackDecentralizedSynchronizerNode
       this.version,
       {
         ...opts,
-        dependsOn: (opts?.dependsOn || []).concat([dbs.sequencerPostgres, dbs.mediatorPostgres]),
+        dependsOn: (opts?.dependsOn || []).concat(
+          [dbs.sequencerPostgres, dbs.mediatorPostgres].concat(
+            dbs.bftSequencerPostgres ? [dbs.bftSequencerPostgres] : []
+          )
+        ),
         parent: this,
       }
     );
@@ -288,12 +299,32 @@ export class InStackCantonBftDecentralizedSynchronizerNode extends InStackDecent
       setCoreDbNames: boolean;
       sequencerPostgres: Postgres;
       mediatorPostgres: Postgres;
+      bftSequencerPostgres?: Postgres;
+      migrateBftSequencerDbFromSharedServer?: boolean;
     },
     version: CnChartVersion,
     imagePullServiceAccountName?: string,
     opts?: SpliceCustomResourceOptions
   ) {
     super(migrationId, xns, version);
+    const databaseName = `sequencer_${migrationId}_dabft`;
+    const persistence = dbs.bftSequencerPostgres
+      ? {
+          host: dbs.bftSequencerPostgres.address,
+          secretName: dbs.bftSequencerPostgres.secretName,
+          databaseName,
+          ...(dbs.migrateBftSequencerDbFromSharedServer
+            ? {
+                migrateFrom: {
+                  host: dbs.sequencerPostgres.address,
+                  secretName: dbs.sequencerPostgres.secretName,
+                },
+              }
+            : {}),
+        }
+      : {
+          databaseName,
+        };
     this.installDecentralizedSynchronizer(
       svConfig,
       migrationId,
@@ -302,9 +333,7 @@ export class InStackCantonBftDecentralizedSynchronizerNode extends InStackDecent
         type: 'cantonbft',
         externalAddress: `sequencer-p2p-${migrationId}.${ingressName}.${CLUSTER_HOSTNAME}`,
         externalPort: 443,
-        persistence: {
-          databaseName: `sequencer_${migrationId}_dabft`,
-        },
+        persistence,
       },
       version,
       svConfig.logging?.cantonLogLevel,


### PR DESCRIPTION
I've tested on a scratchnet that the migration works. I expect we run this one-time on scratche and then delete the code again.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
