### PR TITLE
UI tests janitorization

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/create-proposal.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/create-proposal.test.tsx
@@ -38,11 +38,8 @@ async function checkActionSelection(actionName: string, actionValue: string, tes
   const selectInput = actionDropdown.querySelector('[role="combobox"]') as HTMLElement;
   await user.click(selectInput);
 
-  await waitFor(async () => {
-    const actionToSelect = screen.getByText(actionName);
-    expect(actionToSelect).toBeInTheDocument();
-    await user.click(actionToSelect);
-  });
+  const actionToSelect = await screen.findByText(actionName);
+  await user.click(actionToSelect);
 
   const nextButton = screen.getByText('Next');
   expect(nextButton).toBeInTheDocument();
@@ -191,20 +188,19 @@ describe('Create Proposal', () => {
 
     const nextButton = screen.getByText('Next');
     expect(nextButton).toBeDefined();
-    expect(nextButton.getAttribute('disabled')).toBeDefined();
+    expect(nextButton.getAttribute('disabled')).not.toBeNull();
 
     const actionDropdown = screen.getByTestId('select-action');
     expect(actionDropdown).toBeDefined();
 
     const selectInput = actionDropdown.querySelector('[role="combobox"]') as HTMLElement;
-    user.click(selectInput);
+    await user.click(selectInput);
+
+    const actionToSelect = await screen.findByText('Offboard Member');
+    await user.click(actionToSelect);
 
     await waitFor(() => {
-      const actionToSelect = screen.getByText('Offboard Member');
-      expect(actionToSelect).toBeDefined();
-      user.click(actionToSelect);
+      expect(nextButton.getAttribute('disabled')).toBeNull();
     });
-
-    expect(nextButton.getAttribute('disabled')).toBe('');
   });
 });

