### PR TITLE
Fix a flake in TrafficBasedRewardsTimeBasedIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -44,6 +44,7 @@ import org.lfdecentralizedtrust.splice.util.{
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.SpliceTestConsoleEnvironment
 import org.lfdecentralizedtrust.splice.wallet.admin.api.client.commands.HttpWalletAppClient
 
+import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
@@ -165,7 +166,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
 
       clue("All SVs report zero totals for rounds after bootstrap") {
         Seq(sv1ScanBackend, sv2ScanBackend, sv3ScanBackend, sv4ScanBackend).foreach { scan =>
-          assertZeroTotals(scan, 1L to 2L)
+          assertZeroTotals(scan, 1L to 2L, timeout = 40.seconds)
         }
       }
     }
@@ -480,7 +481,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
         .map(_.payload.round.number)
 
     clue("CalculateRewards and ProcessRewards triggers consume contracts for rounds < 11") {
-      eventually() {
+      eventually(40.seconds) {
         val remainingCalculate = sv1Backend.appState.dsoStore
           .listCalculateRewardsV2()
           .futureValue
@@ -659,9 +660,10 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
   private def assertZeroTotals(
       scan: ScanAppBackendReference,
       rounds: Seq[Long],
+      timeout: FiniteDuration = 20.seconds,
   ): Unit =
     rounds.foreach { round =>
-      eventually() {
+      eventually(timeout) {
         inside(scan.getRewardAccountingActivityTotals(round)) {
           case GetRewardAccountingActivityTotalsResponse.members
                 .RewardAccountingActivityTotalsOk(t) =>


### PR DESCRIPTION
The flakes ([1](https://github.com/canton-network/splice/actions/runs/28228792924/job/83627305553), [2](https://github.com/canton-network/splice/actions/runs/28381619953/job/84085630453l)) occur because the default `eventually` timeout is not enough to consistently complete the reward computation pipeline.
 
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [x] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
