### PR TITLE
[static] Revert "enable configuring more app node pools to counter go…

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -5,17 +5,11 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-    - minNodes: 0
+      minNodes: 0
       # A high max-nodes by default to support large deployments and hard migrations
       # Should be set to a lower number (currently 8) on CI clusters that do neither of those.
       maxNodes: 20
       nodeType: n4d-standard-16
-    # Second, Intel based, pool is supposed to address GCloud compute resource issues.
-    - minNodes: 0
-      # A high max-nodes by default to support large deployments and hard migrations
-      # Should be set to a lower number (currently 8) on CI clusters that do neither of those.
-      maxNodes: 20
-      nodeType: n4-standard-16
     infra:
       minNodes: 1
       maxNodes: 3

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -283,7 +283,9 @@ infra:
 cluster:
   nodePools:
     apps:
-      nodeType: n4d-standard-16
+      nodeType: n2-standard-16
+    hyperdiskApps:
+      nodeType: c4-standard-16
       minNodes: 0
       maxNodes: 1
 gha:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -15,12 +15,9 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4d-standard-16'
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4-standard-16'
+      maxNodes: 20
+      minNodes: 0
+      nodeType: 'n4d-standard-16'
     infra:
       maxNodes: 3
       minNodes: 1

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -15,12 +15,9 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4d-standard-16'
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4-standard-16'
+      maxNodes: 20
+      minNodes: 0
+      nodeType: 'n4d-standard-16'
     infra:
       maxNodes: 3
       minNodes: 1

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -15,12 +15,9 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4d-standard-16'
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4-standard-16'
+      maxNodes: 20
+      minNodes: 0
+      nodeType: 'n4d-standard-16'
     infra:
       maxNodes: 3
       minNodes: 1

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -15,12 +15,9 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4d-standard-16'
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4-standard-16'
+      maxNodes: 20
+      minNodes: 0
+      nodeType: 'n4d-standard-16'
     infra:
       maxNodes: 3
       minNodes: 1

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -15,12 +15,9 @@ cluster:
     enabledForInfra: true
   nodePools:
     apps:
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4d-standard-16'
-      - maxNodes: 20
-        minNodes: 0
-        nodeType: 'n4-standard-16'
+      maxNodes: 20
+      minNodes: 0
+      nodeType: 'n4d-standard-16'
     infra:
       maxNodes: 3
       minNodes: 1

--- a/cluster/expected/cluster/expected.json
+++ b/cluster/expected/cluster/expected.json
@@ -18,7 +18,43 @@
           "cn_apps": "hyperdisk"
         },
         "loggingVariant": "DEFAULT",
