### PR TITLE
Add pulumi config to disable sequencer anti affinity

### DIFF
--- a/cluster/configs/shared/scratchnet-sv.yaml
+++ b/cluster/configs/shared/scratchnet-sv.yaml
@@ -22,6 +22,7 @@ participant:
     requests:
       cpu: "1"
 sequencer:
+  enableAntiAffinity: false
   # formerly the effect of `SEQUENCER_LOW_RESOURCES=true`
   resources:
     limits:

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -542,6 +542,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -616,6 +617,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -690,6 +692,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -764,6 +767,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -838,6 +842,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -912,6 +917,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -986,6 +992,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1060,6 +1067,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1134,6 +1142,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1208,6 +1217,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1282,6 +1292,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1356,6 +1367,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1430,6 +1442,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1504,6 +1517,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1578,6 +1592,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1652,6 +1667,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1726,6 +1742,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1803,6 +1820,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -542,6 +542,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -616,6 +617,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -690,6 +692,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -764,6 +767,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -838,6 +842,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -912,6 +917,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -986,6 +992,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1060,6 +1067,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1134,6 +1142,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1208,6 +1217,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1282,6 +1292,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1356,6 +1367,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1430,6 +1442,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1504,6 +1517,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1578,6 +1592,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1652,6 +1667,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1726,6 +1742,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1803,6 +1820,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -542,6 +542,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -616,6 +617,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -690,6 +692,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -764,6 +767,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -838,6 +842,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -912,6 +917,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -986,6 +992,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1060,6 +1067,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1134,6 +1142,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1208,6 +1217,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1282,6 +1292,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1356,6 +1367,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1430,6 +1442,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1504,6 +1517,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1578,6 +1592,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1652,6 +1667,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1726,6 +1742,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1803,6 +1820,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -542,6 +542,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -616,6 +617,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -690,6 +692,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -764,6 +767,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -838,6 +842,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -912,6 +917,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -986,6 +992,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1060,6 +1067,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1134,6 +1142,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1208,6 +1217,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1282,6 +1292,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1356,6 +1367,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1430,6 +1442,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1504,6 +1517,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1578,6 +1592,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1652,6 +1667,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1726,6 +1742,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1803,6 +1820,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -542,6 +542,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -616,6 +617,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -690,6 +692,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -764,6 +767,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -838,6 +842,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -912,6 +917,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -986,6 +992,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1060,6 +1067,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1134,6 +1142,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1208,6 +1217,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1282,6 +1292,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1356,6 +1367,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1430,6 +1442,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1504,6 +1517,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1578,6 +1592,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1652,6 +1667,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1726,6 +1742,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'
@@ -1803,6 +1820,7 @@ svs:
           cpu: '2'
           memory: '2Gi'
     sequencer:
+      enableAntiAffinity: false
       resources:
         limits:
           cpu: '3'

--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1941,6 +1941,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -2076,6 +2077,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -2207,6 +2209,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -2338,6 +2341,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -5515,6 +5519,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -5650,6 +5655,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -5781,6 +5787,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -5912,6 +5919,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -8375,6 +8383,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -8510,6 +8519,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -8641,6 +8651,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,
@@ -8772,6 +8783,7 @@
           "hostname": "mock.global.canton.network.digitalasset.com",
           "name": "cn-mocknet"
         },
+        "enableAntiAffinity": true,
         "enablePostgresMetrics": true,
         "imageRepo": "us-central1-docker.pkg.dev/da-cn-shared/ghcr/digital-asset/decentralized-canton-sync-dev/docker",
         "logAsyncFlush": false,

--- a/cluster/pulumi/common-sv/src/physicalSynchronizerConfig.ts
+++ b/cluster/pulumi/common-sv/src/physicalSynchronizerConfig.ts
@@ -28,6 +28,7 @@ export const SvSequencerConfigSchema = z
     additionalJvmOptions: z.string().optional(),
     cloudSql: CloudSqlWithOverrideConfigSchema,
     resources: K8sResourceSchema,
+    enableAntiAffinity: z.boolean().default(true),
   })
   .strict();
 export type SvSequencerConfig = z.infer<typeof SvSequencerConfigSchema>;

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -177,6 +177,7 @@ abstract class InStackDecentralizedSynchronizerNode
           ),
           pvc: persistentHeapDumpsPvc(),
           serviceAccountName: imagePullServiceAccountName,
+          enableAntiAffinity: physicalSynchronizerConfig.sequencer.enableAntiAffinity,
         },
       },
       this.version,


### PR DESCRIPTION
disable in scratches
it no longer really makes sense for non prod clusters will also disable in cilr as we moved to fairly big nodes there

[static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
