### PR TITLE
Add NOT_CONNECTED_TO_SYNCHRONIZER to conflict error codes

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/admin/http/HttpErrorHandler.scala
@@ -115,6 +115,7 @@ final class HttpErrorHandler(
           Interpreter.InterpretationUserError,
           Interpreter.TemplatePreconditionViolated,
           SyncServiceInjectionError.NotConnectedToAnySynchronizer,
+          SyncServiceInjectionError.NotConnectedToSynchronizer,
           TransactionRoutingError.TopologyErrors.UnknownContractSynchronizers,
         )
         if (conflictErrorCodes.exists(ErrorCodeUtils.isError(grpcDesc, _)))


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/8957

Addendum to https://github.com/DACH-NY/cn-test-failures/issues/8779 and #5984

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
