### PR TITLE
Fix party auto-ignore for ExpiredAmuletTrigger and ExpiredLockedAmuletTrigger

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/db/DbSvDsoStore.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/db/DbSvDsoStore.scala
@@ -1140,11 +1140,13 @@ class DbSvDsoStore(
   override def listExpiredAmulets(
       ignoredPartiesStore: Option[IgnoredPartiesStore] = None
   ): ListExpiredContracts[splice.amulet.Amulet.ContractId, splice.amulet.Amulet] = {
-    val ignoredParties = ignoredPartiesStore.fold(Set.empty[PartyId])(_.getAll)
-    val filterClause: SQLActionBuilder = if (ignoredParties.nonEmpty) {
-      (sql" and " ++ notInClause("create_arguments->>'owner'", ignoredParties)).toActionBuilder
-    } else {
-      sql""
+    val filterClause: () => SQLActionBuilder = () => {
+      val ignoredParties = ignoredPartiesStore.fold(Set.empty[PartyId])(_.getAll)
+      if (ignoredParties.nonEmpty) {
+        (sql" and " ++ notInClause("create_arguments->>'owner'", ignoredParties)).toActionBuilder
+      } else {
+        sql""
+      }
     }
     listExpiredRoundBased(splice.amulet.Amulet.COMPANION, filterClause)
   }
@@ -1152,14 +1154,16 @@ class DbSvDsoStore(
   override def listLockedExpiredAmulets(
       ignoredPartiesStore: Option[IgnoredPartiesStore] = None
   ): ListExpiredContracts[splice.amulet.LockedAmulet.ContractId, splice.amulet.LockedAmulet] = {
-    val ignoredParties = ignoredPartiesStore.fold(Set.empty[PartyId])(_.getAll)
-    val filterClause = if (ignoredParties.nonEmpty) {
-      (sql" and " ++ notInClause("create_arguments->'amulet'->>'owner'", ignoredParties) ++
-        sql" and not (create_arguments->'lock'->'holders' ??| ${ignoredParties
-            .map(p => lengthLimited(p.toProtoPrimitive))
-            .toArray: Array[String2066]})").toActionBuilder
-    } else {
-      sql""
+    val filterClause: () => SQLActionBuilder = () => {
+      val ignoredParties = ignoredPartiesStore.fold(Set.empty[PartyId])(_.getAll)
+      if (ignoredParties.nonEmpty) {
+        (sql" and " ++ notInClause("create_arguments->'amulet'->>'owner'", ignoredParties) ++
+          sql" and not (create_arguments->'lock'->'holders' ??| ${ignoredParties
+              .map(p => lengthLimited(p.toProtoPrimitive))
+              .toArray: Array[String2066]})").toActionBuilder
+      } else {
+        sql""
+      }
     }
     listExpiredRoundBased(splice.amulet.LockedAmulet.COMPANION, filterClause)
   }
@@ -1304,7 +1308,7 @@ class DbSvDsoStore(
 
   private def listExpiredRoundBased[Id <: ContractId[T], T <: javab.Template](
       companion: Template[Id, T],
-      extraFilter: SQLActionBuilder,
+      extraFilter: () => SQLActionBuilder,
   ): ListExpiredContracts[Id, T] = (_, limit) =>
     implicit tc => {
       waitUntilAcsIngested {
@@ -1339,7 +1343,7 @@ class DbSvDsoStore(
                   splice.externalpartyconfigstate.ExternalPartyConfigState.TEMPLATE_ID_WITH_PACKAGE_ID
                 )}
                     and mining_round is not null
-                  order by mining_round asc limit 1), true)""" ++ extraFilter).toActionBuilder,
+                  order by mining_round asc limit 1), true)""" ++ extraFilter()).toActionBuilder,
               orderLimit = sql"""order by mining_round desc limit ${sqlLimit(limit)}""",
             ),
             "listExpiredRoundBased",

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
@@ -503,6 +503,48 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
           resultNoParty1And2.map(_.contract) should contain theSameElementsAs Seq(expiresAtRound4)
         }
       }
