### PR TITLE
Add retry when checking if the successor is active

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SynchronizerNodeService.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SynchronizerNodeService.scala
@@ -19,6 +19,7 @@ class SynchronizerNodeService[T <: SynchronizerNode](
     participantAdminConnection: ParticipantAdminConnection,
     globalSynchronizerAlias: SynchronizerAlias,
     cacheExpiration: NonNegativeFiniteDuration,
+    retryProvider: RetryProvider,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit ec: ExecutionContext)
     extends NamedLogging {
@@ -28,7 +29,15 @@ class SynchronizerNodeService[T <: SynchronizerNode](
   private val successorActiveCache =
     ScaffeineCache.buildTracedAsync[Future, Unit, Boolean](
       Scaffeine().expireAfterWrite(cacheExpiration.asFiniteApproximation),
-      implicit tc => _ => successorActiveUncached(),
+      implicit tc =>
+        _ =>
+          retryProvider.getValueWithRetries(
+            RetryFor.WaitingOnInitDependency,
+            "successor_active",
+            "whether the successor synchronizer is active",
+            successorActiveUncached(),
+            logger,
+          ),
     )(logger, "successorActive")
 
   private def successorActive()(implicit tc: TraceContext): Future[Boolean] =

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -252,6 +252,7 @@ class ScanApp(
         participantAdminConnection,
         config.globalSynchronizerAlias,
         config.parameters.spliceCachingConfigs.physicalSynchronizerExpiration,
+        retryProvider,
         loggerFactory,
       )
       kvStore <- ScanKeyValueStore(dsoParty, participantId, storage, loggerFactory)

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
@@ -254,6 +254,7 @@ class SvApp(
         participantAdminConnection,
         config.domains.global.alias,
         config.parameters.spliceCachingConfigs.physicalSynchronizerExpiration,
+        retryProvider,
         loggerFactory,
       )
 


### PR DESCRIPTION
It can be that the list synchronizers doesn't return the global one if it's during the LSU. Also handle any availability issues for the sequencer/participant

fixes https://github.com/DACH-NY/cn-test-failures/issues/8906

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
