### PR TITLE
add a log ignore for transaction rejection in an unvetting race scenario

### DIFF
--- a/project/ignore-patterns/canton_before_shutdown.ignore.txt
+++ b/project/ignore-patterns/canton_before_shutdown.ignore.txt
@@ -1,0 +1,2 @@
+# TODO(DACH-NY/cn-test-failures#9055) can be removed when it's no longer a warn.
+LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*Rejected transaction due to a failed model conformance check: UnvettedPackages.*

--- a/project/ignore-patterns/canton_before_shutdown.ignore.txt
+++ b/project/ignore-patterns/canton_before_shutdown.ignore.txt
@@ -1,2 +1,0 @@
-# TODO(DACH-NY/cn-test-failures#9055) can be removed when it's no longer a warn.
-LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*Rejected transaction due to a failed model conformance check: UnvettedPackages.*

--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -198,4 +198,7 @@ Mempool received client request but this node is currently blacklisted, rejectin
 # This should go away with latest Canton bump
 Flyway upgrade recommended: PostgreSQL 18.4 is newer than this version of Flyway and support has not been tested. The latest supported version of PostgreSQL is 17
 
+# TODO(DACH-NY/cn-test-failures#9055) can be removed when it's no longer a warn.
+LOCAL_VERDICT_FAILED_MODEL_CONFORMANCE_CHECK.*Rejected transaction due to a failed model conformance check: UnvettedPackages.*
+
 # Make sure to have a trailing newline


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9108