### PR TITLE
Implement new RadioSelector design (issue #2655)

### DIFF
--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -11,7 +11,7 @@ import { EffectivityType } from '../../utils/types';
 import React, { useMemo, useState } from 'react';
 import { RadioSelector } from './RadioSelector';
 
-const effectiveAtDisplayFormat = 'YY-MM-DD HH:mm';
+const effectiveAtDisplayFormat = 'YYYY-MM-DD HH:mm';
 
 const isPickerTriggerButton = (target: EventTarget | null) =>
   target instanceof Element && Boolean(target.closest('button'));
@@ -100,6 +100,7 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                     openPickerButton: {
                       sx: {
                         color: 'text.light',
+                        marginRight: 0,
                         p: 0,
                         cursor: 'pointer',
                         '& .MuiSvgIcon-root': {
@@ -134,6 +135,7 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                           justifyContent: 'space-between',
                           alignItems: 'center',
                           alignSelf: 'stretch',
+                          flexWrap: 'nowrap',
                           padding: '13px 16px',
                           overflow: 'hidden',
                           minHeight: 'unset',

--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -1,14 +1,20 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Box, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material';
+import { KeyboardArrowDown } from '@mui/icons-material';
 import { useFieldContext } from '../../hooks/formContext';
 import { DesktopDateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
 import dayjs from 'dayjs';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { EffectivityType } from '../../utils/types';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import { RadioSelector } from './RadioSelector';
+
+const effectiveAtDisplayFormat = 'YY-MM-DD HH:mm';
+
+const isPickerTriggerButton = (target: EventTarget | null) =>
+  target instanceof Element && Boolean(target.closest('button'));
 
 export interface EffectiveDateFieldProps {
   title?: string;
@@ -19,10 +25,9 @@ export interface EffectiveDateFieldProps {
 
 export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
   const { initialEffectiveDate, id } = props;
-  const title = props.title ? props.title : 'Vote Proposal Effectivity';
-  const description = props.description
-    ? props.description
-    : 'Select the date and time the proposal will take effect';
+  const title = props.title ?? 'Effective At';
+  const dateDescription =
+    props.description ?? 'Select the block at which the proposal will take effect';
 
   const field = useFieldContext<{
     type: EffectivityType;
@@ -35,6 +40,8 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
     () => dayjs(field.state.value.effectiveDate),
     [field.state.value.effectiveDate]
   );
+
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const handleTypeChange = (type: EffectivityType) => {
     if (type === 'custom') {
@@ -55,72 +62,122 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
   };
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h5" gutterBottom>
-        {title}
-      </Typography>
-
-      <RadioGroup
-        value={currentType}
-        onChange={e => handleTypeChange(e.target.value as EffectivityType)}
-      >
-        <FormControlLabel
-          value="custom"
-          control={<Radio />}
-          label={<Typography>Date</Typography>}
-        />
-
-        {currentType === 'custom' && (
-          <>
-            <Typography variant="body2" color="text.secondary" gutterBottom>
-              {description}
-            </Typography>
-
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-              <DesktopDateTimePicker
-                value={dateValue}
-                format={dateTimeFormatISO}
-                ampm={false}
-                onChange={newDate => {
-                  field.handleChange({
-                    type: 'custom',
-                    effectiveDate: newDate?.format(dateTimeFormatISO) || undefined,
-                  });
-                }}
-                enableAccessibleFieldDOMStructure={false}
-                slotProps={{
-                  textField: {
-                    fullWidth: true,
-                    variant: 'outlined',
-                    id: `${id}-field`,
-                    className: 'effective-date-field',
-                    onBlur: field.handleBlur,
-                    error: !field.state.meta.isValid,
-                    helperText: field.state.meta.errors?.[0],
-                    inputProps: {
-                      'data-testid': `${id}-field`,
+    <RadioSelector
+      id={id}
+      title={title}
+      value={currentType}
+      onChange={value => handleTypeChange(value as EffectivityType)}
+      options={[
+        {
+          value: 'custom',
+          label: 'Date',
+          description: dateDescription,
+          extension:
+            currentType === 'custom' ? (
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DesktopDateTimePicker
+                  value={dateValue}
+                  format={effectiveAtDisplayFormat}
+                  ampm={false}
+                  open={pickerOpen}
+                  sx={{ width: '100%', display: 'block' }}
+                  onOpen={() => setPickerOpen(true)}
+                  onClose={() => {
+                    setPickerOpen(false);
+                    field.handleBlur();
+                  }}
+                  onChange={newDate => {
+                    field.handleChange({
+                      type: 'custom',
+                      effectiveDate: newDate?.format(dateTimeFormatISO) || undefined,
+                    });
+                  }}
+                  enableAccessibleFieldDOMStructure={false}
+                  slots={{
+                    openPickerIcon: KeyboardArrowDown,
+                  }}
+                  slotProps={{
+                    openPickerButton: {
+                      sx: {
+                        color: 'text.light',
+                        p: 0,
+                        cursor: 'pointer',
+                        '& .MuiSvgIcon-root': {
+                          fontSize: 16,
+                        },
+                      },
                     },
-                  },
-                }}
-              />
-            </LocalizationProvider>
-          </>
-        )}
-
-        <FormControlLabel
-          value="threshold"
-          control={<Radio id="effective-at-threshold-radio" />}
-          label={
-            <Box>
-              <Typography>Make effective at threshold</Typography>
-              <Typography variant="body2" color="text.secondary">
-                Allow the vote proposal to take effect immediately when 2/3 vote in favor
-              </Typography>
-            </Box>
-          }
-          sx={{ mt: 2 }}
-        />
-      </RadioGroup>
-    </Box>
+                    textField: {
+                      fullWidth: true,
+                      variant: 'outlined',
+                      id: `${id}-field`,
+                      className: 'effective-date-field',
+                      error: !field.state.meta.isValid,
+                      helperText: field.state.meta.errors?.[0],
+                      onClick: (event: React.MouseEvent<HTMLDivElement>) => {
+                        if (isPickerTriggerButton(event.target)) {
+                          return;
+                        }
+                        setPickerOpen(true);
+                      },
+                      inputProps: {
+                        'data-testid': `${id}-field`,
+                        readOnly: true,
+                      },
+                      sx: theme => ({
+                        width: '100%',
+                        cursor: 'pointer',
+                        '& .MuiOutlinedInput-root': {
+                          backgroundColor: '#363636',
+                          borderRadius: '4px',
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          alignSelf: 'stretch',
+                          padding: '13px 16px',
+                          overflow: 'hidden',
+                          minHeight: 'unset',
+                          cursor: 'pointer',
+                          '& fieldset': {
+                            border: 'none',
+                            borderRadius: '4px',
+                          },
+                        },
+                        '& .MuiOutlinedInput-input': {
+                          ...theme.typography.body2,
+                          flex: 1,
+                          minWidth: 0,
+                          padding: 0,
+                          lineHeight: '22px',
+                          color: theme.palette.text.light,
+                          backgroundColor: 'transparent',
+                          borderRadius: 0,
+                          cursor: 'pointer',
+                          WebkitBoxShadow: 'none',
+                        },
+                        '& .MuiInputAdornment-root': {
+                          flexShrink: 0,
+                          marginLeft: theme.spacing(1.25),
+                        },
+                        '& .MuiFormHelperText-root': {
+                          mx: 0,
+                        },
+                      }),
+                    },
+                  }}
+                />
+              </LocalizationProvider>
+            ) : null,
+        },
+        {
+          value: 'threshold',
+          label: 'Make effective at threshold',
+          description:
+            'This will allow the vote proposal to take effect immediately when 2/3 vote in favor',
+          radioId: 'effective-at-threshold-radio',
+          testId: 'effective-at-threshold-radio',
+        },
+      ]}
+    />
   );
 };

--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -8,13 +8,10 @@ import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils'
 import dayjs from 'dayjs';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { EffectivityType } from '../../utils/types';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { RadioSelector } from './RadioSelector';
 
 const effectiveAtDisplayFormat = 'YYYY-MM-DD HH:mm';
-
-const isPickerTriggerButton = (target: EventTarget | null) =>
-  target instanceof Element && Boolean(target.closest('button'));
 
 export interface EffectiveDateFieldProps {
   title?: string;
@@ -40,8 +37,6 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
     () => dayjs(field.state.value.effectiveDate),
     [field.state.value.effectiveDate]
   );
-
-  const [pickerOpen, setPickerOpen] = useState(false);
 
   const handleTypeChange = (type: EffectivityType) => {
     if (type === 'custom') {
@@ -79,13 +74,8 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                   value={dateValue}
                   format={effectiveAtDisplayFormat}
                   ampm={false}
-                  open={pickerOpen}
                   sx={{ width: '100%', display: 'block' }}
-                  onOpen={() => setPickerOpen(true)}
-                  onClose={() => {
-                    setPickerOpen(false);
-                    field.handleBlur();
-                  }}
+                  onClose={() => field.handleBlur()}
                   onChange={newDate => {
                     field.handleChange({
                       type: 'custom',
@@ -115,18 +105,12 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                       className: 'effective-date-field',
                       error: !field.state.meta.isValid,
                       helperText: field.state.meta.errors?.[0],
-                      onClick: (event: React.MouseEvent<HTMLDivElement>) => {
-                        if (isPickerTriggerButton(event.target)) {
-                          return;
-                        }
-                        setPickerOpen(true);
-                      },
+                      onBlur: field.handleBlur,
                       inputProps: {
                         'data-testid': `${id}-field`,
                       },
                       sx: theme => ({
                         width: '100%',
-                        cursor: 'pointer',
                         '& .MuiOutlinedInput-root': {
                           backgroundColor: '#363636',
                           borderRadius: '4px',
@@ -138,7 +122,6 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                           padding: '13px 16px',
                           overflow: 'hidden',
                           minHeight: 'unset',
-                          cursor: 'pointer',
                           '& fieldset': {
                             border: 'none',
                             borderRadius: '4px',
@@ -153,7 +136,6 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                           color: theme.palette.text.light,
                           backgroundColor: 'transparent',
                           borderRadius: 0,
-                          cursor: 'pointer',
                           WebkitBoxShadow: 'none',
                         },
                         '& .MuiInputAdornment-root': {

--- a/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
+++ b/apps/sv/frontend/src/components/form-components/EffectiveDateField.tsx
@@ -123,7 +123,6 @@ export const EffectiveDateField: React.FC<EffectiveDateFieldProps> = props => {
                       },
                       inputProps: {
                         'data-testid': `${id}-field`,
-                        readOnly: true,
                       },
                       sx: theme => ({
                         width: '100%',

--- a/apps/sv/frontend/src/components/form-components/RadioSelector.tsx
+++ b/apps/sv/frontend/src/components/form-components/RadioSelector.tsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Box, FormControlLabel, Radio, RadioGroup, SvgIcon, Typography } from '@mui/material';
+import type { SvgIconProps } from '@mui/material';
+import React from 'react';
+import type { Theme } from '@mui/material/styles';
+
+export interface RadioSelectorOption {
+  value: string;
+  label: string;
+  description?: string;
+  radioId?: string;
+  testId?: string;
+  extension?: React.ReactNode;
+}
+
+export interface RadioSelectorProps {
+  title: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: RadioSelectorOption[];
+  id: string;
+}
+
+const sectionSx = (theme: Theme) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  alignSelf: 'stretch',
+  gap: theme.spacing(3),
+  width: '100%',
+});
+
+const optionLabelColumnSx = (theme: Theme) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+  width: '100%',
+});
+
+const optionRowSx = (theme: Theme) => ({
+  alignItems: 'flex-start',
+  gap: theme.spacing(1),
+  m: 0,
+  ml: 0,
+  mr: 0,
+  width: '100%',
+  '& .MuiFormControlLabel-label': {
+    flex: 1,
+    minWidth: 0,
+  },
+});
+
+const radioSx = {
+  alignSelf: 'flex-start',
+  p: 0,
+  pt: '3px',
+  '& .MuiSvgIcon-root': {
+    fontSize: 16,
+  },
+} as const;
+
+const RADIO_RING_PATH =
+  'M8.00004 1.33301C4.32004 1.33301 1.33337 4.31967 1.33337 7.99967C1.33337 11.6797 4.32004 14.6663 8.00004 14.6663C11.68 14.6663 14.6667 11.6797 14.6667 7.99967C14.6667 4.31967 11.68 1.33301 8.00004 1.33301ZM8.00004 13.333C5.05337 13.333 2.66671 10.9463 2.66671 7.99967C2.66671 5.05301 5.05337 2.66634 8.00004 2.66634C10.9467 2.66634 13.3334 5.05301 13.3334 7.99967C13.3334 10.9463 10.9467 13.333 8.00004 13.333Z';
+const RADIO_DOT_PATH =
+  'M7.99996 11.3337C9.84091 11.3337 11.3333 9.84127 11.3333 8.00033C11.3333 6.15938 9.84091 4.66699 7.99996 4.66699C6.15901 4.66699 4.66663 6.15938 4.66663 8.00033C4.66663 9.84127 6.15901 11.3337 7.99996 11.3337Z';
+
+const RadioIcon: React.FC<SvgIconProps & { checked?: boolean }> = ({ checked, ...props }) => (
+  <SvgIcon {...props} viewBox="0 0 16 16">
+    <path d={RADIO_RING_PATH} fill="#F3FF97" />
+    {checked && <path d={RADIO_DOT_PATH} fill="#F3FF97" />}
+  </SvgIcon>
+);
+
+export const RadioSelector: React.FC<RadioSelectorProps> = props => {
+  const { title, value, onChange, options, id } = props;
+
+  return (
+    <Box id={id} data-testid={id} sx={sectionSx}>
+      <Typography
+        fontSize={12}
+        lineHeight="22px"
+        fontWeight={600}
+        textTransform="uppercase"
+        color="common.white"
+      >
+        {title}
+      </Typography>
+
+      <RadioGroup
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        sx={theme => ({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing(3),
+          m: 0,
+          width: '100%',
+        })}
+      >
+        {options.map(option => (
+          <FormControlLabel
+            key={option.value}
+            value={option.value}
+            control={
+              <Radio
+                id={option.radioId}
+                data-testid={option.testId}
+                size="small"
+                icon={<RadioIcon />}
+                checkedIcon={<RadioIcon checked />}
+                sx={radioSx}
+              />
+            }
+            label={
+              <Box sx={optionLabelColumnSx}>
+                <Typography variant="body2" lineHeight="22px" color="text.light">
+                  {option.label}
+                </Typography>
+                {option.description && (
+                  <Typography fontSize={12} lineHeight="22px" color="text.light">
+                    {option.description}
+                  </Typography>
+                )}
+                {option.extension && (
+                  <Box
+                    sx={{ width: '100%' }}
+                    onClick={e => e.stopPropagation()}
+                    onMouseDown={e => e.stopPropagation()}
+                  >
+                    {option.extension}
+                  </Box>
+                )}
+              </Box>
+            }
+            sx={optionRowSx}
+          />
+        ))}
+      </RadioGroup>
+    </Box>
+  );
+};

--- a/apps/sv/frontend/src/components/form-components/RadioSelector.tsx
+++ b/apps/sv/frontend/src/components/form-components/RadioSelector.tsx
@@ -5,6 +5,7 @@ import { Box, FormControlLabel, Radio, RadioGroup, SvgIcon, Typography } from '@
 import type { SvgIconProps } from '@mui/material';
 import React from 'react';
 import type { Theme } from '@mui/material/styles';
+import { theme } from '@canton-network/splice-common-frontend';
 
 export interface RadioSelectorOption {
   value: string;
@@ -68,8 +69,8 @@ const RADIO_DOT_PATH =
 
 const RadioIcon: React.FC<SvgIconProps & { checked?: boolean }> = ({ checked, ...props }) => (
   <SvgIcon {...props} viewBox="0 0 16 16">
-    <path d={RADIO_RING_PATH} fill="#F3FF97" />
-    {checked && <path d={RADIO_DOT_PATH} fill="#F3FF97" />}
+    <path d={RADIO_RING_PATH} fill={theme.palette.secondary.main} />
+    {checked && <path d={RADIO_DOT_PATH} fill={theme.palette.secondary.main} />}
   </SvgIcon>
 );
 

--- a/apps/sv/frontend/src/components/forms/OffboardSvForm.tsx
+++ b/apps/sv/frontend/src/components/forms/OffboardSvForm.tsx
@@ -152,8 +152,6 @@ export const OffboardSvForm: React.FC = _ => {
               }}
               children={_ => (
                 <EffectiveDateField
-                  title="Vote Proposal Effectivity"
-                  description="Select the date and time the proposal will take effect"
                   initialEffectiveDate={initialEffectiveDate.format(dateTimeFormatISO)}
                   id="offboard-sv-effective-date"
                 />


### PR DESCRIPTION
### Summary

- Add RadioSelector (presentational radio group with optional per-option extension slot and Figma-aligned custom icons).
- Refactor EffectiveDateField to use it for Date vs Make effective at threshold, with restyled date picker (#363636 surface, YY-MM-DD HH:mm display).
- Remove stale Effective At copy overrides from OffboardSvForm.

Fixes #2655

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
