### PR TITLE
Add `helmForceUpdate` config option

### DIFF
--- a/.envrc.vars
+++ b/.envrc.vars
@@ -70,6 +70,7 @@ export MULTIVALIDATOR_SIZE=0
 # This can over time lead to a very large number of secrets (which is how helm stores the release history) resulting in
 # unnecessary slowness when running helm commands.
 export HELM_MAX_HISTORY_SIZE=10
+export HELM_FORCE_UPDATE="false"
 export OIDC_AUTHORITY_LEDGER_API_AUDIENCE=https://canton.network.global
 export OIDC_AUTHORITY_VALIDATOR_AUDIENCE=https://canton.network.global
 export OIDC_AUTHORITY_SV_AUDIENCE=https://canton.network.global

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -2486,16 +2486,4 @@ if [ ! ${subcommand_whitelist[${SUBCOMMAND_NAME}]+_} ]; then
     _error  "Unknown subcommand: ${SUBCOMMAND_NAME}"
 fi
 
-declare -a NEW_ARGS=()
-for arg in "$@"; do
-    if [[ "$arg" == "--helm-force" ]]; then
-        _warning "You have passed --helm-force. This will force an update for all Pulumi Helm Releases, which is potentially destructive."
-        _prompt_to_confirm "Are you sure you want to proceed?"
-        export HELM_FORCE_UPDATE="true"
-    else
-        NEW_ARGS+=("$arg")
-    fi
-done
-set -- "${NEW_ARGS[@]}"
-
 "subcmd_${SUBCOMMAND_NAME}" "$@"

--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -2486,4 +2486,16 @@ if [ ! ${subcommand_whitelist[${SUBCOMMAND_NAME}]+_} ]; then
     _error  "Unknown subcommand: ${SUBCOMMAND_NAME}"
 fi
 
+declare -a NEW_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--helm-force" ]]; then
+        _warning "You have passed --helm-force. This will force an update for all Pulumi Helm Releases, which is potentially destructive."
+        _prompt_to_confirm "Are you sure you want to proceed?"
+        export HELM_FORCE_UPDATE="true"
+    else
+        NEW_ARGS+=("$arg")
+    fi
+done
+set -- "${NEW_ARGS[@]}"
+
 "subcmd_${SUBCOMMAND_NAME}" "$@"

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -214,7 +214,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/cn-docs",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "docs",
       "namespace": "docs",
@@ -2618,7 +2618,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv-1",
@@ -2718,7 +2718,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "ingress-sv",
       "namespace": "sv-1",
@@ -3999,7 +3999,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv-1",
@@ -4132,7 +4132,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv-1",
@@ -4428,7 +4428,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator-sv-1",
       "namespace": "sv-1",
@@ -4798,7 +4798,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv-da-1",
@@ -4898,7 +4898,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "ingress-sv",
       "namespace": "sv-da-1",
@@ -6036,7 +6036,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv-da-1",
@@ -6170,7 +6170,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv-da-1",
@@ -6418,7 +6418,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator-sv-da-1",
       "namespace": "sv-da-1",

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -214,6 +214,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/cn-docs",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "docs",
       "namespace": "docs",
@@ -2617,6 +2618,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv-1",
@@ -2716,6 +2718,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "ingress-sv",
       "namespace": "sv-1",
@@ -3996,6 +3999,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv-1",
@@ -4128,6 +4132,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv-1",
@@ -4423,6 +4428,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator-sv-1",
       "namespace": "sv-1",
@@ -4792,6 +4798,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv-da-1",
@@ -4891,6 +4898,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "ingress-sv",
       "namespace": "sv-da-1",
