### PR TITLE
Fix scan canton bft config name

### DIFF
--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -2861,7 +2861,7 @@
             "sequencer": "global-domain-8-sequencer"
           },
           "successor": {
-            "bftSequencerConfig": {
+            "cantonBft": {
               "p2pUrl": "https://sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com"
             },
             "mediator": "global-domain-10-mediator",
@@ -3975,7 +3975,7 @@
             "sequencer": "global-domain-8-sequencer"
           },
           "successor": {
-            "bftSequencerConfig": {
+            "cantonBft": {
               "p2pUrl": "https://sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com"
             },
             "mediator": "global-domain-10-mediator",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -684,7 +684,7 @@
             "sequencer": "global-domain-8-sequencer"
           },
           "successor": {
-            "bftSequencerConfig": {
+            "cantonBft": {
               "p2pUrl": "https://sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com"
             },
             "mediator": "global-domain-10-mediator",

--- a/cluster/pulumi/common-sv/src/sv.ts
+++ b/cluster/pulumi/common-sv/src/sv.ts
@@ -540,9 +540,9 @@ function installScan(
   const { active, participant } = synchronizerNodes;
   const scanDbName = `scan_${sanitizedForPostgres(config.nodeName)}`;
 
-  const bftSequencerConfigFor = (node: DecentralizedSynchronizerNode) => {
+  const cantonBftConfigFor = (node: DecentralizedSynchronizerNode) => {
     return {
-      bftSequencerConfig: {
+      cantonBft: {
         p2pUrl: (node as unknown as CantonBftSynchronizerNode).externalSequencerP2pAddress,
       },
     };
@@ -553,7 +553,7 @@ function installScan(
       current: {
         sequencer: active.namespaceInternalSequencerAddress,
         mediator: active.namespaceInternalMediatorAddress,
-        ...(useCantonBft ? bftSequencerConfigFor(active) : {}),
+        ...(useCantonBft ? cantonBftConfigFor(active) : {}),
       },
       ...(synchronizerNodes.upgrade
         ? {
@@ -561,7 +561,7 @@ function installScan(
               sequencer: synchronizerNodes.upgrade.namespaceInternalSequencerAddress,
               mediator: synchronizerNodes.upgrade.namespaceInternalMediatorAddress,
               ...(decentralizedSynchronizerMigrationConfig.upgrade?.sequencer.enableBftSequencer
-                ? bftSequencerConfigFor(synchronizerNodes.upgrade)
+                ? cantonBftConfigFor(synchronizerNodes.upgrade)
                 : {}),
             },
           }
@@ -572,7 +572,7 @@ function installScan(
               sequencer: synchronizerNodes.legacy.namespaceInternalSequencerAddress,
               mediator: synchronizerNodes.legacy.namespaceInternalMediatorAddress,
               ...(decentralizedSynchronizerMigrationConfig.legacy?.sequencer.enableBftSequencer
-                ? bftSequencerConfigFor(synchronizerNodes.legacy)
+                ? cantonBftConfigFor(synchronizerNodes.legacy)
                 : {}),
             },
           }

--- a/cluster/pulumi/sv-runbook/src/installNode.ts
+++ b/cluster/pulumi/sv-runbook/src/installNode.ts
@@ -372,9 +372,9 @@ async function installSvAndValidator(
       SERIAL_ID: decentralizedSynchronizerMigrationConfig.active.id.toString(),
     }
   );
-  const bftSequencerConfigFor = (node: DecentralizedSynchronizerNode) => {
+  const cantonBftConfigFor = (node: DecentralizedSynchronizerNode) => {
     return {
-      bftSequencerConfig: {
+      cantonBft: {
         p2pUrl: (node as unknown as CantonBftSynchronizerNode).externalSequencerP2pAddress,
       },
     };
@@ -384,7 +384,7 @@ async function installSvAndValidator(
     synchronizers: {
       current: {
         ...defaultScanValues.synchronizers.current,
-        ...(useCantonBft ? bftSequencerConfigFor(canton.active) : {}),
+        ...(useCantonBft ? cantonBftConfigFor(canton.active) : {}),
       },
       ...(canton.upgrade
         ? {
@@ -392,7 +392,7 @@ async function installSvAndValidator(
               sequencer: canton.upgrade.namespaceInternalSequencerAddress,
               mediator: canton.upgrade.namespaceInternalMediatorAddress,
               ...(decentralizedSynchronizerMigrationConfig.upgrade?.sequencer.enableBftSequencer
-                ? bftSequencerConfigFor(canton.upgrade)
+                ? cantonBftConfigFor(canton.upgrade)
                 : {}),
             },
           }
@@ -403,7 +403,7 @@ async function installSvAndValidator(
               sequencer: canton.legacy.namespaceInternalSequencerAddress,
               mediator: canton.legacy.namespaceInternalMediatorAddress,
               ...(decentralizedSynchronizerMigrationConfig.legacy?.sequencer.enableBftSequencer
-                ? bftSequencerConfigFor(canton.legacy)
+                ? cantonBftConfigFor(canton.legacy)
                 : {}),
             },
           }


### PR DESCRIPTION
[static]

we updated the helm values yesterday 
it would have no effect for now in cilr because we don't remove the p2p connections if scan doesn't return a url

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
