### PR TITLE
Always log how the app activity record store was initialized

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -70,11 +70,7 @@ object DbAppActivityRecordStore {
       runningUser: Int,
       storedCode: Int,
       storedUser: Int,
-  ) extends MetaCheckResult {
-    def message: String =
-      s"Activity ingestion version downgrade detected: " +
-        s"running=($runningCode,$runningUser), stored=($storedCode,$storedUser)."
-  }
+  ) extends MetaCheckResult
 
   def checkMetaVersions(
       existing: Option[(Int, Int)],
@@ -355,9 +351,23 @@ class DbAppActivityRecordStore(
       }
     } yield ensureResult match {
       case d: DowngradeDetected =>
-        logger.error(s"${d.message} Shutting down to prevent data corruption.")
+        logger.error(
+          s"App activity ingestion version downgrade detected: " +
+            s"running=(${d.runningCode},${d.runningUser}), stored=(${d.storedCode},${d.storedUser}). " +
+            s"Make sure you did not accidentally remove or downgrade the 'activity-ingestion-user-version' field" +
+            s"in the scan app config. Shutting down to prevent data corruption."
+        )
         sys.exit(1)
-      case _ => ()
+      case Resume =>
+        logger.info(
+          s"App activity ingestion resumed with existing meta row for " +
+            s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
+        )
+      case InsertMeta =>
+        logger.info(
+          s"App activity ingestion inserted new meta row for " +
+            s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
+        )
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -349,26 +349,7 @@ class DbAppActivityRecordStore(
         case (Resume, Some(round)) => updateLastArchivedRoundDBIO(round)
         case _ => DBIO.successful(0)
       }
-    } yield ensureResult match {
-      case d: DowngradeDetected =>
-        logger.error(
-          s"App activity ingestion version downgrade detected: " +
-            s"running=(${d.runningCode},${d.runningUser}), stored=(${d.storedCode},${d.storedUser}). " +
-            s"Make sure you did not accidentally remove or downgrade the 'activity-ingestion-user-version' field" +
-            s"in the scan app config. Shutting down to prevent data corruption."
-        )
-        sys.exit(1)
-      case Resume =>
-        logger.info(
-          s"App activity ingestion resumed with existing meta row for " +
-            s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
-        )
-      case InsertMeta =>
-        logger.info(
-          s"App activity ingestion inserted new meta row for " +
-            s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
-        )
-    }
+    } yield ()
   }
 
   /** Insert activity records only, without meta row management.
@@ -479,7 +460,8 @@ class DbAppActivityRecordStore(
   def ensureMetaDBIO(
       ingestionStart: (Long, Long),
       lastArchivedRoundO: Option[Long] = None,
-  ): DBIO[MetaCheckResult] = {
+      exitOnDowngrade: Boolean = true,
+  )(implicit tc: TraceContext): DBIO[MetaCheckResult] = {
     val codeVersion = ingestionVersions.code
     val userVersion = ingestionVersions.user
     val (firstRecordTimeMicros, earliestRound) = ingestionStart
@@ -506,16 +488,34 @@ class DbAppActivityRecordStore(
               earliestRound,
               lastArchivedRoundO,
             ).map { _ =>
+              logger.info(
+                s"App activity ingestion inserted new meta row for " +
+                  s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
+              )
               metaChecked.set(true)
               InsertMeta: MetaCheckResult
             }
           case Resume =>
+            logger.info(
+              s"App activity ingestion resumed with existing meta row for " +
+                s"codeVersion=${ingestionVersions.code}, userVersion=${ingestionVersions.user}."
+            )
             DBIO.successful {
               metaChecked.set(true)
               Resume: MetaCheckResult
             }
           case d: DowngradeDetected =>
-            DBIO.successful(d: MetaCheckResult)
+            logger.error(
+              s"App activity ingestion version downgrade detected: " +
+                s"running=(${d.runningCode},${d.runningUser}), stored=(${d.storedCode},${d.storedUser}). " +
+                s"Make sure you did not accidentally remove or downgrade the 'activity-ingestion-user-version' field" +
+                s"in the scan app config. Shutting down to prevent data corruption."
+            )
+            if (exitOnDowngrade) {
+              sys.exit(1)
+            } else {
+              DBIO.successful(d: MetaCheckResult)
+            }
         }
       } yield result
     }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -778,7 +778,12 @@ class DbAppActivityRecordStoreTest
       for {
         (store, _) <- newStore()
         _ <- store.insertActivityRecordMetaForTesting(2, 0, 1000000L, 10L, None)
-        result <- runEnsureMeta(store, (2000000L, 20L))
+        result <- loggerFactory.assertLogs(
+          runEnsureMeta(store, (2000000L, 20L)),
+          _.errorMessage should include(
+            "App activity ingestion version downgrade detected"
+          ),
+        )
         meta <- store.lookupActivityRecordMeta(2, 0)
       } yield {
         result shouldBe DowngradeDetected(1, 0, 2, 0)
@@ -1000,7 +1005,7 @@ class DbAppActivityRecordStoreTest
   ): Future[MetaCheckResult] =
     futureUnlessShutdownToFuture(
       storage.underlying.queryAndUpdate(
-        store.ensureMetaDBIO(ingestionStart, lastArchivedRoundO),
+        store.ensureMetaDBIO(ingestionStart, lastArchivedRoundO, exitOnDowngrade = false),
         "test.ensureMeta",
       )(implicitly, implicitly, _ => false)
     )


### PR DESCRIPTION
Just one more log line during app startup, and can be helpful if you ever need to investigate the app activity store.