### PR TITLE
Silence SEQUENCER_SUBMISSION_AFTER_UPGRADE_TIME in LSU tests

### DIFF
--- a/project/ignore-patterns/canton_log.ignore.txt
+++ b/project/ignore-patterns/canton_log.ignore.txt
@@ -177,7 +177,7 @@ Missing successor information for the following sequencers.*sv4
 Skipping insertion of pending onboarding flag clearance operation as no party ID was provided
 
 # LSU: submissions on the old physical synchronizer after the upgrade time has passed are rejected
-Request failed for server-DefaultSequencer-0.\\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/SEQUENCER_SUBMISSION_AFTER_UPGRADE_TIME
+GrpcRequestRefusedByServer: FAILED_PRECONDITION/SEQUENCER_SUBMISSION_AFTER_UPGRADE_TIME
 # LSU SV4 migrates late
 SEQ::sv4.*Sequencer can't take requests because it is behind on processing events
 Sequencer can't take requests because it is behind on processing events.*sequencer=>sv4StandaloneSequencer


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9228

It recently flaked with `server-SEQ::sv1::<fingerprint>-0` prefix instead of `server-DefaultSequencer-0`

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
