### PR TITLE
[static] Deprecate splice-postgres chart; switch to bitnami/postgresql

### DIFF
--- a/.github/workflows/build.wallclock_pg17.yml
+++ b/.github/workflows/build.wallclock_pg17.yml
@@ -1,4 +1,4 @@
-name: Wall Clock Tests with Postgres 14
+name: Wall Clock Tests with Postgres 17
 
 on:
   # Scheduled workflows run on the latest commit on the default or base branch.
@@ -24,8 +24,4 @@ jobs:
       commit_sha: ""
       daml_base_version: ""
       protocol_version: ""
-      # This is the Postgres 14 image we built for testing. From 17 onwards, we use the official image.
-      # It doesn't support `-c` init args. `max_connections` is set in the image itself.
-      postgres_image: us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker/splice-test-postgres:0.3.12
-      postgres_init_args: ""
     secrets: inherit

--- a/apps/app/src/pack/examples/sv-helm/postgres-values-apps.yaml
+++ b/apps/app/src/pack/examples/sv-helm/postgres-values-apps.yaml
@@ -1,5 +1,31 @@
-persistence:
-  secretName: apps-pg-secret
+# Values for deploying the Splice apps database with the upstream bitnami/postgresql chart.
+#
+# fullnameOverride sets the Kubernetes Service name; it must equal the release name you
+# `helm install` with AND the `host:` configured in the consuming Canton app values.
+fullnameOverride: apps-pg
 
-db:
-  volumeSize: 48Gi
+auth:
+  enablePostgresUser: false  # Canton connects as cnadmin only; no postgres superuser password needed
+  username: cnadmin
+  database: cantonnet
+  existingSecret: apps-pg-secret
+  secretKeys:
+    userPasswordKey: postgresPassword
+
+primary:
+  initdb:
+    args: "--data-checksums"
+    scripts:
+      grant-createdb.sql: "ALTER USER cnadmin CREATEDB;"
+  extendedConfiguration: |
+    max_connections = 300
+    max_wal_size = 2GB
+  persistence:
+    size: 48Gi
+    storageClass: standard-rwo
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: "0.5"
+      memory: 1Gi

--- a/apps/app/src/pack/examples/sv-helm/postgres-values-mediator.yaml
+++ b/apps/app/src/pack/examples/sv-helm/postgres-values-mediator.yaml
@@ -1,5 +1,31 @@
-persistence:
-  secretName: mediator-pg-secret
+# Values for deploying the mediator database with the upstream bitnami/postgresql chart.
+#
+# fullnameOverride sets the Kubernetes Service name; it must equal the release name you
+# `helm install` with AND the `host:` configured in the consuming Canton app values.
+fullnameOverride: mediator-pg
 
-db:
-  volumeSize: 48Gi
+auth:
+  enablePostgresUser: false  # Canton connects as cnadmin only; no postgres superuser password needed
+  username: cnadmin
+  database: cantonnet
+  existingSecret: mediator-pg-secret
+  secretKeys:
+    userPasswordKey: postgresPassword
+
+primary:
+  initdb:
+    args: "--data-checksums"
+    scripts:
+      grant-createdb.sql: "ALTER USER cnadmin CREATEDB;"
+  extendedConfiguration: |
+    max_connections = 300
+    max_wal_size = 2GB
+  persistence:
+    size: 48Gi
+    storageClass: standard-rwo
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: "0.5"
+      memory: 1Gi

--- a/apps/app/src/pack/examples/sv-helm/postgres-values-participant.yaml
+++ b/apps/app/src/pack/examples/sv-helm/postgres-values-participant.yaml
@@ -1,2 +1,32 @@
-persistence:
-  secretName: participant-pg-secret
+# Values for deploying the participant database with the upstream bitnami/postgresql chart.
+#
+# fullnameOverride sets the Kubernetes Service name; it must equal the release name you
+# `helm install` with AND the `host:` configured in the consuming Canton app values.
+fullnameOverride: participant-pg
+
+auth:
+  enablePostgresUser: false  # Canton connects as cnadmin only; no postgres superuser password needed
+  username: cnadmin
+  database: cantonnet
+  existingSecret: participant-pg-secret
+  secretKeys:
+    userPasswordKey: postgresPassword
+
+primary:
+  initdb:
+    args: "--data-checksums"
+    scripts:
+      grant-createdb.sql: "ALTER USER cnadmin CREATEDB;"
+  extendedConfiguration: |
+    max_connections = 300
+    max_wal_size = 2GB
+  persistence:
+    # The volume usage should be monitored and the size adjusted as usage grows.
+    size: 2800Gi
+    storageClass: standard-rwo
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: "0.5"
+      memory: 1Gi

--- a/apps/app/src/pack/examples/sv-helm/postgres-values-sequencer.yaml
+++ b/apps/app/src/pack/examples/sv-helm/postgres-values-sequencer.yaml
@@ -1,2 +1,31 @@
-persistence:
-  secretName: sequencer-pg-secret
+# Values for deploying the sequencer database with the upstream bitnami/postgresql chart.
+#
+# fullnameOverride sets the Kubernetes Service name; it must equal the release name you
+# `helm install` with AND the `host:` configured in the consuming Canton app values.
+fullnameOverride: sequencer-pg
+
+auth:
+  enablePostgresUser: false  # Canton connects as cnadmin only; no postgres superuser password needed
+  username: cnadmin
+  database: cantonnet
+  existingSecret: sequencer-pg-secret
+  secretKeys:
+    userPasswordKey: postgresPassword
+
+primary:
+  initdb:
+    args: "--data-checksums"
+    scripts:
+      grant-createdb.sql: "ALTER USER cnadmin CREATEDB;"
+  extendedConfiguration: |
+    max_connections = 300
+    max_wal_size = 2GB
+  persistence:
+    size: 2800Gi
+    storageClass: standard-rwo
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: "0.5"
+      memory: 1Gi