-        "machineType": "n4d-standard-16",
+        "machineType": "c4-standard-16",
+        "taints": [
+          {
+            "effect": "NO_SCHEDULE",
+            "key": "cn_apps",
+            "value": "true"
+          }
+        ]
+      },
+      "nodeLocations": [
+        "europe-west6-z"
+      ]
+    },
+    "name": "cn-apps-node-pool-hd",
+    "provider": "",
+    "type": "gcp:container/nodePool:NodePool"
+  },
+  {
+    "custom": true,
+    "id": "",
+    "inputs": {
+      "autoscaling": {
+        "maxNodeCount": 20,
+        "minNodeCount": 0
+      },
+      "cluster": "cn-mocknet",
+      "initialNodeCount": 0,
+      "nodeConfig": {
+        "bootDisk": {
+          "diskType": "hyperdisk-balanced",
+          "sizeGb": 100
+        },
+        "labels": {
+          "cn_apps": "hyperdisk"
+        },
+        "loggingVariant": "DEFAULT",
+        "machineType": "n2-standard-16",
         "taints": [
           {
             "effect": "NO_SCHEDULE",

--- a/cluster/pulumi/cluster/src/config.ts
+++ b/cluster/pulumi/cluster/src/config.ts
@@ -12,12 +12,8 @@ const GkeNodePoolConfigSchema = z.object({
 const GkeClusterConfigSchema = z.object({
   nodePools: z.object({
     infra: GkeNodePoolConfigSchema,
-    apps: z
-      .array(GkeNodePoolConfigSchema)
-      .nonempty()
-      // Single value config is for backwards compatibility. If we stop using it we may remove it.
-      .or(GkeNodePoolConfigSchema)
-      .transform(value => (Array.isArray(value) ? value : [value])),
+    apps: GkeNodePoolConfigSchema,
+    hyperdiskApps: GkeNodePoolConfigSchema.optional(),
   }),
 });
 

--- a/cluster/pulumi/cluster/src/nodePools.ts
+++ b/cluster/pulumi/cluster/src/nodePools.ts
@@ -12,7 +12,21 @@ export function installNodePools(): void {
     ? `projects/${GCP_PROJECT}/locations/${config.requireEnv('CLOUDSDK_COMPUTE_ZONE')}/clusters/${clusterName}`
     : clusterName;
 
-  installAppsNodePools(cluster, gkeClusterConfig.nodePools.apps);
+  const nodepoolLocation = config.optionalEnv('CLOUDSDK_HYPERDISK_NODEPOOL_COMPUTE_ZONE');
+
+  if (gkeClusterConfig.nodePools.hyperdiskApps) {
+    hyperdiskNodePool(cluster, gkeClusterConfig.nodePools.hyperdiskApps, nodepoolLocation);
+  }
+  const appsNodePoolConfig = gkeClusterConfig.nodePools.apps;
+
+  if (
+    hyperdiskSupportConfig.hyperdiskSupport.enabled &&
+    !hyperdiskSupportConfig.hyperdiskSupport.migrating
+  ) {
+    hyperdiskNodePool(cluster, appsNodePoolConfig, nodepoolLocation);
+  } else {
+    appsNodePool(cluster, appsNodePoolConfig);
+  }
 
   const nodePoolComputeZone = config.optionalEnv('CLOUDSDK_NODEPOOL_COMPUTE_ZONE');
   new gcp.container.NodePool(
@@ -66,27 +80,8 @@ export function installNodePools(): void {
     },
   });
 }
-
-function installAppsNodePools(
-  cluster: string,
-  configs: Array<GkeNodePoolConfig>
-): Array<gcp.container.NodePool> {
-  const nodepoolLocation = config.optionalEnv('CLOUDSDK_HYPERDISK_NODEPOOL_COMPUTE_ZONE');
-  return configs.map(config => {
-    if (hyperdiskSupportConfig.hyperdiskSupport.enabled) {
-      return hyperdiskNodePool(cluster, config, nodepoolLocation);
-    } else {
-      return appsNodePool(cluster, config);
-    }
-  });
-}
-
-function hyperdiskNodePool(
-  cluster: string,
-  config: GkeNodePoolConfig,
-  location?: string
-): gcp.container.NodePool {
-  return new gcp.container.NodePool('cn-apps-node-pool-hd', {
+function hyperdiskNodePool(cluster: string, config: GkeNodePoolConfig, location?: string) {
+  new gcp.container.NodePool('cn-apps-node-pool-hd', {
     cluster,
     nodeConfig: {
       machineType: config.nodeType,
@@ -114,11 +109,8 @@ function hyperdiskNodePool(
     },
   });
 }
-function appsNodePool(
-  cluster: string,
-  appsNodePoolConfig: GkeNodePoolConfig
-): gcp.container.NodePool {
-  return new gcp.container.NodePool('cn-apps-node-pool', {
+function appsNodePool(cluster: string, appsNodePoolConfig: GkeNodePoolConfig) {
+  new gcp.container.NodePool('cn-apps-node-pool', {
     cluster,
     nodeConfig: {
       machineType: appsNodePoolConfig.nodeType,

--- a/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
+++ b/cluster/pulumi/common-sv/src/synchronizer/cometbft.ts
@@ -109,6 +109,18 @@ export function installCometBftNode(
       pvcName: `cometbft-migration-${migrationId}-hd-pvc`,
       volumeStorageClass: standardStorageClassName,
     };
+    if (hyperdiskSupportConfig.hyperdiskSupport.migrating) {
+      const { dataSource } = createVolumeSnapshot({
+        resourceName: `cometbft-${xns.logicalName}-migration-${migrationId}-snapshot`,
+        snapshotName: `cometbft-migration-${migrationId}-pd-snapshot`,
+        namespace: xns.logicalName,
+        pvcName: `global-domain-${migrationId}-cometbft-cometbft-data`,
+      });
+      hyperdiskDbValues = {
+        ...hyperdiskDbValues,
+        dataSource,
+      };
+    }
   }
 
   const cometbftChartValues = _.mergeWith(cometBftValues, {

--- a/cluster/pulumi/common/src/config/hyperdiskSupportConfig.ts
+++ b/cluster/pulumi/common/src/config/hyperdiskSupportConfig.ts
@@ -9,6 +9,8 @@ const HyperdiskSupportConfigSchema = z.object({
     .object({
       enabled: z.boolean(),
       enabledForInfra: z.boolean(),
+      migrating: z.boolean().default(false),
+      migratingInfra: z.boolean().default(false),
     })
     .strict(),
 });

--- a/cluster/pulumi/common/src/postgres.ts
+++ b/cluster/pulumi/common/src/postgres.ts
@@ -413,7 +413,20 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
     const supportsHyperdisk = useInfraAffinityAndTolerations
       ? hyperdiskSupportConfig.hyperdiskSupport.enabledForInfra
       : hyperdiskSupportConfig.hyperdiskSupport.enabled;
+    const migratingToHyperdisk = useInfraAffinityAndTolerations
+      ? hyperdiskSupportConfig.hyperdiskSupport.migratingInfra
+      : hyperdiskSupportConfig.hyperdiskSupport.migrating;
 
+    let hyperdiskMigrationValues = {};
+    if (supportsHyperdisk && migratingToHyperdisk) {
+      const { dataSource } = createVolumeSnapshot({
+        resourceName: `pg-data-${xns.logicalName}-${instanceName}-snapshot`,
+        snapshotName: `pg-data-${instanceName}-snapshot`,
+        namespace: xns.logicalName,
+        pvcName: `pg-data-${instanceName}-0`,
+      });
+      hyperdiskMigrationValues = { dataSource };
+    }
     const pg = installSpliceHelmChart(
       xns,
       instanceName,
@@ -427,6 +440,7 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
             ? {
                 volumeStorageClass: standardStorageClassName,
                 pvcTemplateName: 'pg-data-hd',
+                ...hyperdiskMigrationValues,
               }
             : {}),
         },
@@ -438,7 +452,11 @@ export class SplicePostgres extends pulumi.ComponentResource implements Postgres
       {
         aliases: [{ name: logicalNameAlias, type: 'kubernetes:helm.sh/v3:Release' }],
         dependsOn: [passwordSecret],
-        ...(spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges
+        ...((supportsHyperdisk &&
+          // during the migration we first delete the stateful set, which keeps the old pvcs (stateful sets always keep the pvcs), and then recreate with the new pvcs
+          // the stateful sets are immutable so they need to be recreated to force the change of the pvcs
+          migratingToHyperdisk) ||
+        spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges
           ? {
               replaceOnChanges: ['*'],
               deleteBeforeReplace: true,

--- a/cluster/pulumi/multi-validator/src/postgres.ts
+++ b/cluster/pulumi/multi-validator/src/postgres.ts
@@ -36,6 +36,19 @@ export function installPostgres(
   }
   const config = multiValidatorConfig!;
 
+  let hyperdiskMigrationValues = {};
+  if (
+    hyperdiskSupportConfig.hyperdiskSupport.enabled &&
+    hyperdiskSupportConfig.hyperdiskSupport.migrating
+  ) {
+    const { dataSource } = createVolumeSnapshot({
+      resourceName: `pg-data-${xns.logicalName}-${name}-snapshot`,
+      snapshotName: `pg-data-${name}-snapshot`,
+      namespace: xns.logicalName,
+      pvcName: `pg-data-${name}-0`,
+    });
+    hyperdiskMigrationValues = { dataSource };
+  }
   return installSpliceRunbookHelmChart(
     xns,
     name,
@@ -49,6 +62,7 @@ export function installPostgres(
           ? {
               volumeStorageClass: standardStorageClassName,
               pvcTemplateName: 'pg-data-hd',
+              ...hyperdiskMigrationValues,
             }
           : {}),
       },
@@ -58,7 +72,11 @@ export function installPostgres(
     activeVersion,
     {
       dependsOn: [passwordSecret, ...dependsOn],
-      ...(spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges
+      ...((hyperdiskSupportConfig.hyperdiskSupport.enabled &&
+        // during the migration we first delete the stateful set, which keeps the old pvcs, and the recreate with the new pvcs
+        // the stateful sets are immutable so they need to be recreated to force the change of the pvcs
+        hyperdiskSupportConfig.hyperdiskSupport.migrating) ||
+      spliceConfig.pulumiProjectConfig.replacePostgresStatefulSetOnChanges
         ? {
             replaceOnChanges: ['*'],
             deleteBeforeReplace: true,

--- a/cluster/pulumi/observability/src/observability.ts
+++ b/cluster/pulumi/observability/src/observability.ts
@@ -107,6 +107,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
   const namespaceName = namespace.logicalName;
   const postgres = installPostgres(namespace);
   const adminPassword = grafanaKeysFromSecret().adminPassword;
+  const migrationSnapshots = getVolumeSnapshotsForHyperdiskMigration(namespaceName);
   const prometheusStack = new k8s.helm.v3.Release(
     'observability-metrics',
     {
@@ -206,6 +207,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
                       storage: '5Gi',
                     },
                   },
+                  ...(migrationSnapshots.alertManager ? migrationSnapshots.alertManager : {}),
                 },
               },
             },
@@ -267,6 +269,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
                       storage: prometheusConfig.storageSize,
                     },
                   },
+                  ...(migrationSnapshots.prometheus ? migrationSnapshots.prometheus : {}),
                 },
               },
             },
@@ -392,7 +395,7 @@ export function configureObservability(namespace: ExactNamespace): pulumi.Resour
             type: 'Recreate',
           },
           persistence: {
-            enabled: true,
+            enabled: !hyperdiskSupportConfig.hyperdiskSupport.migratingInfra,
             type: 'pvc',
             accessModes: ['ReadWriteOnce'],
             size: '5Gi',
@@ -1184,4 +1187,34 @@ function installPostgres(namespace: ExactNamespace): SplicePostgres {
     undefined, // chart version
     true // useInfraAffinityAndTolerations
   );
+}
+
+function getVolumeSnapshotsForHyperdiskMigration(namespaceName: string) {
+  if (
+    hyperdiskSupportConfig.hyperdiskSupport.enabledForInfra &&
+    hyperdiskSupportConfig.hyperdiskSupport.migratingInfra
+  ) {
+    const { dataSource: prometheusDataSource } = createVolumeSnapshot({
+      resourceName: `prometheus-hd-migration-snapshot`,
+      snapshotName: `prometheus-migration-snapshot`,
+      namespace: namespaceName,
+      pvcName: `prometheus-prometheus-prometheus-db-prometheus-prometheus-prometheus-0`,
+    });
+    const { dataSource: alertManagerDataSource } = createVolumeSnapshot({
+      resourceName: `alertmanager-hd-migration-snapshot`,
+      snapshotName: `alertmanager-migration-snapshot`,
+      namespace: namespaceName,
+      pvcName: `alertmanager-prometheus-alertmanager-db-alertmanager-prometheus-alertmanager-0`,
+    });
+    return {
+      prometheus: {
+        dataSource: prometheusDataSource,
+      },
+      alertManager: {
+        dataSource: alertManagerDataSource,
+      },
+    };
+  } else {
+    return {};
+  }
 }

--- a/cluster/pulumi/validator-runbook/src/partyAllocator.ts
+++ b/cluster/pulumi/validator-runbook/src/partyAllocator.ts
@@ -20,6 +20,18 @@ export function installPartyAllocator(
   config: PartyAllocatorConfig,
   dependsOn: CnInput<pulumi.Resource>[]
 ): InstalledHelmChart {
+  const dataSource =
+    hyperdiskSupportConfig.hyperdiskSupport.enabled &&
+    hyperdiskSupportConfig.hyperdiskSupport.migrating
+      ? {
+          dataSource: createVolumeSnapshot({
+            resourceName: `party-allocator-keys-migration-snapshot`,
+            snapshotName: `party-allocator-keys-snapshot`,
+            namespace: xns.logicalName,
+            pvcName: `party-allocator-keys`,
+          }).dataSource,
+        }
+      : {};
   return installSpliceHelmChart(
     xns,
     'party-allocator',
@@ -43,6 +55,7 @@ export function installPartyAllocator(
         name: hyperdiskSupportConfig.hyperdiskSupport.enabled
           ? 'party-allocator-keys-hd-pvc'
           : 'party-allocator-keys',
+        ...dataSource,
       },
     },
     activeVersion,


### PR DESCRIPTION
…ogle resource issues (#6245)"

This reverts commit 111e0a83f0100e670cbdab801c12b06fe94d9b9a.



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
