### PR TITLE
Source cometbft drivers from public google bucket rather than artifactory

### DIFF
--- a/nix/cometbft-driver.nix
+++ b/nix/cometbft-driver.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "cometbft-driver";
   version = sources.version;
   src = builtins.fetchurl {
-    url = "https://digitalasset.jfrog.io/artifactory/canton-drivers/com/digitalasset/canton/drivers/canton-drivers/${sources.version}/canton-drivers-${sources.version}.tar.gz";
+    url = "https://storage.googleapis.com/da-images-public/canton-drivers/canton-drivers-${sources.version}.tar.gz";
     sha256 = sources.sha256;
   };
   dontUnpack = true;


### PR DESCRIPTION
Source cometbft drivers from public google bucket rather than artifactory

## Rationale

We want to remove all dependency on artifactory for the splcie repo, so all artifacts are pulled from ghcr.io or public locations