### PR TITLE
Return CannotProvide on root-hash and activity-totals on meta version bump

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -326,12 +326,10 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
       ) {
         val round = oldestOpenRound
         doTransfer(bobParty)
-        // Need to advance by two rounds, see note below about last_archived_round
         // Note: we can't use advanceRoundsToNextRoundOpening here, as it blocks
         // on summarizing and issuing round to complete, and here the
         // summarizing round will block until the sv2 provides the round totals
         // via bft read.
-        advanceTimeAndWaitForRoundOpening
         advanceTimeAndWaitForRoundOpening
 
         val (calculateRewardsCid, rootHash) =
@@ -379,16 +377,11 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
               case other => fail(s"Expected DbStorage")
             }
             implicit val closeContext: CloseContext = CloseContext(sv2Db)
-            // Here the last_archived_round must reach earliest_ingested_round + 1 for the scan
-            // to confirm that it CannotProvide for a round.
-            // In practice it would mean that SV2 would wait for its scan to
-            // ingest verdicts for one full round after the version bump,
-            // and only then get to know that its own scan does not have the data.
             sv2Db
               .update_(
                 sqlu"""update app_activity_record_meta
                        set earliest_ingested_round = $round,
-                           last_archived_round = ${round + 1}""",
+                           last_archived_round = null""",
                 "test.increaseAppActivityMeta_EarliestIngestedRound",
               )
               .futureValueUS

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2746,10 +2746,10 @@ class HttpScanHandler(
               }
             case None =>
               appActivityStore.earliestRoundWithCompleteAppActivity().map {
-                case Some(earliest) if roundNumber < earliest =>
+                case Some(earliest) =>
+                  if (roundNumber < earliest) cannotProvide else undetermined
+                case None =>
                   cannotProvide
-                case _ =>
-                  undetermined
               }
           }
         case _ =>
@@ -2792,10 +2792,10 @@ class HttpScanHandler(
               )
             case None =>
               appActivityStore.earliestRoundWithCompleteAppActivity().map {
-                case Some(earliest) if roundNumber < earliest =>
+                case Some(earliest) =>
+                  if (roundNumber < earliest) cannotProvide else undetermined
+                case None =>
                   cannotProvide
-                case _ =>
-                  undetermined
               }
           }
         case _ =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2745,11 +2745,11 @@ class HttpScanHandler(
                   undetermined
               }
             case None =>
-              appActivityStore.earliestRoundWithCompleteAppActivity().map {
-                case Some(earliest) =>
-                  if (roundNumber < earliest) cannotProvide else undetermined
-                case None =>
+              appActivityStore.earliestIngestedRound().map {
+                case Some(earliestIngested) if roundNumber <= earliestIngested =>
                   cannotProvide
+                case _ =>
+                  undetermined
               }
           }
         case _ =>
@@ -2791,11 +2791,11 @@ class HttpScanHandler(
                 )
               )
             case None =>
-              appActivityStore.earliestRoundWithCompleteAppActivity().map {
-                case Some(earliest) =>
-                  if (roundNumber < earliest) cannotProvide else undetermined
-                case None =>
+              appActivityStore.earliestIngestedRound().map {
+                case Some(earliestIngested) if roundNumber <= earliestIngested =>
                   cannotProvide
+                case _ =>
+                  undetermined
               }
           }
         case _ =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -19,7 +19,11 @@ import scala.concurrent.{ExecutionContext, Future}
 object AppActivityComputation {
   val MaxTrafficCostBytes: Long = 100L * 1024 * 1024 // 100 MB
 
-  /** Bump this when the functional behavior of the app activity computation changes. */
+  /** Bump this when the functional behavior of the app activity computation changes.
+    * WARNING: this MUST be bumped with care, and one must avoid an
+    * unjustifiable loss of integrity due to the BFT read fallbacks due to the
+    * loss of app activity records.
+    */
   val ActivityIngestionCodeVersion: Int = 1
 }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -20,9 +20,10 @@ object AppActivityComputation {
   val MaxTrafficCostBytes: Long = 100L * 1024 * 1024 // 100 MB
 
   /** Bump this when the functional behavior of the app activity computation changes.
-    * WARNING: this MUST be bumped with care, and one must avoid an
-    * unjustifiable loss of integrity due to the BFT read fallbacks due to the
-    * loss of app activity records.
+    * WARNING: this MUST be bumped with utmost care to avoid the loss of
+    * actual activity records due to all SV nodes upgrading and resetting
+    * their stores at the same time, which in turn also breaks the BFT-read
+    * fallback as there is no node to fallback to.
     */
   val ActivityIngestionCodeVersion: Int = 1
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AppActivityStore.scala
@@ -18,6 +18,18 @@ trait AppActivityStore {
       tc: TraceContext
   ): Future[Option[Long]]
 
+  /** The earliest round for which we have ingested app activity records.
+    * This round may not have all app activity records ingested.
+    *
+    * Returns None if no app activity records have been ingested.
+    *
+    * Return -1 for the first SV, if the ingestion started from beginning of round 0,
+    * indicating that this SV has complete data of round 0.
+    */
+  def earliestIngestedRound()(implicit
+      tc: TraceContext
+  ): Future[Option[Long]]
+
   /** Find the latest round for which all app activity records have been ingested.
     */
   def latestRoundWithCompleteAppActivity()(implicit

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -174,6 +174,26 @@ class DbAppActivityRecordStore(
     )
   }
 
+  /** The earliest round for which we have ingested app activity records.
+    * This round may not have all app activity records ingested.
+    * Returns None if no app activity records have been ingested, ie meta row does not exist.
+    */
+  def earliestIngestedRound()(implicit
+      tc: TraceContext
+  ): Future[Option[Long]] = {
+    val codeVersion = ingestionVersions.code
+    val userVersion = ingestionVersions.user
+    runQuerySingle(
+      sql"""select m.earliest_ingested_round
+            from #${Tables.activityRecordMeta} m
+            where m.history_id = $historyId
+              and m.activity_ingestion_code_version = $codeVersion
+              and m.activity_ingestion_user_version = $userVersion
+      """.as[Long].headOption,
+      "appActivity.earliestIngestedRound",
+    )
+  }
+
   /** Find the latest round with complete app activity.
     * A round is complete once the verdict ingestion has moved passed its archival.
     * Returns None if no meta row exists or archival of a round has not happened yet.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -154,6 +154,7 @@ class DbAppActivityRecordStore(
   /** Find the earliest round with complete app activity.
     * The first ingested round may be partial, so the earliest complete round
     * is `earliest_ingested_round + 1`.
+    * Returns the round only after it has been archived.
     * Returns None if no meta row exists or if archival of the earliest round has not happened yet.
     */
   def earliestRoundWithCompleteAppActivity()(implicit

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -511,6 +511,55 @@ class DbAppActivityRecordStoreTest
     }
   }
 
+  "earliestIngestedRound" should {
+
+    "return None when no meta record exists" in {
+      for {
+        (store, _) <- newStore()
+        result <- store.earliestIngestedRound()
+      } yield {
+        result shouldBe None
+      }
+    }
+
+    "return the earliest ingested round even when last_archived_round is not set" in {
+      for {
+        (store, _) <- newStore()
+        baseTs = CantonTimestamp.now()
+        // Unlike earliestRoundWithCompleteAppActivity, this does not require any
+        // archival to have happened yet.
+        _ <- store.insertActivityRecordMeta(1, 0, baseTs.toMicros, 42L, None)
+        result <- store.earliestIngestedRound()
+      } yield {
+        result.value shouldBe 42L
+      }
+    }
+
+    "use the current version's meta row when multiple meta rows exist" in {
+      for {
+        (store, _) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- store.insertActivityRecordMeta(0, 0, baseTs.toMicros, 10L, Some(15L))
+        _ <- store.insertActivityRecordMeta(1, 0, baseTs.plusSeconds(10L).toMicros, 20L, None)
+        result <- store.earliestIngestedRound()
+      } yield {
+        result.value shouldBe 20L
+      }
+    }
+
+    "only consider the meta row from own history_id" in {
+      for {
+        (store1, _) <- newStore()
+        (store2, _) <- newStore()
+        baseTs = CantonTimestamp.now()
+        _ <- store2.insertActivityRecordMeta(1, 0, baseTs.toMicros, 10L, Some(11L))
+        result <- store1.earliestIngestedRound()
+      } yield {
+        result shouldBe None
+      }
+    }
+  }
+
   "lookupActivityRecordMeta" should {
 
     "return None when no meta row exists" in {


### PR DESCRIPTION
Fixes #6065 
Avoids one round delay in returning `CannotProvide`

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
