### PR TITLE
Bump the onboarding timeout in FE integration tests

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/FrontendLoginUtil.scala
@@ -124,7 +124,12 @@ trait FrontendLoginUtil extends WithAuth0Support { self: FrontendTestCommon =>
           )
         }
         val userPartyId = if (onboardThroughWalletUI) {
-          actAndCheck("onboard user", eventuallyClickOn(id("onboard-button")))(
+          // Onboarding creates the WalletAppInstall contract
+          // under CI load sequencing can take longer than the default 20s
+          actAndCheck(timeUntilSuccess = 40.seconds)(
+            "onboard user",
+            eventuallyClickOn(id("onboard-button")),
+          )(
             "user is onboarded",
             _ => {
               val userId = seleniumText(find(id("logged-in-user")))


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9242

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
