### PR TITLE
Scan: Use FA weights in app activity computation

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -15,6 +15,10 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.api.token.{
   allocationv1,
   metadatav1,
 }
+import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.FeaturedAppRight_Update
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules_UpdateFeaturedAppRight
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.actionrequiringconfirmation.ARC_DsoRules
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.dsorules_actionrequiringconfirmation.SRARC_UpdateFeaturedAppRight
 import org.lfdecentralizedtrust.splice.console.{ScanAppBackendReference, WalletAppClientReference}
 import org.lfdecentralizedtrust.splice.codegen.java.splice.testing.apps.tradingapp
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms
@@ -36,6 +40,7 @@ import org.lfdecentralizedtrust.splice.sv.automation.confirmation.{
 }
 import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.ExpiredAmuletTransferInstructionTrigger
 import org.lfdecentralizedtrust.splice.util.{
+  AmuletConfigUtil,
   ChoiceContextWithDisclosures,
   TimeTestUtil,
   TriggerTestUtil,
@@ -46,6 +51,7 @@ import org.lfdecentralizedtrust.splice.wallet.admin.api.client.commands.HttpWall
 
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
 import scala.util.Random
 
 // Tests the TrafficSummary ingestion and AppActivityRecord creation for each
@@ -60,10 +66,14 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
     with WalletTestUtil
     with TriggerTestUtil
     with TimeTestUtil
+    with AmuletConfigUtil
     with ExternallySignedPartyTestUtil
     with TokenStandardTest {
 
   protected def rewardConfigMode: TrafficBasedRewardsTimeBasedIntegrationTestBase.RewardConfigMode
+
+  // Applicable for rounds >= 7
+  private val aliceActivityWeight = BigDecimal("2.2")
 
   private def dryRunEnabled: Boolean =
     rewardConfigMode == TrafficBasedRewardsTimeBasedIntegrationTestBase.RewardConfigMode.DryRun
@@ -211,6 +221,8 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
           advanceTimeAndWaitForRoundOpening
           assertOldestOpenRound(5)
 
+          updateFeaturedAppRightWeight(aliceParty, aliceActivityWeight)
+
           settleTrade(aliceParty, bobParty, venueParty)
           settleTrade(aliceParty, bobParty, venueParty)
 
@@ -350,20 +362,34 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
     clue("updateId3") {
       val event = fetchEvent(updateId3, "updateId3")
       assertTrafficSummary(event, "updateId3")
+      // Round 6 opened before the weight change, so alice still has the default weight.
       assertAppActivity(event, "updateId3", Set(venueParty, aliceParty), expectedRound = 6)
     }
 
     clue("updateId4") {
       val event = fetchEvent(updateId4, "updateId4")
       assertTrafficSummary(event, "updateId4")
-      assertAppActivity(event, "updateId4", Set(aliceParty, venueParty), expectedRound = 7)
+      // From round 7 onwards we see aliceActivityWeight
+      assertAppActivity(
+        event,
+        "updateId4",
+        Set(aliceParty, venueParty),
+        expectedRound = 7,
+        scaledProvider = Some(aliceParty -> aliceActivityWeight),
+      )
     }
 
     clue("Alice-submitted create TransferInstruction has app activity for alice") {
       val event = fetchEvent(aliceCreateId, "aliceCreateId")
       event.verdict shouldBe defined
       assertTrafficSummary(event, "aliceCreateId")
-      assertAppActivity(event, "aliceCreateId", Set(aliceParty), expectedRound = 7)
+      assertAppActivity(
+        event,
+        "aliceCreateId",
+        Set(aliceParty),
+        expectedRound = 7,
+        scaledProvider = Some(aliceParty -> aliceActivityWeight),
+      )
     }
 
     clue("SV-submitted expire TransferInstruction creates no app activity for alice") {
@@ -378,13 +404,25 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       assertTrafficSummary(event, "updateId5")
       // Round 9: one DvP — venue has activity but will be below the coupon threshold;
       // alice's additional transfers push her above it.
-      assertAppActivity(event, "updateId5", Set(aliceParty, venueParty), expectedRound = 9)
+      assertAppActivity(
+        event,
+        "updateId5",
+        Set(aliceParty, venueParty),
+        expectedRound = 9,
+        scaledProvider = Some(aliceParty -> aliceActivityWeight),
+      )
     }
 
     clue("updateId6") {
       val event = fetchEvent(updateId6, "updateId6")
       assertTrafficSummary(event, "updateId6")
-      assertAppActivity(event, "updateId6", Set(aliceParty, venueParty), expectedRound = 10)
+      assertAppActivity(
+        event,
+        "updateId6",
+        Set(aliceParty, venueParty),
+        expectedRound = 10,
+        scaledProvider = Some(aliceParty -> aliceActivityWeight),
+      )
     }
 
     clue("updateId7") {
@@ -392,7 +430,13 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       assertTrafficSummary(event, "updateId7")
       // Round 11: venue's FAP was cancelled in round 9, so only alice is a
       // featured-app provider here.
-      assertAppActivity(event, "updateId7", Set(aliceParty), expectedRound = 11)
+      assertAppActivity(
+        event,
+        "updateId7",
+        Set(aliceParty),
+        expectedRound = 11,
+        scaledProvider = Some(aliceParty -> aliceActivityWeight),
+      )
     }
 
     assertRewardCalcs(aliceParty, venueParty)
@@ -629,6 +673,7 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
       cluePrefix: String,
       expectedProviders: Set[PartyId],
       expectedRound: Long,
+      scaledProvider: Option[(PartyId, BigDecimal)] = None,
   ): Unit = {
     withClue(s"$cluePrefix should have app activity") {
       event.appActivityRecords shouldBe defined
@@ -646,13 +691,53 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
           r.weight should be > 0L
         }
       }
-      val weightSum = activity.records.map(_.weight).sum
       val numFeaturedAppParties = expectedProviders.size.toLong
+
+      // Convert the assigned activity back to burn amount using app weight
+      val reconstructedBurnSum = activity.records.map { r =>
+        val weight = scaledProvider match {
+          case Some((party, w)) if r.party == party.toProtoPrimitive => w
+          case _ => BigDecimal(1)
+        }
+        BigDecimal(r.weight) / weight
+      }.sum
       withClue(
-        s"$cluePrefix sum of weights should be within [totalTrafficCost - numFeaturedAppParties, totalTrafficCost]"
+        s"$cluePrefix reconstructed burn should be within [totalTrafficCost - numFeaturedAppParties, totalTrafficCost]"
       ) {
-        weightSum should be >= (totalTrafficCost - numFeaturedAppParties)
-        weightSum should be <= totalTrafficCost
+        reconstructedBurnSum should be >= BigDecimal(totalTrafficCost - numFeaturedAppParties)
+        reconstructedBurnSum should be <= BigDecimal(totalTrafficCost)
+      }
+    }
+  }
+
+  private def updateFeaturedAppRightWeight(
+      party: PartyId,
+      newWeight: BigDecimal,
+  )(implicit env: SpliceTestConsoleEnvironment): Unit = {
+    val rightCid = clue(s"Look up featured app right for $party") {
+      sv1ScanBackend.lookupFeaturedAppRight(party).value.contractId
+    }
+    val action = new ARC_DsoRules(
+      new SRARC_UpdateFeaturedAppRight(
+        new DsoRules_UpdateFeaturedAppRight(
+          rightCid,
+          new FeaturedAppRight_Update("updating activity weight", newWeight.bigDecimal),
+        )
+      )
+    )
+    votingFlow(action, effectivity = None, accept = true, expiration = Duration.ofSeconds(60))
+    clue(s"Wait for $party featured app right weight to be $newWeight") {
+      eventually() {
+        val weight = sv1ScanBackend
+          .lookupFeaturedAppRight(party)
+          .value
+          .payload
+          .activityWeight
+          .toScala
+          .map(BigDecimal(_))
+        withClue(s"activity weight for $party: ") {
+          weight.getOrElse(BigDecimal(1)).compare(newWeight) shouldBe 0
+        }
       }
     }
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsTimeBasedIntegrationTest.scala
@@ -695,11 +695,11 @@ abstract class TrafficBasedRewardsTimeBasedIntegrationTestBase
 
       // Convert the assigned activity back to burn amount using app weight
       val reconstructedBurnSum = activity.records.map { r =>
-        val weight = scaledProvider match {
+        val activityWeight = scaledProvider match {
           case Some((party, w)) if r.party == party.toProtoPrimitive => w
           case _ => BigDecimal(1)
         }
-        BigDecimal(r.weight) / weight
+        BigDecimal(r.weight) / activityWeight
       }.sum
       withClue(
         s"$cluePrefix reconstructed burn should be within [totalTrafficCost - numFeaturedAppParties, totalTrafficCost]"

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -8,7 +8,11 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.mediator.admin.v30
 import com.digitalasset.canton.tracing.TraceContext
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
+import org.lfdecentralizedtrust.splice.scan.store.db.{
+  DbAppActivityRecordStore,
+  DbScanRewardsReferenceStore,
+  DbScanVerdictStore,
+}
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -93,7 +97,9 @@ class AppActivityComputation(
             roundInfoByTime.get(summary.sequencingTime) match {
               case Some((roundNumber, roundOpensAt)) =>
                 for {
-                  providers <- rewardsReferenceStore.lookupFeaturedAppPartiesAsOf(roundOpensAt)
+                  featuredAppWeights <- rewardsReferenceStore.lookupFeaturedAppPartiesAsOf(
+                    roundOpensAt
+                  )
                   svParticipantIds <- rewardsReferenceStore.lookupSvParticipantIdsAsOf(
                     roundOpensAt
                   )
@@ -112,7 +118,7 @@ class AppActivityComputation(
                     (
                       summary,
                       verdict,
-                      computeForSingleVerdict(summary, verdict, roundNumber, providers),
+                      computeForSingleVerdict(summary, verdict, roundNumber, featuredAppWeights),
                     )
                   }
                 }
@@ -134,13 +140,13 @@ class AppActivityComputation(
       summary: DbScanVerdictStore.TrafficSummaryT,
       verdict: v30.Verdict,
       roundNumber: Long,
-      featuredAppProviders: Set[String],
+      featuredAppWeights: Map[String, BigDecimal],
   ): Option[DbAppActivityRecordStore.AppActivityRecordT] = {
     val envelopesWithFeaturedAppConfirmers =
       summary.envelopeTrafficSummarys.flatMap { envelope =>
         val envelopeConfirmers =
           computeEnvelopeConfirmers(envelope, verdict.getTransactionViews.views)
-        val featuredAppConfirmers = envelopeConfirmers.intersect(featuredAppProviders)
+        val featuredAppConfirmers = envelopeConfirmers.intersect(featuredAppWeights.keySet)
         Option.when(featuredAppConfirmers.nonEmpty)((envelope, featuredAppConfirmers))
       }
 
@@ -149,11 +155,17 @@ class AppActivityComputation(
 
     if (totalFeaturedAppEnvelopesTraffic == 0L) None
     else {
-      val aggregatedWeights = computeAggregatedWeights(
+      val aggregatedBurn = computeAggregatedBurn(
         envelopesWithFeaturedAppConfirmers,
         summary.totalTrafficCost,
         totalFeaturedAppEnvelopesTraffic,
       )
+
+      val aggregatedWeights = SortedMap.from(aggregatedBurn.map { case (party, burn) =>
+        val weight =
+          featuredAppWeights.getOrElse(party, DbScanRewardsReferenceStore.DefaultAppActivityWeight)
+        party -> (BigDecimal(burn) * weight).toLong
+      })
 
       Some(
         DbAppActivityRecordStore.AppActivityRecordT(
@@ -177,7 +189,7 @@ class AppActivityComputation(
   /** Here it is important to accumulate per-app numerators and then
     * divide by totalFeaturedAppEnvelopesTraffic once at the end to reduce rounding error.
     */
-  private def computeAggregatedWeights(
+  private def computeAggregatedBurn(
       envelopesWithFeaturedAppConfirmers: Seq[(DbScanVerdictStore.EnvelopeT, Set[String])],
       totalConfirmationRequestTraffic: Long,
       totalFeaturedAppEnvelopesTraffic: Long,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -8,11 +8,7 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.mediator.admin.v30
 import com.digitalasset.canton.tracing.TraceContext
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
-import org.lfdecentralizedtrust.splice.scan.store.db.{
-  DbAppActivityRecordStore,
-  DbScanRewardsReferenceStore,
-  DbScanVerdictStore,
-}
+import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -163,7 +159,12 @@ class AppActivityComputation(
 
       val aggregatedWeights = SortedMap.from(aggregatedBurn.map { case (party, burn) =>
         val weight =
-          featuredAppWeights.getOrElse(party, DbScanRewardsReferenceStore.DefaultAppActivityWeight)
+          featuredAppWeights.getOrElse(
+            party,
+            throw new IllegalStateException(
+              s"No featured app weight found for party=$party"
+            ),
+          )
         party -> (BigDecimal(burn) * weight).toLong
       })
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -7,9 +7,12 @@ import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.mediator.admin.v30
 import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.daml.lf.data.Numeric
+import com.digitalasset.daml.lf.data.{assertRight as damlRight}
 import org.lfdecentralizedtrust.splice.scan.store.ScanRewardsReferenceStore
 import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
 
+import java.math.RoundingMode
 import scala.collection.immutable.SortedMap
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,6 +21,8 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 object AppActivityComputation {
   val MaxTrafficCostBytes: Long = 100L * 1024 * 1024 // 100 MB
+
+  private val scale: Numeric.Scale = Numeric.Scale.assertFromInt(10)
 
   /** Bump this when the functional behavior of the app activity computation changes.
     * WARNING: this MUST be bumped with utmost care to avoid the loss of
@@ -165,7 +170,11 @@ class AppActivityComputation(
               s"No featured app weight found for party=$party"
             ),
           )
-        party -> (BigDecimal(burn) * weight).toLong
+        val weightNumeric = Numeric.assertFromBigDecimal(AppActivityComputation.scale, weight)
+        val burnNumeric = damlRight(Numeric.fromLong(AppActivityComputation.scale, burn))
+        val product =
+          damlRight(Numeric.multiply(AppActivityComputation.scale, burnNumeric, weightNumeric))
+        party -> product.setScale(0, RoundingMode.FLOOR).longValueExact()
       })
 
       Some(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/CachingScanRewardsReferenceStore.scala
@@ -31,8 +31,8 @@ class CachingScanRewardsReferenceStore private[splice] (
     with NamedLogging {
 
   private val featuredAppPartiesCache
-      : ScaffeineCache.TracedAsyncLoadingCache[Future, CantonTimestamp, Set[String]] =
-    ScaffeineCache.buildTracedAsync[Future, CantonTimestamp, Set[String]](
+      : ScaffeineCache.TracedAsyncLoadingCache[Future, CantonTimestamp, Map[String, BigDecimal]] =
+    ScaffeineCache.buildTracedAsync[Future, CantonTimestamp, Map[String, BigDecimal]](
       Scaffeine()
         .maximumSize(2L),
       loader = implicit tc => asOf => store.lookupFeaturedAppPartiesAsOf(asOf),
@@ -57,7 +57,7 @@ class CachingScanRewardsReferenceStore private[splice] (
 
   override def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp
-  )(implicit tc: TraceContext): Future[Set[String]] =
+  )(implicit tc: TraceContext): Future[Map[String, BigDecimal]] =
     featuredAppPartiesCache.get(asOf)
 
   override def lookupSvParticipantIdsAsOf(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -61,7 +61,7 @@ trait ScanRewardsReferenceStore extends AppStore {
 
   def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp
-  )(implicit tc: TraceContext): Future[Set[String]]
+  )(implicit tc: TraceContext): Future[Map[String, BigDecimal]]
 
   /** Returns the set of SV participant UIDs from the DsoRules active as of the given time.
     * Returns an empty set only if asOf time is before the creation time of oldest DsoRules ingested.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -37,6 +37,13 @@ import org.lfdecentralizedtrust.splice.util.FutureUnlessShutdownUtil.futureUnles
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.OptionConverters.*
+
+object DbScanRewardsReferenceStore {
+
+  // same as `defaultAppActivityWeight` in the daml.
+  val DefaultAppActivityWeight: BigDecimal = BigDecimal(1)
+}
 
 class DbScanRewardsReferenceStore(
     override val key: ScanRewardsReferenceStore.Key,
@@ -129,9 +136,14 @@ class DbScanRewardsReferenceStore(
 
   override def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp
-  )(implicit tc: TraceContext): Future[Set[String]] =
+  )(implicit tc: TraceContext): Future[Map[String, BigDecimal]] =
     lookupFeaturedAppRightsAsOf(asOf)
-      .map(_.map(_.contract.payload.provider).toSet)
+      .map(_.map { c =>
+        val payload = c.contract.payload
+        payload.provider -> payload.activityWeight.toScala
+          .map(BigDecimal(_))
+          .getOrElse(DbScanRewardsReferenceStore.DefaultAppActivityWeight)
+      }.toMap)
 
   override def lookupSvParticipantIdsAsOf(
       asOf: CantonTimestamp

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanRewardsReferenceStore.scala
@@ -137,13 +137,16 @@ class DbScanRewardsReferenceStore(
   override def lookupFeaturedAppPartiesAsOf(
       asOf: CantonTimestamp
   )(implicit tc: TraceContext): Future[Map[String, BigDecimal]] =
-    lookupFeaturedAppRightsAsOf(asOf)
-      .map(_.map { c =>
-        val payload = c.contract.payload
-        payload.provider -> payload.activityWeight.toScala
+    lookupFeaturedAppRightsAsOf(asOf).map { rights =>
+      rights.foldLeft(Map.empty[String, BigDecimal]) { (weights, right) =>
+        val payload = right.contract.payload
+        val weight = payload.activityWeight.toScala
           .map(BigDecimal(_))
           .getOrElse(DbScanRewardsReferenceStore.DefaultAppActivityWeight)
-      }.toMap)
+        // Use the max of all weights, in case multiple contracts exist for a party
+        weights.updated(payload.provider, weights.get(payload.provider).fold(weight)(_ max weight))
+      }
+    }
 
   override def lookupSvParticipantIdsAsOf(
       asOf: CantonTimestamp

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputationTest.scala
@@ -59,6 +59,19 @@ class AppActivityComputationTest extends AnyWordSpec with BaseTest {
       result.head.appActivityWeights shouldBe Seq(100L, 100L)
     }
 
+    "scale provider burn by their activity weights" in {
+      val verdict = mkVerdict(Map(0 -> mkView(Seq("partyA", "partyB"))))
+      val summary = mkSummary(200L, Seq(mkEnvelope(200L, Seq(0))))
+
+      val result = computeWithWeights(
+        Map("partyA" -> BigDecimal(2.2), "partyB" -> BigDecimal("0.8")),
+        Seq((summary, verdict)),
+      )
+      result should have size 1
+      result.head.appProviderParties shouldBe Seq("partyA", "partyB")
+      result.head.appActivityWeights shouldBe Seq(220L, 80L)
+    }
+
     // This probably cannot happen, nevertheless we can handle it
     "handle zero traffic cost envelope" in {
       val verdict = mkVerdict(Map(0 -> mkView(Seq("partyA"))))
@@ -187,9 +200,19 @@ class AppActivityComputationTest extends AnyWordSpec with BaseTest {
 
   private val roundOpensAt = CantonTimestamp.ofEpochSecond(0)
 
-  /** Run computation and extract just the AppActivityRecordT results. */
+  /** Run computation and extract just the AppActivityRecordT results.
+    * All featured providers use the default activity weight of 1.0.
+    */
   private def computeWith(
       featured: Set[String],
+      input: Seq[(DbScanVerdictStore.TrafficSummaryT, v30.Verdict)],
+      svParticipantIds: Set[String] = Set("someSvParticipant"),
+  ): Seq[DbAppActivityRecordStore.AppActivityRecordT] =
+    computeWithWeights(featured.map(_ -> BigDecimal(1)).toMap, input, svParticipantIds)
+
+  /** Run computation with explicit per-provider activity weights. */
+  private def computeWithWeights(
+      featuredWeights: Map[String, BigDecimal],
       input: Seq[(DbScanVerdictStore.TrafficSummaryT, v30.Verdict)],
       svParticipantIds: Set[String] = Set("someSvParticipant"),
   ): Seq[DbAppActivityRecordStore.AppActivityRecordT] = {
@@ -199,7 +222,7 @@ class AppActivityComputationTest extends AnyWordSpec with BaseTest {
         Future.successful(times.map(_ -> (0L, roundOpensAt)).toMap)
       }
     when(store.lookupFeaturedAppPartiesAsOf(any[CantonTimestamp])(any[TraceContext]))
-      .thenReturn(Future.successful(featured))
+      .thenReturn(Future.successful(featuredWeights))
     when(store.lookupSvParticipantIdsAsOf(any[CantonTimestamp])(any[TraceContext]))
       .thenReturn(Future.successful(svParticipantIds))
     new AppActivityComputation(store, loggerFactory)(directExecutionContext)


### PR DESCRIPTION
Fixes #6235 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
