### PR TITLE
fix: fix backport remidners

### DIFF
--- a/.github/workflows/backport_reminder.yml
+++ b/.github/workflows/backport_reminder.yml
@@ -11,7 +11,7 @@ jobs:
   add-backport-reminder:
     runs-on: ubuntu-24.04
     steps:
-        - uses: ./github-scripts/actions/backport_reminder
+        - uses: ./gha-scripts/actions/backport_reminder
           with:
             pr_number: ${{ github.event.pull_request.number }}
             lookup_prod_cluster_configs: false

--- a/.github/workflows/do_backports.yml
+++ b/.github/workflows/do_backports.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       branches: ${{ steps.parse_backport_comments.outputs.backport_branches }}
     steps:
-      - uses: ./github-scripts/actions/parse_backport_comments
+      - uses: ./gha-scripts/actions/parse_backport_comments
         id: parse_backport_comments
         with:
           pr_number: ${{ github.event.pull_request.number }}

--- a/gha-scripts/actions/backport_reminder/action.yml
+++ b/gha-scripts/actions/backport_reminder/action.yml
@@ -4,11 +4,11 @@ inputs:
   pr_number:
     description: "The number of the PR to check for backporting."
     required: true
-    type: number
+    # type: number
   lookup_prod_cluster_configs:
     description: "Whether to determine backport branches from prod cluster configs."
     required: true
-    type: boolean
+    # type: boolean
   token:
     description: "The GitHub token to use for API calls."
     default: ${{ github.token }}

--- a/gha-scripts/actions/parse_backport_comments/action.yml
+++ b/gha-scripts/actions/parse_backport_comments/action.yml
@@ -4,7 +4,7 @@ inputs:
   pr_number:
     description: "The number of the PR to check for backporting."
     required: true
-    type: number
+    # type: number
   token:
     description: "The GitHub token to use for API calls."
     default: ${{ github.token }}


### PR DESCRIPTION
Types commented out because of lint issue:
```
.github/workflows/backport_reminder.yml:14:17: could not parse action metadata in "/Users/kczyz/Documents/GitHub/splice/gha-scripts/actions/backport_reminder": line 4: unexpected key "type" for definition of input "lookup_prod_cluster_configs" [action]
   |
14 |         - uses: ./gha-scripts/actions/backport_reminder
   |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.github/workflows/do_backports.yml:16:15: could not parse action metadata in "/Users/kczyz/Documents/GitHub/splice/gha-scripts/actions/parse_backport_comments": line 4: unexpected key "type" for definition of input "pr_number" [action]
   |
16 |       - uses: ./gha-scripts/actions/parse_backport_comments
   |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```