### PR TITLE
SV UI: add Submitted By column to governance tables (#3691)

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/action-required-section.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/action-required-section.test.tsx
@@ -11,24 +11,27 @@ import { VoteRequest } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules'
 import { MemoryRouter } from 'react-router';
 import dayjs from 'dayjs';
 import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
+import { svPartyId, voteRequests } from '../mocks/constants';
+
+const sampleContractId = voteRequests.dso_rules_vote_requests[0]
+  .contract_id as ContractId<VoteRequest>;
 
 const requests: ActionRequiredData[] = [
   {
     actionName: 'Feature Application',
     description: 'Test description for feature application',
-    contractId: '2abcde123456' as ContractId<VoteRequest>,
+    contractId: sampleContractId,
     votingCloses: '2024-09-25 11:00',
     createdAt: '2024-09-25 11:00',
-    requester: 'sv1',
+    requester: svPartyId,
   },
   {
     actionName: 'Set DSO Rules Configuration',
     description: 'Test description for DSO rules configuration',
-    contractId: '2bcde123456' as ContractId<VoteRequest>,
+    contractId: voteRequests.dso_rules_vote_requests[1].contract_id as ContractId<VoteRequest>,
     votingCloses: '2024-09-25 11:00',
     createdAt: '2024-09-25 11:00',
-    requester: 'sv2',
-    isYou: true,
+    requester: svPartyId,
   },
 ];
 
@@ -76,10 +79,10 @@ describe('Action Required', () => {
     const actionRequired = {
       actionName: 'Feature Application',
       description: 'Test description',
-      contractId: '2abcde123456' as ContractId<VoteRequest>,
+      contractId: sampleContractId,
       votingCloses: closesDate,
       createdAt: createdDate,
-      requester: 'sv1',
+      requester: svPartyId,
     };
 
     render(
@@ -104,23 +107,22 @@ describe('Action Required', () => {
     expect(votingCloses).toBeInTheDocument();
     expect(votingCloses.textContent).toBe('10 days');
 
-    const requester = screen.getByTestId('action-required-requester-identifier-value');
-    expect(requester).toBeInTheDocument();
-    expect(requester.textContent).toBe(actionRequired.requester);
+    const submittedBy = screen.getByTestId('action-required-submitted-by-identifier-value');
+    expect(submittedBy).toBeInTheDocument();
+    expect(submittedBy.textContent).toBe(svPartyId);
 
     const viewDetails = screen.getByTestId('action-required-view-details');
     expect(viewDetails).toBeInTheDocument();
   });
 
-  test('should render isYou badge for requests created by viewing sv', () => {
+  test('should render submitted by with copy button and no You badge', () => {
     const actionRequired = {
       actionName: 'Feature Application',
       description: 'Test description',
-      contractId: '2abcde123456' as ContractId<VoteRequest>,
+      contractId: sampleContractId,
       votingCloses: '2029-09-25 11:00',
       createdAt: '2029-09-25 11:00',
-      requester: 'sv1',
-      isYou: true,
+      requester: svPartyId,
     };
 
     render(
@@ -129,18 +131,22 @@ describe('Action Required', () => {
       </MemoryRouter>
     );
 
-    const isYou = screen.getByTestId('action-required-requester-identifier-badge');
-    expect(isYou).toBeInTheDocument();
+    expect(
+      screen.getByTestId('action-required-submitted-by-identifier-copy-button')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('action-required-submitted-by-identifier-badge')
+    ).not.toBeInTheDocument();
   });
 
-  test('should not render isYou badge for requests created by other svs', () => {
+  test('should render vote proposal contract id with full value', () => {
     const actionRequired = {
       actionName: 'Feature Application',
       description: 'Test description',
-      contractId: '2abcde123456' as ContractId<VoteRequest>,
+      contractId: sampleContractId,
       votingCloses: '2029-09-25 11:00',
       createdAt: '2029-09-25 11:00',
-      requester: 'sv1',
+      requester: svPartyId,
     };
 
     render(
@@ -149,8 +155,8 @@ describe('Action Required', () => {
       </MemoryRouter>
     );
 
-    const isYou = screen.queryByTestId('action-required-requester-identifier-badge');
-
-    expect(isYou).not.toBeInTheDocument();
+    expect(screen.getByTestId('action-required-contract-id-value').textContent).toBe(
+      sampleContractId
+    );
   });
 });

--- a/apps/sv/frontend/src/__tests__/governance/governance-sorting.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/governance-sorting.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../components/governance/ActionRequiredSection';
 import { ProposalListingSection } from '../../components/governance/ProposalListingSection';
 import { ProposalListingData } from '../../utils/types';
+import { svPartyId } from '../mocks/constants';
 
 describe('Governance Page Sorting', () => {
   describe('Action Required Section', () => {
@@ -22,7 +23,7 @@ describe('Governance Page Sorting', () => {
           contractId: 'c' as ContractId<VoteRequest>,
           votingCloses: '2025-01-25 12:00',
           createdAt: '2025-01-10 12:00',
-          requester: 'sv1',
+          requester: svPartyId,
         },
         {
           actionName: 'Action A - Earliest',
@@ -30,7 +31,7 @@ describe('Governance Page Sorting', () => {
           contractId: 'a' as ContractId<VoteRequest>,
           votingCloses: '2025-01-15 10:00',
           createdAt: '2025-01-10 12:00',
-          requester: 'sv1',
+          requester: svPartyId,
         },
         {
           actionName: 'Action B - Middle',
@@ -38,7 +39,7 @@ describe('Governance Page Sorting', () => {
           contractId: 'b' as ContractId<VoteRequest>,
           votingCloses: '2025-01-15 18:00',
           createdAt: '2025-01-10 12:00',
-          requester: 'sv1',
+          requester: svPartyId,
         },
       ];
 
@@ -69,6 +70,7 @@ describe('Governance Page Sorting', () => {
       yourVote: 'accepted',
       status: 'In Progress',
       acceptanceThreshold: BigInt(11),
+      requester: svPartyId,
     };
 
     test('should sort with Threshold items first (by votes desc, then deadline asc), then dated items by effective date asc', () => {
@@ -153,6 +155,7 @@ describe('Governance Page Sorting', () => {
       status: 'Implemented',
       voteStats: { accepted: 8, rejected: 2, 'no-vote': 1 },
       acceptanceThreshold: BigInt(11),
+      requester: svPartyId,
     };
 
     test('renders in backend order without client re-sorting', () => {

--- a/apps/sv/frontend/src/__tests__/governance/proposal-listing.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-listing.test.tsx
@@ -7,11 +7,16 @@ import { VoteRequest } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules'
 import { ContractId } from '@daml/types';
 import { ProposalListingData } from '../../utils/types';
 import { MemoryRouter } from 'react-router';
+import { svPartyId, voteRequests } from '../mocks/constants';
+
+const sampleContractId = voteRequests.dso_rules_vote_requests[0]
+  .contract_id as ContractId<VoteRequest>;
 
 const inflightVoteRequests: ProposalListingData[] = [
   {
     actionName: 'Feature Application',
-    contractId: '2abcde123456' as ContractId<VoteRequest>,
+    contractId: sampleContractId,
+    requester: svPartyId,
     votingThresholdDeadline: '2025-09-25 11:00',
     voteTakesEffect: '2025-09-26 11:00',
     yourVote: 'no-vote',
@@ -21,7 +26,8 @@ const inflightVoteRequests: ProposalListingData[] = [
   },
   {
     actionName: 'Set DSO Rules Configuration',
-    contractId: 'bcde123456' as ContractId<VoteRequest>,
+    contractId: voteRequests.dso_rules_vote_requests[1].contract_id as ContractId<VoteRequest>,
+    requester: svPartyId,
     votingThresholdDeadline: '2025-09-25 11:00',
     voteTakesEffect: '2025-09-26 11:00',
     yourVote: 'accepted',
@@ -34,7 +40,8 @@ const inflightVoteRequests: ProposalListingData[] = [
 const voteHistory: ProposalListingData[] = [
   {
     actionName: 'Feature Application',
-    contractId: '2abcde123456' as ContractId<VoteRequest>,
+    contractId: sampleContractId,
+    requester: svPartyId,
     votingThresholdDeadline: '2025-09-25 11:00',
     voteTakesEffect: '2025-09-26 11:00',
     yourVote: 'no-vote',
@@ -44,7 +51,8 @@ const voteHistory: ProposalListingData[] = [
   },
   {
     actionName: 'Set DSO Rules Configuration',
-    contractId: '2bcde123456' as ContractId<VoteRequest>,
+    contractId: voteRequests.dso_rules_vote_requests[1].contract_id as ContractId<VoteRequest>,
+    requester: svPartyId,
     votingThresholdDeadline: '2025-09-25 11:00',
     voteTakesEffect: '2025-09-26 11:00',
     yourVote: 'accepted',
@@ -93,6 +101,8 @@ describe('Inflight Vote Requests', () => {
     const uniqueId = 'proposals-request';
     const data = {
       actionName: 'Feature Application',
+      contractId: sampleContractId,
+      requester: svPartyId,
       votingThresholdDeadline: '2025-09-25 11:00',
       voteTakesEffect: '2025-09-26 11:00',
       yourVote: 'no-vote',
@@ -136,10 +146,49 @@ describe('Inflight Vote Requests', () => {
     expect(yourVote.textContent).toMatch(/No Vote/);
   });
 
+  test('should render submitted by column with full party id and copy button', () => {
+    const uniqueId = 'proposals-request';
+    const data = {
+      actionName: 'Feature Application',
+      contractId: sampleContractId,
+      requester: svPartyId,
+      votingThresholdDeadline: '2025-09-25 11:00',
+      voteTakesEffect: '2025-09-26 11:00',
+      yourVote: 'accepted',
+      status: 'In Progress',
+      voteStats: { accepted: 0, rejected: 0, 'no-vote': 0 },
+      acceptanceThreshold: BigInt(11),
+    } as ProposalListingData;
+
+    render(
+      <MemoryRouter>
+        <ProposalListingSection
+          sectionTitle="Inflight Vote Requests"
+          data={[data]}
+          noDataMessage="No Inflight Vote Requests available"
+          uniqueId={uniqueId}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('SUBMITTED BY')).toBeInTheDocument();
+    expect(screen.getByTestId(`${uniqueId}-row-submitted-by-identifier-value`).textContent).toBe(
+      svPartyId
+    );
+    expect(
+      screen.getByTestId(`${uniqueId}-row-submitted-by-identifier-copy-button`)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${uniqueId}-row-submitted-by-identifier-badge`)
+    ).not.toBeInTheDocument();
+  });
+
   test('should render Accepted inflight vote request', () => {
     const uniqueId = 'proposals-request';
     const data = {
       actionName: 'Feature Application',
+      contractId: sampleContractId,
+      requester: svPartyId,
       votingThresholdDeadline: '2025-09-25 11:00',
       voteTakesEffect: '2025-09-26 11:00',
       yourVote: 'accepted',
@@ -171,6 +220,8 @@ describe('Inflight Vote Requests', () => {
     const uniqueId = 'proposals-request';
     const data = {
       actionName: 'Feature Application',
+      contractId: sampleContractId,
+      requester: svPartyId,
       votingThresholdDeadline: '2025-09-25 11:00',
       voteTakesEffect: '2025-09-26 11:00',
       yourVote: 'rejected',
@@ -255,6 +306,8 @@ describe('Vote history', () => {
     const uniqueId = 'vote-history';
     const data = {
       actionName: 'Feature Application',
+      contractId: sampleContractId,
+      requester: svPartyId,
       votingThresholdDeadline: '2024-09-25 11:00',
       voteTakesEffect: '2024-09-26 11:00',
       yourVote: 'accepted',

--- a/apps/sv/frontend/src/__tests__/utils/getRequesterPartyId.test.ts
+++ b/apps/sv/frontend/src/__tests__/utils/getRequesterPartyId.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import type { SvInfo } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
+import { getRequesterPartyId } from '../../utils/governance';
+
+const partyId = 'digital-asset-2::1220abc';
+const svName = 'Digital-Asset-2';
+
+const svs = {
+  entriesArray: () => [[partyId, { name: svName } as SvInfo] as [string, SvInfo]],
+};
+
+describe('getRequesterPartyId', () => {
+  test('returns requester unchanged when it is already a party id', () => {
+    expect(getRequesterPartyId(partyId, svs)).toBe(partyId);
+  });
+
+  test('resolves sv name to party id', () => {
+    expect(getRequesterPartyId(svName, svs)).toBe(partyId);
+  });
+
+  test('returns requester when svs is undefined', () => {
+    expect(getRequesterPartyId(svName, undefined)).toBe(svName);
+  });
+
+  test('returns requester when sv is not in svs (e.g. offboarded)', () => {
+    expect(getRequesterPartyId('Offboarded-SV', svs)).toBe('Offboarded-SV');
+  });
+});

--- a/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
@@ -5,7 +5,7 @@ import { ContractId } from '@daml/types';
 import { East } from '@mui/icons-material';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router';
-import { CopyableIdentifier, MemberIdentifier, PageSectionHeader } from '../../components/beta';
+import { CopyableIdentifier, PageSectionHeader } from '../../components/beta';
 import React from 'react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -19,7 +19,6 @@ export interface ActionRequiredData {
   votingCloses: string;
   createdAt: string;
   requester: string;
-  isYou?: boolean;
 }
 
 export interface ActionRequiredProps {
@@ -60,7 +59,6 @@ export const ActionRequiredSection: React.FC<ActionRequiredProps> = (
               contractId={ar.contractId}
               votingEnds={ar.votingCloses}
               requester={ar.requester}
-              isYou={ar.isYou}
             />
           ))
         )}
@@ -76,11 +74,13 @@ interface ActionCardProps {
   contractId: ContractId<VoteRequest>;
   votingEnds: string;
   requester: string;
-  isYou?: boolean;
 }
 
+const actionRequiredGridTemplate =
+  'minmax(0, 0.85fr) minmax(0, 1fr) minmax(0, 1.15fr) minmax(0, 0.75fr) minmax(0, 0.85fr) 270px auto';
+
 const ActionCard = (props: ActionCardProps) => {
-  const { action, description, createdAt, contractId, votingEnds, requester, isYou } = props;
+  const { action, description, createdAt, contractId, votingEnds, requester } = props;
   const remainingTime = dayjs(votingEnds).fromNow(true);
 
   return (
@@ -92,99 +92,87 @@ const ActionCard = (props: ActionCardProps) => {
       <Box
         sx={{
           bgcolor: 'colors.neutral.10',
-          p: 2,
           borderRadius: '4px',
+          display: 'grid',
+          gridTemplateColumns: actionRequiredGridTemplate,
+          alignItems: 'center',
           '&:hover': { backgroundColor: '#363636' },
         }}
         className="action-required-card"
         data-testid="action-required-card"
       >
-        <Stack direction="row" gap={5} alignItems="flex-start">
-          <Box sx={{ flexShrink: 0 }}>
-            <ActionCardSegment
-              title="ACTION"
-              content={action}
-              data-testid="action-required-action"
-            />
-          </Box>
-          <Box sx={{ flexShrink: 1, minWidth: 0, maxWidth: 200 }}>
-            <ActionCardSegment
-              title="DESCRIPTION"
-              content={
-                <Typography
-                  variant="body1"
-                  color="text.light"
-                  fontWeight="medium"
-                  fontSize={14}
-                  lineHeight={1.4}
-                  sx={{
-                    display: '-webkit-box',
-                    WebkitLineClamp: 2,
-                    WebkitBoxOrient: 'vertical',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                  }}
-                  data-testid="action-required-description-content"
-                >
-                  {description}
-                </Typography>
-              }
-              data-testid="action-required-description"
-            />
-          </Box>
-          <Box sx={{ flexShrink: 1, minWidth: 0, maxWidth: 300 }}>
-            <ActionCardSegment
-              title="CONTRACT ID"
-              content={
-                <CopyableIdentifier
-                  value={contractId}
-                  size="small"
-                  data-testid="action-required-contract-id"
-                />
-              }
-              data-testid="action-required-contract-id-segment"
-            />
-          </Box>
-          <Box sx={{ flexShrink: 0 }}>
-            <ActionCardSegment
-              title="CREATED AT"
-              content={createdAt}
-              data-testid="action-required-created-at"
-            />
-          </Box>
-          <Box sx={{ flexShrink: 0 }}>
-            <ActionCardSegment
-              title="REMAINING TIME"
-              content={remainingTime}
-              data-testid="action-required-voting-closes"
-            />
-          </Box>
-          <Box sx={{ flexShrink: 1, minWidth: 0, maxWidth: 300 }}>
-            <ActionCardSegment
-              title="REQUESTER"
-              content={
-                <MemberIdentifier
-                  partyId={requester}
-                  isYou={isYou ?? false}
-                  size="small"
-                  data-testid="action-required-requester-identifier"
-                />
-              }
-              data-testid="action-required-requester"
-            />
-          </Box>
-          <Stack
-            direction="row"
-            alignItems="center"
-            gap={1}
-            sx={{ ml: 'auto', flexShrink: 0, alignSelf: 'center' }}
-            data-testid="action-required-view-details"
-          >
-            <Typography fontWeight={500} color="text.light">
-              View Details
+        <ActionCardSegment
+          title="PROPOSAL TYPE"
+          content={action}
+          data-testid="action-required-action"
+        />
+        <ActionCardSegment
+          title="DESCRIPTION"
+          content={
+            <Typography
+              variant="body1"
+              color="text.light"
+              fontWeight="medium"
+              fontSize={14}
+              lineHeight={1.4}
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                width: '100%',
+              }}
+              data-testid="action-required-description-content"
+            >
+              {description}
             </Typography>
-            <East fontSize="small" color="secondary" />
-          </Stack>
+          }
+          data-testid="action-required-description"
+        />
+        <ActionCardSegment
+          title="VOTE PROPOSAL CONTRACT ID"
+          content={
+            <CopyableIdentifier
+              value={contractId}
+              size="small"
+              data-testid="action-required-contract-id"
+            />
+          }
+          data-testid="action-required-contract-id-segment"
+        />
+        <ActionCardSegment
+          title="REMAINING TIME"
+          content={remainingTime}
+          data-testid="action-required-voting-closes"
+        />
+        <ActionCardSegment
+          title="VOTE CREATED"
+          content={createdAt}
+          data-testid="action-required-created-at"
+        />
+        <ActionCardSegment
+          title="SUBMITTED BY"
+          content={
+            <CopyableIdentifier
+              value={requester}
+              size="small"
+              data-testid="action-required-submitted-by-identifier"
+            />
+          }
+          data-testid="action-required-submitted-by"
+        />
+        <Stack
+          direction="row"
+          alignItems="center"
+          gap={1}
+          sx={{ flexShrink: 0, justifySelf: 'end', py: '15px', px: '16px' }}
+          data-testid="action-required-view-details"
+        >
+          <Typography fontWeight={500} color="text.light" whiteSpace="nowrap">
+            View Details
+          </Typography>
+          <East fontSize="small" color="secondary" />
         </Stack>
       </Box>
     </RouterLink>
@@ -202,14 +190,24 @@ const ActionCardSegment: React.FC<ActionCardSegmentProps> = ({
   content,
   'data-testid': testId,
 }) => (
-  <Stack height="100%" justifyContent="space-between" data-testid={testId}>
+  <Stack
+    sx={{
+      py: '15px',
+      px: '16px',
+      gap: '4px',
+      alignItems: 'flex-start',
+      minWidth: 0,
+      overflow: 'hidden',
+      width: '100%',
+    }}
+    data-testid={testId}
+  >
     <Typography
       fontSize={12}
-      lineHeight={2}
-      fontWeight={700}
+      lineHeight="22px"
+      fontWeight={600}
       variant="subtitle2"
-      color="text.light"
-      gutterBottom
+      color="#E2E2E2"
       data-testid={`${testId}-title`}
     >
       {title}
@@ -220,13 +218,13 @@ const ActionCardSegment: React.FC<ActionCardSegmentProps> = ({
         color="text.light"
         fontWeight="medium"
         fontSize={14}
-        lineHeight={2}
+        lineHeight="26px"
         data-testid={`${testId}-content`}
       >
         {content}
       </Typography>
     ) : (
-      content
+      <Box sx={{ width: '100%', minWidth: 0, overflow: 'hidden' }}>{content}</Box>
     )}
   </Stack>
 );

--- a/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ActionRequiredSection.tsx
@@ -207,7 +207,7 @@ const ActionCardSegment: React.FC<ActionCardSegmentProps> = ({
       lineHeight="22px"
       fontWeight={600}
       variant="subtitle2"
-      color="#E2E2E2"
+      color="colors.neutral.80"
       data-testid={`${testId}-title`}
     >
       {title}

--- a/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
@@ -67,10 +67,84 @@ const sortProposals = (
     .toSorted((a, b) => getEffectiveDate(a).diff(getEffectiveDate(b)));
 };
 
-const getColumnsCount = (...shown: (boolean | undefined)[]) => 4 + shown.filter(Boolean).length;
+const getColumnsCount = (...shown: (boolean | undefined)[]) => 5 + shown.filter(Boolean).length;
 
 const getGridTemplate = (columnsCount: number) =>
   `minmax(0, 1fr) minmax(0, 0.7fr) ${'1fr '.repeat(columnsCount - 2).trim()}`;
+
+const governanceTableHeadCellSx = {
+  py: '10px',
+  px: '16px',
+  fontSize: 12,
+  fontWeight: 600,
+  textTransform: 'uppercase' as const,
+  color: '#E2E2E2',
+  borderBottom: 'none',
+  display: 'flex',
+  alignItems: 'center',
+};
+
+const governanceTableBodyCellSx = {
+  py: '15px',
+  px: '16px',
+  borderBottom: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  alignSelf: 'stretch',
+  minWidth: 0,
+};
+
+interface SubmittedByCellProps {
+  requester: string;
+  uniqueId: string;
+}
+
+const identifierCellSx = {
+  ...governanceTableBodyCellSx,
+  overflow: 'visible',
+};
+
+const SubmittedByCell: React.FC<SubmittedByCellProps> = ({ requester, uniqueId }) => (
+  <TableCell sx={identifierCellSx} data-testid={`${uniqueId}-row-submitted-by`}>
+    <CopyableIdentifier
+      value={requester}
+      size="small"
+      data-testid={`${uniqueId}-row-submitted-by-identifier`}
+    />
+  </TableCell>
+);
+
+interface TableHeaderProps {
+  showThresholdDeadline?: boolean;
+  showStatus?: boolean;
+  showVoteStats?: boolean;
+}
+
+const TableHeader: React.FC<TableHeaderProps> = ({
+  showThresholdDeadline,
+  showStatus,
+  showVoteStats,
+}) => (
+  <>
+    <TableCell sx={governanceTableHeadCellSx}>PROPOSAL TYPE</TableCell>
+    <TableCell sx={governanceTableHeadCellSx}>VOTE PROPOSAL CONTRACT ID</TableCell>
+    {showThresholdDeadline ? (
+      <>
+        <TableCell sx={governanceTableHeadCellSx}>THRESHOLD DEADLINE</TableCell>
+        <TableCell sx={governanceTableHeadCellSx}>SUBMITTED BY</TableCell>
+        <TableCell sx={governanceTableHeadCellSx}>EFFECTIVE AT</TableCell>
+      </>
+    ) : (
+      <>
+        <TableCell sx={governanceTableHeadCellSx}>EFFECTIVE AT</TableCell>
+        <TableCell sx={governanceTableHeadCellSx}>SUBMITTED BY</TableCell>
+        {showStatus && <TableCell sx={governanceTableHeadCellSx}>STATUS</TableCell>}
+      </>
+    )}
+    {showVoteStats && <TableCell sx={governanceTableHeadCellSx}>VOTES</TableCell>}
+    <TableCell sx={governanceTableHeadCellSx}>YOUR VOTE</TableCell>
+  </>
+);
 
 export const ProposalListingSection: React.FC<ProposalListingSectionProps> = props => {
   const {
@@ -121,13 +195,11 @@ export const ProposalListingSection: React.FC<ProposalListingSectionProps> = pro
             <Table>
               <TableHead>
                 <TableRow sx={{ display: 'grid', gridTemplateColumns: gridTemplate }}>
-                  <TableCell>ACTION</TableCell>
-                  <TableCell>VOTE PROPOSAL CONTRACT ID</TableCell>
-                  {showThresholdDeadline && <TableCell>THRESHOLD DEADLINE</TableCell>}
-                  <TableCell>EFFECTIVE AT</TableCell>
-                  {showStatus && <TableCell>STATUS</TableCell>}
-                  {showVoteStats && <TableCell>VOTES</TableCell>}
-                  <TableCell>YOUR VOTE</TableCell>
+                  <TableHeader
+                    showThresholdDeadline={showThresholdDeadline}
+                    showStatus={showStatus}
+                    showVoteStats={showVoteStats}
+                  />
                 </TableRow>
               </TableHead>
               <TableBody sx={{ display: 'contents' }}>
@@ -137,6 +209,7 @@ export const ProposalListingSection: React.FC<ProposalListingSectionProps> = pro
                     actionName={vote.actionName}
                     description={vote.description}
                     contractId={vote.contractId}
+                    requester={vote.requester}
                     uniqueId={uniqueId}
                     votingThresholdDeadline={vote.votingThresholdDeadline}
                     voteTakesEffect={vote.voteTakesEffect}
@@ -226,6 +299,7 @@ interface VoteRowProps {
   actionName: string;
   description?: string;
   contractId: ContractId<VoteRequest>;
+  requester: string;
   status: ProposalListingStatus;
   uniqueId: string;
   voteStats: Record<YourVoteStatus, number>;
@@ -243,6 +317,7 @@ const VoteRow: React.FC<VoteRowProps> = React.memo(props => {
     actionName,
     description,
     contractId,
+    requester,
     status,
     uniqueId,
     voteStats,
@@ -272,10 +347,24 @@ const VoteRow: React.FC<VoteRowProps> = React.memo(props => {
       }}
       data-testid={`${uniqueId}-row`}
     >
-      <TableCell data-testid={`${uniqueId}-row-action-name`} sx={{ overflow: 'hidden' }}>
+      <TableCell
+        data-testid={`${uniqueId}-row-action-name`}
+        sx={{
+          ...governanceTableBodyCellSx,
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          overflow: 'hidden',
+        }}
+      >
         <Typography
           {...tableBodyTypography}
-          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          sx={{
+            width: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
         >
           {actionName}
         </Typography>
@@ -283,6 +372,7 @@ const VoteRow: React.FC<VoteRowProps> = React.memo(props => {
           <Typography
             data-testid={`${uniqueId}-row-description`}
             sx={{
+              width: '100%',
               fontSize: 12,
               color: 'text.secondary',
               display: '-webkit-box',
@@ -290,39 +380,54 @@ const VoteRow: React.FC<VoteRowProps> = React.memo(props => {
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              lineHeight: 1.4,
+              lineHeight: '20px',
             }}
           >
             {description}
           </Typography>
         )}
       </TableCell>
-      <TableCell
-        data-testid={`${uniqueId}-row-contract-id`}
-        sx={{ minWidth: 0, overflow: 'visible' }}
-      >
+      <TableCell sx={identifierCellSx} data-testid={`${uniqueId}-row-contract-id`}>
         <CopyableIdentifier
           value={contractId}
           size="small"
           data-testid={`${uniqueId}-row-contract-id-value`}
         />
       </TableCell>
-      {showThresholdDeadline && (
-        <TableCell data-testid={`${uniqueId}-row-voting-threshold-deadline`}>
-          <TableBodyTypography>{votingThresholdDeadline}</TableBodyTypography>
-        </TableCell>
-      )}
-      <TableCell data-testid={`${uniqueId}-row-vote-takes-effect`}>
-        <TableBodyTypography>{voteTakesEffect}</TableBodyTypography>
-      </TableCell>
-
-      {showStatus && (
-        <TableCell data-testid={`${uniqueId}-row-status`}>
-          <TableBodyTypography>{status}</TableBodyTypography>
-        </TableCell>
+      {showThresholdDeadline ? (
+        <>
+          <TableCell
+            sx={governanceTableBodyCellSx}
+            data-testid={`${uniqueId}-row-voting-threshold-deadline`}
+          >
+            <TableBodyTypography>{votingThresholdDeadline}</TableBodyTypography>
+          </TableCell>
+          <SubmittedByCell requester={requester} uniqueId={uniqueId} />
+          <TableCell
+            sx={governanceTableBodyCellSx}
+            data-testid={`${uniqueId}-row-vote-takes-effect`}
+          >
+            <TableBodyTypography>{voteTakesEffect}</TableBodyTypography>
+          </TableCell>
+        </>
+      ) : (
+        <>
+          <TableCell
+            sx={governanceTableBodyCellSx}
+            data-testid={`${uniqueId}-row-vote-takes-effect`}
+          >
+            <TableBodyTypography>{voteTakesEffect}</TableBodyTypography>
+          </TableCell>
+          <SubmittedByCell requester={requester} uniqueId={uniqueId} />
+          {showStatus && (
+            <TableCell sx={governanceTableBodyCellSx} data-testid={`${uniqueId}-row-status`}>
+              <TableBodyTypography>{status}</TableBodyTypography>
+            </TableCell>
+          )}
+        </>
       )}
       {showVoteStats && (
-        <TableCell data-testid={`${uniqueId}-row-all-votes`}>
+        <TableCell sx={governanceTableBodyCellSx} data-testid={`${uniqueId}-row-all-votes`}>
           <AllVotes
             acceptedVotes={voteStats['accepted']}
             rejectedVotes={voteStats['rejected']}
@@ -330,7 +435,7 @@ const VoteRow: React.FC<VoteRowProps> = React.memo(props => {
           />
         </TableCell>
       )}
-      <TableCell data-testid={`${uniqueId}-row-your-vote`}>
+      <TableCell sx={governanceTableBodyCellSx} data-testid={`${uniqueId}-row-your-vote`}>
         <VoteStats
           vote={yourVote}
           typography={tableBodyTypography}

--- a/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalListingSection.tsx
@@ -78,7 +78,7 @@ const governanceTableHeadCellSx = {
   fontSize: 12,
   fontWeight: 600,
   textTransform: 'uppercase' as const,
-  color: '#E2E2E2',
+  color: 'colors.neutral.80',
   borderBottom: 'none',
   display: 'flex',
   alignItems: 'center',

--- a/apps/sv/frontend/src/routes/governance.tsx
+++ b/apps/sv/frontend/src/routes/governance.tsx
@@ -23,6 +23,7 @@ import {
   computeVoteStats,
   computeYourVote,
   getVoteResultStatus,
+  getRequesterPartyId,
 } from '../utils/governance';
 import { SupportedActionTag, ProposalListingData } from '../utils/types';
 import { Link as RouterLink } from 'react-router';
@@ -57,6 +58,7 @@ export const Governance: React.FC = () => {
 
   const svPartyId = dsoInfosQuery.data?.svPartyId;
   const votingThreshold = dsoInfosQuery.data?.votingThreshold;
+  const svs = dsoInfosQuery.data?.dsoRules.payload.svs;
   const alreadyVotedRequestIds: Set<ContractId<VoteRequest>> = useMemo(() => {
     return svPartyId && votesQuery.data
       ? new Set(votesQuery.data.filter(v => v.voter === svPartyId).map(v => v.requestCid))
@@ -81,7 +83,7 @@ export const Governance: React.FC = () => {
         const votes = vr.request.votes.entriesArray().map(e => e[1]);
 
         return {
-          contractId: vr.request.trackingCid,
+          contractId: (vr.request.trackingCid ?? '') as ContractId<VoteRequest>,
           actionName:
             actionTagToTitle(amuletName)[getAction(vr.request.action) as SupportedActionTag],
           description: vr.request.reason.body,
@@ -94,9 +96,10 @@ export const Governance: React.FC = () => {
           status: getVoteResultStatus(vr.outcome),
           voteStats: computeVoteStats(votes),
           acceptanceThreshold: votingThreshold,
+          requester: getRequesterPartyId(vr.request.requester, svs),
         } as ProposalListingData;
       });
-  }, [voteResultsInfiniteQuery.data?.pages, amuletName, svPartyId, votingThreshold]);
+  }, [voteResultsInfiniteQuery.data?.pages, amuletName, svPartyId, votingThreshold, svs]);
 
   if (
     dsoInfosQuery.isPending ||
@@ -128,8 +131,7 @@ export const Governance: React.FC = () => {
         description: vr.payload.reason.body,
         votingCloses: dayjs(vr.payload.voteBefore).format(dateTimeFormatISO),
         createdAt: dayjs(vr.createdAt).format(dateTimeFormatISO),
-        requester: vr.payload.requester,
-        isYou: vr.payload.requester === svPartyId,
+        requester: getRequesterPartyId(vr.payload.requester, svs),
       } as ActionRequiredData;
     });
 
@@ -152,6 +154,7 @@ export const Governance: React.FC = () => {
         status: 'In Progress',
         voteStats: computeVoteStats(votes),
         acceptanceThreshold: dsoInfosQuery.data.votingThreshold,
+        requester: getRequesterPartyId(v.payload.requester, svs),
       } as ProposalListingData;
     });
 

--- a/apps/sv/frontend/src/utils/governance.ts
+++ b/apps/sv/frontend/src/utils/governance.ts
@@ -104,6 +104,20 @@ export function computeVoteStats(votes: Vote[]): {
   );
 }
 
+export function getRequesterPartyId(
+  requester: string,
+  svs: { entriesArray(): [string, SvInfo][] } | undefined
+): string {
+  if (requester.includes('::')) {
+    return requester;
+  }
+  if (!svs) {
+    return requester;
+  }
+  const match = svs.entriesArray().find(([, info]) => info.name === requester);
+  return match?.[0] ?? requester;
+}
+
 export function computeYourVote(votes: Vote[], svPartyId: string | undefined): YourVoteStatus {
   if (svPartyId === undefined) {
     return 'no-vote';

--- a/apps/sv/frontend/src/utils/types.ts
+++ b/apps/sv/frontend/src/utils/types.ts
@@ -157,6 +157,7 @@ export interface ProposalListingData {
   contractId: ContractId<VoteRequest>;
   actionName: string;
   description?: string;
+  requester: string;
   votingThresholdDeadline: string;
   voteTakesEffect: string;
   yourVote: YourVoteStatus;


### PR DESCRIPTION
Fixes #3691

## Summary
- Add a **Submitted by** column to the redesigned governance listing UIs: Action Required, Inflight Votes, and Vote History
- Resolve VoteRequest requester SV names to party IDs and show truncated, copyable identifiers (no You badge)
- Align proposal-type cell layout with Figma (title + description stacked)
- Update unit tests to use shared mock party/contract IDs and cover the new column



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
