### PR TITLE
helm, info, status: Increase threshold for sequencer acknowledgments

### DIFF
--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -12,7 +12,7 @@ SV_THRESHOLD="${SV_THRESHOLD:-600}"
 MEDIATOR_THRESHOLD="${MEDIATOR_THRESHOLD:-900}"
 SCAN_THRESHOLD_ROUNDS="${SCAN_THRESHOLD_ROUNDS:-900}"
 SCAN_THRESHOLD_SNAPSHOT="${SCAN_THRESHOLD_SNAPSHOT:-14400}" # 4 hours
-SEQUENCER_THRESHOLD="${SEQUENCER_THRESHOLD:-1800}" # Sequencer acknowledgments are irregular, so we use a higher threshold here
+SEQUENCER_THRESHOLD="${SEQUENCER_THRESHOLD:-2520}" # 42 minutes, Sequencer acknowledgments are irregular, so we use a higher threshold here
 
 CURL_TIMEOUT="${CURL_TIMEOUT:-15}"
 


### PR DESCRIPTION
Increase the default threshold from 30 to 42 minutes to reduce false negatives (primarily on TestNet).

Here is a relevant graph for TestNet:
<img width="2795" height="1363" alt="Screenshot from 2026-07-06 14-41-41" src="https://github.com/user-attachments/assets/22939041-4b3a-4d23-804c-8530a1f9d0e2" />