--- a/apps/app/src/pack/examples/sv-helm/postgres-values-validator-participant.yaml
+++ b/apps/app/src/pack/examples/sv-helm/postgres-values-validator-participant.yaml
@@ -1,4 +1,33 @@
-db:
-  # This is only the suggested initial value.
-  # The volume usage should be monitored and the size adjusted as usage grows.
-  volumeSize: 50Gi
+# Values for deploying the validator participant database with the upstream bitnami/postgresql chart.
+#
+# fullnameOverride sets the Kubernetes Service name; it must equal the release name you
+# `helm install` with AND the `host:` configured in the consuming Canton app values.
+fullnameOverride: postgres
+
+auth:
+  enablePostgresUser: false  # Canton connects as cnadmin only; no postgres superuser password needed
+  username: cnadmin
+  database: cantonnet
+  existingSecret: postgres-secrets
+  secretKeys:
+    userPasswordKey: postgresPassword
+
+primary:
+  initdb:
+    args: "--data-checksums"
+    scripts:
+      grant-createdb.sql: "ALTER USER cnadmin CREATEDB;"
+  extendedConfiguration: |
+    max_connections = 300
+    max_wal_size = 2GB
+  persistence:
+    # This is only the suggested initial value.
+    # The volume usage should be monitored and the size adjusted as usage grows.
+    size: 50Gi
+    storageClass: standard-rwo
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: "0.5"
+      memory: 1Gi

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2148,7 +2148,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3432,7 +3432,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -4789,6 +4789,93 @@
     "type": "random:index/randomPassword:RandomPassword"
   },
   {
+    "custom": false,
+    "id": "",
+    "inputs": {},
+    "name": "multi-validator-postgres-0",
+    "provider": "",
+    "type": "canton:network:bitnami-postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "postgres-0",
+      "namespace": "multi-validator",
+      "timeout": 600,
+      "values": {
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-0-secret",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres-0",
+        "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "extendedConfiguration": "max_connections = 1000\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
+            }
+          },
+          "persistence": {
+            "size": "100Gi",
+            "storageClass": "hyperdisk-standard-rwo"
+          },
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "memory": "5Gi"
+            }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
+        }
+      },
+      "version": "16.7.27"
+    },
+    "name": "multi-validator-postgres-0",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
+  },
+  {
     "custom": true,
     "id": "",
     "inputs": {
@@ -4799,6 +4886,93 @@
     "name": "multi-validator-postgres-1-passwd",
     "provider": "",
     "type": "random:index/randomPassword:RandomPassword"
+  },
+  {
+    "custom": false,
+    "id": "",
+    "inputs": {},
+    "name": "multi-validator-postgres-1",
+    "provider": "",
+    "type": "canton:network:bitnami-postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "postgres-1",
+      "namespace": "multi-validator",
+      "timeout": 600,
+      "values": {
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-1-secret",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres-1",
+        "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "extendedConfiguration": "max_connections = 1000\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
+            }
+          },
+          "persistence": {
+            "size": "100Gi",
+            "storageClass": "hyperdisk-standard-rwo"
+          },
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "memory": "5Gi"
+            }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
+        }
+      },
+      "version": "16.7.27"
+    },
+    "name": "multi-validator-postgres-1",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
   },
   {
     "custom": true,
@@ -4813,6 +4987,93 @@
     "type": "random:index/randomPassword:RandomPassword"
   },
   {
+    "custom": false,
+    "id": "",
+    "inputs": {},
+    "name": "multi-validator-postgres-2",
+    "provider": "",
+    "type": "canton:network:bitnami-postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "postgres-2",
+      "namespace": "multi-validator",
+      "timeout": 600,
+      "values": {
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-2-secret",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres-2",
+        "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "extendedConfiguration": "max_connections = 1000\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
+            }
+          },
+          "persistence": {
+            "size": "100Gi",
+            "storageClass": "hyperdisk-standard-rwo"
+          },
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "memory": "5Gi"
+            }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
+        }
+      },
+      "version": "16.7.27"
+    },
+    "name": "multi-validator-postgres-2",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
+  },
+  {
     "custom": true,
     "id": "",
     "inputs": {
@@ -4825,6 +5086,93 @@
     "type": "random:index/randomPassword:RandomPassword"
   },
   {
+    "custom": false,
+    "id": "",
+    "inputs": {},
+    "name": "multi-validator-postgres-3",
+    "provider": "",
+    "type": "canton:network:bitnami-postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "postgres-3",
+      "namespace": "multi-validator",
+      "timeout": 600,
+      "values": {
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-3-secret",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres-3",
+        "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "extendedConfiguration": "max_connections = 1000\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
+            }
+          },
+          "persistence": {
+            "size": "100Gi",
+            "storageClass": "hyperdisk-standard-rwo"
+          },
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "memory": "5Gi"
+            }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
+        }
+      },
+      "version": "16.7.27"
+    },
+    "name": "multi-validator-postgres-3",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
+  },
+  {
     "custom": true,
     "id": "",
     "inputs": {
@@ -4835,6 +5183,93 @@
     "name": "multi-validator-postgres-4-passwd",
     "provider": "",
     "type": "random:index/randomPassword:RandomPassword"
+  },
+  {
+    "custom": false,
+    "id": "",
+    "inputs": {},
+    "name": "multi-validator-postgres-4",
+    "provider": "",
+    "type": "canton:network:bitnami-postgres"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
+      "compat": "true",
+      "maxHistory": 10,
+      "name": "postgres-4",
+      "namespace": "multi-validator",
+      "timeout": 600,
+      "values": {
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-4-secret",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres-4",
+        "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "extendedConfiguration": "max_connections = 1000\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
+            }
+          },
+          "persistence": {
+            "size": "100Gi",
+            "storageClass": "hyperdisk-standard-rwo"
+          },
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "memory": "5Gi"
+            }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
+        }
+      },
+      "version": "16.7.27"
+    },
+    "name": "multi-validator-postgres-4",
+    "provider": "",
+    "type": "kubernetes:helm.sh/v3:Release"
   },
   {
     "custom": true,
@@ -4862,495 +5297,5 @@
     "name": "organization/infra/infra.mock",
     "provider": "",
     "type": "pulumi:pulumi:StackReference"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "postgres-0",
-      "namespace": "multi-validator",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "appsAffinityAndTolerations": {
-          "affinity": {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "cn_apps",
-                        "operator": "Exists"
-                      },
-                      {
-                        "key": "cn_apps",
-                        "operator": "In",
-                        "values": [
-                          "hyperdisk"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "tolerations": [
-            {
-              "effect": "NoSchedule",
-              "key": "cn_apps",
-              "operator": "Exists"
-            }
-          ]
-        },
-        "db": {
-          "maxConnections": 1000,
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "100Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-0-secret"
-        },
-        "resources": {
-          "limits": {
-            "memory": "12Gi"
-          },
-          "requests": {
-            "memory": "5Gi"
-          }
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
-      },
-      "version": "0.3.20"
-    },
-    "name": "postgres-0",
-    "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "postgres-1",
-      "namespace": "multi-validator",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "appsAffinityAndTolerations": {
-          "affinity": {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "cn_apps",
-                        "operator": "Exists"
-                      },
-                      {
-                        "key": "cn_apps",
-                        "operator": "In",
-                        "values": [
-                          "hyperdisk"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "tolerations": [
-            {
-              "effect": "NoSchedule",
-              "key": "cn_apps",
-              "operator": "Exists"
-            }
-          ]
-        },
-        "db": {
-          "maxConnections": 1000,
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "100Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-1-secret"
-        },
-        "resources": {
-          "limits": {
-            "memory": "12Gi"
-          },
-          "requests": {
-            "memory": "5Gi"
-          }
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
-      },
-      "version": "0.3.20"
-    },
-    "name": "postgres-1",
-    "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "postgres-2",
-      "namespace": "multi-validator",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "appsAffinityAndTolerations": {
-          "affinity": {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "cn_apps",
-                        "operator": "Exists"
-                      },
-                      {
-                        "key": "cn_apps",
-                        "operator": "In",
-                        "values": [
-                          "hyperdisk"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "tolerations": [
-            {
-              "effect": "NoSchedule",
-              "key": "cn_apps",
-              "operator": "Exists"
-            }
-          ]
-        },
-        "db": {
-          "maxConnections": 1000,
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "100Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-2-secret"
-        },
-        "resources": {
-          "limits": {
-            "memory": "12Gi"
-          },
-          "requests": {
-            "memory": "5Gi"
-          }
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
-      },
-      "version": "0.3.20"
-    },
-    "name": "postgres-2",
-    "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "postgres-3",
-      "namespace": "multi-validator",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "appsAffinityAndTolerations": {
-          "affinity": {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "cn_apps",
-                        "operator": "Exists"
-                      },
-                      {
-                        "key": "cn_apps",
-                        "operator": "In",
-                        "values": [
-                          "hyperdisk"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "tolerations": [
-            {
-              "effect": "NoSchedule",
-              "key": "cn_apps",
-              "operator": "Exists"
-            }
-          ]
-        },
-        "db": {
-          "maxConnections": 1000,
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "100Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-3-secret"
-        },
-        "resources": {
-          "limits": {
-            "memory": "12Gi"
-          },
-          "requests": {
-            "memory": "5Gi"
-          }
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
-      },
-      "version": "0.3.20"
-    },
-    "name": "postgres-3",
-    "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
-  },
-  {
-    "custom": true,
-    "id": "",
-    "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
-      "compat": "true",
-      "maxHistory": 10,
-      "name": "postgres-4",
-      "namespace": "multi-validator",
-      "timeout": 600,
-      "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        },
-        "appsAffinityAndTolerations": {
-          "affinity": {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                  {
-                    "matchExpressions": [
-                      {
-                        "key": "cn_apps",
-                        "operator": "Exists"
-                      },
-                      {
-                        "key": "cn_apps",
-                        "operator": "In",
-                        "values": [
-                          "hyperdisk"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "tolerations": [
-            {
-              "effect": "NoSchedule",
-              "key": "cn_apps",
-              "operator": "Exists"
-            }
-          ]
-        },
-        "db": {
-          "maxConnections": 1000,
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "100Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-4-secret"
-        },
-        "resources": {
-          "limits": {
-            "memory": "12Gi"
-          },
-          "requests": {
-            "memory": "5Gi"
-          }
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
-      },
-      "version": "0.3.20"
-    },
-    "name": "postgres-4",
-    "provider": "",
-    "type": "kubernetes:helm.sh/v3:Release"
   }
 ]

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -689,7 +689,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -889,7 +889,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -1017,7 +1017,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -2550,7 +2550,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -2680,7 +2680,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -2810,7 +2810,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -2940,7 +2940,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3070,7 +3070,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3200,7 +3200,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3330,7 +3330,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3460,7 +3460,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3590,7 +3590,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3720,7 +3720,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3850,7 +3850,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -3980,7 +3980,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -4110,7 +4110,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6190,7 +6190,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6320,7 +6320,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6450,7 +6450,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6580,7 +6580,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6710,7 +6710,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6840,7 +6840,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -6970,7 +6970,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7100,7 +7100,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7230,7 +7230,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7360,7 +7360,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7490,7 +7490,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7620,7 +7620,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -7750,7 +7750,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -8893,7 +8893,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9024,7 +9024,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9155,7 +9155,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9286,7 +9286,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9417,7 +9417,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9548,7 +9548,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9679,7 +9679,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9810,7 +9810,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -9941,7 +9941,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -10072,7 +10072,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -10203,7 +10203,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -10334,7 +10334,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -10465,7 +10465,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1123,7 +1123,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -319,7 +319,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -618,7 +618,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -954,7 +954,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -596,66 +596,44 @@
     "inputs": {},
     "name": "validator-postgres",
     "provider": "",
-    "type": "canton:network:postgres"
+    "type": "canton:network:bitnami-postgres"
   },
   {
     "custom": true,
     "id": "",
     "inputs": {
-      "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
+      "chart": "oci://registry-1.docker.io/bitnamicharts/postgresql",
       "compat": "true",
       "maxHistory": 10,
       "name": "postgres",
       "namespace": "validator",
       "timeout": 600,
       "values": {
-        "affinity": {
-          "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-              "nodeSelectorTerms": [
-                {
-                  "matchExpressions": [
-                    {
-                      "key": "cn_apps",
-                      "operator": "Exists"
-                    },
-                    {
-                      "key": "cn_apps",
-                      "operator": "In",
-                      "values": [
-                        "hyperdisk"
-                      ]
-                    }
-                  ]
-                }
-              ]
+        "auth": {
+          "database": "cantonnet",
+          "enablePostgresUser": false,
+          "existingSecret": "postgres-secrets",
+          "secretKeys": {
+            "userPasswordKey": "postgresPassword"
+          },
+          "username": "cnadmin"
+        },
+        "fullnameOverride": "postgres",
+        "primary": {
+          "extendedConfiguration": "max_connections = 300\nmax_wal_size = 2GB\n",
+          "initdb": {
+            "args": "--data-checksums",
+            "scripts": {
+              "grant-createdb.sql": "ALTER USER cnadmin CREATEDB;"
             }
+          },
+          "persistence": {
+            "size": "200Gi",
+            "storageClass": "hyperdisk-standard-rwo"
           }
-        },
-        "cluster": {
-          "dnsName": "mock.global.canton.network.digitalasset.com",
-          "fixedTokens": false,
-          "hostname": "mock.global.canton.network.digitalasset.com",
-          "name": "cn-mocknet"
-        },
-        "db": {
-          "pvcTemplateName": "pg-data-hd",
-          "volumeSize": "200Gi",
-          "volumeStorageClass": "hyperdisk-standard-rwo"
-        },
-        "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
-        "persistence": {
-          "secretName": "postgres-secrets"
-        },
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "cn_apps",
-            "operator": "Exists"
-          }
-        ]
+        }
       },
-      "version": "0.3.20"
+      "version": "16.7.27"
     },
     "name": "validator-postgres",
     "provider": "",

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -620,6 +620,29 @@
         },
         "fullnameOverride": "postgres",
         "primary": {
+          "affinity": {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "cn_apps",
+                        "operator": "Exists"
+                      },
+                      {
+                        "key": "cn_apps",
+                        "operator": "In",
+                        "values": [
+                          "hyperdisk"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
           "extendedConfiguration": "max_connections = 300\nmax_wal_size = 2GB\n",
           "initdb": {
             "args": "--data-checksums",
@@ -630,7 +653,14 @@
           "persistence": {
             "size": "200Gi",
             "storageClass": "hyperdisk-standard-rwo"
-          }
+          },
+          "tolerations": [
+            {
+              "effect": "NoSchedule",
+              "key": "cn_apps",
+              "operator": "Exists"
+            }
+          ]
         }
       },
       "version": "16.7.27"

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -753,7 +753,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {
@@ -948,7 +948,7 @@
     "custom": true,
     "id": "",
     "inputs": {
-      "databaseVersion": "POSTGRES_14",
+      "databaseVersion": "POSTGRES_17",
       "deletionProtection": false,
       "region": "europe-west6",
       "settings": {

--- a/cluster/helm/splice-postgres/Chart-template.yaml
+++ b/cluster/helm/splice-postgres/Chart-template.yaml
@@ -7,7 +7,12 @@ type: application
 version: VERSION_NUMBER
 appVersion: VERSION_NUMBER
 
-description: Splice Self-Hosted PGSQL
+description: >
+  DEPRECATED: This chart will not receive PostgreSQL version upgrades and will be
+  unsupported after 2026-11-12 (PostgreSQL 14 upstream EOL).
+  Migrate to bitnami/postgresql. See https://github.com/canton-network/splice/issues/1129
+
+deprecated: true
 
 dependencies:
 - name: splice-util-lib

--- a/cluster/helm/splice-postgres/templates/NOTES.txt
+++ b/cluster/helm/splice-postgres/templates/NOTES.txt
@@ -1,1 +1,15 @@
-Splice Self-Hosted PGSQL
+******************************************************************************
+WARNING: splice-postgres IS DEPRECATED
+******************************************************************************
+
+This chart will not receive any further PostgreSQL version upgrades.
+Support ends on 2026-11-12 (PostgreSQL 14 upstream end-of-life).
+
+Please migrate to an upstream PostgreSQL chart before that date.
+We recommend bitnami/postgresql (used by Splice for non-production deployments),
+but it is maintained by Bitnami — not by Splice. Chart issues should be reported
+upstream, not to the Splice project.
+
+Migration guide: docs/src/validator_operator/migrate-postgres-chart.rst
+Tracking issue: https://github.com/canton-network/splice/issues/1129
+******************************************************************************

--- a/cluster/helm/splice-postgres/values-template.yaml
+++ b/cluster/helm/splice-postgres/values-template.yaml
@@ -1,6 +1,12 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+#
+# DEPRECATED: This chart will not receive PostgreSQL version upgrades.
+# The postgres:14 image will reach end-of-life on 2026-11-12.
+# Do not bump imageName here — migrate to bitnami/postgresql instead.
+# See https://github.com/canton-network/splice/issues/1129
+
 imageRepo: "ghcr.io/digital-asset/decentralized-canton-sync/docker"
 imageName: "postgres:14"
 

--- a/cluster/images/splice-test-postgres/Dockerfile
+++ b/cluster/images/splice-test-postgres/Dockerfile
@@ -1,3 +1,6 @@
+# DEPRECATED: This image is no longer used in CI. Wallclock tests now use the
+# official postgres:17 image directly. Kept until splice-postgres chart EOL (2026-11-12).
+# See https://github.com/canton-network/splice/issues/1129
 FROM postgres:14.18@sha256:c0aab7962b283cf24a0defa5d0d59777f5045a7be59905f21ba81a20b1a110c9
 LABEL org.opencontainers.image.base.name="postgres:14.18"
 

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -543,7 +543,9 @@ export class BitnamiPostgres extends pulumi.ComponentResource implements Postgre
     const maxConnections = args.maxConnections ?? 300;
     const maxWalSize = args.maxWalSize ?? '2GB';
     const storageClass = args.storageClass ?? standardStorageClassName;
-    const { affinity, tolerations } = args.affinityAndTolerations ?? {};
+    // Default to the apps node affinity/tolerations so the pod schedules onto cn_apps nodes,
+    // matching the behavior of the splice-postgres chart this replaces.
+    const { affinity, tolerations } = args.affinityAndTolerations ?? appsAffinityAndTolerations;
 
     const helmValues: ChartValues = {
       fullnameOverride: instanceName,

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as gcp from '@pulumi/gcp';
+import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
 import * as random from '@pulumi/random';
 import * as _ from 'lodash';
@@ -19,7 +20,14 @@ import {
 import { installPostgresPasswordSecret } from './secrets';
 import { standardStorageClassName } from './storage/storageClass';
 import { createVolumeSnapshot } from './storage/volumeSnapshot';
-import { ChartValues, CLUSTER_BASENAME, ExactNamespace, GCP_ZONE } from './utils';
+import {
+  ChartValues,
+  CLUSTER_BASENAME,
+  ExactNamespace,
+  GCP_ZONE,
+  HELM_CHART_TIMEOUT_SEC,
+  HELM_MAX_HISTORY_SIZE,
+} from './utils';
 
 const project = gcp.organizations.getProjectOutput({});
 
@@ -118,7 +126,7 @@ export class CloudPostgres
     const databaseInstance = new gcp.sql.DatabaseInstance(
       name,
       {
-        databaseVersion: 'POSTGRES_14',
+        databaseVersion: 'POSTGRES_17',
         // keep always false as this is the terraform provider and cannot be manually removed
         // https://github.com/pulumi/pulumi-gcp/issues/1209
         deletionProtection: false,
@@ -369,6 +377,9 @@ type CloudPostgresOutput = {
   secretName: pulumi.Output<string>;
 };
 
+// @deprecated Use bitnami/postgresql instead. This class installs the splice-postgres chart which
+// is frozen at PostgreSQL 14 and will be unsupported after 2026-11-12.
+// See https://github.com/canton-network/splice/issues/1129
 export class SplicePostgres extends pulumi.ComponentResource implements Postgres {
   instanceName: string;
   namespace: ExactNamespace;
@@ -470,6 +481,124 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
 
     this.registerOutputs({
       address: pg.id.apply(() => `${instanceName}.${xns.logicalName}.svc.cluster.local`),
+      secretName: this.secretName,
+    });
+  }
+
+  addUser(_userName: string): PostgresUser {
+    return {
+      userName: 'cnadmin',
+      secretName: this.secretName,
+    };
+  }
+}
+
+// Pulled directly from the upstream bitnami OCI registry, consistent with how every other external
+// chart in this repo is consumed (prometheus, istio, pulumi-operator, gha runners all pull from
+// their respective upstreams). Note: this is the only external chart sourced from Docker Hub, which
+// is rate-limited and whose free bitnami catalog is being pruned — if that becomes a problem, route
+// it through the Docker Hub read-through mirror (cluster/pulumi/gha/src/dockerMirror.ts) rather than
+// CACHE_GHCR, which only proxies ghcr.io.
+const BITNAMI_POSTGRESQL_CHART = 'oci://registry-1.docker.io/bitnamicharts/postgresql';
+const BITNAMI_POSTGRESQL_CHART_VERSION = '16.7.27'; // PostgreSQL 17.6.0
+
+export type BitnamiPostgresArgs = {
+  secretName: string;
+  volumeSize?: string;
+  storageClass?: string;
+  maxConnections?: number;
+  maxWalSize?: string;
+  resources?: ChartValues;
+  disableProtection?: boolean;
+  affinityAndTolerations?: { affinity?: object; tolerations?: object[] };
+  dependsOn?: pulumi.Input<pulumi.Resource>[];
+};
+
+export class BitnamiPostgres extends pulumi.ComponentResource implements Postgres {
+  instanceName: string;
+  namespace: ExactNamespace;
+  address: pulumi.Output<string>;
+  pg: k8s.helm.v3.Release;
+  secretName: pulumi.Output<string>;
+  userName: string;
+
+  constructor(xns: ExactNamespace, instanceName: string, args: BitnamiPostgresArgs) {
+    const logicalName = `${xns.logicalName}-${instanceName}`;
+    super('canton:network:bitnami-postgres', logicalName, [], {
+      protect: args.disableProtection ? false : spliceConfig.pulumiProjectConfig.cloudSql.protected,
+    });
+
+    this.instanceName = instanceName;
+    this.namespace = xns;
+    this.userName = 'cnadmin';
+    this.address = pulumi.output(`${instanceName}.${xns.logicalName}.svc.cluster.local`);
+
+    // Single-key secret (postgresPassword) for the cnadmin user. We set enablePostgresUser=false
+    // below, so no postgres-superuser password is needed and the secret shape matches what the old
+    // splice-postgres chart used — letting operators reuse their existing secret on migration.
+    const userPassword = generatePassword(`${logicalName}-passwd`, { parent: this }).result;
+    const passwordSecret = installPostgresPasswordSecret(xns, userPassword, args.secretName);
+    this.secretName = passwordSecret.metadata.name;
+
+    const maxConnections = args.maxConnections ?? 300;
+    const maxWalSize = args.maxWalSize ?? '2GB';
+    const storageClass = args.storageClass ?? standardStorageClassName;
+    const { affinity, tolerations } = args.affinityAndTolerations ?? {};
+
+    const helmValues: ChartValues = {
+      fullnameOverride: instanceName,
+      // Chart + images are pulled directly from upstream bitnami (docker.io), consistent with how
+      // every other external chart in this repo is consumed. The repo's Docker Hub rate-limit
+      // mitigation is an anonymous shared read-through cache wired as a containerd registry-mirror
+      // (see cluster/pulumi/gha/src/dockerMirror.ts) — there are no Docker Hub credentials. For
+      // app-cluster image pulls to benefit, the node containerd needs that same registry-mirror;
+      // that is cluster/node config, not something this chart controls.
+      auth: {
+        enablePostgresUser: false, // Canton connects as cnadmin only; no postgres superuser password
+        username: 'cnadmin',
+        database: 'cantonnet',
+        existingSecret: args.secretName,
+        secretKeys: {
+          userPasswordKey: 'postgresPassword',
+        },
+      },
+      primary: {
+        initdb: {
+          args: '--data-checksums',
+          scripts: {
+            'grant-createdb.sql': 'ALTER USER cnadmin CREATEDB;',
+          },
+        },
+        extendedConfiguration: `max_connections = ${maxConnections}\nmax_wal_size = ${maxWalSize}\n`,
+        persistence: {
+          size: args.volumeSize ?? '2800Gi',
+          storageClass,
+        },
+        ...(args.resources ? { resources: args.resources } : {}),
+        ...(affinity ? { affinity } : {}),
+        ...(tolerations ? { tolerations } : {}),
+      },
+    };
+
+    this.pg = new k8s.helm.v3.Release(
+      logicalName,
+      {
+        name: instanceName,
+        namespace: xns.ns.metadata.name,
+        chart: BITNAMI_POSTGRESQL_CHART,
+        version: BITNAMI_POSTGRESQL_CHART_VERSION,
+        values: helmValues,
+        timeout: HELM_CHART_TIMEOUT_SEC,
+        maxHistory: HELM_MAX_HISTORY_SIZE,
+      },
+      {
+        parent: this,
+        dependsOn: [passwordSecret, xns.ns, ...(args.dependsOn ?? [])],
+      }
+    );
+
+    this.registerOutputs({
+      address: this.pg.id.apply(() => `${instanceName}.${xns.logicalName}.svc.cluster.local`),
       secretName: this.secretName,
     });
   }

--- a/cluster/pulumi/gha/src/performanceTests.ts
+++ b/cluster/pulumi/gha/src/performanceTests.ts
@@ -31,7 +31,7 @@ export function createCloudSQLInstanceForPerformanceTests(
   });
   const zone = GCP_ZONE || config.requireEnv('DB_CLOUDSDK_COMPUTE_ZONE');
   const instance = new gcp.sql.DatabaseInstance('performance-tests-db', {
-    databaseVersion: 'POSTGRES_14',
+    databaseVersion: 'POSTGRES_17',
     deletionProtection: false,
     region: GCP_REGION,
     settings: {

--- a/cluster/pulumi/multi-validator/src/postgres.ts
+++ b/cluster/pulumi/multi-validator/src/postgres.ts
@@ -1,87 +1,33 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as pulumi from '@pulumi/pulumi';
-import * as random from '@pulumi/random';
 import {
-  activeVersion,
   appsAffinityAndTolerations,
   CnInput,
   ExactNamespace,
-  InstalledHelmChart,
-  installPostgresPasswordSecret,
-  installSpliceRunbookHelmChart,
-  spliceConfig,
   standardStorageClassName,
-  createVolumeSnapshot,
 } from '@canton-network/splice-pulumi-common';
+import { BitnamiPostgres } from '@canton-network/splice-pulumi-common/src/postgres';
 
-import { hyperdiskSupportConfig } from '../../common/src/config/hyperdiskSupportConfig';
 import { multiValidatorConfig } from './config';
 
 export function installPostgres(
   xns: ExactNamespace,
   name: string,
   dependsOn: CnInput<pulumi.Resource>[]
-): InstalledHelmChart {
-  const password = new random.RandomPassword(`${xns.logicalName}-${name}-passwd`, {
-    length: 16,
-    overrideSpecial: '_%@',
-    special: true,
-  }).result;
-  const secretName = `${name}-secret`;
-  const passwordSecret = installPostgresPasswordSecret(xns, password, secretName);
-
+): BitnamiPostgres {
   if (!multiValidatorConfig) {
     throw new Error('multiValidator config must be set when they are enabled');
   }
   const config = multiValidatorConfig!;
 
-  let hyperdiskMigrationValues = {};
-  if (
-    hyperdiskSupportConfig.hyperdiskSupport.enabled &&
-    hyperdiskSupportConfig.hyperdiskSupport.migrating
-  ) {
-    const { dataSource } = createVolumeSnapshot({
-      resourceName: `pg-data-${xns.logicalName}-${name}-snapshot`,
-      snapshotName: `pg-data-${name}-snapshot`,
-      namespace: xns.logicalName,
-      pvcName: `pg-data-${name}-0`,
-    });
-    hyperdiskMigrationValues = { dataSource };
-  }
-  return installSpliceRunbookHelmChart(
-    xns,
-    name,
-    'splice-postgres',
-    {
-      persistence: { secretName },
-      db: {
-        volumeSize: config.postgresPvcSize,
-        maxConnections: 1000,
-        ...(hyperdiskSupportConfig.hyperdiskSupport.enabled
-          ? {
-              volumeStorageClass: standardStorageClassName,
-              pvcTemplateName: 'pg-data-hd',
-              ...hyperdiskMigrationValues,
-            }
-          : {}),
-      },
-      resources: config.resources?.postgres,
-      appsAffinityAndTolerations,
-    },
-    activeVersion,
-    {
-      dependsOn: [passwordSecret, ...dependsOn],
-      ...((hyperdiskSupportConfig.hyperdiskSupport.enabled &&
-        // during the migration we first delete the stateful set, which keeps the old pvcs, and the recreate with the new pvcs
-        // the stateful sets are immutable so they need to be recreated to force the change of the pvcs
-        hyperdiskSupportConfig.hyperdiskSupport.migrating) ||
-      spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges
-        ? {
-            replaceOnChanges: ['*'],
-            deleteBeforeReplace: true,
-          }
-        : {}),
-    }
-  );
+  return new BitnamiPostgres(xns, name, {
+    secretName: `${name}-secret`,
+    volumeSize: config.postgresPvcSize,
+    storageClass: standardStorageClassName,
+    maxConnections: 1000,
+    resources: config.resources?.postgres,
+    affinityAndTolerations: appsAffinityAndTolerations,
+    dependsOn,
+  });
 }

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -67,7 +67,7 @@ import {
   valuesForSvValidatorApp,
 } from '@canton-network/splice-pulumi-common-sv';
 import { spliceConfig } from '@canton-network/splice-pulumi-common/src/config/config';
-import { CloudPostgres, SplicePostgres } from '@canton-network/splice-pulumi-common/src/postgres';
+import { Postgres } from '@canton-network/splice-pulumi-common/src/postgres';
 import { createHash } from 'node:crypto';
 
 import { installRateLimits } from '../../common/src/ratelimit/rateLimit';
@@ -204,7 +204,7 @@ type SvConfig = {
   cometBftGovernanceKey?: CnInput<SvCometBftGovernanceKey>;
 };
 
-function persistenceForPostgres(pg: SplicePostgres | CloudPostgres, values: ChartValues) {
+function persistenceForPostgres(pg: Postgres, values: ChartValues) {
   return {
     persistence: {
       ...values?.persistence,

--- a/cluster/pulumi/sv-runbook/src/postgres.ts
+++ b/cluster/pulumi/sv-runbook/src/postgres.ts
@@ -1,6 +1,5 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as _ from 'lodash';
 import {
   CloudSqlConfig,
   clusterSmallDisk,
@@ -10,7 +9,7 @@ import {
   supportsSvRunbookReset,
 } from '@canton-network/splice-pulumi-common';
 import { spliceConfig } from '@canton-network/splice-pulumi-common/src/config/config';
-import { CloudPostgres, SplicePostgres } from '@canton-network/splice-pulumi-common/src/postgres';
+import { BitnamiPostgres, CloudPostgres } from '@canton-network/splice-pulumi-common/src/postgres';
 
 export async function installPostgres(
   xns: ExactNamespace,
@@ -19,7 +18,7 @@ export async function installPostgres(
   selfHostedValuesFile: string,
   isActive: boolean = true,
   cloudSqlConfigOverride?: CloudSqlConfig
-): Promise<SplicePostgres | CloudPostgres> {
+): Promise<BitnamiPostgres | CloudPostgres> {
   const cloudSqlConfig = cloudSqlConfigOverride ?? spliceConfig.pulumiProjectConfig.cloudSql;
   if (cloudSqlConfig.enabled) {
     return CloudPostgres.install(`${xns.logicalName}-${name}`, {
@@ -35,24 +34,18 @@ export async function installPostgres(
     const valuesFromFile = loadYamlFromFile(
       `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/${selfHostedValuesFile}`
     );
-    const volumeSizeOverride = determineVolumeSizeOverride(valuesFromFile.db?.volumeSize);
-    const values = _.merge(valuesFromFile || {}, { db: { volumeSize: volumeSizeOverride } });
-    return new SplicePostgres(
-      xns,
-      name,
-      name,
+    const volumeSize = determineVolumeSize(valuesFromFile.primary?.persistence?.size);
+    return new BitnamiPostgres(xns, name, {
       secretName,
-      values,
-      undefined,
-      supportsSvRunbookReset
-    );
+      volumeSize,
+      disableProtection: supportsSvRunbookReset,
+    });
   }
 }
 
-// A bit complicated because some of the values in our examples are actually lower than the default for CLUSTER_SMALL_DISK
-function determineVolumeSizeOverride(volumeSizeFromFile: string | undefined): string | undefined {
+function determineVolumeSize(volumeSizeFromFile: string | undefined): string | undefined {
   const gigs = (s: string) => parseInt(s.replace('Gi', ''));
   return clusterSmallDisk && volumeSizeFromFile && gigs(volumeSizeFromFile) > 240
     ? '240Gi'
-    : undefined;
+    : volumeSizeFromFile;
 }

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -45,7 +45,7 @@ import {
 } from '@canton-network/splice-pulumi-common';
 import { installLoopback } from '@canton-network/splice-pulumi-common-sv';
 import { installParticipant } from '@canton-network/splice-pulumi-common-validator';
-import { SplicePostgres } from '@canton-network/splice-pulumi-common/src/postgres';
+import { BitnamiPostgres } from '@canton-network/splice-pulumi-common/src/postgres';
 
 import { installPartyAllocator } from './partyAllocator';
 import { validatorConfig, validatorName } from './validatorConfig';
@@ -162,23 +162,13 @@ async function installValidator(
   const postgresValuesFromFile: ChartValues = loadYamlFromFile(
     `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/postgres-values-validator-participant.yaml`
   );
-  const postgresValues: ChartValues = validatorConfig.postgresPvcSize
-    ? {
-        ...postgresValuesFromFile,
-        db: { ...postgresValuesFromFile.db, volumeSize: validatorConfig.postgresPvcSize },
-      }
-    : postgresValuesFromFile;
-  const postgres = new SplicePostgres(
-    xns,
-    'postgres',
-    // can be removed once base version > 0.2.1
-    `postgres`,
-    'postgres-secrets',
-    postgresValues,
-    true,
-    supportsValidatorRunbookReset,
-    validatorVersion
-  );
+  const volumeSize =
+    validatorConfig.postgresPvcSize ?? postgresValuesFromFile.primary?.persistence?.size;
+  const postgres = new BitnamiPostgres(xns, 'postgres', {
+    secretName: 'postgres-secrets',
+    volumeSize,
+    disableProtection: supportsValidatorRunbookReset,
+  });
   const participantAddress = (
     await installParticipant(
       validatorConfig,

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -15,6 +15,15 @@
                 This allows node operators to inject raw configuration strings for an external secret manager.
                 To use this, you must have the corresponding mutating webhook installed in your cluster
                 to dynamically resolve raw string references at runtime.
+              - The ``splice-postgres`` Helm chart is now **deprecated** and will not receive
+                further PostgreSQL version upgrades. It will be unsupported after **2026-11-12**
+                (PostgreSQL 14 upstream end-of-life).
+
+                Operators running validator or SV nodes with ``splice-postgres`` should plan a
+                migration to an upstream PostgreSQL chart before that date. We recommend
+                ``bitnami/postgresql``, which Splice uses for its own non-production deployments,
+                but it is maintained by Bitnami and not supported by the Splice project.
+                See :ref:`migrate-postgres-chart` for the migration guide.
 
               - Added support for injecting custom `serviceAccountName` into deployments.
                 Note that Splice Helm charts do not create Service Account resources;

--- a/docs/src/sv_operator/sv_helm.rst
+++ b/docs/src/sv_operator/sv_helm.rst
@@ -521,21 +521,35 @@ The password can be setup with the following command, assuming you set the envir
 Postgres in the Cluster
 +++++++++++++++++++++++
 
-If you wish to run the Postgres instances as pods in your cluster, you can use the `splice-postgres` Helm chart to install them:
+If you wish to run the Postgres instances as pods in your cluster, you can use any well-known
+PostgreSQL Helm chart. The example values files below target the upstream
+`bitnami/postgresql <https://github.com/bitnami/charts/tree/main/bitnami/postgresql>`_ chart,
+which Splice uses for its own non-production deployments. You are free to use a different chart;
+adapt the values accordingly.
+
+.. note::
+
+   Splice previously shipped its own ``splice-postgres`` chart. That chart is **deprecated** and
+   will be removed (PostgreSQL 14 reaches end-of-life on 2026-11-12). Splice does not maintain a
+   PostgreSQL chart; please use an upstream chart such as ``bitnami/postgresql``, which is
+   maintained by Bitnami, not by the Splice project.
 
 .. parsed-literal::
 
-    helm install sequencer-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-sequencer.yaml --wait
-    helm install mediator-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-mediator.yaml --wait
-    helm install participant-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-participant.yaml --wait
-    helm install apps-pg |helm_repo_prefix|/splice-postgres -n sv --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-apps.yaml --wait
+    helm install sequencer-pg oci://registry-1.docker.io/bitnamicharts/postgresql --version 16.7.27 -n sv -f splice-node/examples/sv-helm/postgres-values-sequencer.yaml --wait
+    helm install mediator-pg oci://registry-1.docker.io/bitnamicharts/postgresql --version 16.7.27 -n sv -f splice-node/examples/sv-helm/postgres-values-mediator.yaml --wait
+    helm install participant-pg oci://registry-1.docker.io/bitnamicharts/postgresql --version 16.7.27 -n sv -f splice-node/examples/sv-helm/postgres-values-participant.yaml --wait
+    helm install apps-pg oci://registry-1.docker.io/bitnamicharts/postgresql --version 16.7.27 -n sv -f splice-node/examples/sv-helm/postgres-values-apps.yaml --wait
+
+The release name (``sequencer-pg``, etc.) must match the ``fullnameOverride`` in each values file,
+which is also the ``persistence.host`` the Canton apps connect to.
 
 Cloud-Hosted Postgres
 +++++++++++++++++++++
 
 If you wish to use cloud-hosted Postgres instances, please configure and initialize each of them as follows:
 
-- Use Postgres version 14
+- Use Postgres version 17
 - Create a database called ``cantonnet`` (this is a dummy database that will not be filled with actual data; additional databases will be created as part of deployment and initialization)
 - Create a user called ``cnadmin`` with the password as configured in the kubernetes secrets above
 

--- a/docs/src/validator_operator/index.rst
+++ b/docs/src/validator_operator/index.rst
@@ -45,5 +45,6 @@ You can find hardware requirements for both options in a :ref:`dedicated section
    validator_delegations.rst
    validator_development_fund.rst
    validator_networking.rst
+   migrate-postgres-chart.rst
 
 .. todo:: Add top-level sections on node onboarding, validator functionality

--- a/docs/src/validator_operator/migrate-postgres-chart.rst
+++ b/docs/src/validator_operator/migrate-postgres-chart.rst
@@ -1,0 +1,79 @@
+..
+   Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+..
+   SPDX-License-Identifier: Apache-2.0
+
+.. _migrate-postgres-chart:
+
+Moving off the ``splice-postgres`` chart
+========================================
+
+The ``splice-postgres`` Helm chart is deprecated and will be removed
+(PostgreSQL 14 reaches end-of-life on 2026-11-12). Splice does not maintain a
+PostgreSQL chart. Use any well-known PostgreSQL chart, a managed service, or
+your existing database platform. Splice itself uses
+`bitnami/postgresql <https://github.com/bitnami/charts/tree/main/bitnami/postgresql>`_
+for its non-production deployments, and the example values files target it.
+See `issue #1129 <https://github.com/hyperledger-labs/splice/issues/1129>`_.
+
+.. note::
+
+   This page is guidance, **not a validated end-to-end runbook**. There is no
+   Splice-specific migration tooling. Always rehearse any data migration in a
+   non-production environment first and rely on your own tested backups.
+
+Choosing a replacement
+----------------------
+
+- ``bitnami/postgresql`` — see the example values in
+  ``splice-node/examples/sv-helm/postgres-values-*.yaml`` and the chart's own
+  `documentation <https://github.com/bitnami/charts/tree/main/bitnami/postgresql>`_.
+- Any other PostgreSQL Helm chart, or a managed PostgreSQL (e.g. Cloud SQL).
+
+Migrating existing data
+-----------------------
+
+Use standard PostgreSQL logical backup/restore — there is nothing
+Splice-specific about the mechanics:
+
+- `pg_dump <https://www.postgresql.org/docs/current/app-pgdump.html>`_ /
+  `pg_restore <https://www.postgresql.org/docs/current/app-pgrestore.html>`_
+- `Backup and Restore <https://www.postgresql.org/docs/current/backup.html>`_
+
+Splice-specific considerations
+------------------------------
+
+These are the points generic PostgreSQL/chart docs won't cover:
+
+- **Stop writes before dumping.** Scale every Canton app that uses the database
+  to zero replicas before ``pg_dump``. Canton uses Flyway, and dumping mid-write
+  can capture an inconsistent ``flyway_schema_history``, after which the app will
+  refuse to start.
+- **Match major versions.** Use a ``pg_dump``/``pg_restore`` client matching the
+  target server's major version (PostgreSQL 17 for the bitnami examples).
+- **Service hostname must not change.** Canton apps connect to a fixed host
+  (``persistence.host``, e.g. ``apps-pg``). The replacement must expose the same
+  Kubernetes Service name — with bitnami, set ``fullnameOverride`` to that name.
+- **The app user needs ``CREATEDB``.** Canton init containers run
+  ``CREATE DATABASE``. In ``splice-postgres`` ``cnadmin`` was a superuser; on a
+  generic chart it is a normal user, so grant ``CREATEDB`` (the bitnami examples
+  do this via an ``initdb`` script).
+- **Secret shape.** Apps read the password from the key ``postgresPassword``. The
+  bitnami examples set ``auth.enablePostgresUser: false`` so your existing
+  single-key secret is reusable as-is.
+- **Default database** is ``cantonnet``; additional per-component databases are
+  created automatically at startup.
+
+Value mapping (``splice-postgres`` → ``bitnami/postgresql``)
+------------------------------------------------------------
+
+=============================  ==========================================
+splice-postgres                bitnami/postgresql
+=============================  ==========================================
+``db.volumeSize``              ``primary.persistence.size``
+``db.volumeStorageClass``      ``primary.persistence.storageClass``
+``db.maxConnections``          ``primary.extendedConfiguration``
+``db.maxWalSize``              ``primary.extendedConfiguration``
+``persistence.secretName``     ``auth.existingSecret``
+``resources``                  ``primary.resources``
+=============================  ==========================================

--- a/docs/src/validator_operator/validator_helm.rst
+++ b/docs/src/validator_operator/validator_helm.rst
@@ -412,9 +412,11 @@ Please modify the file ``splice-node/examples/sv-helm/participant-values.yaml`` 
 - Update the `auth.jwksUrl` entry to point to your auth provider's JWK set document by replacing ``OIDC_AUTHORITY_URL`` with your auth provider's OIDC URL, as explained above.
 - If you are running on a version of Kubernetes earlier than 1.24, set `enableHealthProbes` to `false` to disable the gRPC liveness and readiness probes.
 
-If you are using the provided postgres helm chart, modify ``splice-node/examples/sv-helm/postgres-values-validator-participant.yaml`` as follows:
-
-- Add ``db.volumeSize`` and ``db.volumeStorageClass`` to the values file adjust persistant storage size and storage class if necessary. (These values default to 20GiB and ``standard-rwo``)
+If you are running Postgres in-cluster, the example values file
+``splice-node/examples/sv-helm/postgres-values-validator-participant.yaml`` targets the upstream
+``bitnami/postgresql`` chart. Adjust ``primary.persistence.size`` and
+``primary.persistence.storageClass`` if necessary (these default to 50Gi and ``standard-rwo``).
+You are free to use any well-known PostgreSQL chart instead; Splice no longer ships its own.
 
 
 Additionally, please modify the file ``splice-node/examples/sv-helm/standalone-participant-values.yaml`` as follows:
@@ -469,7 +471,7 @@ reaches a stable state prior to moving on to the next step.
 
 .. parsed-literal::
 
-    helm install postgres |helm_repo_prefix|/splice-postgres -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/postgres-values-validator-participant.yaml --wait
+    helm install postgres oci://registry-1.docker.io/bitnamicharts/postgresql --version 16.7.27 -n validator -f splice-node/examples/sv-helm/postgres-values-validator-participant.yaml --wait
     helm install participant |helm_repo_prefix|/splice-participant -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/participant-values.yaml -f splice-node/examples/sv-helm/standalone-participant-values.yaml --wait
     helm install validator |helm_repo_prefix|/splice-validator -n validator --version ${CHART_VERSION} -f splice-node/examples/sv-helm/validator-values.yaml -f splice-node/examples/sv-helm/standalone-validator-values.yaml --wait
 


### PR DESCRIPTION
Fixes https://github.com/canton-network/splice/issues/717

## Problem encountered trying to get this to work: Bitnami business changes: no more free images / helm charts

See https://github.com/bitnami/containers/issues/83267. Free images have been moved to docker.io/bitnamilegacy, and will likely be (re-)moved in the future, so that's not a solution.

- Versioned, hardened image tags were **removed** from the free `docker.io/bitnami/*`
  repos and **moved to `docker.io/bitnamilegacy/*`**.
- The free `bitnami/*` repos now keep only a narrow set of `latest`-style tags;
  the full versioned catalog is behind a paid subscription.
- `bitnamilegacy` is an explicit temporary grace-period namespace and is slated
  for removal.

**Effect:** `docker.io/bitnami/postgresql:17.6.0-debian-12-r4` now returns 404
  (`bitnamilegacy/postgresql:17.6.0-debian-12-r4` still resolves), so the chart's
  pinned image fails to pull → `ImagePullBackOff`. This is a catalog/licensing
  change, not a PostgreSQL version issue — the tag is a current PG 17.6 build that
  was relocated, not deprecated.

  **Implication:** consuming bitnami images directly from the free Docker Hub
  catalog is not reliable; pinned tags get pruned over time.

  Refs:
  - Bitnami announcement: https://github.com/bitnami/containers/issues/83267
  - Bitnami Secure Images: https://www.vmware.com/products/app-platform/bitnami-secure-images

 ## How the bitnami values were derived

  The `postgres-values-*.yaml` values were mapped 1:1 from the deprecated
  `splice-postgres` chart onto the upstream `bitnami/postgresql` value schema.

  **From `splice-postgres` (`values-template.yaml` + ConfigMap):**
  | bitnami field | value | source |
  |---|---|---|
  | `primary.initdb.args` | `--data-checksums` | `POSTGRES_INITDB_ARGS` |
  | `extendedConfiguration` → `max_connections` | `300` | `db.maxConnections` |
  | `extendedConfiguration` → `max_wal_size` | `2GB` | `db.maxWalSize` |
  | `primary.persistence.storageClass` | `standard-rwo` | `db.volumeStorageClass` |
  | `primary.resources` | 12Gi / 0.5 / 1Gi | `resources:` (verbatim) |
  | `auth.username` / `auth.database` | `cnadmin` / `cantonnet` | `POSTGRES_USER` / `POSTGRES_DB` |
  | `auth.secretKeys.userPasswordKey` | `postgresPassword` | existing secret key |

  **From the old example files:**
  | field | value | source |
  |---|---|---|
  | `persistence.size` (apps/mediator) | `48Gi` | old `db.volumeSize` |
  | `persistence.size` (participant/sequencer) | `2800Gi` | chart default |
  | `persistence.size` (validator) | `50Gi` | old `db.volumeSize` |
  | `existingSecret` | `apps-pg-secret`, … | old `persistence.secretName` |
  | `fullnameOverride` | `apps-pg`, `mediator-pg`, … | the `host:` apps connect to |

  **From the bitnami chart:** all key names/structure (`primary.*`, `auth.*`, `global.*`).

  **Behavioral mappings added (not 1:1 copies):**
  - `initdb.scripts: ALTER USER cnadmin CREATEDB;` — `splice-postgres` ran `cnadmin` as superuser; bitnami's
  `auth.username` is a normal user, so it needs `CREATEDB` for the Canton init containers' `CREATE DATABASE`.
  - `auth.enablePostgresUser: false` — keeps the secret single-key (`postgresPassword`), so existing secrets are reusable
  as-is.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
