### PR TITLE
SV UI: support activity weights for GrantFeaturedAppRight

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -31,6 +31,7 @@ import org.openqa.selenium.support.ui.Select
 import org.slf4j.event.Level
 
 import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
 import java.util.Optional
 
 class SvFrontendIntegrationTest
@@ -1421,6 +1422,7 @@ class SvFrontendIntegrationTest
     "NEW UI: Grant and Revoke Featured App Right" in { implicit env =>
       val providerParty = sv3Backend.getDsoInfo().svParty
       val providerPartyId = providerParty.toProtoPrimitive
+      val activityWeight = BigDecimal("2.5")
 
       // First, create a Grant proposal for the provider.
       val grantProposalContractId = assertCreateProposal(
@@ -1428,6 +1430,10 @@ class SvFrontendIntegrationTest
         "grant-featured-app",
       ) { implicit webDriver =>
         fillOutTextField("grant-featured-app-idValue", providerPartyId)
+        inside(find(id("grant-featured-app-activityWeight"))) { case Some(element) =>
+          element.underlying.clear()
+          element.underlying.sendKeys(activityWeight.toString)
+        }
       }
 
       clue("vote the grant request to execution before creating revoke request") {
@@ -1463,7 +1469,11 @@ class SvFrontendIntegrationTest
         }
 
         eventually() {
-          sv1ScanBackend.lookupFeaturedAppRight(providerParty) shouldBe a[Some[?]]
+          val featuredAppRight = sv1ScanBackend.lookupFeaturedAppRight(providerParty)
+          featuredAppRight shouldBe a[Some[?]]
+          featuredAppRight.value.payload.activityWeight.toScala.map(
+            BigDecimal(_)
+          ) shouldBe Some(activityWeight)
         }
       }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -1430,10 +1430,7 @@ class SvFrontendIntegrationTest
         "grant-featured-app",
       ) { implicit webDriver =>
         fillOutTextField("grant-featured-app-idValue", providerPartyId)
-        inside(find(id("grant-featured-app-activityWeight"))) { case Some(element) =>
-          element.underlying.clear()
-          element.underlying.sendKeys(activityWeight.toString)
-        }
+        fillOutTextField("grant-featured-app-activityWeight", activityWeight.toString)
       }
 
       clue("vote the grant request to execution before creating revoke request") {

--- a/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
@@ -214,6 +214,141 @@ describe('Grant Featured App Form', () => {
 
     expect(screen.getByText(PROPOSAL_SUMMARY_TITLE)).toBeInTheDocument();
   });
+
+  test('activity weight is optional and is sent to backend as null when left blank', async () => {
+    let requestBody = '';
+    server.use(
+      http.post(`${svUrl}/v0/admin/sv/voterequest/create`, async ({ request }) => {
+        requestBody = await request.text();
+        return HttpResponse.json({});
+      })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <GrantRevokeFeaturedAppForm selectedAction="SRARC_GrantFeaturedAppRight" />
+      </Wrapper>
+    );
+
+    const activityWeightInput = screen.getByTestId('grant-featured-app-activityWeight');
+    expect(activityWeightInput.getAttribute('value')).toBe('');
+
+    const actionInput = screen.getByTestId('grant-featured-app-action');
+    const submitButton = screen.getByTestId('submit-button');
+
+    const summaryInput = screen.getByTestId('grant-featured-app-summary');
+    await user.type(summaryInput, 'Summary of the proposal');
+
+    const urlInput = screen.getByTestId('grant-featured-app-url');
+    await user.type(urlInput, 'https://example.com');
+
+    const providerInput = screen.getByTestId('grant-featured-app-idValue');
+    await user.type(providerInput, 'a-party-id::1014912492');
+
+    await user.click(activityWeightInput);
+
+    await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation
+
+    await waitFor(() => {
+      expect(screen.queryByText('Validating provider...')).not.toBeInTheDocument();
+    });
+
+    await waitFor(async () => {
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    await user.click(submitButton); // review proposal
+
+    expect(screen.getByTestId('grantRightActivityWeight-field').textContent).toBe('');
+
+    await user.click(submitButton); // submit proposal
+
+    await waitFor(() => {
+      expect(requestBody).toContain('"activityWeight":null');
+    });
+  });
+
+  test('should send explicit activity weight to backend when provided', async () => {
+    let requestBody = '';
+    server.use(
+      http.post(`${svUrl}/v0/admin/sv/voterequest/create`, async ({ request }) => {
+        requestBody = await request.text();
+        return HttpResponse.json({});
+      })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <GrantRevokeFeaturedAppForm selectedAction="SRARC_GrantFeaturedAppRight" />
+      </Wrapper>
+    );
+
+    const actionInput = screen.getByTestId('grant-featured-app-action');
+    const submitButton = screen.getByTestId('submit-button');
+
+    const summaryInput = screen.getByTestId('grant-featured-app-summary');
+    await user.type(summaryInput, 'Summary of the proposal');
+
+    const urlInput = screen.getByTestId('grant-featured-app-url');
+    await user.type(urlInput, 'https://example.com');
+
+    const providerInput = screen.getByTestId('grant-featured-app-idValue');
+    await user.type(providerInput, 'a-party-id::1014912492');
+
+    const activityWeightInput = screen.getByTestId('grant-featured-app-activityWeight');
+    await user.type(activityWeightInput, '2.5');
+
+    await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation
+
+    await waitFor(() => {
+      expect(screen.queryByText('Validating provider...')).not.toBeInTheDocument();
+    });
+
+    await waitFor(async () => {
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    await user.click(submitButton); // review proposal
+    await user.click(submitButton); // submit proposal
+
+    await waitFor(() => {
+      expect(requestBody).toContain('"activityWeight":"2.5"');
+    });
+  });
+
+  test('activity weight rejects negative numbers and more than 10 decimal places', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <GrantRevokeFeaturedAppForm selectedAction="SRARC_GrantFeaturedAppRight" />
+      </Wrapper>
+    );
+
+    const activityWeightInput = screen.getByTestId('grant-featured-app-activityWeight');
+    const activityWeightError = screen.getByTestId('grant-featured-app-activityWeight-error');
+
+    await user.type(activityWeightInput, '-1');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('Weight must be a valid non-negative number');
+    });
+
+    await user.clear(activityWeightInput);
+    await user.type(activityWeightInput, '1.1234567891');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('');
+    });
+
+    await user.clear(activityWeightInput);
+    await user.type(activityWeightInput, '1.12345678912');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('Weight can have at most 10 decimal places');
+    });
+  });
 });
 
 describe('Revoke Featured App Form', () => {

--- a/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
@@ -116,6 +116,7 @@ describe('Review Proposal Component', () => {
   test('should render review proposal component for feature application', () => {
     const actionName = 'Feature Application';
     const provider = 'Digital-Asset-Eng-2';
+    const activityWeight = '2.5';
 
     render(
       <ProposalSummary
@@ -126,6 +127,7 @@ describe('Review Proposal Component', () => {
         effectiveDate={effectiveDate}
         formType="grant-right"
         grantRight={provider}
+        activityWeight={activityWeight}
         onEdit={() => {}}
         onSubmit={() => {}}
       />
@@ -148,6 +150,11 @@ describe('Review Proposal Component', () => {
 
     expect(screen.getByTestId('grantRight-title').textContent).toBe('Provider Party ID');
     expect(screen.getByTestId('grantRight-field').textContent).toBe(provider);
+
+    expect(screen.getByTestId('grantRightActivityWeight-title').textContent).toBe(
+      'Activity Weight'
+    );
+    expect(screen.getByTestId('grantRightActivityWeight-field').textContent).toBe(activityWeight);
   });
 
   test('should render review proposal component for unfeature application', () => {

--- a/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
@@ -5,7 +5,11 @@ import { ActionRequiringConfirmation } from '@daml.js/splice-dso-governance/lib/
 import { useSearchParams } from 'react-router';
 import { useDsoInfos } from '../../contexts/SvContext';
 import dayjs from 'dayjs';
-import { createProposalActions, getInitialExpiration } from '../../utils/governance';
+import {
+  activityWeightToOptional,
+  createProposalActions,
+  getInitialExpiration,
+} from '../../utils/governance';
 import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
 import { useAppForm } from '../../hooks/form';
 import { useStore } from '@tanstack/react-form';
@@ -14,6 +18,7 @@ import { CommonProposalFormData } from '../../utils/types';
 import { ContractId } from '@daml/types';
 import { FeaturedAppRight } from '@daml.js/splice-amulet/lib/Splice/Amulet';
 import {
+  validateActivityWeight,
   validateEffectiveDate,
   validateExpiration,
   validateExpiryEffectiveDate,
@@ -38,6 +43,7 @@ interface ExtraFormField {
   idValue: ProviderId;
   partyId: ProviderId;
   rightCid: FeaturedAppRightId;
+  activityWeight: string;
 }
 
 export type GrantRevokeFeaturedAppFormData = CommonProposalFormData & ExtraFormField;
@@ -137,6 +143,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
     idValue: '',
     partyId: '',
     rightCid: '',
+    activityWeight: '',
   };
 
   const form = useAppForm({
@@ -152,7 +159,10 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
           value: {
             dsoAction: {
               tag: 'SRARC_GrantFeaturedAppRight',
-              value: { provider: formValues.idValue, activityWeight: null },
+              value: {
+                provider: formValues.idValue,
+                activityWeight: activityWeightToOptional(formValues.activityWeight),
+              },
             },
           },
         }),
@@ -215,6 +225,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
             effectiveDate={form.state.values.effectiveDate.effectiveDate}
             formType={reviewFormKey}
             grantRight={form.state.values.idValue}
+            activityWeight={form.state.values.activityWeight}
             providerPartyId={form.state.values.partyId}
             revokeRight={form.state.values.rightCid}
             onEdit={() => setShowConfirmation(false)}
@@ -242,6 +253,24 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                     title={providerFieldTitle}
                     id={`${testIdPrefix}-idValue`}
                     subtitle={field.state.meta.isValidating ? 'Validating provider...' : undefined}
+                  />
+                )}
+              </form.AppField>
+            )}
+
+            {formAction === 'SRARC_GrantFeaturedAppRight' && (
+              <form.AppField
+                name="activityWeight"
+                validators={{
+                  onBlur: ({ value }) => validateActivityWeight(value),
+                  onChange: ({ value }) => validateActivityWeight(value),
+                }}
+              >
+                {field => (
+                  <field.TextField
+                    title="Activity Weight"
+                    id={`${testIdPrefix}-activityWeight`}
+                    subtitle="Optional. Leave blank to use the default weight"
                   />
                 )}
               </form.AppField>

--- a/apps/sv/frontend/src/components/forms/formValidators.ts
+++ b/apps/sv/frontend/src/components/forms/formValidators.ts
@@ -66,6 +66,19 @@ export const rewardAmountSchema = z
     { message: 'Amount can have at most 10 decimal places' }
   );
 
+export const activityWeightSchema = z
+  .string()
+  .refine(v => v === '' || /^\d+(\.\d+)?$/.test(v), {
+    message: 'Weight must be a valid non-negative number',
+  })
+  .refine(
+    v => {
+      const dotIndex = v.indexOf('.');
+      return dotIndex === -1 || v.length - dotIndex - 1 <= 10;
+    },
+    { message: 'Weight can have at most 10 decimal places' }
+  );
+
 export const validateWeight = (value: string): string | false => {
   const result = svWeightSchema.safeParse(value);
   return result.success ? false : result.error.issues[0].message;
@@ -73,6 +86,11 @@ export const validateWeight = (value: string): string | false => {
 
 export const validateRewardAmount = (value: string): string | false => {
   const result = rewardAmountSchema.safeParse(value);
+  return result.success ? false : result.error.issues[0].message;
+};
+
+export const validateActivityWeight = (value: string): string | false => {
+  const result = activityWeightSchema.safeParse(value);
   return result.success ? false : result.error.issues[0].message;
 };
 

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -218,7 +218,10 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
           )}
 
           {proposalDetails.action === 'SRARC_GrantFeaturedAppRight' && (
-            <FeatureAppSection provider={proposalDetails.proposal.provider} />
+            <FeatureAppSection
+              provider={proposalDetails.proposal.provider}
+              activityWeight={proposalDetails.proposal.activityWeight}
+            />
           )}
 
           {proposalDetails.action === 'SRARC_RevokeFeaturedAppRight' && (
@@ -576,9 +579,10 @@ const OffboardMemberSection = ({ memberPartyId }: OffboardMemberSectionProps) =>
 
 interface FeatureAppSectionProps {
   provider: string;
+  activityWeight: string;
 }
 
-const FeatureAppSection = ({ provider }: FeatureAppSectionProps) => {
+const FeatureAppSection = ({ provider, activityWeight }: FeatureAppSectionProps) => {
   return (
     <Box
       id="proposal-details-feature-app-section"
@@ -595,6 +599,12 @@ const FeatureAppSection = ({ provider }: FeatureAppSectionProps) => {
           />
         }
         labelId="proposal-details-feature-app-label"
+      />
+      <DetailItem
+        label="Activity Weight"
+        value={activityWeight}
+        labelId="proposal-details-feature-app-activity-weight-label"
+        valueId="proposal-details-feature-app-activity-weight-value"
       />
     </Box>
   );

--- a/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
@@ -31,6 +31,7 @@ type ProposalSummaryProps = BaseProposalSummaryProps &
     | {
         formType: 'grant-right';
         grantRight: string;
+        activityWeight: string;
       }
     | {
         formType: 'revoke-right';
@@ -105,7 +106,14 @@ export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
         )}
 
         {formType === 'grant-right' && (
-          <ProposalField id="grantRight" title="Provider Party ID" value={props.grantRight} />
+          <>
+            <ProposalField id="grantRight" title="Provider Party ID" value={props.grantRight} />
+            <ProposalField
+              id="grantRightActivityWeight"
+              title="Activity Weight"
+              value={props.activityWeight}
+            />
+          </>
         )}
 
         {formType === 'revoke-right' && (

--- a/apps/sv/frontend/src/components/votes/actions/GrantFeaturedAppRight.tsx
+++ b/apps/sv/frontend/src/components/votes/actions/GrantFeaturedAppRight.tsx
@@ -8,12 +8,14 @@ import { FormControl, Stack, TextField, Typography } from '@mui/material';
 import { ActionRequiringConfirmation } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules/module';
 
 import { useDsoInfos } from '../../../contexts/SvContext';
+import { activityWeightToOptional } from '../../../utils/governance';
 
 const GrantFeaturedAppRight: React.FC<{
   chooseAction: (action: ActionRequiringConfirmation) => void;
 }> = ({ chooseAction }) => {
   const dsoInfosQuery = useDsoInfos();
   const [provider, setProvider] = useState<string>('');
+  const [activityWeight, setActivityWeight] = useState<string>('');
 
   if (dsoInfosQuery.isLoading) {
     return <Loading />;
@@ -23,17 +25,26 @@ const GrantFeaturedAppRight: React.FC<{
     return <p>Error: {JSON.stringify(dsoInfosQuery.error)}</p>;
   }
 
-  function setProviderAction(provider: string) {
-    setProvider(provider);
+  function chooseGrantAction(provider: string, activityWeight: string) {
     chooseAction({
       tag: 'ARC_DsoRules',
       value: {
         dsoAction: {
           tag: 'SRARC_GrantFeaturedAppRight',
-          value: { provider: provider, activityWeight: null },
+          value: { provider: provider, activityWeight: activityWeightToOptional(activityWeight) },
         },
       },
     });
+  }
+
+  function setProviderAction(provider: string) {
+    setProvider(provider);
+    chooseGrantAction(provider, activityWeight);
+  }
+
+  function setActivityWeightAction(activityWeight: string) {
+    setActivityWeight(activityWeight);
+    chooseGrantAction(provider, activityWeight);
   }
 
   return (
@@ -44,6 +55,14 @@ const GrantFeaturedAppRight: React.FC<{
           id="set-application-provider"
           onChange={e => setProviderAction(e.target.value)}
           value={provider}
+        />
+      </FormControl>
+      <Typography variant="h6">Activity Weight</Typography>
+      <FormControl sx={{ marginRight: '32px', flexGrow: '1' }}>
+        <TextField
+          id="set-application-activity-weight"
+          onChange={e => setActivityWeightAction(e.target.value)}
+          value={activityWeight}
         />
       </FormControl>
     </Stack>

--- a/apps/sv/frontend/src/utils/governance.ts
+++ b/apps/sv/frontend/src/utils/governance.ts
@@ -134,7 +134,10 @@ export function buildProposal(action: ActionRequiringConfirmation, dsoInfo?: Dso
           dsoAction.value.expiresAt
         );
       case 'SRARC_GrantFeaturedAppRight':
-        return createGrantFeatureAppProposal(dsoAction.value.provider);
+        return createGrantFeatureAppProposal(
+          dsoAction.value.provider,
+          dsoAction.value.activityWeight ?? ''
+        );
       case 'SRARC_RevokeFeaturedAppRight':
         return createRevokeFeatureAppProposal(dsoAction.value.rightCid);
       case 'SRARC_SetConfig':
@@ -156,9 +159,13 @@ function createOffboardMemberProposal(memberToOffboard: string): OffBoardMemberP
   return { memberToOffboard };
 }
 
-function createGrantFeatureAppProposal(provider: string): FeatureAppProposal {
+function createGrantFeatureAppProposal(
+  provider: string,
+  activityWeight: string
+): FeatureAppProposal {
   return {
     provider: provider,
+    activityWeight: activityWeight,
   };
 }
 
@@ -272,6 +279,10 @@ export function formatBasisPoints(value: string): string {
 export function getSvRewardWeight(svs: [string, SvInfo][], svPartyId: string): string {
   const svInfo = svs.find(sv => sv[0] === svPartyId);
   return svInfo ? svInfo[1].svRewardWeight : '';
+}
+
+export function activityWeightToOptional(weight: string): string | null {
+  return weight.trim() === '' ? null : weight;
 }
 
 export function buildPendingConfigFields(

--- a/apps/sv/frontend/src/utils/types.ts
+++ b/apps/sv/frontend/src/utils/types.ts
@@ -22,6 +22,7 @@ export interface OffBoardMemberProposal {
 
 export interface FeatureAppProposal {
   provider: string;
+  activityWeight: string;
 }
 
 export interface UnfeatureAppProposal {

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -31,3 +31,7 @@
       provision yourself; a managed service such as Amazon RDS or Google Cloud SQL is
       recommended. Follow the `migration guide <https://docs.canton.network/global-synchronizer/production-operations/validator-postgres-migration>`__ to move the data
       of an existing node before that date.
+
+   - SV app
+
+     - Add support for specifying weight in ``GrantFeaturedAppRight`` governance voting UI.


### PR DESCRIPTION
Fixes #6237 

Adds support for specifying weight (decimal value) in GrantFeaturedAppRight UI flow.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
