### PR TITLE
Disable token-standard sanity check in unvetting test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnsupportedPackageVettingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/UnsupportedPackageVettingIntegrationTest.scala
@@ -45,6 +45,11 @@ class UnsupportedPackageVettingIntegrationTest
     with AmuletConfigUtil
     with WalletTestUtil {
 
+  // Prevent failures due to:
+  //   NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE(9,f5ce331d):
+  //   No vetted package for rendering the interface view for package-name 'splice-amulet'
+  override protected def runTokenStandardCliSanityCheck: Boolean = false
+
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
       .simpleTopology1Sv(this.getClass.getSimpleName)


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9203