### PR TITLE
Enable cantonbft for resource intensive and wall clock tests by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,8 +126,7 @@ jobs:
     with:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-resource-intensive.log'
-      start_canton_options: -we
-      pre_sbt_cmd: "export SPLICE_USE_CANTON_BFT_SEQUENCER=1"
+      start_canton_options: -w
       parallelism: 2
       test_name: resource-intensive
       commit_sha: ${{ inputs.commit_sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,8 @@ jobs:
     with:
       runs_on: self-hosted-k8s-x-large
       test_names_file: 'test-full-class-names-resource-intensive.log'
-      start_canton_options: -w
+      start_canton_options: -we
+      pre_sbt_cmd: "export SPLICE_USE_CANTON_BFT_SEQUENCER=1"
       parallelism: 2
       test_name: resource-intensive
       commit_sha: ${{ inputs.commit_sha }}
@@ -210,29 +211,12 @@ jobs:
     with:
       runs_on: self-hosted-k8s-large
       test_names_file: 'test-full-class-names.log'
-      start_canton_options: -w
+      start_canton_options: -we
       # TODO(DACH-NY/canton-network-node#10912) Investigate why things got slower
-      parallelism: 11
+      parallelism: 10
       test_name: wall-clock-time
       with_gcp_creds: true
-      skip_if_commit_tag: "bft"
-      commit_sha: ${{ inputs.commit_sha }}
-      daml_base_version: ${{ inputs.daml_base_version }}
-      protocol_version: ${{ inputs.protocol_version }}
-      oss_only: ${{ inputs.oss_only }}
-    secrets: inherit
-
-  scala_test_wall_clock_time_bft:
-    uses: ./.github/workflows/build.scala_test.yml
-    with:
-      runs_on: self-hosted-k8s-x-large
-      test_names_file: 'test-full-class-names.log'
-      start_canton_options: -we
-      parallelism: 10
-      test_name: wall-clock-time-bft
-      with_gcp_creds: true
-      pre_sbt_cmd: "export SPLICE_USE_BFT_SEQUENCER=1"
-      run_if_commit_tag: 'bft'
+      pre_sbt_cmd: "export SPLICE_USE_CANTON_BFT_SEQUENCER=1"
       commit_sha: ${{ inputs.commit_sha }}
       daml_base_version: ${{ inputs.daml_base_version }}
       protocol_version: ${{ inputs.protocol_version }}

--- a/TESTING.md
+++ b/TESTING.md
@@ -240,11 +240,11 @@ If you wish to extend our testing topology please also consult [this README](/ap
 
 If you want to run the integration tests locally with the new Canton bft, canton must be started with the `-e` flag.
 This can be done by running `./start-canton.sh -we`.
-Furthermore the integration test must run with the `SPLICE_USE_BFT_SEQUENCER` environment variable set to `true`.
+Furthermore the integration test must run with the `SPLICE_USE_CANTON_BFT_SEQUENCER` environment variable set to `true`.
 Eg of test run:
 
 ```bash
- SPLICE_USE_BFT_SEQUENCER=1 sbt 'apps-app/ testOnly org.lfdecentralizedtrust.splice.integration.tests.SvDevNetReonboardingIntegrationTest'
+ SPLICE_USE_CANTON_BFT_SEQUENCER=1 sbt 'apps-app/ testOnly org.lfdecentralizedtrust.splice.integration.tests.SvDevNetReonboardingIntegrationTest'
 ```
 
 ### Testing App Behaviour Outside of Tests Without Running Bundle

--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/ConfigTransforms.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/config/ConfigTransforms.scala
@@ -44,7 +44,7 @@ import scala.io.Source
 
 object ConfigTransforms {
 
-  val IsTheCantonSequencerBFTEnabled: Boolean = sys.env.contains("SPLICE_USE_BFT_SEQUENCER")
+  val IsTheCantonSequencerBFTEnabled: Boolean = sys.env.contains("SPLICE_USE_CANTON_BFT_SEQUENCER")
 
   sealed abstract class ConfigurableApp extends Product with Serializable
 

--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -147,7 +147,9 @@ Timeout 10 seconds expired, but readers are still active. Shutting down forcibly
 # SV-4 is the late-joining SV in this test. Ignoring here as otherwise we would need to suppress logs during the whole
 # SV-4 initialization.
 Not publishing sequencer successor as we are past upgrade time.*LsuNodeInitializer:LsuIntegrationTest.*SV=sv4
-Skipping processing of.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest.*SV=sv4
+Skipping processing of.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest
+The operation 'update sequencing parameters' failed with a non-retryable error.*TOPOLOGY_INVALID_SYNCHRONIZER.*ParticipantAdminConnection:LsuIntegrationTest
+The operation 'processTaskWithRetry' failed with a non-retryable error.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest
 
 # Roll forward tests
 Failed to connect to scan of FAILED Seed URL.*RollForwardLsu.*IntegrationTest


### PR DESCRIPTION
[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
