### PR TITLE
Add dryRun label to TBAR triggers

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/confirmation/CalculateRewardsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/confirmation/CalculateRewardsTrigger.scala
@@ -59,6 +59,8 @@ abstract class CalculateRewardsTriggerBase(
   private val dsoParty = store.key.dsoParty
   private val rewardMetrics = new CalculateRewardsMetrics(context.metricsFactory, isDryRun)
 
+  override def extraMetricLabels: Seq[(String, String)] = Seq("dryRun" -> isDryRun.toString)
+
   override def retrieveTasks()(implicit tc: TraceContext): Future[Seq[Task]] = for {
     // These are ordered by round, so we process the oldest first
     calculateRewards <- store.listCalculateRewardsV2()

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ProcessRewardsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ProcessRewardsTrigger.scala
@@ -70,6 +70,8 @@ private[delegatebased] abstract class ProcessRewardsTriggerBase(
   private val store = svTaskContext.dsoStore
   private val rewardMetrics = new ProcessRewardsMetrics(context.metricsFactory, isDryRun)
 
+  override def extraMetricLabels: Seq[(String, String)] = Seq("dryRun" -> isDryRun.toString)
+
   override protected def source(implicit
       traceContext: TraceContext
   ): Source[ProcessRewardsV2Contract, NotUsed] =


### PR DESCRIPTION
Previously we filtered by dry run in the dashboard by matching the trigger name, which is needlessly complicated.