### PR TITLE
Add KMS snippet markers

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml
@@ -1,3 +1,4 @@
+# KMS_PARTICIPANT_AWS_VALUES_START
 # Participant using AWS KMS (mock values; please modify to match your setup)
 # See https://docs.daml.com/canton/usermanual/kms/kms_aws_setup.html
 kms:
@@ -23,3 +24,4 @@ additionalEnvVars:
       secretKeyRef:
         name: aws-credentials
         key: secretAccessKey
+# KMS_PARTICIPANT_AWS_VALUES_END

--- a/apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml
@@ -1,3 +1,4 @@
+# KMS_PARTICIPANT_GCP_VALUES_START
 # Participant using GCP KMS (mock values; please modify to match your setup)
 # See https://docs.daml.com/canton/usermanual/kms/kms_gcp_setup.html
 
@@ -27,3 +28,4 @@ extraVolumes:
   - name: gcp-credentials
     secret:
       secretName: gke-credentials
+# KMS_PARTICIPANT_GCP_VALUES_END

--- a/docs/src/common/kms_config_aws.rst
+++ b/docs/src/common/kms_config_aws.rst
@@ -7,6 +7,8 @@ The mock configuration below for AWS KMS is included in ``splice-node/examples/s
 
 .. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml
     :language: yaml
+    :start-after: KMS_PARTICIPANT_AWS_VALUES_START
+    :end-before: KMS_PARTICIPANT_AWS_VALUES_END
 
 Please refer to the `Canton documentation <https://docs.daml.com/canton/usermanual/kms/kms_aws_setup.html>`__
 for a list of supported configuration options and their meaning,

--- a/docs/src/common/kms_config_gcp.rst
+++ b/docs/src/common/kms_config_gcp.rst
@@ -7,6 +7,8 @@ The mock configuration below for GCP KMS is included in ``splice-node/examples/s
 
 .. literalinclude:: ../../../apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml
     :language: yaml
+    :start-after: KMS_PARTICIPANT_GCP_VALUES_START
+    :end-before: KMS_PARTICIPANT_GCP_VALUES_END
 
 Please refer to the `Canton documentation <https://docs.daml.com/canton/usermanual/kms/kms_gcp_setup.html>`_
 for a list of supported configuration options and their meaning,


### PR DESCRIPTION
## Summary

- add explicit start/end markers around the AWS and GCP KMS Helm values examples
- update the Splice KMS literalincludes to use those markers instead of whole-file includes

## Coordination

cf-docs companion PR: https://github.com/canton-network/cf-docs/pull/911

Merge this together with the cf-docs PR so cf-docs can switch KMS snippet extraction to these markers.

## Validation

- marker scan for KMS start/end markers and literalinclude options
- git diff --check
