### PR TITLE
[ci] feat: change storage URL

### DIFF
--- a/nix/cometbft-driver-sources.json
+++ b/nix/cometbft-driver-sources.json
@@ -1,5 +1,5 @@
 {
     "version": "3.5.0-snapshot.20260203.17930.0.v8a849517-stable-20260204",
-    "sha256": "sha256:1hznsi7a73qfxwhbdscyz3imfc8i4hbnarc0zb41iryzki3h2f7j",
+    "sha256": "sha256:1cz316hp1km248dc9f7kj8v3n0h6mxy7ss7nbkkdvvviljj1b6a7",
     "image_sha256": "4fee6d941517fa25634bef416d439ec2fd61c81765478d210cca12f9df91d803"
 }

--- a/nix/cometbft-driver-sources.json
+++ b/nix/cometbft-driver-sources.json
@@ -1,5 +1,5 @@
 {
     "version": "3.5.0-snapshot.20260203.17930.0.v8a849517-stable-20260204",
-    "sha256": "sha256:1cz316hp1km248dc9f7kj8v3n0h6mxy7ss7nbkkdvvviljj1b6a7",
+    "sha256": "sha256:1hznsi7a73qfxwhbdscyz3imfc8i4hbnarc0zb41iryzki3h2f7j",
     "image_sha256": "4fee6d941517fa25634bef416d439ec2fd61c81765478d210cca12f9df91d803"
 }

--- a/nix/cometbft-driver.nix
+++ b/nix/cometbft-driver.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "cometbft-driver";
   version = sources.version;
   src = builtins.fetchurl {
-    url = "https://digitalasset.jfrog.io/artifactory/canton-drivers/com/digitalasset/canton/drivers/canton-drivers/${sources.version}/canton-drivers-${sources.version}.tar.gz";
+    url = "https://storage.googleapis.com/da-images-public/canton-drivers/canton-drivers-${version}.tar.gz";
     sha256 = sources.sha256;
   };
   dontUnpack = true;


### PR DESCRIPTION
Source cometbft drivers from public google bucket rather than artifactory

## Rationale

We want to remove all dependency on artifactory for the splcie repo, so all artifacts are pulled from ghcr.io or public locations