### PR TITLE
Lower mediator verdict sending liveness margin for integration tests

### DIFF
--- a/apps/app/src/test/resources/include/mediators.conf
+++ b/apps/app/src/test/resources/include/mediators.conf
@@ -24,4 +24,10 @@ _mediator_template {
     use-new-processor = true
     use-new-client = true
   }
+  parameters {
+    delayed-verdict-sender {
+      # lower the livenss margin to ensure we don't have all the mediators send verdicts during tests
+      liveness-margin = 1
+    }
+  }
 }


### PR DESCRIPTION
ensures not all mediators send verdicts during tests 

So that we test actual real life scenarios

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
