### PR TITLE
SV UI: CIP-104 Support UpdateFeatureAppRight Vote

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -1435,7 +1435,8 @@ class SvFrontendIntegrationTest
 
       clue("vote the grant request to execution before creating revoke request") {
         val grantTrackingCid = eventually() {
-          val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] = voteProposalToExecution(grantProposalContractId)
+          val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] =
+            getVoteRequestForProposal(grantProposalContractId)
 
           if (voteRequest.payload.trackingCid.isPresent) voteRequest.payload.trackingCid.get
           else voteRequest.contractId
@@ -1472,7 +1473,7 @@ class SvFrontendIntegrationTest
 
       clue("vote the update request to execution") {
         val updateTrackingCid = eventually() {
-          val voteRequest = voteProposalToExecution(updateProposalContractId)
+          val voteRequest = getVoteRequestForProposal(updateProposalContractId)
           if (voteRequest.payload.trackingCid.isPresent) voteRequest.payload.trackingCid.get
           else voteRequest.contractId
         }
@@ -1671,8 +1672,8 @@ class SvFrontendIntegrationTest
     }
   }
 
-  def voteProposalToExecution(
-     proposalContractId: String
+  def getVoteRequestForProposal(
+      proposalContractId: String
   )(implicit env: SpliceTestConsoleEnvironment) = {
     val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] = sv1Backend
       .listVoteRequests()

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvFrontendIntegrationTest.scala
@@ -1419,7 +1419,7 @@ class SvFrontendIntegrationTest
       }
     }
 
-    "NEW UI: Grant and Revoke Featured App Right" in { implicit env =>
+    "NEW UI: Grant, Update and Revoke Featured App Right" in { implicit env =>
       val providerParty = sv3Backend.getDsoInfo().svParty
       val providerPartyId = providerParty.toProtoPrimitive
       val activityWeight = BigDecimal("2.5")
@@ -1435,23 +1435,7 @@ class SvFrontendIntegrationTest
 
       clue("vote the grant request to execution before creating revoke request") {
         val grantTrackingCid = eventually() {
-          val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] = sv1Backend
-            .listVoteRequests()
-            .find { request =>
-              val requestCid = request.contractId.contractId
-              val trackingCid =
-                if (request.payload.trackingCid.isPresent) {
-                  Some(request.payload.trackingCid.get.contractId)
-                } else {
-                  None
-                }
-              requestCid == grantProposalContractId || trackingCid.contains(grantProposalContractId)
-            }
-            .getOrElse(
-              fail(
-                s"Could not find vote request for grant proposal contract id: $grantProposalContractId"
-              )
-            )
+          val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] = voteProposalToExecution(grantProposalContractId)
 
           if (voteRequest.payload.trackingCid.isPresent) voteRequest.payload.trackingCid.get
           else voteRequest.contractId
@@ -1471,6 +1455,38 @@ class SvFrontendIntegrationTest
           featuredAppRight.value.payload.activityWeight.toScala.map(
             BigDecimal(_)
           ) shouldBe Some(activityWeight)
+        }
+      }
+
+      val newActivityWeight = BigDecimal("3.0")
+
+      val updateProposalContractId = assertCreateProposal(
+        "SRARC_UpdateFeaturedAppRight",
+        "update-featured-app",
+      ) { implicit webDriver =>
+        fillOutTextField("update-featured-app-partyId", providerPartyId)
+        selectFirstMuiOption("update-featured-app-rightCid-dropdown")
+        fillOutTextField("update-featured-app-activityWeight", newActivityWeight.toString)
+        fillOutTextField("update-featured-app-reason", "increasing weight")
+      }
+
+      clue("vote the update request to execution") {
+        val updateTrackingCid = eventually() {
+          val voteRequest = voteProposalToExecution(updateProposalContractId)
+          if (voteRequest.payload.trackingCid.isPresent) voteRequest.payload.trackingCid.get
+          else voteRequest.contractId
+        }
+
+        eventuallySucceeds() {
+          sv3Backend.castVote(updateTrackingCid, isAccepted = true, "", "")
+        }
+
+        eventually() {
+          val featuredAppRight = sv1ScanBackend.lookupFeaturedAppRight(providerParty)
+          featuredAppRight shouldBe a[Some[?]]
+          featuredAppRight.value.payload.activityWeight.toScala.map(
+            BigDecimal(_)
+          ) shouldBe Some(newActivityWeight)
         }
       }
 
@@ -1653,6 +1669,29 @@ class SvFrontendIntegrationTest
         }
       }
     }
