### PR TITLE
Remove BFT sequencer DB migration from shared server

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -303,8 +303,7 @@
           },
           "sequencer": {
             "dedicatedBftSequencerDb": true,
-            "enableBftSequencer": false,
-            "migrateBftSequencerDbFromSharedServer": false
+            "enableBftSequencer": false
           },
           "version": {
             "type": "remote",
@@ -326,8 +325,7 @@
             },
             "sequencer": {
               "dedicatedBftSequencerDb": true,
-              "enableBftSequencer": false,
-              "migrateBftSequencerDbFromSharedServer": false
+              "enableBftSequencer": false
             },
             "version": {
               "type": "remote",
@@ -348,8 +346,7 @@
             },
             "sequencer": {
               "dedicatedBftSequencerDb": true,
-              "enableBftSequencer": false,
-              "migrateBftSequencerDbFromSharedServer": false
+              "enableBftSequencer": false
             },
             "version": {
               "type": "remote",
@@ -368,8 +365,7 @@
             },
             "sequencer": {
               "dedicatedBftSequencerDb": true,
-              "enableBftSequencer": false,
-              "migrateBftSequencerDbFromSharedServer": false
+              "enableBftSequencer": false
             },
             "version": {
               "type": "remote",
@@ -392,8 +388,7 @@
           },
           "sequencer": {
             "dedicatedBftSequencerDb": true,
-            "enableBftSequencer": false,
-            "migrateBftSequencerDbFromSharedServer": false
+            "enableBftSequencer": false
           },
           "version": {
             "type": "remote",
@@ -414,8 +409,7 @@
           },
           "sequencer": {
             "dedicatedBftSequencerDb": true,
-            "enableBftSequencer": true,
-            "migrateBftSequencerDbFromSharedServer": false
+            "enableBftSequencer": true
           },
           "version": {
             "type": "remote",

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -215,79 +215,44 @@ spec:
               done
       {{- if and (eq .Values.sequencer.driver.type "cantonbft") ((.Values.sequencer.driver).persistence) }}
         {{- $p := .Values.sequencer.driver.persistence }}
-        {{- $targetHost := $p.host | default .Values.sequencer.persistence.host }}
-        {{- $targetPort := $p.port | default .Values.sequencer.persistence.port }}
-        {{- $targetUser := $p.user | default "cnadmin" }}
-        {{- $targetDb := $p.databaseName | default .Values.sequencer.persistence.databaseName }}
-        {{- $targetSecret := $p.secretName | default .Values.sequencer.persistence.secretName }}
+        {{- $dbHost := $p.host | default .Values.sequencer.persistence.host }}
+        {{- $dbPort := $p.port | default .Values.sequencer.persistence.port }}
+        {{- $dbUser := $p.user | default "cnadmin" }}
+        {{- $dbName := $p.databaseName | default .Values.sequencer.persistence.databaseName }}
+        {{- $dbSecret := $p.secretName | default .Values.sequencer.persistence.secretName }}
         - name: pg-init-bft-driver
           image: {{ $p.initImageName | default "postgres:14" }}
           env:
-            - name: PGPASSWORD_TARGET
+            - name: PGPASSWORD
               {{- if or (and .Values.sequencer.driver ((.Values.sequencer.driver.persistence).secretOverrides).postgresPassword) ((.Values.sequencer.persistence).secretOverrides).postgresPassword }}
               value: {{ if and .Values.sequencer.driver ((.Values.sequencer.driver.persistence).secretOverrides).postgresPassword }}{{ .Values.sequencer.driver.persistence.secretOverrides.postgresPassword | quote }}{{ else }}{{ .Values.sequencer.persistence.secretOverrides.postgresPassword | quote }}{{ end }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
                   key: postgresPassword
-                  name: {{ $targetSecret }}
+                  name: {{ $dbSecret }}
               {{- end }}
-            {{- with $p.migrateFrom }}
-            - name: PGPASSWORD_SOURCE
-              {{- if and $.Values.sequencer.driver.persistence.secretOverrides $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword }}
-              value: {{ $.Values.sequencer.driver.persistence.secretOverrides.migrateFromPostgresPassword | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  key: postgresPassword
-                  name: {{ .secretName }}
-              {{- end }}
-            {{- end }}
           command:
             - 'bash'
             - '-c'
             - |
               set -euo pipefail
-              TARGET_HOST="{{ $targetHost }}"
-              TARGET_PORT="{{ $targetPort }}"
-              TARGET_USER="{{ $targetUser }}"
-              TARGET_DB="{{ $targetDb }}"
+              DB_HOST="{{ $dbHost }}"
+              DB_PORT="{{ $dbPort }}"
+              DB_USER="{{ $dbUser }}"
+              DB_NAME="{{ $dbName }}"
 
-              echo "Waiting for target postgres ${TARGET_HOST}:${TARGET_PORT} to become reachable...";
-              until PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
+              echo "Waiting for postgres ${DB_HOST}:${DB_PORT} to become reachable...";
+              until psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
                 sleep 2;
               done
 
-              if [ "$(PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}'")" = "1" ]; then
-                echo "Database ${TARGET_DB} already exists on ${TARGET_HOST}. Done.";
+              if [ "$(psql -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'")" = "1" ]; then
+                echo "Database ${DB_NAME} already exists on ${DB_HOST}. Done.";
                 exit 0;
               fi
-              {{- with $p.migrateFrom }}
-              SOURCE_HOST="{{ .host }}"
-              SOURCE_PORT="{{ .port | default $targetPort }}"
-              SOURCE_USER="{{ .user | default "cnadmin" }}"
-
-              echo "Waiting for source postgres ${SOURCE_HOST}:${SOURCE_PORT} to become reachable...";
-              until PGPASSWORD="$PGPASSWORD_SOURCE" psql -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" --dbname=cantonnet -tAc 'SELECT 1' >/dev/null 2>&1; do
-                sleep 2;
-              done
-
-              if [ "$(PGPASSWORD="$PGPASSWORD_SOURCE" psql -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" --dbname=cantonnet -tAc "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}'")" = "1" ]; then
-                echo "Migrating database ${TARGET_DB} from shared sequencer server ${SOURCE_HOST} to dedicated server ${TARGET_HOST}...";
-                PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "CREATE DATABASE \"${TARGET_DB}\"";
-                if ! PGPASSWORD="$PGPASSWORD_SOURCE" pg_dump --no-owner --no-acl -h "$SOURCE_HOST" -p "$SOURCE_PORT" --username="$SOURCE_USER" "$TARGET_DB" \
-                     | PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname="$TARGET_DB"; then
-                  echo "Migration of ${TARGET_DB} failed; dropping the partially-migrated database so the migration can be retried.";
-                  PGPASSWORD="$PGPASSWORD_TARGET" psql -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "DROP DATABASE IF EXISTS \"${TARGET_DB}\"";
-                  exit 1;
-                fi
-                echo "Migration of ${TARGET_DB} to ${TARGET_HOST} complete.";
-                exit 0;
-              fi
-              echo "Database ${TARGET_DB} not found on source server ${SOURCE_HOST}; creating an empty database on the dedicated server instead.";
-              {{- end }}
-              PGPASSWORD="$PGPASSWORD_TARGET" psql -v ON_ERROR_STOP=1 -h "$TARGET_HOST" -p "$TARGET_PORT" --username="$TARGET_USER" --dbname=cantonnet -c "CREATE DATABASE \"${TARGET_DB}\"";
-              echo "Created empty database ${TARGET_DB} on ${TARGET_HOST}.";
+              psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" --username="$DB_USER" --dbname=cantonnet -c "CREATE DATABASE \"${DB_NAME}\"";
+              echo "Created empty database ${DB_NAME} on ${DB_HOST}.";
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
@@ -308,71 +308,11 @@ tests:
             name: pg-init-bft-driver
             image: postgres:14
             env:
-              - name: PGPASSWORD_TARGET
+              - name: PGPASSWORD
                 valueFrom:
                   secretKeyRef:
                     key: postgresPassword
                     name: custom-pg-secret
-      # Without migrateFrom there is no source password and no migration logic.
-      - notContains:
-          path: spec.template.spec.initContainers[1].env
-          content:
-            name: PGPASSWORD_SOURCE
-          any: true
-      - notMatchRegex:
-          path: spec.template.spec.initContainers[1].command[2]
-          pattern: "Migrating database"
-  - it: "cantonbft driver migrates the dabft database from the shared server when migrateFrom is set"
-    set:
-      sequencer:
-        persistence:
-          host: shared-sequencer-pg
-          secretName: sequencer-pg-secret
-        driver:
-          type: cantonbft
-          externalAddress: "sequencer.example.com"
-          externalPort: 5010
-          persistence:
-            host: dedicated-bft-pg
-            secretName: dedicated-bft-pg-secret
-            databaseName: sequencer_6_dabft
-            migrateFrom:
-              host: shared-sequencer-pg
-              secretName: sequencer-pg-secret
-    documentSelector:
-      path: kind
-      value: Deployment
-    asserts:
-      - isSubset:
-          path: spec.template.spec.initContainers[1]
-          content:
-            name: pg-init-bft-driver
-      - contains:
-          path: spec.template.spec.initContainers[1].env
-          content:
-            name: PGPASSWORD_TARGET
-            valueFrom:
-              secretKeyRef:
-                key: postgresPassword
-                name: dedicated-bft-pg-secret
-      - contains:
-          path: spec.template.spec.initContainers[1].env
-          content:
-            name: PGPASSWORD_SOURCE
-            valueFrom:
-              secretKeyRef:
-                key: postgresPassword
-                name: sequencer-pg-secret
-      # The migration copies the dabft database from the shared sequencer server to the dedicated one.
-      - matchRegex:
-          path: spec.template.spec.initContainers[1].command[2]
-          pattern: 'TARGET_HOST="dedicated-bft-pg"'
-      - matchRegex:
-          path: spec.template.spec.initContainers[1].command[2]
-          pattern: 'SOURCE_HOST="shared-sequencer-pg"'
-      - matchRegex:
-          path: spec.template.spec.initContainers[1].command[2]
-          pattern: 'pg_dump .* "\$SOURCE_HOST"'
 
   - it: "allows setting cometbft sequencer image and primary initImage"
     set:
@@ -444,9 +384,6 @@ tests:
         host: "custom-driver-host"
         secretOverrides:
           postgresPassword: "vault:kv/data/sequencer/driver-password"
-          migrateFromPostgresPassword: "vault:kv/data/sequencer/migrate-from-driver-password"
-        migrateFrom:
-          host: custom-driver-host-source
     documentSelector:
       path: kind
       value: Deployment
@@ -455,11 +392,8 @@ tests:
           path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='SEQUENCER_DRIVER_BFT_POSTGRES_PASSWORD')].value
           pattern: "vault:kv/data/sequencer/driver-password"
       - matchRegex:
-          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD_TARGET')].value
+          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD')].value
           pattern: "vault:kv/data/sequencer/driver-password"
-      - matchRegex:
-          path: spec.template.spec.initContainers[?(@.name=='pg-init-bft-driver')].env[?(@.name=='PGPASSWORD_SOURCE')].value
-          pattern: "vault:kv/data/sequencer/migrate-from-driver-password"
 
   - it: "injects custom serviceAccountName into Deployment when specified"
     set:

--- a/cluster/pulumi/common/src/config/migrationSchema.ts
+++ b/cluster/pulumi/common/src/config/migrationSchema.ts
@@ -34,8 +34,6 @@ export const MigrationInfoSchema = z
         enableBftSequencer: z.boolean().default(false),
         // Use a separate DB server for DABFT.
         dedicatedBftSequencerDb: z.boolean().default(true),
-        // Migrate data from dedicatedBftSequencerDb: false => dedicatedBftSequencerDb: true
-        migrateBftSequencerDbFromSharedServer: z.boolean().default(false),
       })
       .strict()
       .prefault({}),

