### PR TITLE
Redesign JSON diff accordion on governance config forms and reviews

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
@@ -80,7 +80,11 @@ describe('Set Amulet Config Rules Form', () => {
       { timeout: 1000 }
     );
 
-    expect(screen.getByTestId('json-diffs-details')).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByTestId('json-diffs-details')).not.toBeVisible();
   });
 
   test(
@@ -275,6 +279,8 @@ describe('Set Amulet Config Rules Form', () => {
     await user.click(submitButton);
 
     expect(screen.getByText(PROPOSAL_SUMMARY_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText('JSON')).not.toBeInTheDocument();
+    expect(screen.getByTestId('json-diff-toggle')).toHaveTextContent('Show JSON');
   });
 
   test('should show error on form if submission fails', { timeout: 10000 }, async () => {
@@ -376,19 +382,22 @@ describe('Set Amulet Config Rules Form', () => {
     const c2Input = screen.getByTestId('config-field-transferConfigTransferFeeInitialRate');
     await user.type(c2Input, '9.99');
 
-    const jsonDiffs = screen.getByText('JSON Diffs');
-    expect(jsonDiffs).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
 
-    await user.click(jsonDiffs);
-    expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
+    await user.click(jsonDiffsToggle);
+    expect(await screen.findByTestId('config-diffs-display')).toBeVisible();
+    expect(jsonDiffsToggle).toHaveTextContent('Hide JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'true');
 
     const reviewButton = screen.getByTestId('submit-button');
     await waitFor(async () => {
       expect(reviewButton.getAttribute('disabled')).toBeNull();
     });
 
-    expect(jsonDiffs).toBeInTheDocument();
-    await user.click(jsonDiffs);
+    expect(jsonDiffsToggle).toBeInTheDocument();
+    await user.click(jsonDiffsToggle);
     expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
   });
 

--- a/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
@@ -73,7 +73,11 @@ describe('Set DSO Config Rules Form', () => {
       /Unable to find an element/
     );
 
-    expect(screen.getByTestId('json-diffs-details')).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByTestId('json-diffs-details')).not.toBeVisible();
   });
 
   test('should render errors when submit button is clicked on new form', async () => {
@@ -264,6 +268,8 @@ describe('Set DSO Config Rules Form', () => {
     await user.click(submitButton);
 
     expect(screen.getByText('Proposal Summary')).toBeInTheDocument();
+    expect(screen.queryByText('JSON')).not.toBeInTheDocument();
+    expect(screen.getByTestId('json-diff-toggle')).toHaveTextContent('Show JSON');
   });
 
   test('should show error on form if submission fails', async () => {
@@ -374,19 +380,22 @@ describe('Set DSO Config Rules Form', () => {
     const c2Input = screen.getByTestId('config-field-voteCooldownTime');
     await user.type(c2Input, '9999');
 
-    const jsonDiffs = screen.getByText('JSON Diffs');
-    expect(jsonDiffs).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
 
-    await user.click(jsonDiffs);
-    expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
+    await user.click(jsonDiffsToggle);
+    expect(await screen.findByTestId('config-diffs-display')).toBeVisible();
+    expect(jsonDiffsToggle).toHaveTextContent('Hide JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'true');
 
     const reviewButton = screen.getByTestId('submit-button');
     await waitFor(async () => {
       expect(reviewButton.getAttribute('disabled')).not.toBeInTheDocument();
     });
 
-    expect(jsonDiffs).toBeInTheDocument();
-    await user.click(jsonDiffs);
+    expect(jsonDiffsToggle).toBeInTheDocument();
+    await user.click(jsonDiffsToggle);
     expect(await screen.findByTestId('config-diffs-display')).toBeInTheDocument();
   });
 

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -417,7 +417,11 @@ describe('Proposal Details Content', () => {
     const maxNumInputsNewValue = within(changes[1]).getByTestId('config-change-new-value');
     expect(maxNumInputsNewValue.textContent).toBe('4');
 
-    expect(screen.getByTestId('json-diffs-details')).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('JSON')).not.toBeInTheDocument();
+    expect(screen.getByTestId('json-diffs-details')).not.toBeVisible();
   });
 
   test('should render dso rules config changes', () => {
@@ -498,7 +502,11 @@ describe('Proposal Details Content', () => {
     );
     expect(dsoNumUnclaimedRewardsThresholdNewValue.textContent).toBe('20');
 
-    expect(screen.getByTestId('json-diffs-details')).toBeInTheDocument();
+    const jsonDiffsToggle = screen.getByTestId('json-diff-toggle');
+    expect(jsonDiffsToggle).toHaveTextContent('Show JSON');
+    expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('JSON')).not.toBeInTheDocument();
+    expect(screen.getByTestId('json-diffs-details')).not.toBeVisible();
   });
 });
 

--- a/apps/sv/frontend/src/components/forms/FormLayout.tsx
+++ b/apps/sv/frontend/src/components/forms/FormLayout.tsx
@@ -24,7 +24,7 @@ export const FormLayout: React.FC<FormLayoutProps> = props => {
           alignItems: 'center',
         }}
       >
-        <Box sx={{ minWidth: '80%' }}>
+        <Box sx={{ width: '80%', maxWidth: '100%', minWidth: 0, boxSizing: 'border-box' }}>
           <form
             onSubmit={e => {
               e.preventDefault();
@@ -32,7 +32,11 @@ export const FormLayout: React.FC<FormLayoutProps> = props => {
               form.handleSubmit();
             }}
           >
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 8 }}>{children}</Box>
+            <Box
+              sx={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%', minWidth: 0 }}
+            >
+              {children}
+            </Box>
           </form>
         </Box>
       </Paper>

--- a/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
@@ -293,7 +293,7 @@ export const SetAmuletConfigRulesForm: () => JSX.Element = () => {
         </>
       )}
 
-      <JsonDiffAccordion>
+      <JsonDiffAccordion variant={showConfirmation ? 'review' : 'form'}>
         {amuletConfigToCompareWith && amuletConfigToCompareWith[1] ? (
           <PrettyJsonDiff
             changes={{

--- a/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
@@ -309,7 +309,7 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
         </>
       )}
 
-      <JsonDiffAccordion>
+      <JsonDiffAccordion variant={showConfirmation ? 'review' : 'form'}>
         {dsoConfigToCompareWith[1] ? (
           <PrettyJsonDiff
             changes={{

--- a/apps/sv/frontend/src/components/governance/JsonDiffAccordion.tsx
+++ b/apps/sv/frontend/src/components/governance/JsonDiffAccordion.tsx
@@ -5,8 +5,6 @@ import { useState } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Box, Collapse, Typography } from '@mui/material';
 
-const JSON_TOGGLE_ACCENT = '#F3FF97';
-
 const JSON_DIFF_FRAME_BACKGROUND = '#363636';
 
 const JSON_DIFF_VIEWPORT_MAX_HEIGHT = '320px';
@@ -42,7 +40,8 @@ const toggleSx = {
   justifyContent: 'center',
   gap: '4px',
   borderRadius: '2px',
-  border: `1px solid ${JSON_TOGGLE_ACCENT}`,
+  border: '1px solid',
+  borderColor: 'secondary.main',
   bgcolor: 'transparent',
   cursor: 'pointer',
   margin: 0,
@@ -126,7 +125,7 @@ const jsonDiffViewportSx = {
 
   '& [data-testid="stringify-display"]': {
     ...jsonDiffMonoSx,
-    color: '#FFF',
+    color: 'common.white',
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
     overflowWrap: 'break-word',
@@ -134,7 +133,7 @@ const jsonDiffViewportSx = {
 
   [`${DIFF} .jsondiffpatch-delta`]: {
     ...jsonDiffMonoSx,
-    color: '#FFF',
+    color: 'common.white',
     display: 'block',
     maxWidth: '100%',
     boxSizing: 'border-box',
@@ -175,7 +174,7 @@ const jsonDiffViewportSx = {
   [`${DIFF} li.jsondiffpatch-added:not(:last-child) > .jsondiffpatch-value::after, ${DIFF} li.jsondiffpatch-deleted:not(:last-child) > .jsondiffpatch-value::after, ${DIFF} li.jsondiffpatch-modified:not(:last-child) > .jsondiffpatch-right-value::after`]:
     {
       content: '","',
-      color: '#FFF',
+      color: 'common.white',
       padding: 0,
     },
 
@@ -208,7 +207,7 @@ const JsonToggleButton: React.FC<JsonToggleButtonProps> = ({ expanded, onClick }
     </Typography>
     <ExpandMoreIcon
       sx={{
-        color: JSON_TOGGLE_ACCENT,
+        color: 'secondary.main',
         fontSize: 16,
         width: 16,
         height: 16,

--- a/apps/sv/frontend/src/components/governance/JsonDiffAccordion.tsx
+++ b/apps/sv/frontend/src/components/governance/JsonDiffAccordion.tsx
@@ -1,22 +1,270 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
+import { Box, Collapse, Typography } from '@mui/material';
 
-export const JsonDiffAccordion = ({ children }: { children: React.ReactNode }): JSX.Element => {
+const JSON_TOGGLE_ACCENT = '#F3FF97';
+
+const JSON_DIFF_FRAME_BACKGROUND = '#363636';
+
+const JSON_DIFF_VIEWPORT_MAX_HEIGHT = '320px';
+
+const jsonDiffMonoSx = {
+  fontFamily: '"Source Code Pro", monospace',
+  fontSize: '14px',
+  fontWeight: 400,
+  lineHeight: '26px',
+  fontFeatureSettings: "'liga' off, 'clig' off",
+} as const;
+
+const DIFF = '& [data-testid="config-diffs-display"]';
+
+const jsonSectionTitleSx = {
+  color: 'common.white',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: '22px',
+  textTransform: 'uppercase',
+  margin: 0,
+  display: 'block',
+} as const;
+
+const toggleSx = {
+  display: 'inline-flex',
+  boxSizing: 'border-box',
+  height: '28px',
+  minWidth: '108px',
+  padding: '2px 8px',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '4px',
+  borderRadius: '2px',
+  border: `1px solid ${JSON_TOGGLE_ACCENT}`,
+  bgcolor: 'transparent',
+  cursor: 'pointer',
+  margin: 0,
+  minHeight: 0,
+  lineHeight: 0,
+  flexShrink: 0,
+};
+
+const toggleLabelSx = {
+  color: 'common.white',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 14,
+  fontWeight: 400,
+  lineHeight: '22px',
+  margin: 0,
+  display: 'block',
+};
+
+const jsonDiffFrameSx = {
+  display: 'flex',
+  padding: '12px 24px',
+  justifyContent: 'flex-start',
+  alignItems: 'stretch',
+  gap: '10px',
+  alignSelf: 'stretch',
+  width: '100%',
+  minWidth: 0,
+  maxWidth: '100%',
+  boxSizing: 'border-box',
+  backgroundColor: JSON_DIFF_FRAME_BACKGROUND,
+} as const;
+
+const collapseSx = {
+  width: '100%',
+  minWidth: 0,
+  maxWidth: '100%',
+  alignSelf: 'stretch',
+  overflow: 'hidden',
+  '& .MuiCollapse-wrapperInner': {
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+  },
+} as const;
+
+const jsonDiffHeaderRowSx = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  alignSelf: 'stretch',
+  width: '100%',
+} as const;
+
+const jsonDiffRootSx = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+  alignSelf: 'stretch',
+  width: '100%',
+  minWidth: 0,
+  maxWidth: '100%',
+  overflow: 'hidden',
+} as const;
+
+const jsonDiffViewportSx = {
+  width: '100%',
+  minWidth: 0,
+  maxHeight: JSON_DIFF_VIEWPORT_MAX_HEIGHT,
+  overflowY: 'auto',
+  overflowX: 'hidden',
+
+  '& > div': {
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+  },
+
+  '& [data-testid="stringify-display"], & [data-testid="config-diffs-display"]': {
+    width: '100%',
+  },
+
+  '& [data-testid="stringify-display"]': {
+    ...jsonDiffMonoSx,
+    color: '#FFF',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    overflowWrap: 'break-word',
+  },
+
+  [`${DIFF} .jsondiffpatch-delta`]: {
+    ...jsonDiffMonoSx,
+    color: '#FFF',
+    display: 'block',
+    maxWidth: '100%',
+    boxSizing: 'border-box',
+  },
+
+  [`${DIFF} > .jsondiffpatch-delta`]: {
+    padding: 0,
+  },
+
+  [`${DIFF} .jsondiffpatch-delta pre`]: {
+    ...jsonDiffMonoSx,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    overflowWrap: 'break-word',
+  },
+
+  // Unchanged rows inherit grey onto keys and values (do not set color on pre/property-name directly).
+  [`${DIFF} .jsondiffpatch-unchanged, ${DIFF} .jsondiffpatch-movedestination`]: {
+    color: 'gray',
+  },
+
+  [`${DIFF} .jsondiffpatch-delta ul, ${DIFF} ul.jsondiffpatch-delta`]: {
+    listStyleType: 'none',
+    padding: '0 0 0 20px',
+    margin: 0,
+  },
+
+  [`${DIFF} li`]: {
+    display: 'block',
+  },
+
+  [`${DIFF} .jsondiffpatch-added .jsondiffpatch-value pre::after, ${DIFF} .jsondiffpatch-modified .jsondiffpatch-right-value pre::after, ${DIFF} .jsondiffpatch-deleted .jsondiffpatch-value pre::after`]:
+    {
+      content: '""',
+      padding: 0,
+    },
+
+  [`${DIFF} li.jsondiffpatch-added:not(:last-child) > .jsondiffpatch-value::after, ${DIFF} li.jsondiffpatch-deleted:not(:last-child) > .jsondiffpatch-value::after, ${DIFF} li.jsondiffpatch-modified:not(:last-child) > .jsondiffpatch-right-value::after`]:
+    {
+      content: '","',
+      color: '#FFF',
+      padding: 0,
+    },
+
+  [`${DIFF} .jsondiffpatch-modified .jsondiffpatch-right-value`]: {
+    marginLeft: 0,
+  },
+  [`${DIFF} .jsondiffpatch-modified .jsondiffpatch-right-value::before`]: {
+    content: '" -> "',
+  },
+} as const;
+
+interface JsonToggleButtonProps {
+  expanded: boolean;
+  onClick: () => void;
+}
+
+const JsonToggleButton: React.FC<JsonToggleButtonProps> = ({ expanded, onClick }) => (
+  <Box
+    component="button"
+    type="button"
+    onClick={onClick}
+    aria-controls="json-diff-content"
+    aria-expanded={expanded}
+    id="json-diff-header"
+    data-testid="json-diff-toggle"
+    sx={toggleSx}
+  >
+    <Typography component="span" variant="inherit" sx={toggleLabelSx}>
+      {expanded ? 'Hide JSON' : 'Show JSON'}
+    </Typography>
+    <ExpandMoreIcon
+      sx={{
+        color: JSON_TOGGLE_ACCENT,
+        fontSize: 16,
+        width: 16,
+        height: 16,
+        display: 'block',
+        flexShrink: 0,
+        transform: expanded ? 'rotate(180deg)' : 'none',
+        transition: 'transform 0.2s',
+      }}
+    />
+  </Box>
+);
+
+export interface JsonDiffAccordionProps {
+  children: React.ReactNode;
+  /** `form` — JSON label left, toggle right; `review` — toggle only. */
+  variant?: 'form' | 'review';
+}
+
+export const JsonDiffAccordion: React.FC<JsonDiffAccordionProps> = ({
+  children,
+  variant = 'review',
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const toggle = (
+    <JsonToggleButton expanded={expanded} onClick={() => setExpanded(current => !current)} />
+  );
+
+  const content = (
+    <Collapse in={expanded} sx={collapseSx} unmountOnExit={false}>
+      <Box
+        id="json-diff-content"
+        data-testid="json-diffs-details"
+        sx={{
+          ...jsonDiffFrameSx,
+          // Remove frame from horizontal layout when collapsed; keep in DOM for tests.
+          display: expanded ? 'flex' : 'none',
+        }}
+      >
+        <Box sx={jsonDiffViewportSx}>{children}</Box>
+      </Box>
+    </Collapse>
+  );
+
   return (
-    <Box>
-      <Accordion elevation={0}>
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="json-diff-content"
-          id="json-diff-header"
-        >
-          <Typography variant="h6">JSON Diffs</Typography>
-        </AccordionSummary>
-        <AccordionDetails data-testid="json-diffs-details">{children}</AccordionDetails>
-      </Accordion>
+    <Box sx={{ ...jsonDiffRootSx, gap: variant === 'form' ? '14px' : '16px' }}>
+      {variant === 'form' ? (
+        <Box sx={jsonDiffHeaderRowSx}>
+          <Typography component="span" variant="inherit" sx={jsonSectionTitleSx}>
+            JSON
+          </Typography>
+          {toggle}
+        </Box>
+      ) : (
+        <Box sx={{ alignSelf: 'flex-start' }}>{toggle}</Box>
+      )}
+      {content}
     </Box>
   );
 };

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -247,7 +247,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
                 label="Proposed Changes"
                 value={<ConfigValuesChanges changes={proposalDetails.proposal.configChanges} />}
               />
-              <JsonDiffAccordion>
+              <JsonDiffAccordion variant="review">
                 {amuletConfigToCompareWith ? (
                   <PrettyJsonDiff
                     changes={{
@@ -268,7 +268,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
                 label="Proposed Changes"
                 value={<ConfigValuesChanges changes={proposalDetails.proposal.configChanges} />}
               />
-              <JsonDiffAccordion>
+              <JsonDiffAccordion variant="review">
                 {dsoConfigToCompareWith?.[1] ? (
                   <PrettyJsonDiff
                     changes={{


### PR DESCRIPTION
### Summary
- Replace full-width accordion header with Figma toggle chip (Show/Hide JSON)
- Style diff content panel: #363636 frame, Source Code Pro 14px/26px, scroll at 320px
- Add form vs review layout variants (JSON title + 14px gap vs toggle-only + 16px gap)
- Adjust tests to reflect component changes

Fixes #2660
Fixes #2661

Figma reference design: https://www.figma.com/design/sXdsHZtM5c7xXQWckd6Ob8/supervalidator?node-id=552-1899

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
