### PR TITLE
Disallow additional properties for the synchronizers configs in helm

### DIFF
--- a/cluster/helm/splice-scan/tests/scan_test.yaml
+++ b/cluster/helm/splice-scan/tests/scan_test.yaml
@@ -102,6 +102,53 @@ tests:
                 port = 5007
               }
             }
+  - it: "fails when an unknown key is set under synchronizers.current"
+    set:
+      spliceInstanceNames:
+        networkName: MockNet
+        networkFaviconUrl: https://mock.net/favicon.ico
+        amuletName: Mocklet
+        amuletNameAcronym: MCK
+        nameServiceName: Mock Name Service
+        nameServiceNameAcronym: MNS
+      synchronizers:
+        current:
+          sequencer: "current-sequencer-address"
+          mediator: "current-mediator-address"
+          notAValidKey: "boom"
+      participantAddress: "mock-address"
+      persistence:
+        host: mock-pg-host
+        schema: scan
+      maxDarVersion: 1.0.0
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/synchronizers/current': additional properties 'notAValidKey' not allowed"
+  - it: "fails when an unknown key is set under synchronizers.successor"
+    set:
+      spliceInstanceNames:
+        networkName: MockNet
+        networkFaviconUrl: https://mock.net/favicon.ico
+        amuletName: Mocklet
+        amuletNameAcronym: MCK
+        nameServiceName: Mock Name Service
+        nameServiceNameAcronym: MNS
+      synchronizers:
+        current:
+          sequencer: "current-sequencer-address"
+          mediator: "current-mediator-address"
+        successor:
+          sequencer: "successor-sequencer-address"
+          mediator: "successor-mediator-address"
+          notAValidKey: "boom"
+      participantAddress: "mock-address"
+      persistence:
+        host: mock-pg-host
+        schema: scan
+      maxDarVersion: 1.0.0
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/synchronizers/successor': additional properties 'notAValidKey' not allowed"
   - it: "sets legacy synchronizer"
     set:
       spliceInstanceNames:

--- a/cluster/helm/splice-scan/values.schema.json
+++ b/cluster/helm/splice-scan/values.schema.json
@@ -227,76 +227,13 @@
           ],
           "properties": {
             "current": {
-              "type": "object",
-              "required": [
-                "sequencer",
-                "mediator"
-              ],
-              "properties": {
-                "sequencer": {
-                  "type": "string"
-                },
-                "mediator": {
-                  "type": "string"
-                },
-                "cantonBft": {
-                  "type": "object",
-                  "required": ["p2pUrl"],
-                  "properties": {
-                    "p2pUrl": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
+              "$ref": "#/$defs/synchronizer"
             },
             "successor": {
-              "type": "object",
-              "required": [
-                "sequencer",
-                "mediator"
-              ],
-              "properties": {
-                "sequencer": {
-                  "type": "string"
-                },
-                "mediator": {
-                  "type": "string"
-                },
-                "cantonBft": {
-                  "type": "object",
-                  "required": ["p2pUrl"],
-                  "properties": {
-                    "p2pUrl": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
+              "$ref": "#/$defs/synchronizer"
             },
             "legacy": {
-              "type": "object",
-              "required": [
-                "sequencer",
-                "mediator"
-              ],
-              "properties": {
-                "sequencer": {
-                  "type": "string"
-                },
-                "mediator": {
-                  "type": "string"
-                },
-                "cantonBft": {
-                  "type": "object",
-                  "required": ["p2pUrl"],
-                  "properties": {
-                    "p2pUrl": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
+              "$ref": "#/$defs/synchronizer"
             }
           }
         },
@@ -364,5 +301,32 @@
         }
       }
     }
-  ]
+  ],
+  "$defs": {
+    "synchronizer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequencer",
+        "mediator"
+      ],
+      "properties": {
+        "sequencer": {
+          "type": "string"
+        },
+        "mediator": {
+          "type": "string"
+        },
+        "cantonBft": {
+          "type": "object",
+          "required": ["p2pUrl"],
+          "properties": {
+            "p2pUrl": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/cluster/helm/splice-sv-node/tests/sv_synchronizers_test.yaml
+++ b/cluster/helm/splice-sv-node/tests/sv_synchronizers_test.yaml
@@ -335,3 +335,31 @@ tests:
                 }
               }
             }
+
+  - it: "fails when an unknown key is set under synchronizers.current"
+    set:
+      synchronizers:
+        current:
+          sequencerPublicUrl: "https://sequencer1.test.com"
+          sequencerAddress: "sequencer1-address"
+          mediatorAddress: "mediator1-address"
+          notAValidKey: "boom"
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/synchronizers/current': additional properties 'notAValidKey' not allowed"
+
+  - it: "fails when an unknown key is set under synchronizers.successor"
+    set:
+      synchronizers:
+        current:
+          sequencerPublicUrl: "https://sequencer1.test.com"
+          sequencerAddress: "sequencer1-address"
+          mediatorAddress: "mediator1-address"
+        successor:
+          sequencerPublicUrl: "https://sequencer2.test.com"
+          sequencerAddress: "sequencer2-address"
+          mediatorAddress: "mediator2-address"
+          notAValidKey: "boom"
+    asserts:
+      - failedTemplate:
+          errorPattern: "at '/synchronizers/successor': additional properties 'notAValidKey' not allowed"

--- a/cluster/helm/splice-sv-node/values.schema.json
+++ b/cluster/helm/splice-sv-node/values.schema.json
@@ -602,6 +602,7 @@
   "$defs": {
     "synchronizer": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "sequencerPublicUrl",
         "sequencerAddress",


### PR DESCRIPTION


This prevents typos for optional properties and adds safety for future refactorings

prevents https://github.com/canton-network/splice/pull/6183

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
