### PR TITLE
[static] Fix lnav nix package for aarch64-linux

### DIFF
--- a/nix/lnav.nix
+++ b/nix/lnav.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation rec {
       fetchzip {
         url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-aarch64-macos.zip";
         sha256 = "sha256:eXdiy0v15e/MUW2M9NE4QujDqvwH96Od0Lkqeo39pzU=";
+      } else if stdenv.isLinux && stdenv.hostPlatform.isAarch64 then fetchzip {
+        url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-linux-musl-arm64.zip";
+        sha256 = "sha256-sOCjob6SQ8JIExOHQZsBVQHKVfnwa+bHAZI9zUVVh6g=";
       } else fetchzip {
         url = "https://github.com/tstack/lnav/releases/download/v${version}/lnav-${version}-linux-musl-x86_64.zip";
         sha256 = "sha256-k8x83y64GIpGMnNyYLGpo5bRFvaxENhwbKSdWw4UCuU=";


### PR DESCRIPTION
Add missing arm64 case to lnav.nix — the else branch hardcoded the x86_64 musl binary for all non-Darwin systems, causing exec format errors on aarch64 Linux.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
