### PR TITLE
Fix performance readme

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -7,10 +7,10 @@ See the [design document](https://docs.google.com/document/d/1rvAec6BuKx61TdJ6sY
 The performance tests cover three stores. The Tests ingest update data relevant to each store
 and measure the time taken for the ingestion process.
 
-| Store | Description | Content |
-|---------------------|-------------|-------------------|
-| **`SvDsoStore`**    | DSO's internal governance data | ACS contracts |
-| **`ScanStore`**     | DSO's public queryable data | ACS contracts |
+| Store | Description | Content                                           |
+|---------------------|-------------|---------------------------------------------------|
+| **`SvDsoStore`**    | DSO's internal governance data | ACS contracts                                     |
+| **`ScanStore`**     | DSO's public queryable data | ACS contracts and Tx Log                          |
 | **`UpdateHistory`** | DSO's append-only audit log | Updates and associated events (creates/exercises) |
 
 # How to run a test on branch


### PR DESCRIPTION
[static]

In ScanStore, we ingest both ACS + TxLog: 
https://github.com/canton-network/splice/blob/b38cd6edcc544cd01e245f00880160de4c94eeba/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/DbMultiDomainAcsStore.scala#L1696
