### PR TITLE
Unified URLs

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -24,6 +24,12 @@ import { ProposalVoteForm } from '../../components/governance/ProposalVoteForm';
 import App from '../../App';
 import { svPartyId } from '../mocks/constants';
 import { Wrapper } from '../helpers';
+import {
+  PROPOSAL_LINK_LABEL,
+  SUPPORTING_URL_LABEL,
+  VOTE_PROPOSAL_CONTRACT_ID_LABEL,
+} from '../../utils/constants';
+import { getProposalLink } from '../../utils/governance';
 
 const voteRequest = {
   contractId: 'abc123' as ContractId<VoteRequest>,
@@ -165,6 +171,10 @@ describe('Proposal Details Content', () => {
     const action = screen.getByTestId('proposal-details-action-value');
     expect(action.textContent).toMatch(/Offboard Member/);
 
+    expect(screen.getByTestId('proposal-details-contractid-label').textContent).toBe(
+      VOTE_PROPOSAL_CONTRACT_ID_LABEL
+    );
+
     const offboardSection = screen.getByTestId('proposal-details-offboard-member-section');
     expect(offboardSection).toBeInTheDocument();
 
@@ -177,8 +187,16 @@ describe('Proposal Details Content', () => {
     const summary = screen.getByTestId('proposal-details-summary-value');
     expect(summary.textContent).toMatch(/Summary of the proposal/);
 
+    expect(screen.getByTestId('proposal-details-url-label').textContent).toBe(SUPPORTING_URL_LABEL);
+
     const url = screen.getByTestId('proposal-details-url');
     expect(url.textContent).toMatch(/https:\/\/example.com/);
+
+    expect(screen.getByTestId('proposal-details-proposal-link-label').textContent).toBe(
+      PROPOSAL_LINK_LABEL
+    );
+    const proposalLink = screen.getByTestId('proposal-details-proposal-link-link');
+    expect(proposalLink).toHaveAttribute('href', getProposalLink(voteRequest.contractId));
 
     const votingInformationSection = screen.getByTestId('proposal-details-voting-information');
     expect(votingInformationSection).toBeInTheDocument();

--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -24,12 +24,7 @@ import { ProposalVoteForm } from '../../components/governance/ProposalVoteForm';
 import App from '../../App';
 import { svPartyId } from '../mocks/constants';
 import { Wrapper } from '../helpers';
-import {
-  PROPOSAL_LINK_LABEL,
-  SUPPORTING_URL_LABEL,
-  VOTE_PROPOSAL_CONTRACT_ID_LABEL,
-} from '../../utils/constants';
-import { getProposalLink } from '../../utils/governance';
+import { SUPPORTING_URL_LABEL, VOTE_PROPOSAL_CONTRACT_ID_LABEL } from '../../utils/constants';
 
 const voteRequest = {
   contractId: 'abc123' as ContractId<VoteRequest>,
@@ -191,12 +186,6 @@ describe('Proposal Details Content', () => {
 
     const url = screen.getByTestId('proposal-details-url');
     expect(url.textContent).toMatch(/https:\/\/example.com/);
-
-    expect(screen.getByTestId('proposal-details-proposal-link-label').textContent).toBe(
-      PROPOSAL_LINK_LABEL
-    );
-    const proposalLink = screen.getByTestId('proposal-details-proposal-link-link');
-    expect(proposalLink).toHaveAttribute('href', getProposalLink(voteRequest.contractId));
 
     const votingInformationSection = screen.getByTestId('proposal-details-voting-information');
     expect(votingInformationSection).toBeInTheDocument();

--- a/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-summary.test.tsx
@@ -32,7 +32,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -96,7 +96,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -136,7 +136,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -180,7 +180,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -230,7 +230,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -296,7 +296,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');
@@ -368,7 +368,7 @@ describe('Review Proposal Component', () => {
     expect(screen.getByTestId('action-title').textContent).toBe('Action');
     expect(screen.getByTestId('action-field').textContent).toBe(actionName);
 
-    expect(screen.getByTestId('url-title').textContent).toBe('URL');
+    expect(screen.getByTestId('url-title').textContent).toBe('Supporting URL');
     expect(screen.getByTestId('url-field').textContent).toBe(url);
 
     expect(screen.getByTestId('summary-title').textContent).toBe('Summary');

--- a/apps/sv/frontend/src/components/forms/CreateUnallocatedUnclaimedActivityRecordForm.tsx
+++ b/apps/sv/frontend/src/components/forms/CreateUnallocatedUnclaimedActivityRecordForm.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { useDsoInfos } from '../../contexts/SvContext';
 import { useAppForm } from '../../hooks/form';
 import { useProposalMutation } from '../../hooks/useProposalMutation';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import { createProposalActions, getInitialExpiration } from '../../utils/governance';
 import type { CommonProposalFormData } from '../../utils/types';
 import { EffectiveDateField } from '../form-components/EffectiveDateField';
@@ -227,7 +227,7 @@ export const CreateUnallocatedUnclaimedActivityRecordForm: React.FC = _ => {
             >
               {field => (
                 <field.TextField
-                  title="SUPPORTING URL"
+                  title={SUPPORTING_URL_LABEL}
                   id="create-unallocated-unclaimed-activity-record-url"
                 />
               )}

--- a/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
+++ b/apps/sv/frontend/src/components/forms/GrantRevokeFeaturedAppForm.tsx
@@ -13,7 +13,7 @@ import {
 import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
 import { useAppForm } from '../../hooks/form';
 import { useStore } from '@tanstack/react-form';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import { CommonProposalFormData } from '../../utils/types';
 import { ContractId } from '@daml/types';
 import { FeaturedAppRight } from '@daml.js/splice-amulet/lib/Splice/Amulet';
@@ -346,7 +346,7 @@ export const GrantRevokeFeaturedAppForm: React.FC<GrantRevokeFeaturedAppFormProp
                 onChange: ({ value }) => validateUrl(value),
               }}
             >
-              {field => <field.TextField title="SUPPORTING URL" id={`${testIdPrefix}-url`} />}
+              {field => <field.TextField title={SUPPORTING_URL_LABEL} id={`${testIdPrefix}-url`} />}
             </form.AppField>
           </>
         )}

--- a/apps/sv/frontend/src/components/forms/OffboardSvForm.tsx
+++ b/apps/sv/frontend/src/components/forms/OffboardSvForm.tsx
@@ -22,7 +22,7 @@ import { EffectiveDateField } from '../form-components/EffectiveDateField';
 import { ProposalSummary } from '../governance/ProposalSummary';
 import { ProposalSubmissionError } from '../form-components/ProposalSubmissionError';
 import { useProposalMutation } from '../../hooks/useProposalMutation';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 
 interface ExtraFormFields {
   sv: string;
@@ -175,7 +175,7 @@ export const OffboardSvForm: React.FC = _ => {
                 onChange: ({ value }) => validateUrl(value),
               }}
             >
-              {field => <field.TextField title="SUPPORTING URL" id="offboard-sv-url" />}
+              {field => <field.TextField title={SUPPORTING_URL_LABEL} id="offboard-sv-url" />}
             </form.AppField>
           </>
         )}

--- a/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetAmuletConfigRulesForm.tsx
@@ -5,7 +5,7 @@ import {
   ActionRequiringConfirmation,
   AmuletRules_ActionRequiringConfirmation,
 } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import {
   buildAmuletRulesPendingConfigFields,
   configFormDataToConfigChanges,
@@ -288,7 +288,9 @@ export const SetAmuletConfigRulesForm: () => JSX.Element = () => {
               onChange: ({ value }) => validateUrl(value),
             }}
           >
-            {field => <field.TextField title="SUPPORTING URL" id="set-amulet-config-rules-url" />}
+            {field => (
+              <field.TextField title={SUPPORTING_URL_LABEL} id="set-amulet-config-rules-url" />
+            )}
           </form.AppField>
         </>
       )}

--- a/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
@@ -20,7 +20,7 @@ import { useAppForm } from '../../hooks/form';
 import { useProposalMutation } from '../../hooks/useProposalMutation';
 import { buildDsoConfigChanges } from '../../utils/buildDsoConfigChanges';
 import { buildDsoRulesConfigFromChanges } from '../../utils/buildDsoRulesConfigFromChanges';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import {
   buildPendingConfigFields,
   configFormDataToConfigChanges,
@@ -304,7 +304,9 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
               onChange: ({ value }) => validateUrl(value),
             }}
           >
-            {field => <field.TextField title="SUPPORTING URL" id="set-dso-config-rules-url" />}
+            {field => (
+              <field.TextField title={SUPPORTING_URL_LABEL} id="set-dso-config-rules-url" />
+            )}
           </form.AppField>
         </>
       )}

--- a/apps/sv/frontend/src/components/forms/UpdateSvRewardWeightForm.tsx
+++ b/apps/sv/frontend/src/components/forms/UpdateSvRewardWeightForm.tsx
@@ -17,7 +17,7 @@ import {
   validateUrl,
   validateWeight,
 } from './formValidators';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import {
   createProposalActions,
   formatBasisPoints,
@@ -220,7 +220,9 @@ export const UpdateSvRewardWeightForm: React.FC = _ => {
                 onChange: ({ value }) => validateUrl(value),
               }}
             >
-              {field => <field.TextField title="SUPPORTING URL" id="update-sv-reward-weight-url" />}
+              {field => (
+                <field.TextField title={SUPPORTING_URL_LABEL} id="update-sv-reward-weight-url" />
+              )}
             </form.AppField>
           </>
         )}

