### PR TITLE
Await config diffs in Set Amulet Rules proposal

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
@@ -380,7 +380,7 @@ describe('Set Amulet Config Rules Form', () => {
     expect(jsonDiffs).toBeInTheDocument();
 
     await user.click(jsonDiffs);
-    expect(screen.queryByTestId('config-diffs-display')).toBeInTheDocument();
+    expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
 
     const reviewButton = screen.getByTestId('submit-button');
     await waitFor(async () => {
@@ -389,7 +389,7 @@ describe('Set Amulet Config Rules Form', () => {
 
     expect(jsonDiffs).toBeInTheDocument();
     await user.click(jsonDiffs);
-    expect(screen.queryByTestId('config-diffs-display')).toBeInTheDocument();
+    expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
   });
 
   test('should have decentralized synchronizer fields disabled', async () => {


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/8942

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
