### PR TITLE
cantonbft - reconcile configured nodes instead of network status

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerBftAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerBftAdminConnection.scala
@@ -39,6 +39,14 @@ trait SequencerBftAdminConnection {
     )
   }
 
+  def listConfiguredPeerEndpoints()(implicit
+      tc: TraceContext
+  ): Future[Seq[P2PEndpoint]] = {
+    runCmd(
+      SequencerBftAdminCommands.ListConfiguredEndpoints
+    )
+  }
+
   def listCurrentPeerEndpoints()(implicit
       tc: TraceContext
   ): Future[Seq[(Option[SequencerId], Option[P2PEndpoint.Id])]] = {
@@ -59,12 +67,5 @@ trait SequencerBftAdminConnection {
         }
     })
   }
-
-  def listCurrentOutgoingPeerEndpoints()(implicit
-      tc: TraceContext
-  ): Future[Seq[(Option[SequencerId], P2PEndpoint.Id)]] =
-    listCurrentPeerEndpoints().map(_.collect { case (seqId, Some(endpointId)) =>
-      (seqId, endpointId)
-    })
 
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
@@ -67,46 +67,80 @@ abstract class SequencerBftPeerReconciler(
               )
             dsoSequencersWithoutSelf = sequencers.filter(_ != sequencerId)
             sequencersFromScan <- getAllBftSequencers()
-            dsoSequencersWithScanInfo = dsoSequencersWithoutSelf.map { sequencerId =>
-              sequencerId -> sequencersFromScan.find(scanSequencer =>
-                scanSequencer.id == sequencerId && scanSequencer.serialId == serialId
-              )
+            dsoSequencersWithEndpoint = dsoSequencersWithoutSelf.map { sequencerId =>
+              sequencerId -> sequencersFromScan
+                .find(scanSequencer =>
+                  scanSequencer.id == sequencerId && scanSequencer.serialId == serialId
+                )
+                .map(_.peerId)
             }
-            // TODO(#1929) Reconsider whether we can really ignore incoming connections.
-            currentPeers <- sequencerAdminConnection
-              .listCurrentOutgoingPeerEndpoints()
-            peersToAdd = dsoSequencersWithScanInfo
-              .collect { case (id, Some(config)) =>
-                id -> config
-              }
-              .filterNot { case (dsoSequencerId, peer) =>
-                currentPeers.exists { case (peerSequencerId, endpointId) =>
-                  peerSequencerId.forall(_ == dsoSequencerId) && peer.peerId.id == endpointId
-                }
-              }
-            peersToRemove = currentPeers
-              .filterNot {
-                case (Some(peerSequencerId), endpointId) =>
-                  dsoSequencersWithScanInfo.exists { case (sequencerId, config) =>
-                    sequencerId == peerSequencerId && config.forall(_.peerId.id == endpointId)
-                  }
-                case (None, endpointId) =>
-                  dsoSequencersWithScanInfo.exists { case (_, config) =>
-                    config.exists(_.peerId.id == endpointId)
-                  }
-              }
+            dsoSequencerEndpoints = dsoSequencersWithEndpoint.flatMap(_._2)
+            configuredPeers <- sequencerAdminConnection
+              .listConfiguredPeerEndpoints()
+            peersToAdd = dsoSequencerEndpoints
+              .filterNot(endpoint => configuredPeers.exists(_.id == endpoint.id))
+            candidatePeersToRemove = configuredPeers
+              .filterNot(peer => dsoSequencerEndpoints.exists(_.id == peer.id))
+            peersToRemove <- computePeersToRemove(
+              candidatePeersToRemove,
+              dsoSequencersWithEndpoint,
+            )
           } yield {
             if (peersToAdd.nonEmpty || peersToRemove.nonEmpty)
               Seq(
                 BftPeerDifference(
-                  peersToAdd.map(_._2.peerId),
-                  peersToRemove.map(_._2),
-                  currentPeers,
+                  peersToAdd,
+                  peersToRemove.map(_.id),
+                  configuredPeers,
                 )
               )
             else Seq()
           }
     } yield result
