### PR TITLE
Fix VoteRequest created_at to use original proposal time (#3453)

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpVotesHandler.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpVotesHandler.scala
@@ -5,12 +5,15 @@ package org.lfdecentralizedtrust.splice.http
 
 import org.lfdecentralizedtrust.splice.admin.http.HttpErrorHandler
 import org.lfdecentralizedtrust.splice.codegen.java.splice
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.VoteRequest
 import org.lfdecentralizedtrust.splice.http.v0.definitions
 import org.lfdecentralizedtrust.splice.store.ActiveVotesStore
+import org.lfdecentralizedtrust.splice.util.{Contract, VoteRequestContractUtil}
 import com.digitalasset.canton.logging.NamedLogging
 import com.digitalasset.canton.tracing.{Spanning, TraceContext}
 import io.opentelemetry.api.trace.Tracer
 
+import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 trait HttpVotesHandler extends Spanning with NamedLogging {
@@ -19,6 +22,46 @@ trait HttpVotesHandler extends Spanning with NamedLogging {
   protected val workflowId: String
   protected implicit val tracer: Tracer
 
+  /** Resolve the original VoteRequest creation time for the given tracking contract id.
+    *
+    * Implementations must use historical create data (e.g. Scan update history), not ACS
+    * `created_at` / `lookupDsoRulesVoteRequest`. `CastVote` recreates the contract; ACS
+    * `created_at` is then the recreation time. TxLog `VoteRequestTxLogEntry` only covers
+    * closed votes and cannot fix open Action Required rows.
+    */
+  protected def voteRequestOriginalCreatedAt(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[Instant]]
+
+  private def voteRequestToHttp(
+      voteRequest: Contract[VoteRequest.ContractId, VoteRequest]
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[definitions.Contract] =
+    if (VoteRequestContractUtil.needsOriginalCreatedAtLookup(voteRequest)) {
+      voteRequestOriginalCreatedAt(VoteRequestContractUtil.trackingId(voteRequest)).map {
+        case Some(originalCreatedAt) =>
+          VoteRequestContractUtil
+            .withCreatedAt(voteRequest, originalCreatedAt)
+            .toHttp
+        case None => voteRequest.toHttp
+      }
+    } else {
+      Future.successful(voteRequest.toHttp)
+    }
+
+  private def voteRequestsToHttp(
+      voteRequests: Seq[Contract[VoteRequest.ContractId, VoteRequest]]
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Vector[definitions.Contract]] =
+    Future.traverse(voteRequests)(voteRequestToHttp).map(_.toVector)
+
   def listDsoRulesVoteRequests(implicit
       tc: TraceContext,
       ec: ExecutionContext,
@@ -26,9 +69,8 @@ trait HttpVotesHandler extends Spanning with NamedLogging {
     withSpan(s"$workflowId.listDsoRulesVoteRequests") { _ => _ =>
       for {
         dsoRulesVoteRequests <- votesStore.listVoteRequests()
-      } yield definitions.ListDsoRulesVoteRequestsResponse(
-        dsoRulesVoteRequests.map(_.toHttp).toVector
-      )
+        voteRequests <- voteRequestsToHttp(dsoRulesVoteRequests)
+      } yield definitions.ListDsoRulesVoteRequestsResponse(voteRequests)
     }
   }
 
@@ -41,9 +83,8 @@ trait HttpVotesHandler extends Spanning with NamedLogging {
         dsoRulesVotes <- votesStore.listVoteRequestsByTrackingCid(
           body.voteRequestContractIds.map(new splice.dsorules.VoteRequest.ContractId(_))
         )
-      } yield definitions.ListVoteRequestByTrackingCidResponse(
-        dsoRulesVotes.map(_.toHttp).toVector
-      )
+        voteRequests <- voteRequestsToHttp(dsoRulesVotes)
+      } yield definitions.ListVoteRequestByTrackingCidResponse(voteRequests)
     }
   }
 
@@ -58,11 +99,7 @@ trait HttpVotesHandler extends Spanning with NamedLogging {
         )
         .flatMap {
           case Some(voteRequest) =>
-            Future.successful(
-              definitions.LookupDsoRulesVoteRequestResponse(
-                voteRequest.toHttp
-              )
-            )
+            voteRequestToHttp(voteRequest).map(definitions.LookupDsoRulesVoteRequestResponse(_))
           case None =>
             Future.failed(
               HttpErrorHandler.notFound(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/VoteRequestContractUtil.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/util/VoteRequestContractUtil.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.util
+
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.VoteRequest
+
+import java.time.Instant
+import scala.jdk.OptionConverters.*
+
+object VoteRequestContractUtil {
+
+  def trackingId(
+      contract: Contract[VoteRequest.ContractId, VoteRequest]
+  ): VoteRequest.ContractId =
+    contract.payload.trackingCid.toScala.getOrElse(contract.contractId)
+
+  /** Vote requests are recreated when votes are cast; only then is a lookup needed. */
+  def needsOriginalCreatedAtLookup(
+      contract: Contract[VoteRequest.ContractId, VoteRequest]
+  ): Boolean =
+    contract.payload.trackingCid.toScala.exists(_ != contract.contractId)
+
+  def withCreatedAt(
+      contract: Contract[VoteRequest.ContractId, VoteRequest],
+      createdAt: Instant,
+  ): Contract[VoteRequest.ContractId, VoteRequest] =
+    contract.copy(createdAt = createdAt)
+}

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/VoteRequestContractUtilTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/util/VoteRequestContractUtilTest.scala
@@ -1,0 +1,81 @@
+package org.lfdecentralizedtrust.splice.util
+
+import com.google.protobuf.ByteString
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.VoteRequest
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.actionrequiringconfirmation.ARC_DsoRules
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.dsorules_actionrequiringconfirmation.SRARC_AddSv
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.{DsoRules_AddSv, Reason}
+import org.lfdecentralizedtrust.splice.codegen.java.splice.types.Round
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+import java.util.Optional
+import scala.jdk.CollectionConverters.*
+
+class VoteRequestContractUtilTest extends AnyWordSpec with Matchers {
+
+  private val originalCreatedAt = Instant.parse("2025-12-29T10:00:00Z")
+  private val updatedCreatedAt = Instant.parse("2026-07-14T10:00:00Z")
+
+  private def voteRequestContract(
+      contractId: String,
+      trackingCid: Option[String],
+      createdAt: Instant,
+  ): Contract[VoteRequest.ContractId, VoteRequest] = {
+    val action = new ARC_DsoRules(
+      new SRARC_AddSv(
+        new DsoRules_AddSv(
+          "user666",
+          "user666",
+          10_000L,
+          "user666ParticipantId",
+          new Round(1L),
+        )
+      )
+    )
+    val payload = new VoteRequest(
+      "dso",
+      "sv1",
+      action,
+      new Reason("https://www.example.com", ""),
+      createdAt.plusSeconds(3600),
+      Map.empty[String, org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.Vote].asJava,
+      trackingCid match {
+        case Some(id) => Optional.of(new VoteRequest.ContractId(id))
+        case None => Optional.empty()
+      },
+      Optional.empty(),
+    )
+    Contract(
+      identifier = VoteRequest.TEMPLATE_ID_WITH_PACKAGE_ID,
+      contractId = new VoteRequest.ContractId(contractId),
+      payload = payload,
+      createdEventBlob = ByteString.EMPTY,
+      createdAt = createdAt,
+    )
+  }
+
+  "VoteRequestContractUtil" should {
+    "use the contract id as tracking id when trackingCid is unset" in {
+      val contract = voteRequestContract("cid-1", None, originalCreatedAt)
+      VoteRequestContractUtil.trackingId(contract).contractId shouldBe "cid-1"
+      VoteRequestContractUtil.needsOriginalCreatedAtLookup(contract) shouldBe false
+    }
+
+    "require lookup when trackingCid differs from the current contract id" in {
+      val contract =
+        voteRequestContract("cid-2", Some("cid-1"), updatedCreatedAt)
+      VoteRequestContractUtil.trackingId(contract).contractId shouldBe "cid-1"
+      VoteRequestContractUtil.needsOriginalCreatedAtLookup(contract) shouldBe true
+    }
+
+    "replace createdAt when original creation time is known" in {
+      val contract =
+        voteRequestContract("cid-2", Some("cid-1"), updatedCreatedAt)
+      VoteRequestContractUtil
+        .withCreatedAt(contract, originalCreatedAt)
+        .createdAt shouldBe originalCreatedAt
+    }
+  }
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/BftScanConnection.scala
@@ -185,6 +185,17 @@ class BftScanConnection(
       "listVoteRequests",
     )
 
+  override def lookupDsoRulesVoteRequest(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[Contract[VoteRequest.ContractId, VoteRequest]]] =
+    bftCall(
+      _.lookupDsoRulesVoteRequest(trackingId),
+      "lookupDsoRulesVoteRequest",
+    )
+
   override def getDsoPartyId()(implicit ec: ExecutionContext, tc: TraceContext): Future[PartyId] =
     bftCall(
       _.getDsoPartyId(),

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/ScanConnection.scala
@@ -212,6 +212,33 @@ trait ScanConnection
   ): Future[Seq[Contract[VoteRequest.ContractId, VoteRequest]]] =
     listVoteRequests()
 
+  def lookupDsoRulesVoteRequest(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[Contract[VoteRequest.ContractId, VoteRequest]]]
+
+  /** Original VoteRequest ledger create time for the given tracking contract id.
+    *
+    * Must not use ACS `created_at`: `CastVote` archives and recreates the contract, so the
+    * active ACS row's `created_at` is the latest recreation time. Scan resolves this via
+    * `update_history_creates` when listing vote requests. `VoteRequestTxLogEntry` only records
+    * closed votes and cannot fix open Action Required rows.
+    */
+  def lookupVoteRequestOriginalCreatedAt(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[java.time.Instant]] =
+    listVoteRequests().map { requests =>
+      requests.collectFirst {
+        case request if VoteRequestContractUtil.trackingId(request) == trackingId =>
+          request.createdAt
+      }
+    }
+
   def getAmuletRules()(implicit
       tc: TraceContext
   ): Future[Contract[AmuletRules.ContractId, AmuletRules]] =

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/SingleScanConnection.scala
@@ -269,6 +269,17 @@ class SingleScanConnection private[client] (
       HttpScanAppClient.ListDsoRulesVoteRequests(),
     )
 
+  override def lookupDsoRulesVoteRequest(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[Contract[VoteRequest.ContractId, VoteRequest]]] =
+    runHttpCmd(
+      config.adminApi.url,
+      HttpScanAppClient.LookupVoteRequest(trackingId),
+    )
+
   override def getExternalPartyAmuletRules()(implicit
       ec: ExecutionContext,
       tc: TraceContext,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -36,6 +36,7 @@ import org.lfdecentralizedtrust.splice.codegen.java.splice.{amulet, ans as ansCo
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amuletrules.AmuletRules
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dso.decentralizedsynchronizer.SynchronizerNodeConfig
 import org.lfdecentralizedtrust.splice.codegen.java.splice.dso.svstate.SvNodeState
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.VoteRequest
 import org.lfdecentralizedtrust.splice.codegen.java.splice.externalpartyamuletrules.{
   ExternalPartyAmuletRules,
   TransferCommand,
@@ -134,7 +135,7 @@ import java.time.{Instant, OffsetDateTime, ZoneOffset}
 import java.util.Base64
 import java.util.zip.GZIPOutputStream
 import scala.collection.concurrent
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
@@ -181,6 +182,18 @@ class HttpScanHandler(
   override protected val workflowId: String = this.getClass.getSimpleName
   override protected val votesStore: VotesStore = store
   override protected val validatorLicensesStore: AppStore = store
+
+  override protected def voteRequestOriginalCreatedAt(
+      trackingId: VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[java.time.Instant]] =
+    // Historical create event — not ACS. ACS lookupDsoRulesVoteRequest returns the current
+    // recreated contract after CastVote; VoteRequestTxLogEntry only exists after close.
+    updateHistory
+      .lookupContractById(VoteRequest.COMPANION)(trackingId)
+      .map(_.map(_.createdAt))
 
   private val initializedBftSequencersCache
       : concurrent.Map[Int, definitions.SynchronizerBftSequencer] =

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
@@ -49,7 +49,7 @@ import org.lfdecentralizedtrust.splice.sv.{LocalSynchronizerNode, SvApp}
 import org.lfdecentralizedtrust.splice.util.{Codec, Contract, TemplateJsonDecoder}
 
 import java.util.Optional
-import scala.concurrent.{blocking, ExecutionContextExecutor, Future}
+import scala.concurrent.{blocking, ExecutionContext, ExecutionContextExecutor, Future}
 
 class HttpSvOperatorHandler(
     svStoreWithIngestion: AppStoreWithIngestion[SvSvStore],
@@ -85,6 +85,29 @@ class HttpSvOperatorHandler(
   private val mutex = Mutex()
   override protected val votesStore: ActiveVotesStore = dsoStore
   override protected val validatorLicensesStore: AppStore = dsoStore
+
+  override protected def voteRequestOriginalCreatedAt(
+      trackingId: spliceCodegen.dsorules.VoteRequest.ContractId
+  )(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[Option[java.time.Instant]] =
+    // Do not use Scan.lookupDsoRulesVoteRequest / ACS created_at: that endpoint looks up the
+    // current ACS contract by trackingCid, whose ledger created_at is the last CastVote
+    // recreation. Scan resolves the original create time from update_history_creates.
+    scanConnectionF.flatMap(_.lookupVoteRequestOriginalCreatedAt(trackingId))
+
+  override def listDsoRulesVoteRequests(implicit
+      tc: TraceContext,
+      ec: ExecutionContext,
+  ): Future[definitions.ListDsoRulesVoteRequestsResponse] = {
+    withSpan(s"$workflowId.listDsoRulesVoteRequests") { _ => _ =>
+      // Prefer Scan's list: each created_at is already corrected via update history.
+      scanConnectionF
+        .flatMap(_.getVoteRequests())
+        .map(reqs => definitions.ListDsoRulesVoteRequestsResponse(reqs.map(_.toHttp).toVector))
+    }
+  }
 
   // Similar to PublishScanConfigTrigger, this class creates its own scan connection
   // on demand, because scan might not be available at application startup.

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
@@ -18,7 +18,7 @@ import io.grpc.{Status, StatusRuntimeException}
 import io.grpc.Status.Code
 import io.opentelemetry.api.trace.Tracer
 import org.lfdecentralizedtrust.splice.admin.http.HttpErrorHandler
-import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.DsoRules
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.{DsoRules, VoteRequest}
 import org.lfdecentralizedtrust.splice.codegen.java.splice.svonboarding.SvOnboardingRequest
 import org.lfdecentralizedtrust.splice.codegen.java.splice.validatoronboarding.ValidatorOnboarding
 import org.lfdecentralizedtrust.splice.config.Thresholds
@@ -41,7 +41,9 @@ import org.lfdecentralizedtrust.splice.sv.util.{Secrets, SvOnboardingToken}
 import org.lfdecentralizedtrust.splice.sv.util.SvUtil.generateRandomOnboardingSecret
 import org.lfdecentralizedtrust.splice.util.{Codec, Contract}
 
+import java.time.Instant
 import java.util.Base64
+import scala.annotation.unused
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
@@ -74,6 +76,13 @@ class HttpSvPublicHandler(
 
   override protected val votesStore: ActiveVotesStore = dsoStore
   override protected val workflowId: String = this.getClass.getSimpleName
+
+  override protected def voteRequestOriginalCreatedAt(
+      @unused trackingId: VoteRequest.ContractId
+  )(implicit
+      @unused tc: TraceContext,
+      @unused ec: ExecutionContext,
+  ): Future[Option[Instant]] = Future.successful(None)
 
   /** Intended use: Other validators call this endpoint to onboard themselves,
     * passing their onboarding secret in the request payload.

--- a/test-full-class-names-non-integration.log
+++ b/test-full-class-names-non-integration.log
@@ -60,6 +60,7 @@ org.lfdecentralizedtrust.splice.util.SpliceUtilTest
 org.lfdecentralizedtrust.splice.util.TransactionTreeExtensionsTest
 org.lfdecentralizedtrust.splice.util.ValueJsonCodecCodegenTest
 org.lfdecentralizedtrust.splice.util.ValueJsonCodecProtobufTest
+org.lfdecentralizedtrust.splice.util.VoteRequestContractUtilTest
 org.lfdecentralizedtrust.splice.validator.store.DbValidatorConfigProviderTest
 org.lfdecentralizedtrust.splice.validator.store.DbValidatorStoreTest
 org.lfdecentralizedtrust.splice.wallet.util.ExtraTrafficTopupParametersTest


### PR DESCRIPTION

CastVote recreates the ACS contract, so list APIs were returning the latest recreation time. Resolve original create time from Scan update history before serializing vote requests (#3453).

Fixes #3453

## Summary
- `CastVote` archives and recreates the `VoteRequest`, so ACS `created_at` becomes the latest vote/recreation time instead of the original proposal time.
- Resolve original create time from Scan **update history** (`update_history_creates`) before serializing vote-request HTTP responses.
- SV operator list proxies Scan’s already-corrected list; do not use ACS `lookupDsoRulesVoteRequest` or close-only `VoteRequestTxLogEntry` for open Action Required rows.

## Changes
- Shared correction in `HttpVotesHandler` when `trackingCid ≠ contractId` (`VoteRequestContractUtil`).
- Scan implements `voteRequestOriginalCreatedAt` via `updateHistory.lookupContractById`.
- SV operator uses history-backed Scan lookup / list; public handler stubs to `None`.
- Unit tests for `VoteRequestContractUtil`.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
