### PR TITLE
Fix flake, confirm vetting state more aggressively in test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -6,7 +6,7 @@ import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.transaction.VettedPackage
 import com.digitalasset.canton.topology.{ForceFlag, ForceFlags, ParticipantId, PartyId}
-import com.digitalasset.daml.lf.data.Ref.PackageId
+import com.digitalasset.daml.lf.data.Ref.{PackageId, PackageVersion}
 import java.time.Duration
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.FeaturedAppRight
 import org.lfdecentralizedtrust.splice.codegen.java.splice.api.rewardassignmentv1.{
@@ -314,9 +314,9 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
         },
       )
 
-      actAndCheck(timeUntilSuccess = 40.seconds)(
+      actAndCheck(
         "Re-vet Alice",
-        revetV2AmuletOnAlice(aliceParticipantId),
+        revetV2AmuletOnAlice(aliceParticipantId, aliceParty),
       )(
         "ExpireRewardCouponV2Trigger archives once Alice is re-vetted",
         _ => {
@@ -422,9 +422,11 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
     )
 
   private def revetV2AmuletOnAlice(
-      aliceParticipantId: ParticipantId
+      aliceParticipantId: ParticipantId,
+      aliceParty: PartyId,
   )(implicit env: SpliceTestConsoleEnvironment): Unit =
-    actAndCheck(
+    // Allocate sufficient time for the change to be visible on SV1, and avoid CI flake
+    actAndCheck(timeUntilSuccess = 60.seconds)(
       "Re-vet the V2-capable amulet versions on Alice",
       aliceValidatorBackend.participantClient.topology.vetted_packages.propose_delta(
         aliceParticipantId,
@@ -435,10 +437,29 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
       ),
     )(
       "sv1's participant observes Alice has the correct vetting state again",
-      _ =>
+      _ => {
         v2CapableAmuletPackageIds.toSet
-          .subsetOf(aliceVettedPackagesOnSv1View(aliceParticipantId).toSet) shouldBe true,
+          .subsetOf(aliceVettedPackagesOnSv1View(aliceParticipantId).toSet) shouldBe true
+        aliceLedgerApiAmuletVersionOnSv1View(aliceParty).exists(
+          _ >= v2AmuletVersion
+        ) shouldBe true
+      },
     )
+
+  /** Confirm Alice's preferred amulet package version as resolved through sv1's
+    * Ledger API, i.e. the exact path the ExpireRewardCouponV2Trigger uses to
+    * determine the vetted version.
+    */
+  private def aliceLedgerApiAmuletVersionOnSv1View(
+      aliceParty: PartyId
+  )(implicit env: SpliceTestConsoleEnvironment): Option[PackageVersion] =
+    sv1Backend.participantClient.ledger_api.interactive_submission
+      .preferred_package_version(
+        Set(aliceParty),
+        DarResources.amulet.latest.metadata.name,
+        Some(decentralizedSynchronizerId),
+      )
+      .flatMap(_.packageReference.map(ref => PackageVersion.assertFromString(ref.packageVersion)))
 
   private def assertOldestOpenRound(
       expected: Long

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -316,7 +316,7 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
             .futureValue
             .map(_.contractId.contractId)
             .toSet
-          remaining shouldBe aliceObservedCoupons
+          aliceObservedCoupons.subsetOf(remaining) shouldBe true
         },
       )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest.scala
@@ -295,6 +295,12 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
 
       unvetV2AmuletOnAlice(aliceParticipantId)
 
+      val couponsBeforeAdvance = sv1Backend.appState.dsoStore
+        .listRewardCouponsV2()
+        .futureValue
+        .map(_.contractId.contractId)
+        .toSet
+
       actAndCheck(
         "Advance past the coupon TTL",
         advanceTime(Duration.ofHours(37)),
@@ -324,7 +330,12 @@ class UnhideAndExpireRewardCouponV2TimeBasedIntegrationTest
             .trigger[ExpireRewardCouponV2Trigger]
             .runOnce()
             .futureValue
-          sv1Backend.appState.dsoStore.listRewardCouponsV2().futureValue shouldBe empty
+          val remaining = sv1Backend.appState.dsoStore
+            .listRewardCouponsV2()
+            .futureValue
+            .map(_.contractId.contractId)
+            .toSet
+          remaining.intersect(couponsBeforeAdvance) shouldBe empty
         },
       )
     }


### PR DESCRIPTION
Hopefully this resolves the CI fiake failures happening recently at the `ExpireRewardCouponV2Trigger`.

The earlier fix added here didn't work
https://github.com/canton-network/splice/pull/6088#discussion_r3457941368

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
