### PR TITLE
Backport log ignores

### DIFF
--- a/project/ignore-patterns/canton-standalone-sv123-non-sv1-svs.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-sv123-non-sv1-svs.ignore.txt
@@ -1,3 +1,4 @@
 # Sequencer was offboarded
 The operation 'request current time' was not successful.*Outcome\(Left\(RequestInvalid\(Unregistered recipients: Set\(\), unregistered senders: Set\(SEQ::sv1::.*\)\)\)\)
+The operation 'request current time' was not successful.*Outcome\(Left\(RequestFailed\(No connection available\)\)\)
 Now retrying operation 'request current time'

--- a/project/ignore-patterns/canton-standalone-sv123-reonboarding.ignore.txt
+++ b/project/ignore-patterns/canton-standalone-sv123-reonboarding.ignore.txt
@@ -22,3 +22,5 @@ Sequencing result message timed out
 Could not send a time-advancing message
 
 Request failed for sequencer.* Is the server running.*Causes: finishConnect.*
+
+SEQUENCER_SUBMISSION_REQUEST_MALFORMED.*MED::sv4SvReonboarding.*is not part of the mediator group

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -192,4 +192,10 @@ Missing successor information for the following sequencers.*participant=alicePar
 # TODO(DACH-NY/cn-test-failures#7920) Remove once Canton is fixed
 loadVettedPackages.*mismatch between reference and current state.*Map\(\)
 
+# can happen during start-up
+Mempool received client request but this node is currently blacklisted, rejecting
+
+# This should go away with latest Canton bump
+Flyway upgrade recommended: PostgreSQL 18.4 is newer than this version of Flyway and support has not been tested. The latest supported version of PostgreSQL is 17
+
 # Make sure to have a trailing newline

--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -133,6 +133,10 @@ Circuit breaker .* tripped after .* failures.*(Command|Splice)CircuitBreakerTest
 # This is more likely in test code where we run multiple apps against the same database, all trying to create the same index.
 Index .* should be created and is invalid, dropping it
 
+# TODO(#4738) - remove this
+processTaskWithRetry failed with an unknown exception, not retrying.*SqlIndexInitializationTrigger.*PSQLException: ERROR: tuple concurrently updated
+Skipping processing of.*due to unexpected failure.*SqlIndexInitializationTrigger.*PSQLException: ERROR: tuple concurrently updated
+
 # Injected errors in s3Mock
 Simulated S3 error
 
@@ -147,7 +151,9 @@ Timeout 10 seconds expired, but readers are still active. Shutting down forcibly
 # SV-4 is the late-joining SV in this test. Ignoring here as otherwise we would need to suppress logs during the whole
 # SV-4 initialization.
 Not publishing sequencer successor as we are past upgrade time.*LsuNodeInitializer:LsuIntegrationTest.*SV=sv4
-Skipping processing of.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest.*SV=sv4
+Skipping processing of.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest
+The operation 'update sequencing parameters' failed with a non-retryable error.*TOPOLOGY_INVALID_SYNCHRONIZER.*ParticipantAdminConnection:LsuIntegrationTest
+The operation 'processTaskWithRetry' failed with a non-retryable error.*TOPOLOGY_INVALID_SYNCHRONIZER.*ReconcileSequencingParametersTrigger:LsuIntegrationTest
 
 # Roll forward tests
 Failed to connect to scan of FAILED Seed URL.*RollForwardLsu.*IntegrationTest


### PR DESCRIPTION
[static]

fixes https://github.com/DACH-NY/cn-test-failures/issues/9108

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
