### PR TITLE
Fix missing TransferInstruction in TestTokenV2SettlementIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TestTokenV2SettlementIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TestTokenV2SettlementIntegrationTest.scala
@@ -252,7 +252,7 @@ class TestTokenV2SettlementIntegrationTest
         )
 
       // Bob accepts
-      val transferInstruction =
+      val transferInstruction = eventually() {
         Contract
           .fromCreatedEvent(transferinstructionv2.TransferInstruction.INTERFACE)(
             CreatedEvent.fromProto(
@@ -275,6 +275,7 @@ class TestTokenV2SettlementIntegrationTest
             )
           )
           .valueOrFail("Failed to read transferinstructionv2.TransferInstruction")
+      }
       val acceptContext =
         registry.getContext(
           transferInstruction.payload.transfer.inputHoldingCids.asScala.toSeq


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9174
Bob is just an observer so it can be slow to see the TransferInstruction