### PR TITLE
Fix informees in ExpiredAmuletAllocationTrigger

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletAllocationTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletAllocationTrigger.scala
@@ -58,9 +58,8 @@ class ExpiredAmuletAllocationTrigger(
   ): Future[TaskOutcome] = {
     val informees = task.work.expiredContracts.flatMap { contract =>
       val sender = PartyId.tryFromProtoPrimitive(contract.payload.allocation.transferLeg.sender)
-      val receiver = PartyId.tryFromProtoPrimitive(contract.payload.allocation.transferLeg.receiver)
       val executor = PartyId.tryFromProtoPrimitive(contract.payload.allocation.settlement.executor)
-      Seq(sender, receiver, executor)
+      Seq(sender, executor)
     }.toSet
     completeWithIgnoredAmuletVersionCheck(
       task.work.vettedVersion.toString,

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletAllocationTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ExpiredAmuletAllocationTrigger.scala
@@ -44,7 +44,6 @@ class ExpiredAmuletAllocationTrigger(
       allocation =>
         Seq(
           allocation.allocation.transferLeg.sender,
-          allocation.allocation.transferLeg.receiver,
           allocation.allocation.settlement.executor,
           svTaskContext.dsoStore.key.dsoParty.partyId.toProtoPrimitive,
         ).map(PartyId.tryFromProtoPrimitive),


### PR DESCRIPTION
```
template AmuletAllocation
  with
    lockedAmulet : ContractId LockedAmulet -- ^ Locked amulet that holds the funds for the allocation
    allocation : AllocationSpecification
  where
    signatory allocationInstrumentAdmin allocation, allocation.transferLeg.sender
    observer allocation.settlement.executor
```

Receiver is not informee, and the content of that field is not enforced to contain a valid PartyId, so the trigger fails hard if someone enters nonsense in that field.