+  }
+
+  /** If all DSO sequencers have an associated peer endpoint advertised by scan, any configured peer
+    * that does not correspond to one of those endpoints is stale and safe to remove.
+    *
+    * Otherwise we cannot rely on scan alone (as some scans can be unavailable), so we cross-check the peer network status to find the
+    * sequencer id backing each candidate endpoint. Removal is only safe if that sequencer id is no
+    * longer part of the DSO sequencers, or if it is now associated with a different endpoint. If no
+    * sequencer id can be found for a candidate endpoint we keep it and log a warning.
+    */
+  private def computePeersToRemove(
+      candidatePeersToRemove: Seq[P2PEndpoint],
+      dsoSequencersWithEndpoint: Seq[(SequencerId, Option[P2PEndpoint])],
+  )(implicit tc: TraceContext, ec: ExecutionContext): Future[Seq[P2PEndpoint]] = {
+    val allDsoSequencersHaveEndpoint = dsoSequencersWithEndpoint.forall { case (_, endpoint) =>
+      endpoint.isDefined
+    }
+    if (candidatePeersToRemove.isEmpty || allDsoSequencersHaveEndpoint) {
+      Future.successful(candidatePeersToRemove)
+    } else {
+      sequencerAdminConnection.listCurrentPeerEndpoints().map { networkStatus =>
+        candidatePeersToRemove.filter { peer =>
+          networkStatus.collectFirst {
+            case (Some(sequencerId), Some(endpointId)) if endpointId == peer.id => sequencerId
+          } match {
+            case Some(sequencerId) =>
+              val sequencerNoLongerInDso =
+                !dsoSequencersWithEndpoint.exists { case (dsoSequencerId, _) =>
+                  dsoSequencerId == sequencerId
+                }
+              val sequencerMovedToDifferentEndpoint =
+                dsoSequencersWithEndpoint.exists { case (dsoSequencerId, endpoint) =>
+                  dsoSequencerId == sequencerId && endpoint.exists(_.id != peer.id)
+                }
+              sequencerNoLongerInDso || sequencerMovedToDifferentEndpoint
+            case None =>
+              logger.warn(
+                s"Could not find a sequencer id for the configured peer endpoint ${peer.id} in the peer network status; not removing it to be safe."
+              )
+              false
+          }
+        }
+      }
+    }
   }
 
   private def getAllBftSequencers()(implicit ec: ExecutionContext, tc: TraceContext) = {
@@ -127,6 +161,6 @@ object SequencerBftPeerReconciler {
   case class BftPeerDifference(
       toAdd: Seq[P2PEndpoint],
       toRemove: Seq[P2PEndpoint.Id],
-      currentPeers: Seq[(Option[SequencerId], P2PEndpoint.Id)],
+      currentPeers: Seq[P2PEndpoint],
   )
 }

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconcilerSpec.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconcilerSpec.scala
@@ -46,6 +46,8 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
   private val sequencer1Host = createP2PEndpoint("host")
   private val sequencer2Id = SequencerId(UniqueIdentifier.tryFromProtoPrimitive("seq::2"))
   private val sequencer2Host = createP2PEndpoint("host2")
+  private val sequencer3Id = SequencerId(UniqueIdentifier.tryFromProtoPrimitive("seq::3"))
+  private val sequencer3Host = createP2PEndpoint("host3")
 
   private val svDsoStoreMock = mock[SvDsoStore]
   private val sequencerAdminConnection = mock[SequencerAdminConnection]
@@ -107,7 +109,7 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       ),
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(Future.successful(Seq.empty))
 
     val result = reconciler.diffDsoRulesWithTopology().futureValue.loneElement
@@ -135,12 +137,12 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       ),
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (Some(sequencer1Id), sequencer1Host),
-            (Some(sequencer2Id), sequencer2Host),
+            configuredPeer(sequencer1Host),
+            configuredPeer(sequencer2Host),
           )
         )
       )
@@ -171,12 +173,12 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       ),
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (Some(sequencer1Id), sequencer1Host),
-            (Some(sequencer2Id), sequencer2Host),
+            configuredPeer(sequencer1Host),
+            configuredPeer(sequencer2Host),
           )
         )
       )
@@ -185,7 +187,7 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
     result should be(empty)
   }
 
-  it should "do nothing when scan doesn't contain the sequencer info but the dso state contains it" in {
+  it should "do nothing when scan doesn't contain the sequencer info but the dso state still contains it and the network status confirms the sequencer" in {
     withConfiguredDsoSequencers(
       Seq(
         createSequencerConfig(sequencer1Id),
@@ -201,15 +203,20 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       )
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (Some(sequencer1Id), sequencer1Host),
-            (Some(sequencer2Id), sequencer2Host),
+            configuredPeer(sequencer1Host),
+            configuredPeer(sequencer2Host),
           )
         )
       )
+
+    withNetworkStatus(
+      (Some(sequencer1Id), Some(sequencer1Host)),
+      (Some(sequencer2Id), Some(sequencer2Host)),
+    )
 
     val result = reconciler.diffDsoRulesWithTopology().futureValue
     result should be(empty)
@@ -232,11 +239,11 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       )
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (Some(sequencer1Id), sequencer1Host)
+            configuredPeer(sequencer1Host)
           )
         )
       )
@@ -266,20 +273,24 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       ),
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (Some(sequencer1Id), sequencer1Host)
+            configuredPeer(sequencer1Host)
           )
         )
       )
+
+    withNetworkStatus(
+      (Some(sequencer1Id), Some(sequencer1Host))
+    )
 
     val result = reconciler.diffDsoRulesWithTopology().futureValue
     result should be(empty)
   }
 
-  it should "keep sequencer that does not have a sequencer id in the peer info yet and is returned by scan" in {
+  it should "keep a configured peer whose endpoint is still advertised by scan" in {
     withConfiguredDsoSequencers(
       Seq(
         createSequencerConfig(sequencer1Id)
@@ -294,11 +305,11 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       )
     )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (None, sequencer1Host)
+            configuredPeer(sequencer1Host)
           )
         )
       )