--- a/apps/sv/frontend/src/__tests__/governance/forms/create-unallocated-unclaimed-activity-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/create-unallocated-unclaimed-activity-form.test.tsx
@@ -32,7 +32,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     await user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 
@@ -99,7 +99,7 @@ describe('Create Unallocated Unclaimed Activity Record Form', () => {
     expect(submitButton).toBeInTheDocument();
 
     await user.click(submitButton);
-    expect(submitButton.getAttribute('disabled')).toBeDefined();
+    expect(submitButton.getAttribute('disabled')).not.toBeNull();
     await expect(async () => await user.click(submitButton)).rejects.toThrowError(
       /Unable to perform pointer interaction/
     );

--- a/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/grant-revoke-featured-app-form.test.tsx
@@ -32,7 +32,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     await user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 

--- a/apps/sv/frontend/src/__tests__/governance/forms/offboard-sv-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/offboard-sv-form.test.tsx
@@ -32,7 +32,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     await user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 
@@ -85,7 +85,7 @@ describe('Offboard SV Form', () => {
     expect(screen.getByText('Review Proposal')).toBeInTheDocument();
 
     await user.click(submitButton);
-    expect(submitButton.getAttribute('disabled')).toBeDefined();
+    expect(submitButton.getAttribute('disabled')).not.toBeNull();
     await expect(async () => await user.click(submitButton)).rejects.toThrowError(
       /Unable to perform pointer interaction/
     );
@@ -109,11 +109,8 @@ describe('Offboard SV Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation
 
@@ -221,10 +218,8 @@ describe('Offboard SV Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     expect(screen.getByText('Review Proposal')).toBeInTheDocument();
     const submitButton = screen.getByTestId('submit-button');
@@ -265,10 +260,8 @@ describe('Offboard SV Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     expect(screen.getByText('Review Proposal')).toBeInTheDocument();
     const submitButton = screen.getByTestId('submit-button');
@@ -312,10 +305,8 @@ describe('Offboard SV Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const submitButton = screen.getByTestId('submit-button');
     await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation

--- a/apps/sv/frontend/src/__tests__/governance/forms/pending-fields.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/pending-fields.test.tsx
@@ -78,7 +78,7 @@ describe('DSO Pending Fields', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     await user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 

--- a/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-amulet-rules-form.test.tsx
@@ -32,7 +32,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 
@@ -103,7 +103,7 @@ describe('Set Amulet Config Rules Form', () => {
       expect(submitButton).toBeInTheDocument();
 
       await user.click(submitButton);
-      expect(submitButton.getAttribute('disabled')).toBeDefined();
+      expect(submitButton.getAttribute('disabled')).not.toBeNull();
       await expect(async () => await user.click(submitButton)).rejects.toThrowError(
         /Unable to perform pointer interaction/
       );

--- a/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
@@ -34,7 +34,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     await user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 
@@ -94,7 +94,7 @@ describe('Set DSO Config Rules Form', () => {
     expect(submitButton).toBeInTheDocument();
 
     await user.click(submitButton);
-    expect(submitButton.getAttribute('disabled')).toBeDefined();
+    expect(submitButton.getAttribute('disabled')).not.toBeNull();
     expect(async () => await user.click(submitButton)).rejects.toThrowError(
       /Unable to perform pointer interaction/
     );

--- a/apps/sv/frontend/src/__tests__/governance/forms/update-sv-reward-weight-form-test.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/update-sv-reward-weight-form-test.test.tsx
@@ -32,7 +32,7 @@ describe('SV user can', () => {
     const button = screen.getByRole('button', { name: 'Log In' });
     user.click(button);
 
-    expect(await screen.findAllByDisplayValue(svPartyId)).not.toBe([]);
+    expect(await screen.findAllByDisplayValue(svPartyId)).not.toHaveLength(0);
   });
 });
 
@@ -86,7 +86,7 @@ describe('Update Super Validator Reward Weight Form', () => {
     expect(submitButton).toBeInTheDocument();
 
     await user.click(submitButton);
-    expect(submitButton.getAttribute('disabled')).toBeDefined();
+    expect(submitButton.getAttribute('disabled')).not.toBeNull();
     await expect(async () => await user.click(submitButton)).rejects.toThrowError(
       /Unable to perform pointer interaction/
     );
@@ -111,11 +111,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
     expect(weightInput).toBeInTheDocument();
@@ -123,7 +120,7 @@ describe('Update Super Validator Reward Weight Form', () => {
 
     await user.click(actionInput); // using this to trigger the onBlur event which triggers the validation
 
-    expect(submitButton.getAttribute('disabled')).toBe(null);
+    expect(submitButton.getAttribute('disabled')).toBeNull();
   });
 
   test('expiry date must be in the future', async () => {
@@ -222,13 +219,10 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
 
     const validateCurrentWeightFor = async (sv: string, weight: string) => {
-      await waitFor(async () => {
-        fireEvent.mouseDown(selectInput);
-        const memberToSelect = screen.getByText(sv);
-        expect(memberToSelect).not.toBeNull();
-        await user.click(memberToSelect);
-        expect(await screen.findByText(`Current Weight: ${weight}`)).toBeInTheDocument();
-      });
+      fireEvent.mouseDown(selectInput);
+      const memberToSelect = await screen.findByText(sv);
+      await user.click(memberToSelect);
+      expect(await screen.findByText(`Current Weight: ${weight}`)).toBeInTheDocument();
     };
 
     await validateCurrentWeightFor('Digital-Asset-2', '0_0010');
@@ -257,11 +251,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     expect(weightInput.getAttribute('value')).toBe('');
   });
@@ -334,11 +325,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
     expect(weightInput).toBeInTheDocument();
@@ -383,11 +371,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
     expect(weightInput.getAttribute('value')).toBe('');
@@ -438,11 +423,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      expect(memberToSelect).toBeInTheDocument();
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
     expect(weightInput).toBeInTheDocument();
@@ -488,10 +470,8 @@ describe('Update Super Validator Reward Weight Form', () => {
     const selectInput = screen.getByRole('combobox');
     fireEvent.mouseDown(selectInput);
 
-    await waitFor(async () => {
-      const memberToSelect = screen.getByText('Digital-Asset-Eng-2');
-      await user.click(memberToSelect);
-    });
+    const memberToSelect = await screen.findByText('Digital-Asset-Eng-2');
+    await user.click(memberToSelect);
 
     const weightInput = screen.getByTestId('update-sv-reward-weight-weight');
     await user.type(weightInput, '0_1000');

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -909,8 +909,10 @@ describe('Proposal Details > Votes & Voting', () => {
     // This is because awaiting the button click makes it very difficult for the test runner to see the loading state
     user.click(acceptButton);
 
-    await waitFor(async () => {
-      expect(acceptButton.getAttribute('disabled')).toBeDefined();
+    // once submission starts, the vote buttons are unmounted (replaced by the
+    // "Submitting..." state and then the submission message)
+    await waitFor(() => {
+      expect(acceptButton).not.toBeInTheDocument();
     });
 
     const submissionMessage = await screen.findByTestId('submission-message');
@@ -972,8 +974,10 @@ describe('Proposal Details > Votes & Voting', () => {
     // This is because awaiting the button click makes it very difficult for the test runner to see the loading state
     user.click(acceptButton);
 
-    await waitFor(async () => {
-      expect(acceptButton.getAttribute('disabled')).toBeDefined();
+    // once submission starts, the vote buttons are unmounted (replaced by the
+    // "Submitting..." state and then the submission message)
+    await waitFor(() => {
+      expect(acceptButton).not.toBeInTheDocument();
     });
 
     const submissionMessage = await screen.findByTestId('submission-message');

--- a/apps/sv/frontend/src/__tests__/sv.test.tsx
+++ b/apps/sv/frontend/src/__tests__/sv.test.tsx
@@ -209,7 +209,7 @@ describe('An SetConfig request', () => {
     );
 
     const button = screen.getByRole('button', { name: 'Send Request to Super Validators' });
-    expect(button.getAttribute('disabled')).toBeDefined();
+    expect(button.getAttribute('disabled')).not.toBeNull();
   });
 
   test('displays a warning when an SV tries to modify an AmuletRules field already changed by another request', async () => {
@@ -240,7 +240,7 @@ describe('An SetConfig request', () => {
         'You are therefore not allowed to modify the fields: transferConfig.createFee.fee'
     );
     const button = screen.getByTestId('create-voterequest-submit-button');
-    expect(button.getAttribute('disabled')).toBeDefined();
+    expect(button.getAttribute('disabled')).not.toBeNull();
   });
 
   test('disables the Proceed button in the confirmation dialog if a conflict arises after request creation', async () => {
@@ -281,7 +281,10 @@ describe('An SetConfig request', () => {
     );
 
     const button = screen.getByRole('button', { name: 'Proceed' });
-    expect(button.getAttribute('disabled')).toBeDefined();
+    // the conflict is only detected once the vote requests query re-polls (1s interval)
+    await waitFor(() => expect(button.getAttribute('disabled')).not.toBeNull(), {
+      timeout: 5000,
+    });
   });
 });
 
@@ -315,8 +318,8 @@ describe('An AddFutureAmuletConfigSchedule request', () => {
     expect(await screen.findByDisplayValue('validator::15')).toBeDefined();
 
     // secrets
-    expect(await screen.queryByText('encoded_secret')).toBeDefined();
-    expect(await screen.queryByText('candidate_secret')).toBeNull();
+    expect(screen.queryByText('encoded_secret')).not.toBeNull();
+    expect(screen.queryByText('candidate_secret')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Among the other things 
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9237

Complete list of changes:
1. `user.click` no longer hides behind `waitFor`

- Why? It's an antipattern: see https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-side-effects.md. Basically `user.click` has it's own waiting behaviour which is more robust than `waitFor`'s

2. Replaced `getAttribute('disabled').toBeDefined` with `getAttribute('disabled').not.toBeNull`

-   Why? `getAttribute('disabled')` returns `null` when `false` and `""` when `true`. and `toBeDefined` checks only for `!== undefined`, hence it's always producing true and false positives

3. Replaced `not.toBe([])` with `.not.toHaveLength(0)`

- Why? `not.toBe([])` compares an array with newly created `[]` so it's always true
  

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