+
+      "correctly ignore parties added after referencing the party ignore store" in {
+        val party1 = userParty(1)
+        val party2 = userParty(2)
+        val party3 = userParty(3)
+        val expiresAtRound3 = lockedAmulet(party2, 1.0, 2, 1.0, holders = Seq(party2, party3))
+        val expiresAtRound4 = lockedAmulet(party3, 3.0, 1, 1.0, holders = Seq.empty)
+        val partiesToIgnore = new IgnoredPartiesStore(Set(party1))
+        val wontExpireAnyTimeSoon = lockedAmulet(party1, 10.0, 2, 0.0001, holders = Seq(party1))
+        for {
+          store <- mkStore()
+          _ <- dummyDomain.create(dsoRules())(store.multiDomainAcsStore)
+          _ <- createMiningRoundsTriple(store, startRound = 4L) // oldest is round 4, newest is 6
+          _ <- MonadUtil.sequentialTraverse(
+            Seq(expiresAtRound3, expiresAtRound4, wontExpireAnyTimeSoon)
+          )(
+            dummyDomain.create(_)(store.multiDomainAcsStore)
+          )
+          expiredLockedAmuletFunction = store.listLockedExpiredAmulets(Some(partiesToIgnore))
+          result_beforeAdd <- expiredLockedAmuletFunction(
+            CantonTimestamp.now(),
+            PageLimit.tryCreate(100),
+          )(
+            traceContext
+          )
+          _ = partiesToIgnore.addAll(Set(party2))
+          result_afterAdd <- expiredLockedAmuletFunction(
+            CantonTimestamp.now(),
+            PageLimit.tryCreate(100),
+          )(
+            traceContext
+          )
+        } yield {
+          result_beforeAdd.map(_.contract) should contain theSameElementsAs Seq(
+            expiresAtRound3,
+            expiresAtRound4,
+          )
+          result_afterAdd.map(_.contract) should contain theSameElementsAs Seq(
+            expiresAtRound4
+          )
+        }
+      }
     }
 
     "listExpiredAmuletAllocations" should {

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
@@ -337,6 +337,48 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
         }
       }
 
+      "correctly ignore parties added after referencing the party ignore store" in {
+        val party1 = userParty(1)
+        val party2 = userParty(2)
+        val party3 = userParty(3)
+        val expiresAtRound3 = amulet(party2, 1.0, 2, 1.0)
+        val expiresAtRound4 = amulet(party3, 3.0, 1, 1.0)
+        val partiesToIgnore = new IgnoredPartiesStore(Set(party1))
+        val wontExpireAnyTimeSoon = amulet(party1, 10.0, 2, 0.0001)
+        for {
+          store <- mkStore()
+          _ <- dummyDomain.create(dsoRules())(store.multiDomainAcsStore)
+          _ <- createMiningRoundsTriple(store, startRound = 4L) // oldest is round 4, newest is 6
+          _ <- MonadUtil.sequentialTraverse(
+            Seq(expiresAtRound3, expiresAtRound4, wontExpireAnyTimeSoon)
+          )(
+            dummyDomain.create(_)(store.multiDomainAcsStore)
+          )
+          expiredAmuletFunction = store.listExpiredAmulets(Some(partiesToIgnore))
+          result_beforeAdd <- expiredAmuletFunction(
+            CantonTimestamp.now(),
+            PageLimit.tryCreate(100),
+          )(
+            traceContext
+          )
+          _ = partiesToIgnore.addAll(Set(party2))
+          result_afterAdd <- expiredAmuletFunction(
+            CantonTimestamp.now(),
+            PageLimit.tryCreate(100),
+          )(
+            traceContext
+          )
+        } yield {
+          result_beforeAdd.map(_.contract) should contain theSameElementsAs Seq(
+            expiresAtRound3,
+            expiresAtRound4,
+          )
+          result_afterAdd.map(_.contract) should contain theSameElementsAs Seq(
+            expiresAtRound4
+          )
+        }
+      }
+
     }
 
     "listLockedExpiredAmulets" should {


### PR DESCRIPTION
see https://daholdings.slack.com/archives/C03J6NCPSE4/p1782892926662029

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