--- a/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
@@ -6,6 +6,7 @@ import { East } from '@mui/icons-material';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router';
 import { CopyableIdentifier, PageSectionHeader } from '../../components/beta';
+import { VOTE_PROPOSAL_CONTRACT_ID_LABEL } from '../../utils/constants';
 import React from 'react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -131,7 +132,7 @@ const ActionCard = (props: ActionCardProps) => {
           data-testid="action-required-description"
         />
         <ActionCardSegment
-          title="VOTE PROPOSAL CONTRACT ID"
+          title={VOTE_PROPOSAL_CONTRACT_ID_LABEL}
           content={
             <CopyableIdentifier
               value={contractId}

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -36,13 +36,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
 import {
   DEFAULT_APP_ACTIVITY_WEIGHT,
-  PROPOSAL_LINK_LABEL,
   SUPPORTING_URL_LABEL,
   VOTE_PROPOSAL_CONTRACT_ID_LABEL,
   VOTE_REASON_SUMMARY_LABEL,
   VOTE_REASON_URL_LABEL,
 } from '../../utils/constants';
-import { getProposalLink } from '../../utils/governance';
 
 dayjs.extend(relativeTime);
 
@@ -319,18 +317,6 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
               />
             }
             labelId="proposal-details-url-label"
-          />
-
-          <DetailItem
-            label={PROPOSAL_LINK_LABEL}
-            value={
-              <CopyableUrl
-                url={getProposalLink(contractId)}
-                size="large"
-                data-testid="proposal-details-proposal-link"
-              />
-            }
-            labelId="proposal-details-proposal-link-label"
           />
         </VoteSection>
 

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -34,7 +34,15 @@ import { CreateUnallocatedUnclaimedActivityRecordSection } from './proposal-deta
 import { CopyableIdentifier, CopyableUrl, MemberIdentifier, VoteStats } from '../beta';
 import { useQuery } from '@tanstack/react-query';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
