### PR TITLE
expose LSU information through Scan

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -856,6 +856,16 @@ abstract class ScanAppReference(
         HttpScanAppClient.GetActivePhysicalSynchronizerSerial()
       )
     }
+
+  @Help.Summary(
+    "Retrieve information on the next logical synchronizer upgrade (LSU)"
+  )
+  def getLsu(): Option[HttpScanAppClient.Lsu] =
+    consoleEnvironment.run {
+      httpCommand(
+        HttpScanAppClient.GetLsu()
+      )
+    }
 }
 
 final class ScanAppBackendReference(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -419,6 +419,13 @@ class LsuIntegrationTest
         waitForLsuAnnouncement()
       }
 
+      clue(s"Scan API returns proper LSU info after LSU announcement") {
+        val lsu = sv1ScanBackend.getLsu().value
+        lsu.topologyFreezeTime shouldBe topologyFreezeTime
+        lsu.upgradeTime shouldBe upgradeTime
+        lsu.successorPhysicalSynchronizerSerial shouldBe newSynchronizerSerial.value.toLong
+      }
+
       clue("new nodes are initialized") {
         initialSvNodesDoingTheLsu.map { backend =>
           val upgradeSequencerClient = backend.sequencerClientFor(_.successor.value)
@@ -439,6 +446,10 @@ class LsuIntegrationTest
 
       clue(s"wait for upgrade time $upgradeTime") {
         Threading.sleep(Duration.between(Instant.now(), upgradeTime.toInstant).toMillis.abs)
+      }
+
+      clue(s"Scan API returns empty LSU info after upgrade") {
+        sv1ScanBackend.getLsu() shouldBe None
       }
 
       clue("Restart sv2 and resume traffic transfer trigger") {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -421,7 +421,12 @@ class LsuIntegrationTest
 
       clue(s"Scan API returns proper LSU info after LSU announcement") {
         val lsu = sv1ScanBackend.getLsu().value
-        lsu.topologyFreezeTime shouldBe topologyFreezeTime
+        val actualTopologyFreezeTime = sv1ScanBackend.participantClient.topology.lsu.announcement
+          .list(Some(Synchronizer(decentralizedSynchronizerId)))
+          .head
+          .context
+          .validFrom
+        lsu.topologyFreezeTime shouldBe CantonTimestamp.assertFromInstant(actualTopologyFreezeTime)
         lsu.upgradeTime shouldBe upgradeTime
         lsu.successorPhysicalSynchronizerSerial shouldBe newSynchronizerSerial.value.toLong
       }
@@ -446,10 +451,6 @@ class LsuIntegrationTest
 
       clue(s"wait for upgrade time $upgradeTime") {
         Threading.sleep(Duration.between(Instant.now(), upgradeTime.toInstant).toMillis.abs)
-      }
-
-      clue(s"Scan API returns empty LSU info after upgrade") {
-        sv1ScanBackend.getLsu() shouldBe None
       }
 
       clue("Restart sv2 and resume traffic transfer trigger") {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -428,7 +428,7 @@ class LsuIntegrationTest
           .validFrom
         lsu.topologyFreezeTime shouldBe CantonTimestamp.assertFromInstant(actualTopologyFreezeTime)
         lsu.upgradeTime shouldBe upgradeTime
-        lsu.successorPhysicalSynchronizerSerial shouldBe newSynchronizerSerial.value.toLong
+        lsu.successorPhysicalSynchronizerId shouldBe successorPsid
       }
 
       clue("new nodes are initialized") {

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -172,6 +172,21 @@ paths:
               schema:
                 "$ref": "#/components/schemas/GetRollForwardLsuResponse"
 
+  /v0/lsu:
+    get:
+      tags: [internal, scan]
+      x-jvm-package: scan
+      operationId: "getLsu"
+      description: |
+        Retrieve information on the next LSU
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetLsuResponse"
+
   /v0/active-synchronizer-serial:
     get:
       tags: [internal, scan]
@@ -2106,6 +2121,26 @@ components:
           type: string
         successorPhysicalSynchronizerId:
           type: string
+    GetLsuResponse:
+      type: object
+      properties:
+        lsu:
+          description: Info on the next LSU
+          "$ref": "#/components/schemas/Lsu"
+    Lsu:
+      type: object
+      required:
+        - freezeTime
+        - upgradeTime
+      properties:
+        freezeTime:
+          description: The time when topology freeze starts
+          type: string
+          format: date-time
+        upgradeTime:
+          description: The time at which to upgrade
+          type: string
+          format: date-time
     GetActivePhysicalSynchronizerSerialResponse:
       type: object
       required: ["serial"]
@@ -4235,7 +4270,7 @@ components:
           description: Total amount of minting allowances that fell below the configured app reward threshold and was thus burned.
         total_app_reward_unclaimed:
           type: string
-          description: Total amount of app rewards which could not be attributed to app providers in this round because of limit on app rewards per activity (aka the app rewards cap). 
+          description: Total amount of app rewards which could not be attributed to app providers in this round because of limit on app rewards per activity (aka the app rewards cap).
         rewarded_app_provider_parties_count:
           type: integer
           format: int64

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -178,7 +178,7 @@ paths:
       x-jvm-package: scan
       operationId: "getLsu"
       description: |
-        Retrieve information on the next LSU
+        Retrieve information on the next logical synchronizer upgrade (LSU)
       responses:
         "200":
           description: ok
@@ -2130,10 +2130,11 @@ components:
     Lsu:
       type: object
       required:
-        - freezeTime
+        - topologyFreezeTime
         - upgradeTime
+        - successorPhysicalSynchronizerSerial
       properties:
-        freezeTime:
+        topologyFreezeTime:
           description: The time when topology freeze starts
           type: string
           format: date-time
@@ -2141,6 +2142,10 @@ components:
           description: The time at which to upgrade
           type: string
           format: date-time
+        successorPhysicalSynchronizerSerial:
+          description: The successor physical synchronizer serial
+          type: integer
+          format: int64
     GetActivePhysicalSynchronizerSerialResponse:
       type: object
       required: ["serial"]

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -2132,7 +2132,7 @@ components:
       required:
         - topologyFreezeTime
         - upgradeTime
-        - successorPhysicalSynchronizerSerial
+        - successorPhysicalSynchronizerId
       properties:
         topologyFreezeTime:
           description: The time when topology freeze starts
@@ -2142,10 +2142,9 @@ components:
           description: The time at which to upgrade
           type: string
           format: date-time
-        successorPhysicalSynchronizerSerial:
-          description: The successor physical synchronizer serial
-          type: integer
-          format: int64
+        successorPhysicalSynchronizerId:
+          description: The successor physical synchronizer ID
+          type: string
     GetActivePhysicalSynchronizerSerialResponse:
       type: object
       required: ["serial"]

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -298,6 +298,12 @@ class BftScanConnection(
     bftCall(_.lookupRollForwardLsu(), "lookupRollForwardLsu")
   }
 
+  override def getLsu()(implicit
+      tc: TraceContext
+  ): Future[Option[HttpScanAppClient.Lsu]] = {
+    bftCall(_.getLsu(), "getLsu")
+  }
+
   override def getPartyToParticipant(
       synchronizerId: SynchronizerId,
       partyId: PartyId,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
@@ -165,6 +165,10 @@ trait ScanConnection
       tc: TraceContext
   ): Future[Option[HttpScanAppClient.RollForwardLsu]]
 
+  def getLsu()(implicit
+      tc: TraceContext
+  ): Future[Option[HttpScanAppClient.Lsu]]
+
   def getPartyToParticipant(
       synchronizerId: SynchronizerId,
       partyId: PartyId,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
@@ -432,6 +432,15 @@ class SingleScanConnection private[client] (
     )
   }
 
+  override def getLsu()(implicit
+      tc: TraceContext
+  ): Future[Option[HttpScanAppClient.Lsu]] = {
+    runHttpCmd(
+      config.adminApi.url,
+      HttpScanAppClient.GetLsu(),
+    )
+  }
+
   override def getPartyToParticipant(
       synchronizerId: SynchronizerId,
       partyId: PartyId,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -44,6 +44,7 @@ import org.lfdecentralizedtrust.splice.http.v0.scan.{
   ForceAcsSnapshotNowResponse,
   GetDateOfFirstSnapshotAfterResponse,
   GetDateOfMostRecentSnapshotBeforeResponse,
+  GetLsuResponse,
   ListBulkAcsSnapshotObjectsResponse,
   ListBulkUpdateHistoryObjectsResponse,
 }
@@ -2726,6 +2727,43 @@ object HttpScanAppClient {
       param("upgradeTime", _.upgradeTime),
     )
   }
+
+  case class GetLsu() extends InternalBaseCommand[http.GetLsuResponse, Option[Lsu]] {
+    override def submitRequest(
+        client: Client,
+        headers: List[HttpHeader],
+    ): EitherT[Future, Either[Throwable, HttpResponse], GetLsuResponse] =
+      client.getLsu()
+
+    override protected def handleOk()(implicit
+        decoder: TemplateJsonDecoder
+    ): PartialFunction[GetLsuResponse, Either[String, Option[Lsu]]] = {
+      case http.GetLsuResponse.OK(response) =>
+        Right(
+          response.lsu.map(lsu =>
+            Lsu(
+              topologyFreezeTime =
+                CantonTimestamp.assertFromInstant(lsu.topologyFreezeTime.toInstant),
+              upgradeTime = CantonTimestamp.assertFromInstant(lsu.upgradeTime.toInstant),
+              successorPhysicalSynchronizerSerial = lsu.successorPhysicalSynchronizerSerial,
+            )
+          )
+        )
+    }
+  }
+
+  case class Lsu(
+      topologyFreezeTime: CantonTimestamp,
+      upgradeTime: CantonTimestamp,
+      successorPhysicalSynchronizerSerial: Long,
+  ) extends PrettyPrinting {
+    override def pretty: Pretty[this.type] = prettyOfClass(
+      param("topologyFreezeTime", _.topologyFreezeTime),
+      param("upgradeTime", _.upgradeTime),
+      param("successorPhysicalSynchronizerSerial", _.successorPhysicalSynchronizerSerial),
+    )
+  }
+
   case class GetRewardAccountingEarliestAvailableRound()
       extends InternalBaseCommand[
         http.GetRewardAccountingEarliestAvailableRoundResponse,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -2745,7 +2745,8 @@ object HttpScanAppClient {
               topologyFreezeTime =
                 CantonTimestamp.assertFromInstant(lsu.topologyFreezeTime.toInstant),
               upgradeTime = CantonTimestamp.assertFromInstant(lsu.upgradeTime.toInstant),
-              successorPhysicalSynchronizerSerial = lsu.successorPhysicalSynchronizerSerial,
+              successorPhysicalSynchronizerId =
+                PhysicalSynchronizerId.tryFromString(lsu.successorPhysicalSynchronizerId),
             )
           )
         )
@@ -2755,12 +2756,12 @@ object HttpScanAppClient {
   case class Lsu(
       topologyFreezeTime: CantonTimestamp,
       upgradeTime: CantonTimestamp,
-      successorPhysicalSynchronizerSerial: Long,
+      successorPhysicalSynchronizerId: PhysicalSynchronizerId,
   ) extends PrettyPrinting {
     override def pretty: Pretty[this.type] = prettyOfClass(
       param("topologyFreezeTime", _.topologyFreezeTime),
       param("upgradeTime", _.upgradeTime),
-      param("successorPhysicalSynchronizerSerial", _.successorPhysicalSynchronizerSerial),
+      param("successorPhysicalSynchronizerSerial", _.successorPhysicalSynchronizerId),
     )
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -13,7 +13,7 @@ import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.participant.admin.data.ActiveContract
 import com.digitalasset.canton.time.Clock
-import com.digitalasset.canton.topology.store.TimeQuery.HeadState
+import com.digitalasset.canton.topology.store.TimeQuery
 import com.digitalasset.canton.topology.{Member, PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.{
@@ -2683,15 +2683,17 @@ class HttpScanHandler(
         .getPhysicalSynchronizerId()
       maybeAnnouncement <- participantAdminConnection.lookupSynchronizerLsuAnnouncement(
         synchronizerId = currentSynchronizerId.logical,
-        timeQuery = HeadState,
+        timeQuery = TimeQuery.HeadState,
         topologyTransactionType = TopologyTransactionType.AuthorizedState,
       )
     } yield ScanResource.GetLsuResponse.OK(
       definitions.GetLsuResponse(
         maybeAnnouncement.map { announcement =>
           definitions.Lsu(
-            freezeTime = announcement.base.validFrom.atOffset(ZoneOffset.UTC),
+            topologyFreezeTime = announcement.base.validFrom.atOffset(ZoneOffset.UTC),
             upgradeTime = announcement.mapping.upgradeTime.toInstant.atOffset(ZoneOffset.UTC),
+            successorPhysicalSynchronizerSerial =
+              announcement.mapping.successorSynchronizerId.serial.unwrap.toLong,
           )
         }
       )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -13,6 +13,7 @@ import com.digitalasset.canton.discard.Implicits.DiscardOps
 import com.digitalasset.canton.logging.NamedLoggerFactory
 import com.digitalasset.canton.participant.admin.data.ActiveContract
 import com.digitalasset.canton.time.Clock
+import com.digitalasset.canton.topology.store.TimeQuery.HeadState
 import com.digitalasset.canton.topology.{Member, PartyId, SynchronizerId}
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.{
@@ -52,7 +53,10 @@ import org.lfdecentralizedtrust.splice.environment.{
   SequencerAdminConnection,
   SynchronizerNodeService,
 }
-import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologySnapshot
+import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.{
+  TopologySnapshot,
+  TopologyTransactionType,
+}
 import org.lfdecentralizedtrust.splice.environment.TopologyAdminConnection.TopologyTransactionType.AuthorizedState
 import org.lfdecentralizedtrust.splice.http.{
   HttpFeatureSupportHandler,
@@ -2668,6 +2672,30 @@ class HttpScanHandler(
           )
         )
     }
+  }
+
+  override def getLsu(respond: ScanResource.GetLsuResponse.type)()(
+      extracted: TraceContext
+  ): Future[ScanResource.GetLsuResponse] = {
+    implicit val tc = extracted
+    for {
+      currentSynchronizerId <- synchronizerNodeService.nodes.current.sequencerAdminConnection
+        .getPhysicalSynchronizerId()
+      maybeAnnouncement <- participantAdminConnection.lookupSynchronizerLsuAnnouncement(
+        synchronizerId = currentSynchronizerId.logical,
+        timeQuery = HeadState,
+        topologyTransactionType = TopologyTransactionType.AuthorizedState,
+      )
+    } yield ScanResource.GetLsuResponse.OK(
+      definitions.GetLsuResponse(
+        maybeAnnouncement.map { announcement =>
+          definitions.Lsu(
+            freezeTime = announcement.base.validFrom.atOffset(ZoneOffset.UTC),
+            upgradeTime = announcement.mapping.upgradeTime.toInstant.atOffset(ZoneOffset.UTC),
+          )
+        }
+      )
+    )
   }
 
   def getRewardAccountingEarliestAvailableRound(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2692,8 +2692,8 @@ class HttpScanHandler(
           definitions.Lsu(
             topologyFreezeTime = announcement.base.validFrom.atOffset(ZoneOffset.UTC),
             upgradeTime = announcement.mapping.upgradeTime.toInstant.atOffset(ZoneOffset.UTC),
-            successorPhysicalSynchronizerSerial =
-              announcement.mapping.successorSynchronizerId.serial.unwrap.toLong,
+            successorPhysicalSynchronizerId =
+              announcement.mapping.successorSynchronizerId.toProtoPrimitive,
           )
         }
       )

--- a/cluster/configs/shared/rate-limits/unlimited.yaml
+++ b/cluster/configs/shared/rate-limits/unlimited.yaml
@@ -193,6 +193,10 @@ rateLimits:
     name: rollForwardLsu
     type: unlimited
 
+  /api/scan/v0/lsu:
+    name: lsu
+    type: unlimited
+
   /api/scan/v0/internal/reward-accounting-process:
     name: reward-accounting-process
     type: unlimited

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -279,6 +279,9 @@ sv:
         /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
+        /api/scan/v0/lsu:
+          name: 'lsu'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -279,6 +279,9 @@ sv:
         /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
+        /api/scan/v0/lsu:
+          name: 'lsu'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -279,6 +279,9 @@ sv:
         /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
+        /api/scan/v0/lsu:
+          name: 'lsu'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -279,6 +279,9 @@ sv:
         /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
+        /api/scan/v0/lsu:
+          name: 'lsu'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -279,6 +279,9 @@ sv:
         /api/scan/v0/internal/reward-accounting-process:
           name: 'reward-accounting-process'
           type: 'unlimited'
+        /api/scan/v0/lsu:
+          name: 'lsu'
+          type: 'unlimited'
         /api/scan/v0/migrations:
           name: 'migrations-schedule'
           type: 'unlimited'

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1699,6 +1699,10 @@
           "name": "reward-accounting-process",
           "type": "unlimited"
         },
+        "/api/scan/v0/lsu": {
+          "name": "lsu",
+          "type": "unlimited"
+        },
         "/api/scan/v0/migrations": {
           "name": "migrations-schedule",
           "type": "unlimited"
@@ -1928,6 +1932,10 @@
         },
         "/api/scan/v0/internal/reward-accounting-process": {
           "name": "reward-accounting-process",
+          "type": "unlimited"
+        },
+        "/api/scan/v0/lsu": {
+          "name": "lsu",
           "type": "unlimited"
         },
         "/api/scan/v0/migrations": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -950,6 +950,10 @@
           "name": "reward-accounting-process",
           "type": "unlimited"
         },
+        "/api/scan/v0/lsu": {
+          "name": "lsu",
+          "type": "unlimited"
+        },
         "/api/scan/v0/migrations": {
           "name": "migrations-schedule",
           "type": "unlimited"


### PR DESCRIPTION
Fixes https://github.com/canton-network/splice/issues/5855

I was supposed to get an intro from @nicu-da for this issue but didn't manage to do so before his vacation. I inferred the current implementation from the existing code and I'm not very confident about that. I'm not sure if I should also add this endpoint to the Scan client. Should I add a test for it? I took inspiration from `getRollForwardLsu` and I couldn't find a test for it.