### PR TITLE
prevent pr_cluster_test failing on unrelated comments and notifying the authors

### DIFF
--- a/.github/workflows/pr_cluster_test.yml
+++ b/.github/workflows/pr_cluster_test.yml
@@ -82,6 +82,7 @@ jobs:
     needs:
       - get_head
       - determine_test_type
+    if: needs.determine_test_type.outputs.workflow != ''
     uses: ./.github/workflows/cluster_tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I noticed while commenting on PRs that I got notifications about failed workflows which should not happen. It should silently cancel execution if the comment does not pertain to a cluster test.