### PR TITLE
Actually use the validator1 additionalEnvVvars setting

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -9,6 +9,10 @@ validator1:
     cron: "0 /10 * * * ?" # Run every 10min
     maxDuration: "5m"
     retention: "30d"
+  validatorApp:
+    additionalEnvVars:
+      - name: ADDITIONAL_CONFIG_VALIDATOR1_DUMMY_NAME
+        value: ADDITIONAL_CONFIG_VALIDATOR1_DUMMY_NAME
 multiValidator:
   postgresPvcSize: '100Gi'
   # Dummy values for testing

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -1019,6 +1019,12 @@
       "values": {
         "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
         "value": {
+          "additionalEnvVars": [
+            {
+              "name": "ADDITIONAL_CONFIG_VALIDATOR1_DUMMY_NAME",
+              "value": "ADDITIONAL_CONFIG_VALIDATOR1_DUMMY_NAME"
+            }
+          ],
           "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1",
           "additionalUsers": [],
           "affinity": {

--- a/cluster/pulumi/validator1/src/validator1.ts
+++ b/cluster/pulumi/validator1/src/validator1.ts
@@ -128,6 +128,7 @@ export async function installValidator1(
     deduplicationDuration: validator1Config?.deduplicationDuration,
     disableAuth: validator1Config?.disableAuth,
     version: activeVersion,
+    additionalEnvVars: validator1Config?.validatorApp?.additionalEnvVars,
   });
   installIngress(xns, installSplitwell, decentralizedSynchronizerMigrationConfig);
 


### PR DESCRIPTION
Seems to have been broken forever.

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