@@ -306,27 +317,115 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
     reconciler.diffDsoRulesWithTopology().futureValue should be(empty)
   }
 
-  it should "remove sequencer that does not have a sequencer id in the peer info yet and is not returned by scan" in {
+  it should "remove a configured peer whose sequencer id is no longer in the dso, using the network status as a fallback" in {
     withConfiguredDsoSequencers(
       Seq(
-        createSequencerConfig(sequencer1Id)
+        createSequencerConfig(sequencer1Id),
+        createSequencerConfig(sequencer2Id),
       )
     )
 
-    withScanSequencers()
+    withScanSequencers(
+      BftSequencer(
+        serialId,
+        sequencer1Id,
+        sequencer1Host.url,
+      )
+    )
 
-    when(sequencerAdminConnection.listCurrentOutgoingPeerEndpoints())
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
       .thenReturn(
         Future.successful(
           Seq(
-            (None, sequencer1Host)
+            configuredPeer(sequencer1Host),
+            configuredPeer(sequencer3Host),
           )
         )
       )
 
+    withNetworkStatus(
+      (Some(sequencer1Id), Some(sequencer1Host)),
+      (Some(sequencer3Id), Some(sequencer3Host)),
+    )
+
     val result = reconciler.diffDsoRulesWithTopology().futureValue.loneElement
     result.toAdd should be(empty)
+    result.toRemove should contain only sequencer3Host
+  }
+
+  it should "replace a configured peer whose sequencer moved to a different endpoint, using the network status as a fallback" in {
+    withConfiguredDsoSequencers(
+      Seq(
+        createSequencerConfig(sequencer1Id),
+        createSequencerConfig(sequencer2Id),
+      )
+    )
+
+    val newSequencer1Host = createP2PEndpoint("newhost")
+
+    withScanSequencers(
+      BftSequencer(
+        serialId,
+        sequencer1Id,
+        newSequencer1Host.url,
+      )
+    )
+
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
+      .thenReturn(
+        Future.successful(
+          Seq(
+            configuredPeer(sequencer1Host)
+          )
+        )
+      )
+
+    withNetworkStatus(
+      (Some(sequencer1Id), Some(sequencer1Host))
+    )
+
+    val result = reconciler.diffDsoRulesWithTopology().futureValue.loneElement
+    result.toAdd.map(_.id) should contain only newSequencer1Host
     result.toRemove should contain only sequencer1Host
+  }
+
+  it should "keep a configured peer and log a warning when no sequencer id can be found for it in the network status" in {
+    withConfiguredDsoSequencers(
+      Seq(
+        createSequencerConfig(sequencer1Id),
+        createSequencerConfig(sequencer2Id),
+      )
+    )
+
+    withScanSequencers(
+      BftSequencer(
+        serialId,
+        sequencer1Id,
+        sequencer1Host.url,
+      )
+    )
+
+    when(sequencerAdminConnection.listConfiguredPeerEndpoints())
+      .thenReturn(
+        Future.successful(
+          Seq(
+            configuredPeer(sequencer1Host),
+            configuredPeer(sequencer2Host),
+          )
+        )
+      )
+
+    withNetworkStatus(
+      (Some(sequencer1Id), Some(sequencer1Host))
+    )
+
+    val result = loggerFactory.assertLogs(
+      reconciler.diffDsoRulesWithTopology().futureValue,
+      _.warningMessage should include(
+        s"Could not find a sequencer id for the configured peer endpoint ${sequencer2Host}"
+      ),
+    )
+    result should be(empty)
   }
 
   it should "do nothing if the sequencer is not initialized" in {
@@ -407,4 +506,13 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       transportSecurity = true,
     )
   }
+
+  private def configuredPeer(host: P2PEndpoint.Id): P2PEndpoint =
+    BftSequencer(serialId, selfSequencerId, host.url).peerId
+
+  private def withNetworkStatus(
+      entries: (Option[SequencerId], Option[P2PEndpoint.Id])*
+  ) =
+    when(sequencerAdminConnection.listCurrentPeerEndpoints())
+      .thenReturn(Future.successful(entries))
 }

--- a/project/ignore-patterns/canton-standalone-sv123-non-sv1-svs.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-sv123-non-sv1-svs.ignore.txt
@@ -1,3 +1,4 @@
 # Sequencer was offboarded
 The operation 'request current time' was not successful.*Outcome\(Left\(RequestInvalid\(Unregistered recipients: Set\(\), unregistered senders: Set\(SEQ::sv1::.*\)\)\)\)
+The operation 'request current time' was not successful.*Outcome\(Left\(RequestFailed\(No connection available\)\)\)
 Now retrying operation 'request current time'

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -192,4 +192,7 @@ Missing successor information for the following sequencers.*participant=alicePar
 # TODO(DACH-NY/cn-test-failures#7920) Remove once Canton is fixed
 loadVettedPackages.*mismatch between reference and current state.*Map\(\)
 
+# can happen during start-up
+Mempool received client request but this node is currently blacklisted, rejecting
+
 # Make sure to have a trailing newline


### PR DESCRIPTION
[bft]
[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