-import { DEFAULT_APP_ACTIVITY_WEIGHT } from '../../utils/constants';
+import {
+  DEFAULT_APP_ACTIVITY_WEIGHT,
+  PROPOSAL_LINK_LABEL,
+  SUPPORTING_URL_LABEL,
+  VOTE_PROPOSAL_CONTRACT_ID_LABEL,
+  VOTE_REASON_SUMMARY_LABEL,
+  VOTE_REASON_URL_LABEL,
+} from '../../utils/constants';
+import { getProposalLink } from '../../utils/governance';
 
 dayjs.extend(relativeTime);
 
@@ -203,7 +211,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
           />
 
           <DetailItem
-            label="Vote Proposal Contract ID"
+            label={VOTE_PROPOSAL_CONTRACT_ID_LABEL}
             value={
               <CopyableIdentifier
                 value={contractId}
@@ -302,7 +310,7 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
           />
 
           <DetailItem
-            label="URL"
+            label={SUPPORTING_URL_LABEL}
             value={
               <CopyableUrl
                 url={proposalDetails.url}
@@ -311,6 +319,18 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
               />
             }
             labelId="proposal-details-url-label"
+          />
+
+          <DetailItem
+            label={PROPOSAL_LINK_LABEL}
+            value={
+              <CopyableUrl
+                url={getProposalLink(contractId)}
+                size="large"
+                data-testid="proposal-details-proposal-link"
+              />
+            }
+            labelId="proposal-details-proposal-link-label"
           />
         </VoteSection>
 
@@ -529,11 +549,23 @@ const VoteItem: React.FC<VoteItemProps> = ({
           />
         </Box>
         {comment && (
-          <Typography fontSize={16} color="text.secondary">
-            {comment}
-          </Typography>
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+              {VOTE_REASON_SUMMARY_LABEL}
+            </Typography>
+            <Typography fontSize={16} color="text.secondary">
+              {comment}
+            </Typography>
+          </Box>
         )}
-        {url && <CopyableUrl url={url} size="small" data-testid="proposal-details-vote-url" />}
+        {url && (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+              {VOTE_REASON_URL_LABEL}
+            </Typography>
+            <CopyableUrl url={url} size="small" data-testid="proposal-details-vote-url" />
+          </Box>
+        )}
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
         <VoteStats

--- a/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
@@ -18,6 +18,7 @@ import { VoteRequest } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules'
 import { ContractId } from '@daml/types';
 import { useNavigate } from 'react-router';
 import { CopyableIdentifier, PageSectionHeader, VoteStats } from '../../components/beta';
+import { VOTE_PROPOSAL_CONTRACT_ID_LABEL } from '../../utils/constants';
 import { ProposalListingData, ProposalListingStatus, YourVoteStatus } from '../../utils/types';
 import { InfoOutlined } from '@mui/icons-material';
 import dayjs from 'dayjs';
@@ -127,7 +128,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
 }) => (
   <>
     <TableCell sx={governanceTableHeadCellSx}>PROPOSAL TYPE</TableCell>
-    <TableCell sx={governanceTableHeadCellSx}>VOTE PROPOSAL CONTRACT ID</TableCell>
+    <TableCell sx={governanceTableHeadCellSx}>{VOTE_PROPOSAL_CONTRACT_ID_LABEL}</TableCell>
     {showThresholdDeadline ? (
       <>
         <TableCell sx={governanceTableHeadCellSx}>THRESHOLD DEADLINE</TableCell>

--- a/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalSummary.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Typography } from '@mui/material';
-import { THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
+import { SUPPORTING_URL_LABEL, THRESHOLD_DEADLINE_SUBTITLE } from '../../utils/constants';
 import type { ConfigChange } from '../../utils/types';
 import { scrollContainerSx, scrollableIdentifierFieldSx } from '../beta/identifierStyles';
 import { ConfigValuesChanges } from './ConfigValuesChanges';
@@ -71,7 +71,7 @@ export const ProposalSummary: React.FC<ProposalSummaryProps> = props => {
       <Box>
         <ProposalField id="action" title="Action" value={actionName} />
 
-        <ProposalField id="url" title="URL" value={url} />
+        <ProposalField id="url" title={SUPPORTING_URL_LABEL} value={url} />
 
         <ProposalField id="summary" title="Summary" value={summary} />
 

--- a/apps/sv/frontend/src/components/governance/ProposalVoteForm.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalVoteForm.tsx
@@ -10,6 +10,7 @@ import { ContractId } from '@daml/types';
 import { VoteRequest } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
 import { ProposalVote } from '../../utils/types';
 import { Alert, Box, Button, Stack, TextField, Typography } from '@mui/material';
+import { VOTE_REASON_SUMMARY_LABEL, VOTE_REASON_URL_LABEL } from '../../utils/constants';
 interface CastVoteArgs {
   accepted: boolean;
   url: string;
@@ -109,7 +110,7 @@ export const ProposalVoteForm: React.FC<ProposalVoteFormProps> = props => {
                     fontSize={18}
                     lineHeight={1}
                   >
-                    Reason
+                    {VOTE_REASON_SUMMARY_LABEL}
                   </Typography>
                   <TextField
                     variant="filled"
@@ -161,7 +162,7 @@ export const ProposalVoteForm: React.FC<ProposalVoteFormProps> = props => {
                     fontSize={18}
                     lineHeight={1}
                   >
-                    Vote Reason URL
+                    {VOTE_REASON_URL_LABEL}
                   </Typography>
                   <TextField
                     variant="filled"

--- a/apps/sv/frontend/src/utils/constants.ts
+++ b/apps/sv/frontend/src/utils/constants.ts
@@ -7,3 +7,9 @@ export const DEFAULT_PROPOSAL_SUMMARY_MAX_LENGTH = 1024;
 export const THRESHOLD_DEADLINE_SUBTITLE =
   'Proposal remains open only if ⅔ of nodes place a vote before this date-time';
 export const DEFAULT_APP_ACTIVITY_WEIGHT = '1.0';
+
+export const SUPPORTING_URL_LABEL = 'Supporting URL';
+export const PROPOSAL_LINK_LABEL = 'Proposal Link';
+export const VOTE_REASON_URL_LABEL = 'Vote Reason URL';
+export const VOTE_REASON_SUMMARY_LABEL = 'Vote Reason Summary';
+export const VOTE_PROPOSAL_CONTRACT_ID_LABEL = 'Vote Proposal Contract ID';

--- a/apps/sv/frontend/src/utils/constants.ts
+++ b/apps/sv/frontend/src/utils/constants.ts
@@ -9,7 +9,6 @@ export const THRESHOLD_DEADLINE_SUBTITLE =
 export const DEFAULT_APP_ACTIVITY_WEIGHT = '1.0';
 
 export const SUPPORTING_URL_LABEL = 'Supporting URL';
-export const PROPOSAL_LINK_LABEL = 'Proposal Link';
 export const VOTE_REASON_URL_LABEL = 'Vote Reason URL';
 export const VOTE_REASON_SUMMARY_LABEL = 'Vote Reason Summary';
 export const VOTE_PROPOSAL_CONTRACT_ID_LABEL = 'Vote Proposal Contract ID';

--- a/apps/sv/frontend/src/utils/governance.ts
+++ b/apps/sv/frontend/src/utils/governance.ts
@@ -372,3 +372,8 @@ export function buildAmuletRulesPendingConfigFields(
       }));
     });
 }
+
+export function getProposalLink(contractId: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/governance/proposals/${contractId}`;
+}

--- a/apps/sv/frontend/src/utils/governance.ts
+++ b/apps/sv/frontend/src/utils/governance.ts
@@ -372,8 +372,3 @@ export function buildAmuletRulesPendingConfigFields(
       }));
     });
 }
-
-export function getProposalLink(contractId: string): string {
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
-  return `${origin}/governance/proposals/${contractId}`;
-}


### PR DESCRIPTION
### Summary

Fixes #3022

- Rename generic `URL` fields to Supporting URL across initiate-proposal forms and the review step
- Add shared governance label constants and use them for vote reason and contract ID fields
- Add copyable Proposal Link field on proposal details via `getProposalLink(contractId)`
- Label vote reason text/URL in proposal details and cast-vote form as Vote Reason Summary / Vote Reason URL


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
