### PR TITLE
Improve removal of CantonBFT p2p connections

### DIFF
--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
@@ -79,10 +79,10 @@ abstract class SequencerBftPeerReconciler(
               .listConfiguredPeerEndpoints()
             peersToAdd = dsoSequencerEndpoints
               .filterNot(endpoint => configuredPeers.exists(_.id == endpoint.id))
-            candidatePeersToRemove = configuredPeers
+            peersWithNoDsoRulesEndpoint = configuredPeers
               .filterNot(peer => dsoSequencerEndpoints.exists(_.id == peer.id))
             peersToRemove <- computePeersToRemove(
-              candidatePeersToRemove,
+              configuredPeers,
               dsoSequencersWithEndpoint,
             )
           } yield {
@@ -99,47 +99,43 @@ abstract class SequencerBftPeerReconciler(
     } yield result
   }
 
-  /** If all DSO sequencers have an associated peer endpoint advertised by scan, any configured peer
-    * that does not correspond to one of those endpoints is stale and safe to remove.
-    *
-    * Otherwise we cannot rely on scan alone (as some scans can be unavailable), so we cross-check the peer network status to find the
-    * sequencer id backing each candidate endpoint. Removal is only safe if that sequencer id is no
-    * longer part of the DSO sequencers, or if it is now associated with a different endpoint. If no
-    * sequencer id can be found for a candidate endpoint we keep it and log a warning.
-    */
   private def computePeersToRemove(
-      candidatePeersToRemove: Seq[P2PEndpoint],
+      configuredPeers: Seq[P2PEndpoint],
       dsoSequencersWithEndpoint: Seq[(SequencerId, Option[P2PEndpoint])],
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[Seq[P2PEndpoint]] = {
-    val allDsoSequencersHaveEndpoint = dsoSequencersWithEndpoint.forall { case (_, endpoint) =>
-      endpoint.isDefined
-    }
-    if (candidatePeersToRemove.isEmpty || allDsoSequencersHaveEndpoint) {
-      Future.successful(candidatePeersToRemove)
-    } else {
-      sequencerAdminConnection.listCurrentPeerEndpoints().map { networkStatus =>
-        candidatePeersToRemove.filter { peer =>
-          networkStatus.collectFirst {
-            case (Some(sequencerId), Some(endpointId)) if endpointId == peer.id => sequencerId
-          } match {
-            case Some(sequencerId) =>
-              val sequencerNoLongerInDso =
-                !dsoSequencersWithEndpoint.exists { case (dsoSequencerId, _) =>
-                  dsoSequencerId == sequencerId
-                }
-              val sequencerMovedToDifferentEndpoint =
-                dsoSequencersWithEndpoint.exists { case (dsoSequencerId, endpoint) =>
-                  dsoSequencerId == sequencerId && endpoint.exists(_.id != peer.id)
-                }
-              sequencerNoLongerInDso || sequencerMovedToDifferentEndpoint
-            case None =>
-              logger.warn(
-                s"Could not find a sequencer id for the configured peer endpoint ${peer.id} in the peer network status; not removing it to be safe."
-              )
-              false
-          }
+    sequencerAdminConnection.listCurrentPeerEndpoints().map { networkStatus =>
+      val configuredPeersWithSequencerId = configuredPeers.map { peer =>
+        peer -> networkStatus.collectFirst {
+          case (Some(sequencerId), Some(endpoint)) if endpoint == peer.id => sequencerId
         }
       }
+      val peersWithWrongSequencerId = configuredPeersWithSequencerId.filter {
+        case (peer, Some(sequencerId)) =>
+          !dsoSequencersWithEndpoint.exists({ case (dsoSequencerId, _) =>
+            sequencerId == dsoSequencerId
+          })
+        case _ => false
+      }
+      val peersWithChangedEndpoint = configuredPeersWithSequencerId.filter {
+        case (peer, Some(sequencerId)) =>
+          dsoSequencersWithEndpoint.exists({ case (dsoSequencerId, endpoint) =>
+            sequencerId == dsoSequencerId && endpoint.exists(_.id != peer.id)
+          })
+        case _ => false
+      }
+      // we only remove connections for which we don't have a sequencer id when we have been able to query all scans to get connections. otherwise a temporary scan issue could result in us removing the peer.
+      val unknownPeers =
+        if (dsoSequencersWithEndpoint.forall { case (_, endpoint) => endpoint.isDefined }) {
+          configuredPeers.filter(peer =>
+            !dsoSequencersWithEndpoint.exists { case (_, endpoint) =>
+              endpoint.exists(_.id == peer.id)
+            }
+          )
+        } else Seq.empty
+
+      (peersWithWrongSequencerId.map(_._1) ++ peersWithChangedEndpoint.map(
+        _._1
+      ) ++ unknownPeers).distinct
     }
   }
 

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconcilerSpec.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconcilerSpec.scala
@@ -91,6 +91,8 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       )
     )
 
+    withNetworkStatus()
+
     withScanSequencers(
       BftSequencer(
         serialId,
@@ -389,7 +391,7 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
     result.toRemove should contain only sequencer1Host
   }
 
-  it should "keep a configured peer and log a warning when no sequencer id can be found for it in the network status" in {
+  it should "keep a configured peer when no sequencer id can be found for it in the network status" in {
     withConfiguredDsoSequencers(
       Seq(
         createSequencerConfig(sequencer1Id),
@@ -419,12 +421,7 @@ class SequencerBftPeerReconcilerSpec extends AnyFlatSpec with BaseTest with HasR
       (Some(sequencer1Id), Some(sequencer1Host))
     )
 
-    val result = loggerFactory.assertLogs(
-      reconciler.diffDsoRulesWithTopology().futureValue,
-      _.warningMessage should include(
-        s"Could not find a sequencer id for the configured peer endpoint ${sequencer2Host}"
-      ),
-    )
+    val result = reconciler.diffDsoRulesWithTopology().futureValue
     result should be(empty)
   }
 


### PR DESCRIPTION
In particular this can now remove connections with wrong sequencer ids in some cases it didn't before. I personally also just find it easier to follow what is going on. Note that this does not fix the issues we encountered still sadly, we do now issue a remove before add. But that's not sufficient due to
https://github.com/DACH-NY/canton/issues/34191.

In combination with a restart it does work but that's obviously meh.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