@@ -6028,6 +6036,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv-da-1",
@@ -6161,6 +6170,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv-da-1",
@@ -6408,6 +6418,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator-sv-da-1",
       "namespace": "sv-da-1",

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1406,7 +1406,7 @@
     "inputs": {
       "chart": "base",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "istio-base",
       "namespace": "istio-system",
@@ -1430,7 +1430,7 @@
     "inputs": {
       "chart": "gateway",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "istio-ingress-cometbft",
       "namespace": "cluster-ingress",
@@ -1703,7 +1703,7 @@
     "inputs": {
       "chart": "gateway",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "istio-ingress",
       "namespace": "cluster-ingress",
@@ -1902,7 +1902,7 @@
     "inputs": {
       "chart": "istiod",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "istiod",
       "namespace": "cluster-ingress",
@@ -2179,7 +2179,7 @@
     "inputs": {
       "chart": "reloader",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "reloader",
       "namespace": "reloader",

--- a/cluster/expected/infra/expected.json
+++ b/cluster/expected/infra/expected.json
@@ -1406,6 +1406,7 @@
     "inputs": {
       "chart": "base",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "istio-base",
       "namespace": "istio-system",
@@ -1429,6 +1430,7 @@
     "inputs": {
       "chart": "gateway",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "istio-ingress-cometbft",
       "namespace": "cluster-ingress",
@@ -1701,6 +1703,7 @@
     "inputs": {
       "chart": "gateway",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "istio-ingress",
       "namespace": "cluster-ingress",
@@ -1899,6 +1902,7 @@
     "inputs": {
       "chart": "istiod",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "istiod",
       "namespace": "cluster-ingress",
@@ -2175,6 +2179,7 @@
     "inputs": {
       "chart": "reloader",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "reloader",
       "namespace": "reloader",

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -4869,6 +4869,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres-0",
       "namespace": "multi-validator",
@@ -4967,6 +4968,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres-1",
       "namespace": "multi-validator",
@@ -5065,6 +5067,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres-2",
       "namespace": "multi-validator",
@@ -5163,6 +5166,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres-3",
       "namespace": "multi-validator",
@@ -5261,6 +5265,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres-4",
       "namespace": "multi-validator",

--- a/cluster/expected/multi-validator/expected.json
+++ b/cluster/expected/multi-validator/expected.json
@@ -4869,7 +4869,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres-0",
       "namespace": "multi-validator",
@@ -4968,7 +4968,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres-1",
       "namespace": "multi-validator",
@@ -5067,7 +5067,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres-2",
       "namespace": "multi-validator",
@@ -5166,7 +5166,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres-3",
       "namespace": "multi-validator",
@@ -5265,7 +5265,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres-4",
       "namespace": "multi-validator",

--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -1044,7 +1044,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "grafana-postgres",
       "namespace": "observability",
@@ -1101,7 +1101,7 @@
     "inputs": {
       "chart": "kube-prometheus-stack",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "prometheus-grafana-monitoring",
       "namespace": "observability",

--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -1044,6 +1044,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "grafana-postgres",
       "namespace": "observability",
@@ -1100,6 +1101,7 @@
     "inputs": {
       "chart": "kube-prometheus-stack",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "prometheus-grafana-monitoring",
       "namespace": "observability",

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -329,6 +329,7 @@
     "inputs": {
       "chart": "flux2",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "flux",
       "namespace": "operator",
@@ -591,6 +592,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator",
       "compat": "true",
+      "forceUpdate": false,
       "name": "pulumi-kubernetes-operator",
       "namespace": "operator",
       "values": {

--- a/cluster/expected/operator/expected.json
+++ b/cluster/expected/operator/expected.json
@@ -329,7 +329,7 @@
     "inputs": {
       "chart": "flux2",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "flux",
       "namespace": "operator",
@@ -592,7 +592,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "name": "pulumi-kubernetes-operator",
       "namespace": "operator",
       "values": {

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -359,7 +359,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cluster-ingress-splitwell-uis",
       "namespace": "splitwell",
@@ -533,7 +533,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "splitwell",
@@ -756,7 +756,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-splitwell-app",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "splitwell-app",
       "namespace": "splitwell",
@@ -1087,7 +1087,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator-splitwell",
       "namespace": "splitwell",

--- a/cluster/expected/splitwell/expected.json
+++ b/cluster/expected/splitwell/expected.json
@@ -359,6 +359,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cluster-ingress-splitwell-uis",
       "namespace": "splitwell",
@@ -532,6 +533,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "splitwell",
@@ -754,6 +756,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-splitwell-app",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "splitwell-app",
       "namespace": "splitwell",
@@ -1084,6 +1087,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator-splitwell",
       "namespace": "splitwell",

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1533,6 +1533,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv-1",
@@ -1645,6 +1646,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv-1",
@@ -1905,6 +1907,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv-1",
@@ -2041,6 +2044,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv-1",
@@ -2173,6 +2177,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv-1",
@@ -2305,6 +2310,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv-1",
@@ -4891,6 +4897,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv",
@@ -5000,6 +5007,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv",
@@ -5109,6 +5117,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv-da-1",
@@ -5222,6 +5231,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv-da-1",
@@ -5483,6 +5493,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv-da-1",
@@ -5619,6 +5630,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv-da-1",
@@ -5751,6 +5763,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv-da-1",
@@ -5883,6 +5896,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv-da-1",
@@ -8347,6 +8361,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv",
@@ -8483,6 +8498,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv",
@@ -8615,6 +8631,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv",
@@ -8747,6 +8764,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv",

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1533,7 +1533,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv-1",
@@ -1646,7 +1646,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv-1",
@@ -1907,7 +1907,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv-1",
@@ -2044,7 +2044,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv-1",
@@ -2177,7 +2177,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv-1",
@@ -2310,7 +2310,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv-1",
@@ -4897,7 +4897,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv",
@@ -5007,7 +5007,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv",
@@ -5117,7 +5117,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-7",
       "namespace": "sv-da-1",
@@ -5231,7 +5231,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cometbft",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cometbft-global-domain-8",
       "namespace": "sv-da-1",
@@ -5493,7 +5493,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv-da-1",
@@ -5630,7 +5630,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv-da-1",
@@ -5763,7 +5763,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv-da-1",
@@ -5896,7 +5896,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv-da-1",
@@ -8361,7 +8361,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-10",
       "namespace": "sv",
@@ -8498,7 +8498,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-7",
       "namespace": "sv",
@@ -8631,7 +8631,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-8",
       "namespace": "sv",
@@ -8764,7 +8764,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-global-domain",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "global-domain-9",
       "namespace": "sv",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -47,7 +47,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cluster-ingress-sv",
       "namespace": "sv",
@@ -186,7 +186,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv",
@@ -620,7 +620,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv",
@@ -1346,7 +1346,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv",
@@ -2714,7 +2714,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator",
       "namespace": "sv",

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -47,6 +47,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cluster-ingress-sv",
       "namespace": "sv",
@@ -185,6 +186,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-info",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "info",
       "namespace": "sv",
@@ -618,6 +620,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-scan",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "scan",
       "namespace": "sv",
@@ -1343,6 +1346,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-sv-node",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "sv-app",
       "namespace": "sv",
@@ -2710,6 +2714,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator",
       "namespace": "sv",

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -384,7 +384,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv-1",
@@ -685,7 +685,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv-da-1",
@@ -1023,7 +1023,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv",

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -384,6 +384,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv-1",
@@ -684,6 +685,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv-da-1",
@@ -1021,6 +1023,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant",
       "namespace": "sv",

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -47,6 +47,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cluster-ingress-validator",
       "namespace": "validator",
@@ -419,6 +420,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "validator",
@@ -513,6 +515,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-party-allocator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "party-allocator",
       "namespace": "validator",
@@ -604,6 +607,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "postgres",
       "namespace": "validator",
@@ -684,6 +688,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator",
       "namespace": "validator",

--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -47,7 +47,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cluster-ingress-validator",
       "namespace": "validator",
@@ -420,7 +420,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "validator",
@@ -515,7 +515,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-party-allocator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "party-allocator",
       "namespace": "validator",
@@ -607,7 +607,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-postgres",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "postgres",
       "namespace": "validator",
@@ -688,7 +688,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator",
       "namespace": "validator",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -442,6 +442,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "cluster-ingress-validator1",
       "namespace": "validator1",
@@ -570,6 +571,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "validator1",
@@ -818,6 +820,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-splitwell-web-ui",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "splitwell-web-ui",
       "namespace": "validator1",
@@ -1014,6 +1017,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
+      "forceUpdate": false,
       "maxHistory": 10,
       "name": "validator-validator1",
       "namespace": "validator1",

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -442,7 +442,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-cluster-ingress-runbook",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "cluster-ingress-validator1",
       "namespace": "validator1",
@@ -571,7 +571,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-participant",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "participant-2",
       "namespace": "validator1",
@@ -820,7 +820,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-splitwell-web-ui",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "splitwell-web-ui",
       "namespace": "validator1",
@@ -1017,7 +1017,7 @@
     "inputs": {
       "chart": "oci://ghcr.io/digital-asset/decentralized-canton-sync-dev/helm/splice-validator",
       "compat": "true",
-      "forceUpdate": false,
+      "forceUpdate": true,
       "maxHistory": 10,
       "name": "validator-validator1",
       "namespace": "validator1",

--- a/cluster/pulumi/canton-network/src/chaosMesh.ts
+++ b/cluster/pulumi/canton-network/src/chaosMesh.ts
@@ -6,6 +6,7 @@ import {
   clusterYamlConfig,
   DecentralizedSynchronizerUpgradeConfig,
   GCP_PROJECT,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
 } from '@canton-network/splice-pulumi-common';
@@ -205,6 +206,7 @@ export const installChaosMesh = ({ dependsOn }: ChaosMeshArguments): k8s.helm.v3
       chart: 'chaos-mesh',
       version: '2.7.2',
       namespace: ns.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://charts.chaos-mesh.org',
       },

--- a/cluster/pulumi/circleci/src/index.ts
+++ b/cluster/pulumi/circleci/src/index.ts
@@ -6,6 +6,7 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   appsAffinityAndTolerations,
   ChartValues,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
 } from '@canton-network/splice-pulumi-common';
@@ -176,6 +177,7 @@ new k8s.helm.v3.Release('container-agent', {
   chart: 'container-agent',
   version: '101.1.3',
   namespace: circleCiNamespace.metadata.name,
+  forceUpdate: HELM_FORCE_UPDATE,
   repositoryOpts: {
     repo: 'https://packagecloud.io/circleci/container-agent/helm',
   },

--- a/cluster/pulumi/cluster/src/fluentBit.ts
+++ b/cluster/pulumi/cluster/src/fluentBit.ts
@@ -6,6 +6,7 @@ import {
   CLUSTER_NAME,
   exactNamespace,
   GCP_REGION,
+  HELM_FORCE_UPDATE,
   infraAffinityAndTolerations,
 } from '@canton-network/splice-pulumi-common';
 
@@ -153,6 +154,7 @@ export function installFluentBit(): void {
     name: 'fluent-bit',
     chart: 'fluent-bit',
     version: '0.51.0',
+    forceUpdate: HELM_FORCE_UPDATE,
     repositoryOpts: {
       repo: 'https://fluent.github.io/helm-charts',
     },

--- a/cluster/pulumi/common/src/config/configSchema.ts
+++ b/cluster/pulumi/common/src/config/configSchema.ts
@@ -15,6 +15,7 @@ const PulumiProjectConfigSchema = z.object({
   cloudSql: CloudSqlConfigSchema,
   allowDowngrade: z.boolean(),
   replacePostgresStatefulSetOnChanges: z.boolean().default(false),
+  helmForceUpdate: z.boolean().default(true),
 });
 export type PulumiProjectConfig = z.infer<typeof PulumiProjectConfigSchema>;
 export const ConfigSchema = z.object({

--- a/cluster/pulumi/common/src/helm.ts
+++ b/cluster/pulumi/common/src/helm.ts
@@ -19,6 +19,7 @@ import {
   ExactNamespace,
   fixedTokens,
   HELM_CHART_TIMEOUT_SEC,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   HELM_REPO,
   loadJsonFromFile,
@@ -93,6 +94,7 @@ function installSpliceHelmChartByNamespaceName(
         },
         timeout,
         maxHistory: HELM_MAX_HISTORY_SIZE,
+        forceUpdate: HELM_FORCE_UPDATE,
       },
       opts
     );
@@ -178,6 +180,7 @@ export function installSpliceRunbookHelmChartByNamespaceName(
         },
         timeout,
         maxHistory: HELM_MAX_HISTORY_SIZE,
+        forceUpdate: HELM_FORCE_UPDATE,
       },
       opts
     );

--- a/cluster/pulumi/common/src/utils.ts
+++ b/cluster/pulumi/common/src/utils.ts
@@ -14,6 +14,7 @@ import { jmxOptions } from './jmx';
 /// Environment variables
 export const HELM_CHART_TIMEOUT_SEC = Number(config.optionalEnv('HELM_CHART_TIMEOUT_SEC')) || 600;
 export const HELM_MAX_HISTORY_SIZE = Number(config.optionalEnv('HELM_MAX_HISTORY_SIZE')) || 0; // 0 => no limit
+export const HELM_FORCE_UPDATE = (config.optionalEnv('HELM_FORCE_UPDATE') || 'false') === 'true';
 
 const MOCK_SPLICE_ROOT = config.optionalEnv('MOCK_SPLICE_ROOT');
 export const SPLICE_ROOT = config.requireEnv('SPLICE_ROOT', 'root directory of the repo');

--- a/cluster/pulumi/common/src/utils.ts
+++ b/cluster/pulumi/common/src/utils.ts
@@ -14,7 +14,7 @@ import { jmxOptions } from './jmx';
 /// Environment variables
 export const HELM_CHART_TIMEOUT_SEC = Number(config.optionalEnv('HELM_CHART_TIMEOUT_SEC')) || 600;
 export const HELM_MAX_HISTORY_SIZE = Number(config.optionalEnv('HELM_MAX_HISTORY_SIZE')) || 0; // 0 => no limit
-export const HELM_FORCE_UPDATE = (config.optionalEnv('HELM_FORCE_UPDATE') || 'false') === 'true';
+export const HELM_FORCE_UPDATE = spliceConfig.pulumiProjectConfig.helmForceUpdate;
 
 const MOCK_SPLICE_ROOT = config.optionalEnv('MOCK_SPLICE_ROOT');
 export const SPLICE_ROOT = config.requireEnv('SPLICE_ROOT', 'root directory of the repo');

--- a/cluster/pulumi/gha/src/controller.ts
+++ b/cluster/pulumi/gha/src/controller.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
 } from '@canton-network/splice-pulumi-common';
@@ -21,6 +22,7 @@ export function installController(repo: string, runnersNamespaceName: string): k
     chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller',
     version: ghaConfig.runnerScaleSetVersion,
     namespace: controllerNamespace.metadata.name,
+    forceUpdate: HELM_FORCE_UPDATE,
     values: {
       ...infraAffinityAndTolerations,
       maxHistory: HELM_MAX_HISTORY_SIZE,

--- a/cluster/pulumi/gha/src/dockerMirror.ts
+++ b/cluster/pulumi/gha/src/dockerMirror.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
+  HELM_FORCE_UPDATE,
   infraAffinityAndTolerations,
   standardStorageClassName,
 } from '@canton-network/splice-pulumi-common';
@@ -21,6 +22,7 @@ export function installDockerRegistryMirror(): k8s.helm.v3.Release {
       chart: 'docker-registry',
       version: '3.0.0',
       namespace: namespace.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://twuni.github.io/docker-registry.helm',
       },

--- a/cluster/pulumi/gha/src/runners.ts
+++ b/cluster/pulumi/gha/src/runners.ts
@@ -6,6 +6,7 @@ import {
   appsAffinityAndTolerations,
   DOCKER_REPO,
   ExactNamespace,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   imagePullSecretByNamespaceNameForServiceAccount,
   infraAffinityAndTolerations,
@@ -79,6 +80,7 @@ function installDockerRunnerScaleSet(
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,
       namespace: runnersNamespace.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       values: {
         githubConfigUrl: `https://github.com/${ghaConfig.githubOrg}/${repo}`,
         githubConfigSecret: tokenSecret.metadata.name,
@@ -432,6 +434,7 @@ function installK8sRunnerScaleSet(
       chart: 'oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
       version: ghaConfig.runnerScaleSetVersion,
       namespace: runnersNamespace.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       values: {
         githubConfigUrl: `${ghaConfig.githubOrg.startsWith('https://github.com/') ? ghaConfig.githubOrg : `https://github.com/${ghaConfig.githubOrg}`}/${repo}`,
         githubConfigSecret: tokenSecret.metadata.name,

--- a/cluster/pulumi/infra/src/istio.ts
+++ b/cluster/pulumi/infra/src/istio.ts
@@ -20,6 +20,7 @@ import {
   GCP_PROJECT,
   GCP_ZONE,
   getDnsNames,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
   isDevNet,
@@ -56,6 +57,7 @@ function configureIstioBase(
       chart: 'base',
       version: istioVersion.istio,
       namespace: ns.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://istio-release.storage.googleapis.com/charts',
       },
@@ -166,6 +168,7 @@ function configureIstiod(
       chart: 'istiod',
       version: istioVersion.istio,
       namespace: ingressNs.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://istio-release.storage.googleapis.com/charts',
       },
@@ -446,6 +449,7 @@ function configureGatewayService(
       chart: 'gateway',
       version: istioVersion.istio,
       namespace: ingressNs.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://istio-release.storage.googleapis.com/charts',
       },

--- a/cluster/pulumi/infra/src/reloader.ts
+++ b/cluster/pulumi/infra/src/reloader.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   exactNamespace,
   infraAffinityAndTolerations,
@@ -17,6 +18,7 @@ export function configureReloader(): k8s.helm.v3.Release {
       chart: 'reloader',
       version: '2.2.8',
       namespace: ns.ns.metadata.name,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://stakater.github.io/stakater-charts',
       },

--- a/cluster/pulumi/observability/src/observability.ts
+++ b/cluster/pulumi/observability/src/observability.ts
@@ -15,6 +15,7 @@ import {
   ExactNamespace,
   GCP_PROJECT,
   GrafanaKeys,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
   infraPremiumStorageClassName,
@@ -112,6 +113,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
       chart: 'kube-prometheus-stack',
       version: stackVersion,
       namespace: namespaceName,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://prometheus-community.github.io/helm-charts',
       },
@@ -557,6 +559,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
       chart: 'prometheus-pushgateway',
       version: '3.4.1',
       namespace: namespaceName,
+      forceUpdate: HELM_FORCE_UPDATE,
       repositoryOpts: {
         repo: 'https://prometheus-community.github.io/helm-charts',
       },

--- a/cluster/pulumi/operator/src/flux/flux.ts
+++ b/cluster/pulumi/operator/src/flux/flux.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as k8s from '@pulumi/kubernetes';
 import {
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   infraAffinityAndTolerations,
 } from '@canton-network/splice-pulumi-common';
@@ -11,6 +12,7 @@ import { namespace } from '../namespace';
 export const flux = new k8s.helm.v3.Release('flux', {
   name: 'flux',
   chart: 'flux2',
+  forceUpdate: HELM_FORCE_UPDATE,
   // When trying to upgrade to 2.15.0 and 2.16.2, source-controller failed to pull the code, with an error of git not being found in PATH
   // (source-controller does not use git from PATH, but a built-in git implementation, so this seems to be a symptom of some other failure,
   //  perhaps authentication to the private repo), so for now we do not upgrade past 2.14.1.

--- a/cluster/pulumi/operator/src/operator.ts
+++ b/cluster/pulumi/operator/src/operator.ts
@@ -5,6 +5,7 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   commandScriptPath,
   config,
+  HELM_FORCE_UPDATE,
   HELM_MAX_HISTORY_SIZE,
   imagePullSecret,
   infraAffinityAndTolerations,
@@ -33,6 +34,7 @@ export const operator = new k8s.helm.v3.Release(
     chart: 'oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator',
     version: operatorVersion,
     namespace: namespace.ns.metadata.name,
+    forceUpdate: HELM_FORCE_UPDATE,
     values: {
       resources: {
         limits: {


### PR DESCRIPTION
Fixes #4940 

Added a `helmForceUpdate` config option (`true` by default).
Tested on scratchneta.

#### Test
1. Manually add an annotation to a deamonset (fluentbit)
2. run `cncluster pulumi cluster up`
3. The annotation disappears
4. readd the annotation
5. change the `helmForceUpdate` setting to `false`
6. run `cncluster pulumi cluster up`
7. the annotation stays on the resource