### PR TITLE
BftScanConnectionsTest flake fix

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -37,6 +37,7 @@ import org.lfdecentralizedtrust.splice.util.{
 }
 import org.lfdecentralizedtrust.splice.wallet.automation.AcceptedTransferOfferTrigger
 
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 
@@ -318,7 +319,7 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
         },
       )
 
-      actAndCheck(
+      actAndCheck(timeUntilSuccess = 40.seconds)(
         "Re-vet Alice",
         revetV2AmuletOnAlice(aliceParticipantId),
       )(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnectionTest.scala
@@ -1244,20 +1244,23 @@ class BftScanConnectionTest
       val bft = getBft(connections)
 
       // With n=4, we query only two connections randomly, and even with
-      // retries it can sometimes fail. This eventually is here to avoid flakyness.
+      // retries a single call can fail to reach consensus.
+      def attempt(remaining: Int): Future[GetRewardAccountingRootHashResponse] =
+        bft.getRewardAccountingRootHash(round).flatMap {
+          case ok: GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashOk =>
+            Future.successful(ok)
+          case _ if remaining > 1 => attempt(remaining - 1)
+          case other => Future.successful(other)
+        }
+
       loggerFactory
         .assertEventuallyLogsSeq(SuppressionRule.LevelAndAbove(Level.INFO))(
-          {
-            // TODO(tech-debt): make the retry params configurable so that we
-            // don't spend time waiting in long backoffs
-            eventually(timeUntilSuccess = 40.seconds) {
-              inside(bft.getRewardAccountingRootHash(round).futureValue) {
-                case GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashOk(ok) =>
-                  ok.rootHash should be("aabb")
-                  ok.roundNumber should be(round)
-              }
+          attempt(100).map { resp =>
+            inside(resp) {
+              case GetRewardAccountingRootHashResponse.members.RewardAccountingRootHashOk(ok) =>
+                ok.rootHash should be("aabb")
+                ok.roundNumber should be(round)
             }
-            Future.unit
           },
           logs =>
             logs.exists(l =>
@@ -1362,21 +1365,26 @@ class BftScanConnectionTest
       val bft = getBft(connections)
 
       // With n=4, we query only two connections randomly, and even with
-      // retries it can sometimes fail. This eventually is here to avoid flakyness.
+      // retries a single call can fail to reach consensus.
+      def attempt(remaining: Int): Future[GetRewardAccountingActivityTotalsResponse] =
+        bft.getRewardAccountingActivityTotals(round).flatMap {
+          case ok: GetRewardAccountingActivityTotalsResponse.members.RewardAccountingActivityTotalsOk =>
+            Future.successful(ok)
+          case _ if remaining > 1 => attempt(remaining - 1)
+          case other => Future.successful(other)
+        }
+
       loggerFactory
         .assertEventuallyLogsSeq(SuppressionRule.LevelAndAbove(Level.INFO))(
-          {
-            eventually(timeUntilSuccess = 40.seconds) {
-              inside(bft.getRewardAccountingActivityTotals(round).futureValue) {
-                case GetRewardAccountingActivityTotalsResponse.members
-                      .RewardAccountingActivityTotalsOk(ok) =>
-                  ok.roundNumber should be(round)
-                  ok.totalAppActivityWeight should be(100L)
-                  ok.activePartiesCount should be(10L)
-                  ok.activityRecordsCount should be(5L)
-              }
+          attempt(100).map { resp =>
+            inside(resp) {
+              case GetRewardAccountingActivityTotalsResponse.members
+                    .RewardAccountingActivityTotalsOk(ok) =>
+                ok.roundNumber should be(round)
+                ok.totalAppActivityWeight should be(100L)
+                ok.activePartiesCount should be(10L)
+                ok.activityRecordsCount should be(5L)
             }
-            Future.unit
           },
           logs =>
             logs.exists(l =>


### PR DESCRIPTION
Replace eventually with manual retries to avoid CI flake. As 40s was also not sufficient as reported here
https://github.com/canton-network/splice/actions/runs/27809981022

This should also make test execution faster, as we no longer wait on long backoffs.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
