### PR TITLE
Log providers with wrong vetting state

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ProcessRewardsTrigger.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/automation/delegatebased/ProcessRewardsTrigger.scala
@@ -169,6 +169,11 @@ private[delegatebased] abstract class ProcessRewardsTriggerBase(
       }
       .map { supportByProvider =>
         val withWrongVettingState = supportByProvider.collect { case (provider, false) => provider }
+        if (withWrongVettingState.nonEmpty) {
+          logger.info(
+            s"Providers with wrong vetting state for batch: ${withWrongVettingState.mkString(", ")}"
+          )
+        }
         damlSetOf(withWrongVettingState)
       }
   }


### PR DESCRIPTION
Ideally the list is empty most of the time, and there's some overlap with the metric for hidden coupons, but logging the list before exercising the choice helps with debugging.