--- a/cluster/pulumi/sv-canton/pulumi.ts
+++ b/cluster/pulumi/sv-canton/pulumi.ts
@@ -90,7 +90,6 @@ export function runSvCantonForSvs<T>(
           sequencer: {
             enableBftSequencer: false,
             dedicatedBftSequencerDb: true,
-            migrateBftSequencerDbFromSharedServer: false,
           },
         };
       })

--- a/cluster/pulumi/sv-canton/src/canton.ts
+++ b/cluster/pulumi/sv-canton/src/canton.ts
@@ -124,8 +124,6 @@ export async function installCantonComponents(
             sequencerPostgres: sequencerPostgres,
             mediatorPostgres: mediatorPostgres,
             bftSequencerPostgres: bftSequencerPostgres,
-            migrateBftSequencerDbFromSharedServer:
-              migrationInfo.sequencer.migrateBftSequencerDbFromSharedServer,
             setCoreDbNames: svConfig.isCoreSv,
           },
           version,

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -98,12 +98,6 @@ abstract class InStackDecentralizedSynchronizerNode
             databaseName?: string;
             port?: number;
             user?: string;
-            migrateFrom?: {
-              host: Output<string>;
-              secretName: Output<string>;
-              port?: number;
-              user?: string;
-            };
           };
         },
     version: CnChartVersion,
@@ -300,7 +294,6 @@ export class InStackCantonBftDecentralizedSynchronizerNode extends InStackDecent
       sequencerPostgres: Postgres;
       mediatorPostgres: Postgres;
       bftSequencerPostgres?: Postgres;
-      migrateBftSequencerDbFromSharedServer?: boolean;
     },
     version: CnChartVersion,
     imagePullServiceAccountName?: string,
@@ -313,14 +306,6 @@ export class InStackCantonBftDecentralizedSynchronizerNode extends InStackDecent
           host: dbs.bftSequencerPostgres.address,
           secretName: dbs.bftSequencerPostgres.secretName,
           databaseName,
-          ...(dbs.migrateBftSequencerDbFromSharedServer
-            ? {
-                migrateFrom: {
-                  host: dbs.sequencerPostgres.address,
-                  secretName: dbs.sequencerPostgres.secretName,
-                },
-              }
-            : {}),
         }
       : {
           databaseName,


### PR DESCRIPTION
Didn't actually work on the network I wanted to use it (not fully sure why and doesn't seem worth debugging) and it was
always intended to be a one-time thing anyway.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
