### PR TITLE
feat: Add monitoring for cloud nat

### DIFF
--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -893,6 +893,135 @@
     "custom": true,
     "id": "",
     "inputs": {
+      "alertStrategy": {
+        "autoClose": "3600s",
+        "notificationChannelStrategies": [
+          {
+            "notificationChannelNames": [
+              null
+            ],
+            "renotifyInterval": "14400s"
+          }
+        ]
+      },
+      "combiner": "OR",
+      "conditions": [
+        {
+          "conditionPrometheusQueryLanguage": {
+            "duration": "0s",
+            "evaluationInterval": "30s",
+            "query": "sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource=\"nat_gateway\"}) > 0"
+          },
+          "displayName": "NAT allocation failed in mock"
+        }
+      ],
+      "displayName": "NAT allocation failed in mock",
+      "documentation": {
+        "content": "Cloud NAT failed to allocate IPs or ports for at least one VM in cluster mock. This typically indicates NAT IP or port exhaustion.",
+        "mimeType": "text/markdown",
+        "subject": "NAT allocation failed in mock"
+      },
+      "notificationChannels": [
+        null
+      ],
+      "userLabels": {
+        "cluster": "mock"
+      }
+    },
+    "name": "natAllocationFailedAlert",
+    "provider": "",
+    "type": "gcp:monitoring/alertPolicy:AlertPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "alertStrategy": {
+        "autoClose": "3600s",
+        "notificationChannelStrategies": [
+          {
+            "notificationChannelNames": [
+              null
+            ],
+            "renotifyInterval": "14400s"
+          }
+        ]
+      },
+      "combiner": "OR",
+      "conditions": [
+        {
+          "conditionPrometheusQueryLanguage": {
+            "duration": "0s",
+            "evaluationInterval": "30s",
+            "query": "sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource=\"nat_gateway\"}) > 0"
+          },
+          "displayName": "NAT dropped sent packets in mock"
+        }
+      ],
+      "displayName": "NAT dropped sent packets in mock",
+      "documentation": {
+        "content": "Cloud NAT is dropping outbound packets in cluster mock. This can be caused by NAT IP/port exhaustion (OUT_OF_RESOURCES) or endpoint independence conflicts (ENDPOINT_INDEPENDENCE_CONFLICT).",
+        "mimeType": "text/markdown",
+        "subject": "NAT dropped sent packets in mock"
+      },
+      "notificationChannels": [
+        null
+      ],
+      "userLabels": {
+        "cluster": "mock"
+      }
+    },
+    "name": "natDroppedSentPacketsAlert",
+    "provider": "",
+    "type": "gcp:monitoring/alertPolicy:AlertPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "alertStrategy": {
+        "autoClose": "3600s",
+        "notificationChannelStrategies": [
+          {
+            "notificationChannelNames": [
+              null
+            ],
+            "renotifyInterval": "14400s"
+          }
+        ]
+      },
+      "combiner": "OR",
+      "conditions": [
+        {
+          "conditionPrometheusQueryLanguage": {
+            "duration": "0s",
+            "evaluationInterval": "30s",
+            "query": "sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource=\"nat_gateway\"} / 64512) * 100) > 80"
+          },
+          "displayName": "NAT port usage high in mock"
+        }
+      ],
+      "displayName": "NAT port usage high in mock",
+      "documentation": {
+        "content": "Cloud NAT port usage exceeded 80% of the maximum for at least one NAT gateway in cluster mock. Consider increasing NAT IPs or ports per VM.",
+        "mimeType": "text/markdown",
+        "subject": "NAT port usage high in mock"
+      },
+      "notificationChannels": [
+        null
+      ],
+      "userLabels": {
+        "cluster": "mock"
+      }
+    },
+    "name": "natPortUsageAlert",
+    "provider": "",
+    "type": "gcp:monitoring/alertPolicy:AlertPolicy"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
       "length": 16,
       "overrideSpecial": "_%@",
       "special": true

--- a/cluster/pulumi/observability/src/config.ts
+++ b/cluster/pulumi/observability/src/config.ts
@@ -121,6 +121,11 @@ const MonitoringConfigSchema = z
           tolerance: z.number(),
         }),
         gcpQuotas: GcpQuotasConfigSchema,