+  }
+
+  def voteProposalToExecution(
+     proposalContractId: String
+  )(implicit env: SpliceTestConsoleEnvironment) = {
+    val voteRequest: Contract[VoteRequest.ContractId, VoteRequest] = sv1Backend
+      .listVoteRequests()
+      .find { request =>
+        val requestCid = request.contractId.contractId
+        val trackingCid =
+          if (request.payload.trackingCid.isPresent) {
+            Some(request.payload.trackingCid.get.contractId)
+          } else {
+            None
+          }
+        requestCid == proposalContractId || trackingCid.contains(proposalContractId)
+      }
+      .getOrElse(
+        fail(
+          s"Could not find vote request for proposal contract id: $proposalContractId"
+        )
+      )
+    voteRequest
   }
 
   def changeAction(actionName: String)(implicit webDriver: WebDriverType) = {

--- a/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
@@ -364,7 +364,7 @@ describe('Revoke Featured App Form', () => {
     fireEvent.blur(partyIdInput);
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading featured app rights...')).not.toBeInTheDocument();
+      expect(screen.queryByText('Loading app rights...')).not.toBeInTheDocument();
     });
 
     const rightCidDropdown = screen.getByTestId('revoke-featured-app-rightCid-dropdown');

--- a/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
@@ -364,7 +364,7 @@ describe('Revoke Featured App Form', () => {
     fireEvent.blur(partyIdInput);
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading app rights...')).not.toBeInTheDocument();
+      expect(screen.queryByText('Loading featured app rights...')).not.toBeInTheDocument();
     });
 
     const rightCidDropdown = screen.getByTestId('revoke-featured-app-rightCid-dropdown');

--- a/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
@@ -1,0 +1,342 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
+import dayjs from 'dayjs';
+import { SvConfigProvider } from '../../../utils';
+import App from '../../../App';
+import { svPartyId } from '../../mocks/constants';
+import { Wrapper } from '../../helpers';
+import { UpdateFeaturedAppForm } from '../../../components/forms/UpdateFeaturedAppForm';
+import { server, svUrl } from '../../setup/setup';
+import { http, HttpResponse } from 'msw';
+import { PROPOSAL_SUMMARY_SUBTITLE, PROPOSAL_SUMMARY_TITLE } from '../../../utils/constants';
+
+// Logs in once so the admin client has an access token for the rest of the file.
+describe('SV user can', () => {
+  test('login and see the SV party ID', async () => {
+    const user = userEvent.setup();
+    render(
+      <SvConfigProvider>
+        <App />
+      </SvConfigProvider>
+    );
+
+    expect(await screen.findByText('Log In')).toBeInTheDocument();
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'sv1');
+
+    const button = screen.getByRole('button', { name: 'Log In' });
+    await user.click(button);
+
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+  });
+});
+
+describe('Update Featured App Form', () => {
+  const fillOutUpdateForm = async (user: ReturnType<typeof userEvent.setup>) => {
+    const summaryInput = screen.getByTestId('update-featured-app-summary');
+    await user.type(summaryInput, 'Summary of the proposal');
+
+    const urlInput = screen.getByTestId('update-featured-app-url');
+    await user.type(urlInput, 'https://example.com');
+
+    const partyIdInput = screen.getByTestId('update-featured-app-partyId');
+    await user.type(partyIdInput, 'a-party-id::1014912492');
+    fireEvent.blur(partyIdInput);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading app rights...')).not.toBeInTheDocument();
+    });
+
+    const rightCidDropdown = screen.getByTestId('update-featured-app-rightCid-dropdown');
+    await waitFor(
+      () => {
+        expect(rightCidDropdown).not.toBeDisabled();
+      },
+      { timeout: 3000 }
+    );
+    fireEvent.change(rightCidDropdown, { target: { value: 'rightCid123' } });
+    fireEvent.blur(rightCidDropdown);
+    await waitFor(() => {
+      expect(screen.getByTestId('update-featured-app-rightCid-error').textContent).toBeFalsy();
+    });
+
+    const activityWeightInput = screen.getByTestId('update-featured-app-activityWeight');
+    await user.type(activityWeightInput, '2.5');
+
+    const reasonInput = screen.getByTestId('update-featured-app-reason');
+    await user.type(reasonInput, 'test');
+  };
+
+  test('should render all Form components', () => {
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('update-featured-app-form')).toBeInTheDocument();
+    expect(screen.getByText('Proposal type')).toBeInTheDocument();
+
+    const actionInput = screen.getByTestId('update-featured-app-action');
+    expect(actionInput).toBeInTheDocument();
+    expect(actionInput.textContent).toBe('Update Featured Application');
+
+    const summaryInput = screen.getByTestId('update-featured-app-summary');
+    expect(summaryInput).toBeInTheDocument();
+    expect(summaryInput.getAttribute('value')).toBeNull();
+
+    const summarySubtitle = screen.getByTestId('update-featured-app-summary-subtitle');
+    expect(summarySubtitle).toBeInTheDocument();
+    expect(summarySubtitle.textContent).toBe(PROPOSAL_SUMMARY_SUBTITLE);
+
+    const urlInput = screen.getByTestId('update-featured-app-url');
+    expect(urlInput).toBeInTheDocument();
+    expect(urlInput.getAttribute('value')).toBe('');
+
+    const partyIdInput = screen.getByTestId('update-featured-app-partyId');
+    expect(partyIdInput).toBeInTheDocument();
+    expect(partyIdInput.getAttribute('value')).toBe('');
+
+    const partyIdTitle = screen.getByTestId('update-featured-app-partyId-title');
+    expect(partyIdTitle).toBeInTheDocument();
+    expect(partyIdTitle.textContent).toBe('Provider Party ID');
+
+    const rightCidDropdown = screen.getByTestId('update-featured-app-rightCid-dropdown');
+    expect(rightCidDropdown).toBeInTheDocument();
+    expect(rightCidDropdown).toBeDisabled();
+
+    expect(screen.getByTestId('update-featured-app-activityWeight')).toBeInTheDocument();
+    expect(screen.getByTestId('update-featured-app-reason')).toBeInTheDocument();
+
+    expect(screen.getByText('Review Proposal')).toBeInTheDocument();
+  });
+
+  test('activity weight is required', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const activityWeightInput = screen.getByTestId('update-featured-app-activityWeight');
+    const actionInput = screen.getByTestId('update-featured-app-action');
+
+    await user.click(activityWeightInput);
+    await user.click(actionInput); // blur to trigger validation
+
+    await waitFor(() => {
+      expect(screen.getByTestId('update-featured-app-activityWeight-error').textContent).toBe(
+        'Weight is required'
+      );
+    });
+  });
+
+  test('should send new activity weight and reason to backend', async () => {
+    let requestBody = '';
+    server.use(
+      http.post(`${svUrl}/v0/admin/sv/voterequest/create`, async ({ request }) => {
+        requestBody = await request.text();
+        return HttpResponse.json({});
+      })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    await fillOutUpdateForm(user);
+
+    const actionInput = screen.getByTestId('update-featured-app-action');
+    await user.click(actionInput); // blur to trigger validation
+
+    const submitButton = screen.getByTestId('submit-button');
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    await user.click(submitButton); // review proposal
+    await user.click(submitButton); // submit proposal
+
+    await waitFor(() => {
+      expect(requestBody).toContain('"newActivityWeight":"2.5"');
+      expect(requestBody).toContain('"reason":"test"');
+    });
+  });
+
+  test('activity weight rejects negative numbers and more than 10 decimal places', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const activityWeightInput = screen.getByTestId('update-featured-app-activityWeight');
+    const activityWeightError = screen.getByTestId('update-featured-app-activityWeight-error');
+
+    await user.type(activityWeightInput, '-1');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('Weight must be a valid non-negative number');
+    });
+
+    await user.clear(activityWeightInput);
+    await user.type(activityWeightInput, '1.1234567891');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('');
+    });
+
+    await user.clear(activityWeightInput);
+    await user.type(activityWeightInput, '1.12345678912');
+    await waitFor(() => {
+      expect(activityWeightError.textContent).toBe('Weight can have at most 10 decimal places');
+    });
+  });
+
+  test('reason is required', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const reasonInput = screen.getByTestId('update-featured-app-reason');
+    const actionInput = screen.getByTestId('update-featured-app-action');
+
+    await user.click(reasonInput);
+    await user.click(actionInput); // blur to trigger validation
+
+    await waitFor(() => {
+      expect(screen.getByTestId('update-featured-app-reason-error').textContent).toBe(
+        'Reason is required'
+      );
+    });
+  });
+
+  test('communicates when the provider has no featured app rights to update', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const partyIdInput = screen.getByTestId('update-featured-app-partyId');
+    await user.type(partyIdInput, 'no-rights-party::1014912492');
+    fireEvent.blur(partyIdInput);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('update-featured-app-rightCid')).toHaveTextContent(
+        'No featured application rights found for this provider'
+      );
+    });
+
+    expect(screen.getByTestId('update-featured-app-rightCid-dropdown')).toBeDisabled();
+  });
+
+  test('expiry date must be in the future', async () => {
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const expiryDateInput = screen.getByTestId('update-featured-app-expiry-date-field');
+    expect(expiryDateInput).toBeInTheDocument();
+
+    const thePast = dayjs().subtract(1, 'day').format(dateTimeFormatISO);
+    const theFuture = dayjs().add(1, 'day').format(dateTimeFormatISO);
+
+    fireEvent.change(expiryDateInput, { target: { value: thePast } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Expiration must be in the future')).toBeInTheDocument();
+    });
+
+    fireEvent.change(expiryDateInput, { target: { value: theFuture } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Expiration must be in the future')).not.toBeInTheDocument();
+    });
+  });
+
+  test('effective date must be after expiry date', async () => {
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    const expiryDateInput = screen.getByTestId('update-featured-app-expiry-date-field');
+    const effectiveDateInput = screen.getByTestId('update-featured-app-effective-date-field');
+
+    const expiryDate = dayjs().add(1, 'week');
+    const effectiveDate = expiryDate.subtract(1, 'day');
+
+    fireEvent.change(expiryDateInput, { target: { value: expiryDate.format(dateTimeFormatISO) } });
+    fireEvent.change(effectiveDateInput, {
+      target: { value: effectiveDate.format(dateTimeFormatISO) },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Effective Date must be after expiration date')
+      ).toBeInTheDocument();
+    });
+
+    const validEffectiveDate = expiryDate.add(1, 'day').format(dateTimeFormatISO);
+
+    fireEvent.change(effectiveDateInput, { target: { value: validEffectiveDate } });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Effective Date must be after expiration date')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('should show proposal review page after form completion', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <UpdateFeaturedAppForm />
+      </Wrapper>
+    );
+
+    await fillOutUpdateForm(user);
+
+    const actionInput = screen.getByTestId('update-featured-app-action');
+    await user.click(actionInput); // blur to trigger validation
+
+    const submitButton = screen.getByTestId('submit-button');
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    await user.click(submitButton); // review proposal
+
+    expect(screen.getByText(PROPOSAL_SUMMARY_TITLE)).toBeInTheDocument();
+    expect(screen.getByTestId('updateProviderPartyId-field').textContent).toBe(
+      'a-party-id::1014912492'
+    );
+    expect(screen.getByTestId('updateRight-field').textContent).toBe('rightCid123');
+    expect(screen.getByTestId('updateActivityWeight-field').textContent).toBe('2.5');
+    expect(screen.getByTestId('updateReason-field').textContent).toBe('test');
+  });
+});

--- a/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
@@ -336,7 +336,8 @@ describe('Update Featured App Form', () => {
       'a-party-id::1014912492'
     );
     expect(screen.getByTestId('updateRight-field').textContent).toBe('rightCid123');
-    expect(screen.getByTestId('updateActivityWeight-field').textContent).toBe('2.5');
+    expect(screen.getByTestId('config-change-current-value').textContent).toBe('1.0');
+    expect(screen.getByTestId('config-change-new-value').textContent).toBe('2.5');
     expect(screen.getByTestId('updateReason-field').textContent).toBe('test');
   });
 });

--- a/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/update-featured-app-form.test.tsx
@@ -50,7 +50,7 @@ describe('Update Featured App Form', () => {
     fireEvent.blur(partyIdInput);
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading app rights...')).not.toBeInTheDocument();
+      expect(screen.queryByText('Loading featured app rights...')).not.toBeInTheDocument();
     });
 
     const rightCidDropdown = screen.getByTestId('update-featured-app-rightCid-dropdown');

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -286,7 +286,7 @@ describe('Proposal Details Content', () => {
     expect(rightContractIdValue.textContent).toMatch(/rightContractId/);
   });
 
-  test('should render update featured app proposal details', () => {
+  test('should render update featured app proposal details', async () => {
     const updateFeaturedAppDetails = {
       actionName: 'Update Featured Application',
       action: 'SRARC_UpdateFeaturedAppRight',
@@ -323,15 +323,13 @@ describe('Proposal Details Content', () => {
     const updateFeaturedAppValue = screen.getByTestId('proposal-details-update-feature-app-value');
     expect(updateFeaturedAppValue.textContent).toMatch('rightCid123');
 
-    const updateFeaturedActivityWeightLabel = screen.getByTestId(
-      'proposal-details-update-feature-activity-weight-label'
-    );
-    expect(updateFeaturedActivityWeightLabel.textContent).toMatch('Activity Weight');
+    await waitFor(() => {
+      const currentFeaturedAppWeight = screen.getByTestId('config-change-current-value');
+      expect(currentFeaturedAppWeight.textContent).toMatch('1.0');
+    });
 
-    const updateFeaturedActivityWeightValue = screen.getByTestId(
-      'proposal-details-update-feature-activity-weight-value'
-    );
-    expect(updateFeaturedActivityWeightValue.textContent).toMatch('2.5');
+    const newFeaturedAppWeight = screen.getByTestId('config-change-new-value');
+    expect(newFeaturedAppWeight.textContent).toMatch('2.5');
 
     const updateFeaturedReasonLabel = screen.getByTestId(
       'proposal-details-update-feature-reason-label'
@@ -342,6 +340,38 @@ describe('Proposal Details Content', () => {
       'proposal-details-update-feature-reason-value'
     );
     expect(updateFeaturedReasonValue.textContent).toMatch('boosting rewards');
+  });
+
+  test('should show only new weight when featured app right is not found', async () => {
+    const updateFeaturedAppDetails = {
+      actionName: 'Update Featured Application',
+      action: 'SRARC_UpdateFeaturedAppRight',
+      proposal: {
+        rightContractId: 'archivedRightCid', // <- not 'rightCid123', so the mock returns not-found
+        newActivityWeight: '2.5',
+        reason: 'boosting rewards',
+      } as UpdateFeatureAppProposal,
+    } as ProposalDetails;
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId={voteRequest.votingInformation.requester}
+          contractId={voteRequest.contractId}
+          proposalDetails={updateFeaturedAppDetails}
+          votingInformation={voteRequest.votingInformation}
+          votes={voteRequest.votes}
+        />
+      </Wrapper>
+    );
+
+    // new value still shows
+    await waitFor(() => {
+      const newFeaturedAppWeight = screen.getByTestId('config-change-new-value');
+      expect(newFeaturedAppWeight.textContent).toMatch('2.5');
+    });
+    // ...but there's no current-value box (contract archived → currentWeight '')
+    expect(screen.queryByTestId('config-change-current-value')).toBeNull();
   });
 
   test('should render update sv reward weight proposal details', () => {

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -13,6 +13,7 @@ import {
   ProposalVote,
   ProposalVotingInformation,
   UnclaimedActivityRecordProposal,
+  UpdateFeatureAppProposal,
   UpdateSvRewardWeightProposal,
 } from '../../utils/types';
 import userEvent from '@testing-library/user-event';
@@ -283,6 +284,64 @@ describe('Proposal Details Content', () => {
 
     const rightContractIdValue = screen.getByTestId('proposal-details-unfeature-app-value');
     expect(rightContractIdValue.textContent).toMatch(/rightContractId/);
+  });
+
+  test('should render update featured app proposal details', () => {
+    const updateFeaturedAppDetails = {
+      actionName: 'Update Featured Application',
+      action: 'SRARC_UpdateFeaturedAppRight',
+      proposal: {
+        rightContractId: 'rightCid123',
+        newActivityWeight: '2.5',
+        reason: 'boosting rewards',
+      } as UpdateFeatureAppProposal,
+    } as ProposalDetails;
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId={voteRequest.votingInformation.requester}
+          contractId={voteRequest.contractId}
+          proposalDetails={updateFeaturedAppDetails}
+          votingInformation={voteRequest.votingInformation}
+          votes={voteRequest.votes}
+        />
+      </Wrapper>
+    );
+
+    const action = screen.getByTestId('proposal-details-action-value');
+    expect(action.textContent).toMatch('Update Featured Application');
+
+    const updateFeaturedAppSection = screen.getByTestId(
+      'proposal-details-update-feature-app-section'
+    );
+    expect(updateFeaturedAppSection).toBeInTheDocument();
+
+    const updateFeaturedAppLabel = screen.getByTestId('proposal-details-update-feature-app-label');
+    expect(updateFeaturedAppLabel.textContent).toMatch('Featured Application Contract ID');
+
+    const updateFeaturedAppValue = screen.getByTestId('proposal-details-update-feature-app-value');
+    expect(updateFeaturedAppValue.textContent).toMatch('rightCid123');
+
+    const updateFeaturedActivityWeightLabel = screen.getByTestId(
+      'proposal-details-update-feature-activity-weight-label'
+    );
+    expect(updateFeaturedActivityWeightLabel.textContent).toMatch('Activity Weight');
+
+    const updateFeaturedActivityWeightValue = screen.getByTestId(
+      'proposal-details-update-feature-activity-weight-value'
+    );
+    expect(updateFeaturedActivityWeightValue.textContent).toMatch('2.5');
+
+    const updateFeaturedReasonLabel = screen.getByTestId(
+      'proposal-details-update-feature-reason-label'
+    );
+    expect(updateFeaturedReasonLabel.textContent).toMatch('Reason');
+
+    const updateFeaturedReasonValue = screen.getByTestId(
+      'proposal-details-update-feature-reason-value'
+    );
+    expect(updateFeaturedReasonValue.textContent).toMatch('boosting rewards');
   });
 
   test('should render update sv reward weight proposal details', () => {

--- a/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
@@ -201,6 +201,60 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('revokeRight-field').textContent).toBe(contractId);
   });
 
+  test('should render review proposal component for update feature application', () => {
+    const actionName = 'Update Featured Application';
+    const providerPartyId = 'a-party-id::1014912492';
+    const rightCid = 'bcde123456';
+    const newActivityWeight = '2.5';
+    const reason = 'boosting rewards';
+
+    render(
+      <ProposalSummary
+        actionName={actionName}
+        url={url}
+        summary={summary}
+        expiryDate={expiryDate}
+        effectiveDate={effectiveDate}
+        formType="update-right"
+        providerPartyId={providerPartyId}
+        rightCid={rightCid}
+        newActivityWeight={newActivityWeight}
+        reason={reason}
+        onEdit={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('action-title').textContent).toBe('Action');
+    expect(screen.getByTestId('action-field').textContent).toBe(actionName);
+
+    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-field').textContent).toBe(url);
+
+    expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
+    expect(screen.getByTestId('summary-field').textContent).toBe(summary);
+
+    expect(screen.getByTestId('expiryDate-title').textContent).toBe('Threshold Deadline');
+    expect(screen.getByTestId('expiryDate-field').textContent).toBe(expiryDate);
+
+    expect(screen.getByTestId('effectiveDate-title').textContent).toBe('Effective Date');
+    expect(screen.getByTestId('effectiveDate-field').textContent).toBe(effectiveDate);
+
+    expect(screen.getByTestId('updateProviderPartyId-title').textContent).toBe('Provider Party ID');
+    expect(screen.getByTestId('updateProviderPartyId-field').textContent).toBe(providerPartyId);
+
+    expect(screen.getByTestId('updateRight-title').textContent).toBe(
+      'Featured Application Contract ID'
+    );
+    expect(screen.getByTestId('updateRight-field').textContent).toBe(rightCid);
+
+    expect(screen.getByTestId('updateActivityWeight-title').textContent).toBe('Activity Weight');
+    expect(screen.getByTestId('updateActivityWeight-field').textContent).toBe(newActivityWeight);
+
+    expect(screen.getByTestId('updateReason-title').textContent).toBe('Reason');
+    expect(screen.getByTestId('updateReason-field').textContent).toBe(reason);
+  });
+
   test('should render review proposal component for dso rules config', () => {
     const actionName = 'Set DSO Rules Configuration';
     const numThresholdTitle = 'Number of Unclaimed Rewards Threshold';

--- a/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
@@ -205,6 +205,7 @@ describe('Review Proposal Component', () => {
     const actionName = 'Update Featured Application';
     const providerPartyId = 'a-party-id::1014912492';
     const rightCid = 'bcde123456';
+    const currentActivityWeight = '1.0';
     const newActivityWeight = '2.5';
     const reason = 'boosting rewards';
 
@@ -215,9 +216,10 @@ describe('Review Proposal Component', () => {
         summary={summary}
         expiryDate={expiryDate}
         effectiveDate={effectiveDate}
-        formType="update-right"
+        formType="update-right-weight"
         providerPartyId={providerPartyId}
         rightCid={rightCid}
+        currentActivityWeight={currentActivityWeight}
         newActivityWeight={newActivityWeight}
         reason={reason}
         onEdit={() => {}}
@@ -248,8 +250,10 @@ describe('Review Proposal Component', () => {
     );
     expect(screen.getByTestId('updateRight-field').textContent).toBe(rightCid);
 
-    expect(screen.getByTestId('updateActivityWeight-title').textContent).toBe('Activity Weight');
-    expect(screen.getByTestId('updateActivityWeight-field').textContent).toBe(newActivityWeight);
+    expect(screen.getByTestId('config-change-current-value').textContent).toBe(
+      currentActivityWeight
+    );
+    expect(screen.getByTestId('config-change-new-value').textContent).toBe(newActivityWeight);
 
     expect(screen.getByTestId('updateReason-title').textContent).toBe('Reason');
     expect(screen.getByTestId('updateReason-field').textContent).toBe(reason);

--- a/apps/sv/frontend/src/__tests__/mocks/handlers/sv-api.ts
+++ b/apps/sv/frontend/src/__tests__/mocks/handlers/sv-api.ts
@@ -273,7 +273,7 @@ export const buildSvMock = (svUrl: string): HttpHandler[] => [
               {
                 template_id: 'featured-app-right-template-id',
                 contract_id: 'rightCid123',
-                payload: {},
+                payload: { activityWeight: '1.0' },
                 created_event_blob: '',
                 created_at: '2026-02-26T13:00:00.000000Z',
               },
@@ -293,7 +293,7 @@ export const buildSvMock = (svUrl: string): HttpHandler[] => [
         ? {
             template_id: 'featured-app-right-template-id',
             contract_id: 'rightCid123',
-            payload: { provider: 'a-party-id::1014912492' },
+            payload: { provider: 'a-party-id::1014912492', activityWeight: '1.0' },
             created_event_blob: '',
             created_at: '2026-02-26T13:00:00.000000Z',
           }

--- a/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
@@ -22,7 +22,6 @@ import {
   validateEffectiveDate,
   validateExpiration,
   validateExpiryEffectiveDate,
-  validateRevokeFeaturedAppRight,
   validatePartyId,
   validateSummary,
   validateUrl,
@@ -34,7 +33,7 @@ import { ProposalSummary } from '../governance/ProposalSummary';
 import { ProposalSubmissionError } from '../form-components/ProposalSubmissionError';
 import { useProposalMutation } from '../../hooks/useProposalMutation';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
-import { Option } from '../form-components/SelectField';
+import { useFeaturedAppRightPicker } from '../../hooks/useFeaturedAppRightPicker';
 
 type ProviderId = string;
 type FeaturedAppRightId = string;
@@ -75,8 +74,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
   const initialExpiration = getInitialExpiration(dsoInfosQuery.data);
   const initialEffectiveDate = dayjs(initialExpiration).add(1, 'day');
   const [showConfirmation, setShowConfirmation] = useState(false);
-  const [revokeRightOptions, setRevokeRightOptions] = useState<Option[]>([]);
-  const [providerSearched, setProviderSearched] = useState(false);
+  const picker = useFeaturedAppRightPicker(svAdminClient);
   const mutation = useProposalMutation();
 
   // TODO(#1819): use either search params or props and not both.
@@ -101,34 +99,6 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
     } catch {
       return 'Provider party not found on ledger';
     }
-  };
-
-  const loadFeaturedAppRightsAndValidate = async (value: string) => {
-    if (validatePartyId(value)) return undefined;
-
-    try {
-      const response = await svAdminClient.listFeaturedAppRightsByProvider(value);
-      const options = response.featured_app_rights.map((contract: { contract_id: string }) => ({
-        key: contract.contract_id,
-        value: contract.contract_id,
-      }));
-      setRevokeRightOptions(options);
-      setProviderSearched(true);
-      return undefined;
-    } catch {
-      setRevokeRightOptions([]);
-      setProviderSearched(false);
-      return 'Could not load featured app rights for this provider';
-    }
-  };
-
-  const validateRevokeRightSelection = (value: string): string | false => {
-    const requiredError = validateRevokeFeaturedAppRight(value);
-    if (requiredError) return requiredError;
-
-    return revokeRightOptions.some(option => option.value === value)
-      ? false
-      : 'Select a valid contract id';
   };
 
   const defaultValues: GrantRevokeFeaturedAppFormData = {
@@ -202,16 +172,16 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
     if (formAction !== 'SRARC_RevokeFeaturedAppRight') return;
 
     const currentRightCid = form.state.values.rightCid;
-    const hasSelectedOption = revokeRightOptions.some(option => option.value === currentRightCid);
+    const hasSelectedOption = picker.rightOptions.some(option => option.value === currentRightCid);
     if (hasSelectedOption) return;
 
-    const nextRightCid = revokeRightOptions.length === 1 ? revokeRightOptions[0].value : '';
+    const nextRightCid = picker.rightOptions.length === 1 ? picker.rightOptions[0].value : '';
     form.setFieldValue('rightCid', nextRightCid);
-  }, [form, formAction, revokeRightOptions]);
+  }, [form, formAction, picker.rightOptions]);
 
   const partyId = useStore(form.store, state => state.values.partyId);
   const providerHasNoRights =
-    providerSearched && revokeRightOptions.length === 0 && !validatePartyId(partyId);
+    picker.providerSearched && picker.rightOptions.length === 0 && !validatePartyId(partyId);
 
   return (
     <>
@@ -284,7 +254,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                   validators={{
                     onChange: ({ value }) => validatePartyId(value),
                     onChangeAsyncDebounceMs: 500,
-                    onChangeAsync: ({ value }) => loadFeaturedAppRightsAndValidate(value),
+                    onChangeAsync: ({ value }) => picker.loadFeaturedAppRightsAndValidate(value),
                   }}
                 >
                   {field => (
@@ -294,8 +264,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                       scrollableIdentifier
                       subtitle={field.state.meta.isValidating ? 'Loading app rights...' : undefined}
                       onChange={() => {
-                        setRevokeRightOptions([]);
-                        setProviderSearched(false);
+                        picker.resetOptions();
                       }}
                     />
                   )}
@@ -304,17 +273,17 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                 <form.AppField
                   name="rightCid"
                   validators={{
-                    onBlur: ({ value }) => validateRevokeRightSelection(value),
-                    onChange: ({ value }) => validateRevokeRightSelection(value),
+                    onBlur: ({ value }) => picker.validateRightSelection(value),
+                    onChange: ({ value }) => picker.validateRightSelection(value),
                   }}
                 >
                   {field => (
                     <field.SelectField
                       title={rightCidFieldTitle!}
                       id={`${testIdPrefix}-rightCid`}
-                      options={revokeRightOptions}
+                      options={picker.rightOptions}
                       scrollableIdentifier
-                      disabled={revokeRightOptions.length === 0}
+                      disabled={picker.rightOptions.length === 0}
                       placeholder={
                         providerHasNoRights
                           ? 'No featured application rights found for this provider'

--- a/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
@@ -262,7 +262,9 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                       title={providerFieldTitle}
                       id={`${testIdPrefix}-partyId`}
                       scrollableIdentifier
-                      subtitle={field.state.meta.isValidating ? 'Loading featured app rights...' : undefined}
+                      subtitle={
+                        field.state.meta.isValidating ? 'Loading featured app rights...' : undefined
+                      }
                       onChange={() => {
                         picker.resetOptions();
                       }}

--- a/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
@@ -262,7 +262,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                       title={providerFieldTitle}
                       id={`${testIdPrefix}-partyId`}
                       scrollableIdentifier
-                      subtitle={field.state.meta.isValidating ? 'Loading app rights...' : undefined}
+                      subtitle={field.state.meta.isValidating ? 'Loading featured app rights...' : undefined}
                       onChange={() => {
                         picker.resetOptions();
                       }}

--- a/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
@@ -140,7 +140,9 @@ export const UpdateFeaturedAppForm: React.FC = () => {
                 <field.TextField
                   title={'Provider Party ID'}
                   id={`${idPrefix}-partyId`}
-                  subtitle={field.state.meta.isValidating ? 'Loading app rights...' : undefined}
+                  subtitle={
+                    field.state.meta.isValidating ? 'Loading featured app rights...' : undefined
+                  }
                   onChange={() => {
                     picker.resetOptions();
                   }}

--- a/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
@@ -1,0 +1,262 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState, useEffect } from 'react';
+import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
+import { useDsoInfos } from '../../contexts/SvContext';
+import { useFeaturedAppRightPicker } from '../../hooks/useFeaturedAppRightPicker';
+import { useProposalMutation } from '../../hooks/useProposalMutation';
+import { UpdateFeatureAppFormData } from '../../utils/types';
+import { createProposalActions, getInitialExpiration } from '../../utils/governance';
+import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
+import dayjs from 'dayjs';
+import { useAppForm } from '../../hooks/form';
+import { ActionRequiringConfirmation } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
+import { ContractId } from '@daml/types';
+import { FeaturedAppRight } from '@daml.js/splice-amulet/lib/Splice/Amulet';
+import {
+  validateEffectiveDate,
+  validateExpiration,
+  validateExpiryEffectiveDate,
+  validatePartyId,
+  validateReason,
+  validateRequiredActivityWeight,
+  validateSummary,
+  validateUrl,
+} from './formValidators';
+import { FormLayout } from './FormLayout';
+import { ProposalSummary } from '../governance/ProposalSummary';
+import { useStore } from '@tanstack/react-form';
+import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { EffectiveDateField } from '../form-components/EffectiveDateField';
+import { ProposalSubmissionError } from '../form-components/ProposalSubmissionError';
+
+export const UpdateFeaturedAppForm: React.FC = () => {
+  const svAdminClient = useSvAdminClient();
+  const dsoInfosQuery = useDsoInfos();
+  const initialExpiration = getInitialExpiration(dsoInfosQuery.data);
+  const initialEffectiveDate = dayjs(initialExpiration).add(1, 'day');
+  const picker = useFeaturedAppRightPicker(svAdminClient);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const mutation = useProposalMutation();
+  const idPrefix = 'update-featured-app';
+
+  const createProposalAction = createProposalActions.find(
+    a => a.value === 'SRARC_UpdateFeaturedAppRight'
+  );
+
+  const defaultValues: UpdateFeatureAppFormData = {
+    action: createProposalAction?.name || '',
+    expiryDate: initialExpiration.format(dateTimeFormatISO),
+    effectiveDate: {
+      type: 'custom',
+      effectiveDate: initialEffectiveDate.format(dateTimeFormatISO),
+    },
+    url: '',
+    summary: '',
+    partyId: '',
+    rightCid: '',
+    newActivityWeight: '',
+    reason: '',
+  };
+
+  const form = useAppForm({
+    defaultValues,
+    onSubmit: async ({ value }) => {
+      const action: ActionRequiringConfirmation = {
+        tag: 'ARC_DsoRules',
+        value: {
+          dsoAction: {
+            tag: 'SRARC_UpdateFeaturedAppRight',
+            value: {
+              rightCid: value.rightCid as ContractId<FeaturedAppRight>,
+              update: { reason: value.reason, newActivityWeight: value.newActivityWeight },
+            },
+          },
+        },
+      };
+      if (!showConfirmation) setShowConfirmation(true);
+      else
+        await mutation.mutateAsync({ formData: value, action }).catch(e => {
+          console.error('Failed to submit proposal', e);
+        });
+    },
+    validators: {
+      onChange: ({ value }) =>
+        validateExpiryEffectiveDate({
+          expiration: value.expiryDate,
+          effectiveDate: value.effectiveDate.effectiveDate,
+        }),
+    },
+  });
+
+  useEffect(() => {
+    const currentRightCid = form.state.values.rightCid;
+    const hasSelectedOption = picker.rightOptions.some(o => o.value === currentRightCid);
+    if (hasSelectedOption) return;
+
+    const nextRightCid = picker.rightOptions.length === 1 ? picker.rightOptions[0].value : '';
+    form.setFieldValue('rightCid', nextRightCid);
+  }, [form, picker.rightOptions]);
+
+  const partyId = useStore(form.store, state => state.values.partyId);
+
+  const providerHasNoRights =
+    picker.providerSearched && picker.rightOptions.length === 0 && !validatePartyId(partyId);
+
+  return (
+    <>
+      <FormLayout form={form} id={`${idPrefix}-form`}>
+        {showConfirmation ? (
+          <ProposalSummary
+            actionName={form.state.values.action}
+            url={form.state.values.url}
+            summary={form.state.values.summary}
+            expiryDate={form.state.values.expiryDate}
+            effectiveDate={form.state.values.effectiveDate.effectiveDate}
+            formType="update-right"
+            providerPartyId={form.state.values.partyId}
+            rightCid={form.state.values.rightCid}
+            newActivityWeight={form.state.values.newActivityWeight}
+            reason={form.state.values.reason}
+            onEdit={() => setShowConfirmation(false)}
+            onSubmit={() => {}}
+          />
+        ) : (
+          <>
+            <form.AppField name="action">
+              {field => <field.ProposalTypeField id={`${idPrefix}-action`} />}
+            </form.AppField>
+
+            <form.AppField
+              name="partyId"
+              validators={{
+                onChange: ({ value }) => validatePartyId(value),
+                onChangeAsyncDebounceMs: 500,
+                onChangeAsync: ({ value }) => picker.loadFeaturedAppRightsAndValidate(value),
+              }}
+            >
+              {field => (
+                <field.TextField
+                  title={'Provider Party ID'}
+                  id={`${idPrefix}-partyId`}
+                  subtitle={field.state.meta.isValidating ? 'Loading app rights...' : undefined}
+                  onChange={() => {
+                    picker.resetOptions();
+                  }}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
+              name="rightCid"
+              validators={{
+                onBlur: ({ value }) => picker.validateRightSelection(value),
+                onChange: ({ value }) => picker.validateRightSelection(value),
+              }}
+            >
+              {field => (
+                <field.SelectField
+                  title="Featured Application Contract ID"
+                  id={`${idPrefix}-rightCid`}
+                  options={picker.rightOptions}
+                  disabled={picker.rightOptions.length === 0}
+                  placeholder={
+                    providerHasNoRights
+                      ? 'No featured application rights found for this provider'
+                      : undefined
+                  }
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
+              name="newActivityWeight"
+              validators={{
+                onBlur: ({ value }) => validateRequiredActivityWeight(value),
+                onChange: ({ value }) => validateRequiredActivityWeight(value),
+              }}
+            >
+              {field => (
+                <field.TextField
+                  title="Activity Weight"
+                  id={`${idPrefix}-activityWeight`}
+                  subtitle="Required. Scales the app's share of traffic-based rewards"
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
+              name="reason"
+              validators={{
+                onBlur: ({ value }) => validateReason(value),
+                onChange: ({ value }) => validateReason(value),
+              }}
+            >
+              {field => <field.TextField title="Proposal Reason" id={`${idPrefix}-reason`} />}
+            </form.AppField>
+
+            <form.AppField
+              name="expiryDate"
+              validators={{
+                onChange: ({ value }) => validateExpiration(value),
+                onBlur: ({ value }) => validateExpiration(value),
+              }}
+            >
+              {field => (
+                <field.DateField
+                  title="Threshold Deadline"
+                  description={THRESHOLD_DEADLINE_SUBTITLE}
+                  id={`${idPrefix}-expiry-date`}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField
+              name="effectiveDate"
+              validators={{
+                onChange: ({ value }) => validateEffectiveDate(value),
+                onBlur: ({ value }) => validateEffectiveDate(value),
+              }}
+              children={_ => (
+                <EffectiveDateField
+                  initialEffectiveDate={initialEffectiveDate.format(dateTimeFormatISO)}
+                  id={`${idPrefix}-effective-date`}
+                />
+              )}
+            />
+
+            <form.AppField
+              name="summary"
+              validators={{
+                onBlur: ({ value }) => validateSummary(value),
+                onChange: ({ value }) => validateSummary(value),
+              }}
+            >
+              {field => <field.ProposalSummaryField id={`${idPrefix}-summary`} />}
+            </form.AppField>
+
+            <form.AppField
+              name="url"
+              validators={{
+                onBlur: ({ value }) => validateUrl(value),
+                onChange: ({ value }) => validateUrl(value),
+              }}
+            >
+              {field => <field.TextField title="URL" id={`${idPrefix}-url`} />}
+            </form.AppField>
+          </>
+        )}
+
+        <form.AppForm>
+          <ProposalSubmissionError error={mutation.error} />
+          <form.FormErrors />
+          <form.FormControls
+            showConfirmation={showConfirmation}
+            onEdit={() => setShowConfirmation(false)}
+          />
+        </form.AppForm>
+      </FormLayout>
+    </>
+  );
+};

--- a/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
@@ -100,9 +100,14 @@ export const UpdateFeaturedAppForm: React.FC = () => {
   }, [form, picker.rightOptions]);
 
   const partyId = useStore(form.store, state => state.values.partyId);
+  const rightCid = useStore(form.store, state => state.values.rightCid);
+  const currentWeight = picker.currentWeights[rightCid] ?? 'None';
 
   const providerHasNoRights =
     picker.providerSearched && picker.rightOptions.length === 0 && !validatePartyId(partyId);
+
+  const requiredActivityWeightSubtitle =
+    "Required. Scales the app's share of traffic-based rewards";
 
   return (
     <>
@@ -114,10 +119,11 @@ export const UpdateFeaturedAppForm: React.FC = () => {
             summary={form.state.values.summary}
             expiryDate={form.state.values.expiryDate}
             effectiveDate={form.state.values.effectiveDate.effectiveDate}
-            formType="update-right"
+            formType="update-right-weight"
             providerPartyId={form.state.values.partyId}
             rightCid={form.state.values.rightCid}
             newActivityWeight={form.state.values.newActivityWeight}
+            currentActivityWeight={currentWeight}
             reason={form.state.values.reason}
             onEdit={() => setShowConfirmation(false)}
             onSubmit={() => {}}
@@ -183,7 +189,11 @@ export const UpdateFeaturedAppForm: React.FC = () => {
                 <field.TextField
                   title="Activity Weight"
                   id={`${idPrefix}-activityWeight`}
-                  subtitle="Required. Scales the app's share of traffic-based rewards"
+                  subtitle={
+                    rightCid
+                      ? `Current Weight: ${currentWeight}. ${requiredActivityWeightSubtitle}`
+                      : requiredActivityWeightSubtitle
+                  }
                 />
               )}
             </form.AppField>

--- a/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateFeaturedAppForm.tsx
@@ -27,7 +27,7 @@ import {
 import { FormLayout } from './FormLayout';
 import { ProposalSummary } from '../governance/ProposalSummary';
 import { useStore } from '@tanstack/react-form';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { DEFAULT_APP_ACTIVITY_WEIGHT, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import { EffectiveDateField } from '../form-components/EffectiveDateField';
 import { ProposalSubmissionError } from '../form-components/ProposalSubmissionError';
 
@@ -101,7 +101,7 @@ export const UpdateFeaturedAppForm: React.FC = () => {
 
   const partyId = useStore(form.store, state => state.values.partyId);
   const rightCid = useStore(form.store, state => state.values.rightCid);
-  const currentWeight = picker.currentWeights[rightCid] ?? 'None';
+  const currentWeight = picker.currentWeights[rightCid] ?? DEFAULT_APP_ACTIVITY_WEIGHT;
 
   const providerHasNoRights =
     picker.providerSearched && picker.rightOptions.length === 0 && !validatePartyId(partyId);

--- a/apps/sv/frontend/src/components/forms/formValidators.ts
+++ b/apps/sv/frontend/src/components/forms/formValidators.ts
@@ -12,6 +12,8 @@ export const urlSchema = z.string().refine(url => isValidUrl(url), {
 
 export const summarySchema = z.string().min(1, { message: 'Summary is required' });
 
+export const reasonSchema = z.string().min(1, { message: 'Reason is required' });
+
 export const svSelectionSchema = z.string().min(1, { message: 'SV is required' });
 
 const getExpirationSchema = (errMessage: string) => {
@@ -66,6 +68,18 @@ export const rewardAmountSchema = z
     { message: 'Amount can have at most 10 decimal places' }
   );
 
+export const requiredActivityWeightSchema = z
+  .string()
+  .min(1, { message: 'Weight is required' })
+  .regex(/^\d+(\.\d+)?$/, { message: 'Weight must be a valid non-negative number' })
+  .refine(
+    v => {
+      const i = v.indexOf('.');
+      return i === -1 || v.length - i - 1 <= 10;
+    },
+    { message: 'Weight can have at most 10 decimal places' }
+  );
+
 export const activityWeightSchema = z
   .string()
   .refine(v => v === '' || /^\d+(\.\d+)?$/.test(v), {
@@ -91,6 +105,11 @@ export const validateRewardAmount = (value: string): string | false => {
 
 export const validateActivityWeight = (value: string): string | false => {
   const result = activityWeightSchema.safeParse(value);
+  return result.success ? false : result.error.issues[0].message;
+};
+
+export const validateRequiredActivityWeight = (value: string): string | false => {
+  const result = requiredActivityWeightSchema.safeParse(value);
   return result.success ? false : result.error.issues[0].message;
 };
 
@@ -163,6 +182,11 @@ export const validateMintBeforeAndEffectiveDate = (value: {
 
 export const validateSummary = (value: string): string | false => {
   const result = summarySchema.safeParse(value);
+  return result.success ? false : result.error.issues[0].message;
+};
+
+export const validateReason = (value: string): string | false => {
+  const result = reasonSchema.safeParse(value);
   return result.success ? false : result.error.issues[0].message;
 };
 

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -228,6 +228,14 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
             <UnfeatureAppSection rightContractId={proposalDetails.proposal.rightContractId} />
           )}
 
+          {proposalDetails.action === 'SRARC_UpdateFeaturedAppRight' && (
+            <UpdateFeatureAppSection
+              rightContractId={proposalDetails.proposal.rightContractId}
+              newActivityWeight={proposalDetails.proposal.newActivityWeight}
+              reason={proposalDetails.proposal.reason}
+            />
+          )}
+
           {proposalDetails.action === 'SRARC_UpdateSvRewardWeight' && (
             <UpdateSvRewardWeightSection
               svToUpdate={proposalDetails.proposal.svToUpdate}
@@ -654,6 +662,72 @@ const UnfeatureAppSection = ({ rightContractId }: UnfeatureAppSectionProps) => {
           />
         }
         labelId="proposal-details-unfeature-app-label"
+      />
+    </Box>
+  );
+};
+
+interface UpdateFeatureAppSectionProps {
+  rightContractId: string;
+  newActivityWeight: string;
+  reason: string;
+}
+
+const UpdateFeatureAppSection = ({
+  rightContractId,
+  newActivityWeight,
+  reason,
+}: UpdateFeatureAppSectionProps) => {
+  const svAdminClient = useSvAdminClient();
+  const providerQuery = useQuery({
+    queryKey: ['featuredAppRightProvider', rightContractId],
+    queryFn: async () => {
+      const response = await svAdminClient.lookupFeaturedAppRightByContractId(rightContractId);
+      const contract = response.featured_app_right;
+      return (contract?.payload as { provider?: string } | undefined)?.provider ?? null;
+    },
+  });
+  return (
+    <Box
+      id="proposal-details-update-feature-app-section"
+      data-testid="proposal-details-update-feature-app-section"
+      sx={{ display: 'contents' }}
+    >
+      {providerQuery.data && (
+        <DetailItem
+          label="Provider Party ID"
+          value={
+            <CopyableIdentifier
+              value={providerQuery.data}
+              size="large"
+              data-testid="proposal-details-update-feature-value"
+            />
+          }
+          labelId="proposal-details-update-feature-label"
+        />
+      )}
+      <DetailItem
+        label="Featured Application Contract ID"
+        value={
+          <CopyableIdentifier
+            value={rightContractId}
+            size="large"
+            data-testid="proposal-details-update-feature-app-value"
+          />
+        }
+        labelId="proposal-details-update-feature-app-label"
+      />
+      <DetailItem
+        label="Activity Weight"
+        value={newActivityWeight}
+        labelId="proposal-details-update-feature-value"
+        valueId="proposal-details-update-feature-app-label"
+      />
+      <DetailItem
+        label="Reason"
+        value={reason}
+        labelId="proposal-details-update-feature-value"
+        valueId="proposal-details-update-feature-app-label"
       />
     </Box>
   );

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -684,7 +684,13 @@ const UpdateFeatureAppSection = ({
     queryFn: async () => {
       const response = await svAdminClient.lookupFeaturedAppRightByContractId(rightContractId);
       const contract = response.featured_app_right;
-      return (contract?.payload as { provider?: string } | undefined)?.provider ?? null;
+      const payload = contract?.payload as
+        | { provider?: string; activityWeight?: string | null }
+        | undefined;
+      return {
+        provider: payload?.provider ?? null,
+        currentWeight: payload?.activityWeight ?? '',
+      };
     },
   });
   return (
@@ -693,12 +699,12 @@ const UpdateFeatureAppSection = ({
       data-testid="proposal-details-update-feature-app-section"
       sx={{ display: 'contents' }}
     >
-      {providerQuery.data && (
+      {providerQuery?.data?.provider && (
         <DetailItem
           label="Provider Party ID"
           value={
             <CopyableIdentifier
-              value={providerQuery.data}
+              value={providerQuery.data?.provider}
               size="large"
               data-testid="proposal-details-update-feature-value"
             />
@@ -718,10 +724,19 @@ const UpdateFeatureAppSection = ({
         labelId="proposal-details-update-feature-app-label"
       />
       <DetailItem
-        label="Activity Weight"
-        value={newActivityWeight}
-        labelId="proposal-details-update-feature-activity-weight-label"
-        valueId="proposal-details-update-feature-activity-weight-value"
+        label="Proposed Changes"
+        value={
+          <ConfigValuesChanges
+            changes={[
+              {
+                label: 'Activity Weight',
+                fieldName: 'newActivityWeight',
+                currentValue: providerQuery.data?.currentWeight ?? '',
+                newValue: newActivityWeight,
+              },
+            ]}
+          />
+        }
       />
       <DetailItem
         label="Reason"

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -720,14 +720,14 @@ const UpdateFeatureAppSection = ({
       <DetailItem
         label="Activity Weight"
         value={newActivityWeight}
-        labelId="proposal-details-update-feature-value"
-        valueId="proposal-details-update-feature-app-label"
+        labelId="proposal-details-update-feature-activity-weight-label"
+        valueId="proposal-details-update-feature-activity-weight-value"
       />
       <DetailItem
         label="Reason"
         value={reason}
-        labelId="proposal-details-update-feature-value"
-        valueId="proposal-details-update-feature-app-label"
+        labelId="proposal-details-update-feature-reason-label"
+        valueId="proposal-details-update-feature-reason-value"
       />
     </Box>
   );

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -680,7 +680,7 @@ const UpdateFeatureAppSection = ({
 }: UpdateFeatureAppSectionProps) => {
   const svAdminClient = useSvAdminClient();
   const providerQuery = useQuery({
-    queryKey: ['featuredAppRightProvider', rightContractId],
+    queryKey: ['featuredAppRightProviderAndWeight', rightContractId],
     queryFn: async () => {
       const response = await svAdminClient.lookupFeaturedAppRightByContractId(rightContractId);
       const contract = response.featured_app_right;

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -34,6 +34,7 @@ import { CreateUnallocatedUnclaimedActivityRecordSection } from './proposal-deta
 import { CopyableIdentifier, CopyableUrl, MemberIdentifier, VoteStats } from '../beta';
 import { useQuery } from '@tanstack/react-query';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
+import { DEFAULT_APP_ACTIVITY_WEIGHT } from '../../utils/constants';
 
 dayjs.extend(relativeTime);
 
@@ -689,7 +690,7 @@ const UpdateFeatureAppSection = ({
         | undefined;
       return {
         provider: payload?.provider ?? null,
-        currentWeight: payload?.activityWeight ?? '',
+        currentWeight: contract ? (payload?.activityWeight ?? DEFAULT_APP_ACTIVITY_WEIGHT) : '',
       };
     },
   });

--- a/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
@@ -49,6 +49,13 @@ type ProposalSummaryProps = BaseProposalSummaryProps &
         amount: string;
         expiresAt: string;
       }
+    | {
+        formType: 'update-right';
+        providerPartyId: string;
+        rightCid: string;
+        newActivityWeight: string;
+        reason: string;
+      }
   );
 
 export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
@@ -137,6 +144,27 @@ export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
               value={props.revokeRight}
               scrollableIdentifier
             />
+          </>
+        )}
+
+        {formType === 'update-right' && (
+          <>
+            <ProposalField
+              id="updateProviderPartyId"
+              title="Provider Party ID"
+              value={props.providerPartyId}
+            />
+            <ProposalField
+              id="updateRight"
+              title="Featured Application Contract ID"
+              value={props.rightCid}
+            />
+            <ProposalField
+              id="updateActivityWeight"
+              title="Activity Weight"
+              value={props.newActivityWeight}
+            />
+            <ProposalField id="updateReason" title="Reason" value={props.reason} />
           </>
         )}
 

--- a/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
@@ -50,9 +50,10 @@ type ProposalSummaryProps = BaseProposalSummaryProps &
         expiresAt: string;
       }
     | {
-        formType: 'update-right';
+        formType: 'update-right-weight';
         providerPartyId: string;
         rightCid: string;
+        currentActivityWeight: string;
         newActivityWeight: string;
         reason: string;
       }
@@ -147,7 +148,7 @@ export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
           </>
         )}
 
-        {formType === 'update-right' && (
+        {formType === 'update-right-weight' && (
           <>
             <ProposalField
               id="updateProviderPartyId"
@@ -161,8 +162,19 @@ export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
             />
             <ProposalField
               id="updateActivityWeight"
-              title="Activity Weight"
-              value={props.newActivityWeight}
+              title="Proposed Changes"
+              value={
+                <ConfigValuesChanges
+                  changes={[
+                    {
+                      label: 'Activity Weight',
+                      fieldName: 'newActivityWeight',
+                      currentValue: props.currentActivityWeight,
+                      newValue: props.newActivityWeight,
+                    },
+                  ]}
+                />
+              }
             />
             <ProposalField id="updateReason" title="Reason" value={props.reason} />
           </>

--- a/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
+++ b/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+import { Option } from '../components/form-components/SelectField';
+import {
+  validatePartyId,
+  validateRevokeFeaturedAppRight,
+} from '../components/forms/formValidators';
+import { useSvAdminClient } from '../contexts/SvAdminServiceContext';
+
+interface FeatureAppRightPicker {
+  rightOptions: Option[];
+  providerSearched: boolean;
+  loadFeaturedAppRightsAndValidate: (value: string) => Promise<string | undefined>;
+  validateRightSelection: (value: string) => string | false;
+  resetOptions: () => void;
+}
+
+export const useFeaturedAppRightPicker = (
+  svAdminClient: ReturnType<typeof useSvAdminClient>
+): FeatureAppRightPicker => {
+  const [rightOptions, setRightOptions] = useState<Option[]>([]);
+  const [providerSearched, setProviderSearched] = useState(false);
+
+  const loadFeaturedAppRightsAndValidate = async (value: string) => {
+    if (validatePartyId(value)) return undefined;
+
+    try {
+      const response = await svAdminClient.listFeaturedAppRightsByProvider(value);
+      const options = response.featured_app_rights.map((contract: { contract_id: string }) => ({
+        key: contract.contract_id,
+        value: contract.contract_id,
+      }));
+      setRightOptions(options);
+      setProviderSearched(true);
+      return undefined;
+    } catch {
+      setRightOptions([]);
+      setProviderSearched(false);
+      return 'Could not load featured app rights for this provider';
+    }
+  };
+
+  const validateRightSelection = (value: string): string | false => {
+    const requiredError = validateRevokeFeaturedAppRight(value);
+    if (requiredError) return requiredError;
+
+    return rightOptions.some(option => option.value === value)
+      ? false
+      : 'Select a valid contract id';
+  };
+
+  const resetOptions = () => {
+    setRightOptions([]);
+    setProviderSearched(false);
+  };
+
+  return {
+    rightOptions,
+    providerSearched,
+    loadFeaturedAppRightsAndValidate,
+    validateRightSelection,
+    resetOptions,
+  };
+};

--- a/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
+++ b/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
@@ -11,6 +11,7 @@ import { useSvAdminClient } from '../contexts/SvAdminServiceContext';
 
 interface FeatureAppRightPicker {
   rightOptions: Option[];
+  currentWeights: Record<string, string>;
   providerSearched: boolean;
   loadFeaturedAppRightsAndValidate: (value: string) => Promise<string | undefined>;
   validateRightSelection: (value: string) => string | false;
@@ -22,6 +23,7 @@ export const useFeaturedAppRightPicker = (
 ): FeatureAppRightPicker => {
   const [rightOptions, setRightOptions] = useState<Option[]>([]);
   const [providerSearched, setProviderSearched] = useState(false);
+  const [currentWeights, setCurrentWeights] = useState<Record<string, string>>({});
 
   const loadFeaturedAppRightsAndValidate = async (value: string) => {
     if (validatePartyId(value)) return undefined;
@@ -32,11 +34,19 @@ export const useFeaturedAppRightPicker = (
         key: contract.contract_id,
         value: contract.contract_id,
       }));
+      const weights = Object.fromEntries(
+        response.featured_app_rights.map(c => {
+          const aw = (c.payload as { activityWeight?: string | null }).activityWeight;
+          return [c.contract_id, aw ?? 'None'];
+        })
+      );
       setRightOptions(options);
+      setCurrentWeights(weights);
       setProviderSearched(true);
       return undefined;
     } catch {
       setRightOptions([]);
+      setCurrentWeights({});
       setProviderSearched(false);
       return 'Could not load featured app rights for this provider';
     }
@@ -53,11 +63,13 @@ export const useFeaturedAppRightPicker = (
 
   const resetOptions = () => {
     setRightOptions([]);
+    setCurrentWeights({});
     setProviderSearched(false);
   };
 
   return {
     rightOptions,
+    currentWeights,
     providerSearched,
     loadFeaturedAppRightsAndValidate,
     validateRightSelection,

--- a/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
+++ b/apps/sv/frontend/src/hooks/useFeaturedAppRightPicker.ts
@@ -8,6 +8,7 @@ import {
   validateRevokeFeaturedAppRight,
 } from '../components/forms/formValidators';
 import { useSvAdminClient } from '../contexts/SvAdminServiceContext';
+import { DEFAULT_APP_ACTIVITY_WEIGHT } from '../utils/constants';
 
 interface FeatureAppRightPicker {
   rightOptions: Option[];
@@ -37,7 +38,7 @@ export const useFeaturedAppRightPicker = (
       const weights = Object.fromEntries(
         response.featured_app_rights.map(c => {
           const aw = (c.payload as { activityWeight?: string | null }).activityWeight;
-          return [c.contract_id, aw ?? 'None'];
+          return [c.contract_id, aw ?? DEFAULT_APP_ACTIVITY_WEIGHT];
         })
       );
       setRightOptions(options);

--- a/apps/sv/frontend/src/routes/createProposal.tsx
+++ b/apps/sv/frontend/src/routes/createProposal.tsx
@@ -14,6 +14,7 @@ import { useDsoInfos } from '../contexts/SvContext';
 import { createProposalActions } from '../utils/governance';
 import type { SupportedActionTag } from '../utils/types';
 import { Box } from '@mui/material';
+import { UpdateFeaturedAppForm } from '../components/forms/UpdateFeaturedAppForm';
 
 const ProposalForm: React.FC<{ action: SupportedActionTag }> = ({ action }) => {
   const dsoInfosQuery = useDsoInfos();
@@ -35,6 +36,8 @@ const ProposalForm: React.FC<{ action: SupportedActionTag }> = ({ action }) => {
       return <SetDsoConfigRulesForm />;
     case 'CRARC_SetConfig':
       return <SetAmuletConfigRulesForm />;
+    case 'SRARC_UpdateFeaturedAppRight':
+      return <UpdateFeaturedAppForm />;
   }
 };
 

--- a/apps/sv/frontend/src/utils/constants.ts
+++ b/apps/sv/frontend/src/utils/constants.ts
@@ -6,3 +6,4 @@ export const PROPOSAL_SUMMARY_SUBTITLE = 'For CIP votes, consider copying the CI
 export const DEFAULT_PROPOSAL_SUMMARY_MAX_LENGTH = 1024;
 export const THRESHOLD_DEADLINE_SUBTITLE =
   'Proposal remains open only if ⅔ of nodes place a vote before this date-time';
+export const DEFAULT_APP_ACTIVITY_WEIGHT = '1.0';

--- a/apps/sv/frontend/src/utils/governance.ts
+++ b/apps/sv/frontend/src/utils/governance.ts
@@ -28,6 +28,7 @@ import type {
   SupportedActionTag,
   UnclaimedActivityRecordProposal,
   UnfeatureAppProposal,
+  UpdateFeatureAppProposal,
   UpdateSvRewardWeightProposal,
   YourVoteStatus,
 } from '../utils/types';
@@ -46,6 +47,7 @@ export const actionTagToTitle = (amuletName: string): Record<SupportedActionTag,
   SRARC_CreateUnallocatedUnclaimedActivityRecord: 'Create Unclaimed Activity Record',
   SRARC_SetConfig: 'Set Decentralized Synchronizer Operations (DSO) Rules Configuration',
   SRARC_UpdateSvRewardWeight: 'Update Super Validator Reward Weight',
+  SRARC_UpdateFeaturedAppRight: 'Update Featured Application',
 });
 
 export const createProposalActions: {
@@ -55,6 +57,7 @@ export const createProposalActions: {
   { name: 'Offboard Member', value: 'SRARC_OffboardSv' },
   { name: 'Feature Application', value: 'SRARC_GrantFeaturedAppRight' },
   { name: 'Unfeature Application', value: 'SRARC_RevokeFeaturedAppRight' },
+  { name: 'Update Featured Application', value: 'SRARC_UpdateFeaturedAppRight' },
   {
     name: 'Set Decentralized Synchronizer Operations (DSO) Rules Configuration',
     value: 'SRARC_SetConfig',
@@ -140,6 +143,12 @@ export function buildProposal(action: ActionRequiringConfirmation, dsoInfo?: Dso
         );
       case 'SRARC_RevokeFeaturedAppRight':
         return createRevokeFeatureAppProposal(dsoAction.value.rightCid);
+      case 'SRARC_UpdateFeaturedAppRight':
+        return createUpdateFeatureAppProposal(
+          dsoAction.value.rightCid,
+          dsoAction.value.update.newActivityWeight,
+          dsoAction.value.update.reason
+        );
       case 'SRARC_SetConfig':
         return createDsoRulesConfigProposal(dsoAction.value.baseConfig, dsoAction.value.newConfig);
     }
@@ -167,6 +176,14 @@ function createGrantFeatureAppProposal(
     provider: provider,
     activityWeight: activityWeight,
   };
+}
+
+function createUpdateFeatureAppProposal(
+  rightContractId: string,
+  newActivityWeight: string,
+  reason: string
+): UpdateFeatureAppProposal {
+  return { rightContractId, newActivityWeight, reason };
 }
 
 function createRevokeFeatureAppProposal(rightContractId: string): UnfeatureAppProposal {

--- a/apps/sv/frontend/src/utils/types.ts
+++ b/apps/sv/frontend/src/utils/types.ts
@@ -29,6 +29,12 @@ export interface UnfeatureAppProposal {
   rightContractId: string;
 }
 
+export interface UpdateFeatureAppProposal {
+  rightContractId: string;
+  newActivityWeight: string;
+  reason: string;
+}
+
 export interface UnclaimedActivityRecordProposal {
   beneficiary: string;
   amount: string;
@@ -86,6 +92,7 @@ export type Proposal =
   | UnclaimedActivityRecordProposal
   | AmuletRulesConfigProposal
   | DsoRulesConfigProposal
+  | UpdateFeatureAppProposal
   | undefined;
 
 export type ProposalActionMap = {
@@ -96,6 +103,7 @@ export type ProposalActionMap = {
   SRARC_CreateUnallocatedUnclaimedActivityRecord: UnclaimedActivityRecordProposal;
   CRARC_SetConfig: AmuletRulesConfigProposal;
   SRARC_SetConfig: DsoRulesConfigProposal;
+  SRARC_UpdateFeaturedAppRight: UpdateFeatureAppProposal;
   // If no proposal type is defined, can use unknown or a specific type:
   CRARC_AddFutureAmuletConfigSchedule: unknown;
 };
@@ -134,7 +142,8 @@ export type SupportedActionTag =
   | 'SRARC_RevokeFeaturedAppRight'
   | 'SRARC_SetConfig'
   | 'SRARC_UpdateSvRewardWeight'
-  | 'SRARC_CreateUnallocatedUnclaimedActivityRecord';
+  | 'SRARC_CreateUnallocatedUnclaimedActivityRecord'
+  | 'SRARC_UpdateFeaturedAppRight';
 
 export type ProposalListingStatus =
   | 'Accepted'
@@ -199,11 +208,19 @@ export interface ProposalMutationArgs {
   action: ActionRequiringConfirmation;
 }
 
+export interface UpdateFeatureAppFormData extends CommonProposalFormData {
+  partyId: string;
+  rightCid: string;
+  newActivityWeight: string;
+  reason: string;
+}
+
 export type NonConfigProposalFormData =
   | UpdateSvRewardWeightFormData
   | OffboardSvFormData
   | GrantRevokeFeaturedAppFormData
-  | CreateUnallocatedUnclaimedActivityRecordFormData;
+  | CreateUnallocatedUnclaimedActivityRecordFormData
+  | UpdateFeatureAppFormData;
 
 export type ConfigProposalFormData = SetDsoConfigCompleteFormData | SetAmuletConfigCompleteFormData;
 

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -32,3 +32,7 @@
     - Deployment
 
         - The sequencer and mediator can now be configured with independent ``additionalJvmOptions`` via the new ``sequencer.additionalJvmOptions`` and ``mediator.additionalJvmOptions`` values in the ``splice-global-domain`` helm chart.
+
+    - SV app
+
+      - Add support for updating weight via ``UpdateFeaturedAppRight`` governance voting UI.


### PR DESCRIPTION
fixes: https://github.com/canton-network/splice/issues/6236

refactor
- `GrantRevokeFeaturedAppForm` had some hooks that could also be used in the new form needed to support this vote so it was abstracted away into `useFeaturedAppRightPicker`