+        natPortUsage: z
+          .object({
+            thresholdPercent: z.number().min(0).max(100),
+          })
+          .default({ thresholdPercent: 80 }),
         trafficBasedRewards: z.object({
           featuredAppRightsLimit: z.number(),
         }),
@@ -145,6 +150,12 @@ const MonitoringConfigSchema = z
 export const monitoringConfig = MonitoringConfigSchema.parse(clusterSubConfig('monitoring'));
 
 export type GcpQuotaAlertsConfig = z.infer<typeof GcpQuotasConfigSchema>;
+
+const NatPortUsageConfigSchema = z.object({
+  thresholdPercent: z.number().min(0).max(100),
+});
+
+export type NatPortUsageConfig = z.infer<typeof NatPortUsageConfigSchema>;
 
 const PrometheusConfigSchema = z.object({
   prometheus: z.object({

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -440,15 +440,28 @@ export function installGcpQuotaAlerts(
   });
 }
 
-export function installNatAllocationFailedAlert(
-  notificationChannel: gcp.monitoring.NotificationChannel
+export function installNatAlerts(
+  notificationChannel: gcp.monitoring.NotificationChannel,
+  natConfig: NatPortUsageConfig
 ): void {
-  new gcp.monitoring.AlertPolicy('natAllocationFailedAlert', {
+  const baseArgs: Pick<
+    gcp.monitoring.AlertPolicyArgs,
+    'alertStrategy' | 'combiner' | 'notificationChannels' | 'userLabels'
+  > = {
     alertStrategy: getAlertStrategy(notificationChannel),
     combiner: 'OR',
     notificationChannels: [notificationChannel.name],
-    displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
     userLabels: { cluster: CLUSTER_BASENAME },
+  };
+
+  const prometheusDefaults = {
+    duration: '0s',
+    evaluationInterval: '30s',
+  };
+
+  new gcp.monitoring.AlertPolicy('natAllocationFailedAlert', {
+    ...baseArgs,
+    displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
     documentation: {
       subject: `NAT allocation failed in ${CLUSTER_BASENAME}`,
       content: `Cloud NAT failed to allocate IPs or ports for at least one VM in cluster ${CLUSTER_BASENAME}. This typically indicates NAT IP or port exhaustion.`,
@@ -458,24 +471,16 @@ export function installNatAllocationFailedAlert(
       {
         displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: `sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0`,
-          duration: '0s',
-          evaluationInterval: '30s',
+          query: 'sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0',
+          ...prometheusDefaults,
         },
       },
     ],
   });
-}
 
-export function installNatDroppedSentPacketsAlert(
-  notificationChannel: gcp.monitoring.NotificationChannel
-): void {
   new gcp.monitoring.AlertPolicy('natDroppedSentPacketsAlert', {
-    alertStrategy: getAlertStrategy(notificationChannel),
-    combiner: 'OR',
-    notificationChannels: [notificationChannel.name],
+    ...baseArgs,
     displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
-    userLabels: { cluster: CLUSTER_BASENAME },
     documentation: {
       subject: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
       content: `Cloud NAT is dropping outbound packets in cluster ${CLUSTER_BASENAME}. This can be caused by NAT IP/port exhaustion (OUT_OF_RESOURCES) or endpoint independence conflicts (ENDPOINT_INDEPENDENCE_CONFLICT).`,
@@ -485,39 +490,28 @@ export function installNatDroppedSentPacketsAlert(
       {
         displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: `sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > 0`,
-          duration: '0s',
-          evaluationInterval: '30s',
+          query: 'sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > 0',
+          ...prometheusDefaults,
         },
       },
     ],
   });
-}
-
-export function installNatPortUsageAlert(
-  notificationChannel: gcp.monitoring.NotificationChannel,
-  natPortUsageConfig: NatPortUsageConfig
-): void {
-  const portUsageThresholdPercent = natPortUsageConfig.thresholdPercent;
 
   new gcp.monitoring.AlertPolicy('natPortUsageAlert', {
-    alertStrategy: getAlertStrategy(notificationChannel),
-    combiner: 'OR',
-    notificationChannels: [notificationChannel.name],
+    ...baseArgs,
     displayName: `NAT port usage high in ${CLUSTER_BASENAME}`,
-    userLabels: { cluster: CLUSTER_BASENAME },
     documentation: {
       subject: `NAT port usage high in ${CLUSTER_BASENAME}`,
-      content: `Cloud NAT port usage exceeded ${portUsageThresholdPercent}% of the maximum for at least one NAT gateway in cluster ${CLUSTER_BASENAME}. Consider increasing NAT IPs or ports per VM.`,
+      content: `Cloud NAT port usage exceeded ${natConfig.thresholdPercent}% of the maximum for at least one NAT gateway in cluster ${CLUSTER_BASENAME}. Consider increasing NAT IPs or ports per VM.`,
       mimeType: 'text/markdown',
     },
     conditions: [
       {
         displayName: `NAT port usage high in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: `sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource="nat_gateway"} / 64512) * 100) > ${portUsageThresholdPercent}`,
-          duration: '0s',
-          evaluationInterval: '30s',
+          query: `sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource="nat_gateway"} / 64512) * 100) > ${natConfig.thresholdPercent}`,
+          // 64512 is the maximum number of ports per IP for Cloud NAT, as documented here: https://docs.cloud.google.com/nat/docs/ports-and-addresses#ports
+          ...prometheusDefaults,
         },
       },
     ],

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -471,7 +471,8 @@ export function installNatAlerts(
       {
         displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: 'sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0',
+          query:
+            'sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0',
           ...prometheusDefaults,
         },
       },
@@ -490,7 +491,8 @@ export function installNatAlerts(
       {
         displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: 'sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > 0',
+          query:
+            'sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > 0',
           ...prometheusDefaults,
         },
       },

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -10,7 +10,7 @@ import {
 } from '@canton-network/splice-pulumi-common';
 
 import { slackAlertNotificationChannel, slackToken } from './alertings';
-import { type GcpQuotaAlertsConfig, monitoringConfig } from './config';
+import { type GcpQuotaAlertsConfig, monitoringConfig, type NatPortUsageConfig } from './config';
 
 const enableChaosMesh = config.envFlag('ENABLE_CHAOS_MESH');
 
@@ -434,6 +434,90 @@ export function installGcpQuotaAlerts(
             > ${quotaUsageThreshold}
           `,
           ...windowSettings,
+        },
+      },
+    ],
+  });
+}
+
+export function installNatAllocationFailedAlert(
+  notificationChannel: gcp.monitoring.NotificationChannel
+): void {
+  new gcp.monitoring.AlertPolicy('natAllocationFailedAlert', {
+    alertStrategy: getAlertStrategy(notificationChannel),
+    combiner: 'OR',
+    notificationChannels: [notificationChannel.name],
+    displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
+    userLabels: { cluster: CLUSTER_BASENAME },
+    documentation: {
+      subject: `NAT allocation failed in ${CLUSTER_BASENAME}`,
+      content: `Cloud NAT failed to allocate IPs or ports for at least one VM in cluster ${CLUSTER_BASENAME}. This typically indicates NAT IP or port exhaustion.`,
+      mimeType: 'text/markdown',
+    },
+    conditions: [
+      {
+        displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
+        conditionPrometheusQueryLanguage: {
+          query: `sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0`,
+          duration: '0s',
+          evaluationInterval: '30s',
+        },
+      },
+    ],
+  });
+}
+
+export function installNatDroppedSentPacketsAlert(
+  notificationChannel: gcp.monitoring.NotificationChannel
+): void {
+  new gcp.monitoring.AlertPolicy('natDroppedSentPacketsAlert', {
+    alertStrategy: getAlertStrategy(notificationChannel),
+    combiner: 'OR',
+    notificationChannels: [notificationChannel.name],
+    displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
+    userLabels: { cluster: CLUSTER_BASENAME },
+    documentation: {
+      subject: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
+      content: `Cloud NAT is dropping outbound packets in cluster ${CLUSTER_BASENAME}. This can be caused by NAT IP/port exhaustion (OUT_OF_RESOURCES) or endpoint independence conflicts (ENDPOINT_INDEPENDENCE_CONFLICT).`,
+      mimeType: 'text/markdown',
+    },
+    conditions: [
+      {
+        displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
+        conditionPrometheusQueryLanguage: {
+          query: `sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > 0`,
+          duration: '0s',
+          evaluationInterval: '30s',
+        },
+      },
+    ],
+  });
+}
+
+export function installNatPortUsageAlert(
+  notificationChannel: gcp.monitoring.NotificationChannel,
+  natPortUsageConfig: NatPortUsageConfig
+): void {
+  const portUsageThresholdPercent = natPortUsageConfig.thresholdPercent;
+
+  new gcp.monitoring.AlertPolicy('natPortUsageAlert', {
+    alertStrategy: getAlertStrategy(notificationChannel),
+    combiner: 'OR',
+    notificationChannels: [notificationChannel.name],
+    displayName: `NAT port usage high in ${CLUSTER_BASENAME}`,
+    userLabels: { cluster: CLUSTER_BASENAME },
+    documentation: {
+      subject: `NAT port usage high in ${CLUSTER_BASENAME}`,
+      content: `Cloud NAT port usage exceeded ${portUsageThresholdPercent}% of the maximum for at least one NAT gateway in cluster ${CLUSTER_BASENAME}. Consider increasing NAT IPs or ports per VM.`,
+      mimeType: 'text/markdown',
+    },
+    conditions: [
+      {
+        displayName: `NAT port usage high in ${CLUSTER_BASENAME}`,
+        conditionPrometheusQueryLanguage: {
+          query: `sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource="nat_gateway"} / 64512) * 100) > ${portUsageThresholdPercent}`,
+          duration: '0s',
+          evaluationInterval: '30s',
         },
       },
     ],

--- a/cluster/pulumi/observability/src/index.ts
+++ b/cluster/pulumi/observability/src/index.ts
@@ -10,6 +10,9 @@ import {
   installCloudSQLMaintenanceUpdateAlerts,
   installCloudSqlTxIdUtilizationAlert,
   installClusterMaintenanceUpdateAlerts,
+  installNatAllocationFailedAlert,
+  installNatDroppedSentPacketsAlert,
+  installNatPortUsageAlert,
   installGcpLoggingAlerts,
   installGcpQuotaAlerts,
   installLoggedSecretsAlerts,
@@ -53,5 +56,8 @@ if (enableAlerts && !clusterIsResetPeriodically) {
     }
     installGcpQuotaAlerts(notificationChannel, monitoringConfig.alerting.alerts.gcpQuotas);
     installCloudSqlTxIdUtilizationAlert(notificationChannel);
+    installNatAllocationFailedAlert(notificationChannel);
+    installNatDroppedSentPacketsAlert(notificationChannel);
+    installNatPortUsageAlert(notificationChannel, monitoringConfig.alerting.alerts.natPortUsage);
   }
 }

--- a/cluster/pulumi/observability/src/index.ts
+++ b/cluster/pulumi/observability/src/index.ts
@@ -10,9 +10,7 @@ import {
   installCloudSQLMaintenanceUpdateAlerts,
   installCloudSqlTxIdUtilizationAlert,
   installClusterMaintenanceUpdateAlerts,
-  installNatAllocationFailedAlert,
-  installNatDroppedSentPacketsAlert,
-  installNatPortUsageAlert,
+  installNatAlerts,
   installGcpLoggingAlerts,
   installGcpQuotaAlerts,
   installLoggedSecretsAlerts,
@@ -56,8 +54,6 @@ if (enableAlerts && !clusterIsResetPeriodically) {
     }
     installGcpQuotaAlerts(notificationChannel, monitoringConfig.alerting.alerts.gcpQuotas);
     installCloudSqlTxIdUtilizationAlert(notificationChannel);
-    installNatAllocationFailedAlert(notificationChannel);
-    installNatDroppedSentPacketsAlert(notificationChannel);
-    installNatPortUsageAlert(notificationChannel, monitoringConfig.alerting.alerts.natPortUsage);
+    installNatAlerts(notificationChannel, monitoringConfig.alerting.alerts.natPortUsage);
   }
 }


### PR DESCRIPTION
I made IP usage alert configurable w/ 80% default (I'd like to avoid it being noisy).
I'm running with the assumption that [we're using 1 IP per NAT GW](https://docs.cloud.google.com/nat/docs/ports-and-addresses#ports) (which probably maybe is correct AFAICT)

Fixes #5757 