### PR TITLE
Add in-depth migration id validations and tests

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/forms/set-dso-rules-form.test.tsx
@@ -5,6 +5,7 @@ import {
   dateTimeFormatISO,
   nextScheduledSynchronizerUpgradeFormat,
 } from '@canton-network/splice-common-frontend-utils';
+import { dsoInfo } from '@canton-network/splice-common-test-handlers';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
@@ -12,6 +13,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, test } from 'vitest';
 import App from '../../../App';
 import { SetDsoConfigRulesForm } from '../../../components/forms/SetDsoConfigRulesForm';
+import { SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE } from '../../../components/forms/formValidators';
 import { SvConfigProvider } from '../../../utils';
 import { Wrapper } from '../../helpers';
 import { svPartyId } from '../../mocks/constants';
@@ -481,8 +483,7 @@ describe('Next Scheduled Synchronizer Upgrade', () => {
         <SetDsoConfigRulesForm />
       </Wrapper>
     );
-    const errorMessage =
-      'Upgrade Time and Migration ID are required for a Scheduled Synchronizer Upgrade';
+    const errorMessage = SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE;
 
     expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
 
@@ -492,10 +493,12 @@ describe('Next Scheduled Synchronizer Upgrade', () => {
     );
     expect(migrationIdInput).toBeInTheDocument();
 
-    await user.type(migrationIdInput, '12345');
+    await user.type(migrationIdInput, '1');
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+      expect(
+        screen.getByTestId('config-field-error-nextScheduledSynchronizerUpgradeMigrationId')
+      ).toHaveTextContent(errorMessage);
     });
 
     // Error should be gone when migration ID is cleared
@@ -503,7 +506,9 @@ describe('Next Scheduled Synchronizer Upgrade', () => {
     await user.click(screen.getByTestId('set-dso-config-rules-action'));
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('config-field-error-nextScheduledSynchronizerUpgradeMigrationId')
+      ).not.toBeInTheDocument();
     });
 
     const timeInput = screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeTime');
@@ -513,14 +518,18 @@ describe('Next Scheduled Synchronizer Upgrade', () => {
     await user.type(timeInput, futureTime);
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+      expect(
+        screen.getByTestId('config-field-error-nextScheduledSynchronizerUpgradeTime')
+      ).toHaveTextContent(errorMessage);
     });
 
     // Error should be gone when upgrade time is cleared
     await user.clear(timeInput);
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('config-field-error-nextScheduledSynchronizerUpgradeTime')
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -553,22 +562,182 @@ describe('Next Scheduled Synchronizer Upgrade', () => {
       .add(30, 'minute')
       .format(nextScheduledSynchronizerUpgradeFormat);
     await user.type(timeInput, invalidTime);
-    await user.type(migrationIdInput, '12345');
+    await user.type(migrationIdInput, '1');
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+      expect(
+        screen.getByTestId('config-field-error-nextScheduledSynchronizerUpgradeTime')
+      ).toHaveTextContent(errorMessage);
+    });
+  });
+
+  test('shows current migration id subtext before the field is edited', async () => {
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('nextScheduledSynchronizerUpgradeMigrationId-current')
+      ).toHaveTextContent('Current migration ID: 0');
     });
 
-    // Set upgrade time to be more than 1 hour after effective date - error should disappear
+    expect(
+      screen.queryByTestId('config-current-value-nextScheduledSynchronizerUpgradeMigrationId')
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not show current configuration for synchronizer upgrade time fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    const effectiveDate = dayjs().add(10, 'day').format(dateTimeFormatISO);
+    fireEvent.change(screen.getByTestId('set-dso-config-rules-effective-date-field'), {
+      target: { value: effectiveDate },
+    });
+
     const validTime = dayjs(effectiveDate)
       .utc()
       .add(2, 'hours')
       .format(nextScheduledSynchronizerUpgradeFormat);
-    await user.clear(timeInput);
-    await user.type(timeInput, validTime);
+
+    await user.type(
+      screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeTime'),
+      validTime
+    );
+
+    expect(
+      screen.queryByTestId('config-current-value-nextScheduledSynchronizerUpgradeTime')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('nextScheduledSynchronizerUpgradeTime-default')).toBeInTheDocument();
+  });
+
+  test('shows current configuration but not migration id subtext when field changes', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    const effectiveDate = dayjs().add(10, 'day').format(dateTimeFormatISO);
+    fireEvent.change(screen.getByTestId('set-dso-config-rules-effective-date-field'), {
+      target: { value: effectiveDate },
+    });
+
+    const validTime = dayjs(effectiveDate)
+      .utc()
+      .add(2, 'hours')
+      .format(nextScheduledSynchronizerUpgradeFormat);
+
+    await user.type(
+      screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeTime'),
+      validTime
+    );
+
+    const migrationIdInput = screen.getByTestId(
+      'config-field-nextScheduledSynchronizerUpgradeMigrationId'
+    );
+    await user.type(migrationIdInput, '1');
 
     await waitFor(() => {
-      expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('config-current-value-nextScheduledSynchronizerUpgradeMigrationId')
+      ).toHaveTextContent('Current Configuration: 0');
+      expect(
+        screen.queryByTestId('nextScheduledSynchronizerUpgradeMigrationId-current')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows field error for invalid migration id format without upgrade time', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    await user.type(
+      screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeMigrationId'),
+      'abc'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('config-field-error-nextScheduledSynchronizerUpgradeMigrationId')
+      ).toHaveTextContent('Migration ID must be a whole number');
+    });
+  });
+
+  test('shows field error when migration id is not current + 1 without upgrade time', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    await user.type(
+      screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeMigrationId'),
+      '2'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('config-field-error-nextScheduledSynchronizerUpgradeMigrationId')
+      ).toHaveTextContent('Migration ID must be 1 (current migration ID + 1)');
+      expect(
+        screen.getByTestId('config-current-value-nextScheduledSynchronizerUpgradeMigrationId')
+      ).toHaveTextContent('Current Configuration: 0');
+    });
+  });
+
+  test('skips synchronizer upgrade validation when effective at threshold', async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByLabelText(/Make effective at threshold/i));
+
+    await user.type(
+      screen.getByTestId('config-field-nextScheduledSynchronizerUpgradeMigrationId'),
+      'abc'
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('config-field-error-nextScheduledSynchronizerUpgradeMigrationId')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows unavailable message when current migration id cannot be determined', async () => {
+    server.use(
+      http.get(`${svUrl}/v0/dso`, () => {
+        return HttpResponse.json({ ...dsoInfo, sv_node_states: [] });
+      })
+    );
+
+    render(
+      <Wrapper>
+        <SetDsoConfigRulesForm />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('nextScheduledSynchronizerUpgradeMigrationId-current')
+      ).toHaveTextContent('Current migration ID unavailable');
     });
   });
 });

--- a/apps/sv/frontend/src/__tests__/utils/buildDsoRulesConfigFromChanges.test.ts
+++ b/apps/sv/frontend/src/__tests__/utils/buildDsoRulesConfigFromChanges.test.ts
@@ -119,7 +119,35 @@ describe('buildDsoRulesConfigFromChanges', () => {
     });
   });
 
-  it('should handle voteCooldownTime when provided', () => {
+  it('should set nextScheduledSynchronizerUpgrade to null when only upgrade time is provided', () => {
+    const changes: ConfigChange[] = [
+      {
+        fieldName: 'nextScheduledSynchronizerUpgradeTime',
+        label: 'Upgrade Time',
+        currentValue: '',
+        newValue: '2023-01-01T00:00:00Z',
+      },
+    ];
+    const result = buildDsoRulesConfigFromChanges(changes);
+
+    expect(result.nextScheduledSynchronizerUpgrade).toBeNull();
+  });
+
+  it('should set nextScheduledSynchronizerUpgrade to null when only migration id is provided', () => {
+    const changes: ConfigChange[] = [
+      {
+        fieldName: 'nextScheduledSynchronizerUpgradeMigrationId',
+        label: 'Migration ID',
+        currentValue: '',
+        newValue: '1',
+      },
+    ];
+    const result = buildDsoRulesConfigFromChanges(changes);
+
+    expect(result.nextScheduledSynchronizerUpgrade).toBeNull();
+  });
+
+  it('should handle voteCooldownTime when not provided', () => {
     const changes: ConfigChange[] = [];
     const result = buildDsoRulesConfigFromChanges(changes);
     expect(result.voteCooldownTime).toBeNull();

--- a/apps/sv/frontend/src/__tests__/utils/migration-id.test.ts
+++ b/apps/sv/frontend/src/__tests__/utils/migration-id.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { dsoInfo } from '@canton-network/splice-common-test-handlers';
+import { Contract } from '@canton-network/splice-common-frontend-utils';
+import { AmuletRules } from '@daml.js/splice-amulet/lib/Splice/AmuletRules';
+import { SvNodeState } from '@daml.js/splice-dso-governance/lib/Splice/DSO/SvState';
+import { DsoRules } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
+import type { DsoInfo } from '@canton-network/splice-common-frontend';
+import {
+  getCurrentMigrationIdFromDsoInfo,
+  getConfigFieldCurrentConfigurationValue,
+  isValidMigrationIdFormat,
+  MIGRATION_ID_WHOLE_NUMBER_ERROR,
+  validateMigrationIdAgainstCurrent,
+} from '../../utils/migrationId';
+import {
+  validateNextScheduledSynchronizerUpgrade,
+  getSynchronizerUpgradeFieldError,
+  SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE,
+} from '../../components/forms/formValidators';
+import { nextScheduledSynchronizerUpgradeFormat } from '@canton-network/splice-common-frontend-utils';
+
+const testDsoInfo: DsoInfo = {
+  svUser: dsoInfo.sv_user,
+  svPartyId: dsoInfo.sv_party_id,
+  dsoPartyId: dsoInfo.dso_party_id,
+  votingThreshold: BigInt(dsoInfo.voting_threshold),
+  amuletRules: Contract.decodeOpenAPI(dsoInfo.amulet_rules.contract, AmuletRules),
+  dsoRules: Contract.decodeOpenAPI(dsoInfo.dso_rules.contract, DsoRules),
+  nodeStates: dsoInfo.sv_node_states.map(c => Contract.decodeOpenAPI(c.contract, SvNodeState)),
+};
+
+describe('migrationId utils', () => {
+  test('getCurrentMigrationIdFromDsoInfo reads sequencer migration id from node states', () => {
+    expect(getCurrentMigrationIdFromDsoInfo(testDsoInfo)).toBe(0);
+  });
+
+  test('getCurrentMigrationIdFromDsoInfo returns undefined when node states are missing', () => {
+    expect(getCurrentMigrationIdFromDsoInfo({ ...testDsoInfo, nodeStates: [] })).toBeUndefined();
+  });
+
+  test('getConfigFieldCurrentConfigurationValue uses cluster migration id when unset', () => {
+    expect(
+      getConfigFieldCurrentConfigurationValue('nextScheduledSynchronizerUpgradeMigrationId', '', 0)
+    ).toBe('0');
+    expect(
+      getConfigFieldCurrentConfigurationValue('nextScheduledSynchronizerUpgradeMigrationId', '2', 0)
+    ).toBe('2');
+    expect(getConfigFieldCurrentConfigurationValue('voteCooldownTime', '', 0)).toBe('');
+  });
+
+  test('isValidMigrationIdFormat accepts whole numbers without leading zeros', () => {
+    expect(isValidMigrationIdFormat('0')).toBe(true);
+    expect(isValidMigrationIdFormat('42')).toBe(true);
+    expect(isValidMigrationIdFormat('')).toBe(false);
+    expect(isValidMigrationIdFormat('-1')).toBe(false);
+    expect(isValidMigrationIdFormat('1.5')).toBe(false);
+    expect(isValidMigrationIdFormat('abc')).toBe(false);
+    expect(isValidMigrationIdFormat('01')).toBe(false);
+    expect(isValidMigrationIdFormat(' 1')).toBe(false);
+    expect(isValidMigrationIdFormat(String(Number.MAX_SAFE_INTEGER))).toBe(true);
+    expect(isValidMigrationIdFormat(String(Number.MAX_SAFE_INTEGER + 1))).toBe(false);
+  });
+
+  test('validateMigrationIdAgainstCurrent requires current + 1', () => {
+    expect(validateMigrationIdAgainstCurrent('1', 0)).toBe(false);
+    expect(validateMigrationIdAgainstCurrent('6', 5)).toBe(false);
+    expect(validateMigrationIdAgainstCurrent('0', 0)).toBe(
+      'Migration ID must be 1 (current migration ID + 1)'
+    );
+    expect(validateMigrationIdAgainstCurrent('2', 0)).toBe(
+      'Migration ID must be 1 (current migration ID + 1)'
+    );
+    expect(validateMigrationIdAgainstCurrent('4', 5)).toBe(
+      'Migration ID must be 6 (current migration ID + 1)'
+    );
+    expect(validateMigrationIdAgainstCurrent('7', 5)).toBe(
+      'Migration ID must be 6 (current migration ID + 1)'
+    );
+    expect(validateMigrationIdAgainstCurrent('abc', 0)).toBe(MIGRATION_ID_WHOLE_NUMBER_ERROR);
+    expect(validateMigrationIdAgainstCurrent('01', 0)).toBe(MIGRATION_ID_WHOLE_NUMBER_ERROR);
+    expect(validateMigrationIdAgainstCurrent('1', undefined)).toBe(
+      'Unable to determine current migration ID'
+    );
+  });
+});
+
+describe('validateNextScheduledSynchronizerUpgrade', () => {
+  const effectiveDate = '2030-01-01T12:00:00';
+  const validUpgradeTime = '2030-01-01T14:00:00Z';
+  const formatError = MIGRATION_ID_WHOLE_NUMBER_ERROR;
+
+  test('accepts empty upgrade time and migration id', () => {
+    expect(validateNextScheduledSynchronizerUpgrade('', '', effectiveDate, 0)).toBe(false);
+  });
+
+  test('requires both upgrade time and migration id when one is set', () => {
+    expect(validateNextScheduledSynchronizerUpgrade('', '1', effectiveDate, 0)).toBe(
+      SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE
+    );
+  });
+
+  test('requires migration id to be current + 1', () => {
+    expect(validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '0', effectiveDate, 0)).toBe(
+      'Migration ID must be 1 (current migration ID + 1)'
+    );
+    expect(validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '2', effectiveDate, 0)).toBe(
+      'Migration ID must be 1 (current migration ID + 1)'
+    );
+    expect(validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '1', effectiveDate, 0)).toBe(
+      false
+    );
+  });
+
+  test('rejects invalid migration id format', () => {
+    expect(
+      validateNextScheduledSynchronizerUpgrade(validUpgradeTime, 'abc', effectiveDate, 0)
+    ).toBe(formatError);
+    expect(
+      validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '1.5', effectiveDate, 0)
+    ).toBe(formatError);
+    expect(validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '-1', effectiveDate, 0)).toBe(
+      formatError
+    );
+    expect(validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '01', effectiveDate, 0)).toBe(
+      formatError
+    );
+  });
+
+  test('rejects migration id when current migration id is unavailable', () => {
+    expect(
+      validateNextScheduledSynchronizerUpgrade(validUpgradeTime, '1', effectiveDate, undefined)
+    ).toBe('Unable to determine current migration ID');
+  });
+
+  test('rejects invalid upgrade time format', () => {
+    expect(validateNextScheduledSynchronizerUpgrade('not-a-time', '1', effectiveDate, 0)).toBe(
+      `Upgrade Time must be in ${nextScheduledSynchronizerUpgradeFormat} format`
+    );
+  });
+
+  test('treats whitespace-only fields as empty for mutual requirement', () => {
+    expect(validateNextScheduledSynchronizerUpgrade('   ', '', effectiveDate, 0)).toBe(false);
+    expect(validateNextScheduledSynchronizerUpgrade('', '   ', effectiveDate, 0)).toBe(false);
+    expect(validateNextScheduledSynchronizerUpgrade('   ', '1', effectiveDate, 0)).toBe(
+      SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE
+    );
+  });
+
+  test('skips validation when effective date is undefined (effective at threshold)', () => {
+    expect(validateNextScheduledSynchronizerUpgrade('', 'abc', undefined, 0)).toBe(false);
+    expect(
+      validateNextScheduledSynchronizerUpgrade('2030-01-01T14:00:00Z', 'abc', undefined, 0)
+    ).toBe(false);
+    expect(getSynchronizerUpgradeFieldError('migrationId', '', 'abc', undefined, 0)).toBe(false);
+    expect(
+      getSynchronizerUpgradeFieldError('upgradeTime', '2030-01-01T14:00:00Z', '', undefined, 0)
+    ).toBe(false);
+  });
+});
+
+describe('synchronizer upgrade field validators', () => {
+  const effectiveDate = '2030-01-01T12:00:00';
+
+  test('migration id field validates format before mutual requirement', () => {
+    expect(getSynchronizerUpgradeFieldError('migrationId', '', 'abc', effectiveDate, 0)).toBe(
+      MIGRATION_ID_WHOLE_NUMBER_ERROR
+    );
+    expect(getSynchronizerUpgradeFieldError('migrationId', '', '1', effectiveDate, 0)).toBe(
+      SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE
+    );
+  });
+
+  test('upgrade time field requires migration id when upgrade time is set', () => {
+    expect(
+      getSynchronizerUpgradeFieldError('upgradeTime', '2030-01-01T14:00:00Z', '', effectiveDate, 0)
+    ).toBe(SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE);
+  });
+});

--- a/apps/sv/frontend/src/components/form-components/ConfigField.tsx
+++ b/apps/sv/frontend/src/components/form-components/ConfigField.tsx
@@ -3,17 +3,39 @@
 
 import { Link as RouterLink } from 'react-router';
 import { Box, Divider, TextField as MuiTextField, Typography } from '@mui/material';
+import type { FormHelperTextProps } from '@mui/material';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useFieldContext } from '../../hooks/formContext';
 import type { ConfigChange, PendingConfigFieldInfo } from '../../utils/types';
+import { getConfigFieldCurrentConfigurationValue } from '../../utils/migrationId';
 import { nextScheduledSynchronizerUpgradeFormat } from '@canton-network/splice-common-frontend-utils';
 
 dayjs.extend(relativeTime);
 
+const configFieldErrorFormHelperTextProps = (testId: string): Partial<FormHelperTextProps> =>
+  ({
+    sx: {
+      color: '#FD8575',
+      fontFeatureSettings: "'liga' off, 'clig' off",
+      fontFamily: 'Inter',
+      fontSize: '12px',
+      fontStyle: 'normal',
+      fontWeight: 400,
+      lineHeight: '16px',
+      alignSelf: 'stretch',
+      wordBreak: 'break-word',
+      overflowWrap: 'break-word',
+      mx: 0,
+      mt: 0.5,
+    },
+    'data-testid': testId,
+  }) as Partial<FormHelperTextProps>;
+
 export interface ConfigFieldProps {
   configChange: ConfigChange;
   effectiveDate?: string | undefined;
+  currentMigrationId?: number | undefined;
   pendingFieldInfo?: PendingConfigFieldInfo;
 }
 
@@ -23,7 +45,7 @@ export type ConfigFieldState = {
 };
 
 export const ConfigField: React.FC<ConfigFieldProps> = props => {
-  const { configChange, effectiveDate, pendingFieldInfo } = props;
+  const { configChange, effectiveDate, currentMigrationId, pendingFieldInfo } = props;
   const field = useFieldContext<ConfigFieldState>();
 
   const isSynchronizerUpgradeTime = [
@@ -31,9 +53,9 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
     'nextScheduledLogicalSynchronizerUpgradeTopologyFreezeTime',
     'nextScheduledLogicalSynchronizerUpgradeUpgradeTime',
   ].includes(field.state.value?.fieldName);
-  const isSynchronizerUpgradeField =
-    field.state.value?.fieldName.startsWith('nextScheduledSynchronizerUpgrade') ||
-    field.state.value?.fieldName.startsWith('nextScheduledLogicalSynchronizerUpgrade');
+  const isSynchronizerUpgradeMigrationIdField =
+    field.state.value?.fieldName === 'nextScheduledSynchronizerUpgradeMigrationId';
+  const isFieldEdited = !field.state.meta.isDefaultValue;
 
   // We disable the field if it is pending and the value is the default value.
   // The default value check is to handle the case where the user made a change
@@ -44,6 +66,10 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
 
   const isEffectiveAtThreshold = !effectiveDate;
 
+  const isSynchronizerUpgradeField =
+    field.state.value?.fieldName.startsWith('nextScheduledSynchronizerUpgrade') ||
+    field.state.value?.fieldName.startsWith('nextScheduledLogicalSynchronizerUpgrade');
+
   // When effective at Threshold, we disable the upgrade time and migrationId config fields
   const isEffectiveAtThresholdAndSyncUpgradeTimeOrMigrationId =
     isEffectiveAtThreshold && (isSynchronizerUpgradeTime || isSynchronizerUpgradeField);
@@ -53,17 +79,36 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
     isEffectiveAtThresholdAndSyncUpgradeTimeOrMigrationId ||
     configChange.disabled;
 
+  const displayedCurrentConfiguration = getConfigFieldCurrentConfigurationValue(
+    configChange.fieldName,
+    configChange.currentValue,
+    currentMigrationId
+  );
+  const fieldError = field.state.meta.errors?.[0];
+  const showFieldError = !field.state.meta.isValid && Boolean(fieldError);
+
+  const showCurrentConfiguration = isFieldEdited && !isSynchronizerUpgradeTime;
+  const showCurrentConfigurationSubtext =
+    showCurrentConfiguration && (!showFieldError || isSynchronizerUpgradeMigrationIdField);
+
   const textFieldProps = {
     variant: 'outlined' as const,
     size: 'small' as const,
-    color: field.state.meta.isDefaultValue ? ('primary' as const) : ('secondary' as const),
-    focused: !field.state.meta.isDefaultValue,
+    ...(showFieldError
+      ? {}
+      : {
+          color: field.state.meta.isDefaultValue ? ('primary' as const) : ('secondary' as const),
+          focused: !field.state.meta.isDefaultValue,
+        }),
     autoComplete: 'off' as const,
     inputProps: {
       sx: { textAlign: 'right' },
       'data-testid': `config-field-${configChange.fieldName}`,
     },
     disabled: isDisabled,
+    FormHelperTextProps: showFieldError
+      ? configFieldErrorFormHelperTextProps(`config-field-error-${configChange.fieldName}`)
+      : undefined,
   };
 
   return (
@@ -72,10 +117,10 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: 'flex-start',
         }}
       >
-        <Box>
+        <Box sx={{ flex: 1, minWidth: 0, pr: 2 }}>
           <Typography variant="body1" data-testid={`config-label-${configChange.fieldName}`}>
             {configChange.label}
           </Typography>
@@ -89,9 +134,12 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
           </Typography>
         </Box>
 
-        <Box sx={{ width: 250 }}>
+        <Box sx={{ width: 250, maxWidth: '100%', flexShrink: 0, minWidth: 0 }}>
           <MuiTextField
             {...textFieldProps}
+            fullWidth
+            error={showFieldError}
+            helperText={showFieldError ? fieldError : undefined}
             // We choose empty string to represent fields that could be undefined because their values have not been set.
             value={field.state.value?.value || ''}
             onBlur={field.handleBlur}
@@ -103,14 +151,27 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
             }
           />
 
-          {!field.state.meta.isDefaultValue && (
+          {showCurrentConfigurationSubtext && (
             <Typography
               variant="caption"
               color="text.secondary"
               sx={{ mt: 0.5, display: 'block' }}
               data-testid={`config-current-value-${configChange.fieldName}`}
             >
-              Current Configuration: {configChange.currentValue}
+              Current Configuration: {displayedCurrentConfiguration}
+            </Typography>
+          )}
+
+          {isSynchronizerUpgradeMigrationIdField && !isFieldEdited && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5, display: 'block' }}
+              data-testid="nextScheduledSynchronizerUpgradeMigrationId-current"
+            >
+              {currentMigrationId !== undefined
+                ? `Current migration ID: ${currentMigrationId}`
+                : 'Current migration ID unavailable'}
             </Typography>
           )}
 

--- a/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
+++ b/apps/sv/frontend/src/components/forms/SetDsoConfigRulesForm.tsx
@@ -13,6 +13,7 @@ import {
 import { dateTimeFormatISO } from '@canton-network/splice-common-frontend-utils';
 import { Alert, Box, Typography } from '@mui/material';
 import dayjs from 'dayjs';
+import type { DeepKeys } from '@tanstack/react-form';
 import { useMemo, useState } from 'react';
 import { useDsoInfos } from '../../contexts/SvContext';
 import { useListDsoRulesVoteRequests } from '../../hooks';
@@ -27,19 +28,20 @@ import {
   createProposalActions,
   getInitialExpiration,
 } from '../../utils/governance';
+import { getCurrentMigrationIdFromDsoInfo } from '../../utils/migrationId';
 import type { CommonProposalFormData, ConfigFormData } from '../../utils/types';
 import { EffectiveDateField } from '../form-components/EffectiveDateField';
 import { ProposalSubmissionError } from '../form-components/ProposalSubmissionError';
 import { JsonDiffAccordion } from '../governance/JsonDiffAccordion';
 import { ProposalSummary } from '../governance/ProposalSummary';
 import { FormLayout } from './FormLayout';
+import type { ConfigFieldState } from '../form-components/ConfigField';
 import {
   validateEffectiveDate,
   validateExpiration,
-  validateExpiryEffectiveDate,
-  validateNextScheduledSynchronizerUpgrade,
-  validateNextScheduledLogicalSynchronizerUpgrade,
+  validateSetDsoConfigRulesFormFields,
   validateSummary,
+  getSynchronizerUpgradeFieldError,
   validateUrl,
 } from './formValidators';
 
@@ -50,9 +52,75 @@ export type SetDsoConfigCompleteFormData = {
 
 const createProposalAction = createProposalActions.find(a => a.value === 'SRARC_SetConfig');
 
+type SyncUpgradeFieldValidatorConfig = {
+  listenTo: DeepKeys<SetDsoConfigCompleteFormData>[];
+  validate: (
+    value: ConfigFieldState,
+    formData: SetDsoConfigCompleteFormData,
+    currentMigrationId: number | undefined
+  ) => string | false;
+};
+
+const SYNC_UPGRADE_FIELD_VALIDATOR_CONFIG: Record<string, SyncUpgradeFieldValidatorConfig> = {
+  nextScheduledSynchronizerUpgradeMigrationId: {
+    listenTo: ['config.nextScheduledSynchronizerUpgradeTime', 'common.effectiveDate'],
+    validate: (value, formData, currentMigrationId) =>
+      getSynchronizerUpgradeFieldError(
+        'migrationId',
+        formData.config.nextScheduledSynchronizerUpgradeTime?.value ?? '',
+        value?.value ?? '',
+        formData.common.effectiveDate.effectiveDate,
+        currentMigrationId
+      ),
+  },
+  nextScheduledSynchronizerUpgradeTime: {
+    listenTo: ['config.nextScheduledSynchronizerUpgradeMigrationId', 'common.effectiveDate'],
+    validate: (value, formData, currentMigrationId) =>
+      getSynchronizerUpgradeFieldError(
+        'upgradeTime',
+        value?.value ?? '',
+        formData.config.nextScheduledSynchronizerUpgradeMigrationId?.value ?? '',
+        formData.common.effectiveDate.effectiveDate,
+        currentMigrationId
+      ),
+  },
+};
+
+const makeSyncUpgradeFieldValidators = (
+  config: SyncUpgradeFieldValidatorConfig,
+  currentMigrationId: number | undefined
+) => {
+  const validate = ({
+    value,
+    fieldApi,
+  }: {
+    value: ConfigFieldState;
+    fieldApi: { form: { state: { values: SetDsoConfigCompleteFormData } } };
+  }) => config.validate(value, fieldApi.form.state.values, currentMigrationId);
+
+  return {
+    onChangeListenTo: config.listenTo,
+    onChange: validate,
+    onBlur: validate,
+    onSubmit: validate,
+  };
+};
+
+const getSynchronizerUpgradeFieldValidators = (
+  fieldName: string,
+  currentMigrationId: number | undefined
+) => {
+  const config = SYNC_UPGRADE_FIELD_VALIDATOR_CONFIG[fieldName];
+  return config ? makeSyncUpgradeFieldValidators(config, currentMigrationId) : undefined;
+};
+
 export const SetDsoConfigRulesForm: () => JSX.Element = () => {
   const dsoInfoQuery = useDsoInfos();
   const dsoProposalsQuery = useListDsoRulesVoteRequests();
+  const currentMigrationId = useMemo(
+    () => (dsoInfoQuery.data ? getCurrentMigrationIdFromDsoInfo(dsoInfoQuery.data) : undefined),
+    [dsoInfoQuery.data]
+  );
   const votesHooks = useVotesHooks();
   const pendingConfigFields = useMemo(
     () => buildPendingConfigFields(dsoProposalsQuery.data),
@@ -104,6 +172,20 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
     };
   }, [dsoInfoQuery.data, initialExpiration, initialEffectiveDate]);
 
+  const synchronizerUpgradeFieldValidators = useMemo(
+    () => ({
+      nextScheduledSynchronizerUpgradeMigrationId: getSynchronizerUpgradeFieldValidators(
+        'nextScheduledSynchronizerUpgradeMigrationId',
+        currentMigrationId
+      ),
+      nextScheduledSynchronizerUpgradeTime: getSynchronizerUpgradeFieldValidators(
+        'nextScheduledSynchronizerUpgradeTime',
+        currentMigrationId
+      ),
+    }),
+    [currentMigrationId]
+  );
+
   const form = useAppForm({
     defaultValues,
     onSubmit: async ({ value: formData }) => {
@@ -133,37 +215,12 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
     },
 
     validators: {
-      onChange: ({ value: formData }) => {
-        const expiryError = validateExpiryEffectiveDate({
-          expiration: formData.common.expiryDate,
-          effectiveDate: formData.common.effectiveDate.effectiveDate,
-        });
-
-        if (expiryError) return expiryError;
-
-        const syncUpgradeTime = formData.config.nextScheduledSynchronizerUpgradeTime.value;
-        const syncMigrationId = formData.config.nextScheduledSynchronizerUpgradeMigrationId.value;
-        const effectiveDate = formData.common.effectiveDate.effectiveDate;
-
-        const synchronizerUpgradeError = validateNextScheduledSynchronizerUpgrade(
-          syncUpgradeTime,
-          syncMigrationId,
-          effectiveDate
-        );
-        if (synchronizerUpgradeError) return synchronizerUpgradeError;
-        const logicalSynchronizerUpgradeError = validateNextScheduledLogicalSynchronizerUpgrade(
-          formData.config.nextScheduledLogicalSynchronizerUpgradeTopologyFreezeTime.value,
-          formData.config.nextScheduledLogicalSynchronizerUpgradeUpgradeTime.value,
-          formData.config.nextScheduledLogicalSynchronizerUpgradeNewPhysicalSynchronizerSerial
-            .value,
-          formData.config
-            .nextScheduledLogicalSynchronizerUpgradeNewPhysicalSynchronizerProtocolVersion.value,
-          effectiveDate
-        );
-        if (logicalSynchronizerUpgradeError) return logicalSynchronizerUpgradeError;
-        return false;
-      },
+      onChange: ({ value: formData }) =>
+        validateSetDsoConfigRulesFormFields(formData, currentMigrationId),
       onSubmit: ({ value: formData }) => {
+        const formError = validateSetDsoConfigRulesFormFields(formData, currentMigrationId);
+        if (formError) return formError;
+
         const changes = configFormDataToConfigChanges(formData.config, dsoConfigChanges);
 
         if (changes.length === 0) {
@@ -242,7 +299,15 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
             </Typography>
 
             {dsoConfigChanges.map((change, index) => (
-              <form.AppField name={`config.${change.fieldName}`} key={index}>
+              <form.AppField
+                name={`config.${change.fieldName}`}
+                key={index}
+                validators={
+                  synchronizerUpgradeFieldValidators[
+                    change.fieldName as keyof typeof synchronizerUpgradeFieldValidators
+                  ]
+                }
+              >
                 {field => (
                   <field.ConfigField
                     configChange={change}
@@ -251,6 +316,7 @@ export const SetDsoConfigRulesForm: () => JSX.Element = () => {
                       f => f.fieldName === change.fieldName
                     )}
                     effectiveDate={form.state.values.common.effectiveDate.effectiveDate}
+                    currentMigrationId={currentMigrationId}
                   />
                 )}
               </form.AppField>

--- a/apps/sv/frontend/src/components/forms/formValidators.ts
+++ b/apps/sv/frontend/src/components/forms/formValidators.ts
@@ -3,7 +3,10 @@
 
 import dayjs from 'dayjs';
 import { z } from 'zod';
+import { nextScheduledSynchronizerUpgradeFormat } from '@canton-network/splice-common-frontend-utils';
+import { validateMigrationIdAgainstCurrent } from '../../utils/migrationId';
 import type { EffectivityType } from '../../utils/types';
+import type { CommonProposalFormData, ConfigFormData } from '../../utils/types';
 import { isValidUrl } from '../../utils/validations';
 
 export const urlSchema = z.string().refine(url => isValidUrl(url), {
@@ -181,29 +184,176 @@ export const validatePartyId = (value: string): string | false => {
   return result.success ? false : result.error.issues[0].message;
 };
 
-export const validateNextScheduledSynchronizerUpgrade = (
+const isValidSynchronizerUpgradeTimeFormat = (value: string): boolean =>
+  dayjs.utc(value, nextScheduledSynchronizerUpgradeFormat, true).isValid();
+
+export const SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE =
+  'Upgrade Time and Migration ID are required for a Scheduled Synchronizer Upgrade';
+
+type SynchronizerUpgradeErrorField = 'migrationId' | 'upgradeTime' | 'both';
+
+type SynchronizerUpgradeValidationResult =
+  | false
+  | { field: SynchronizerUpgradeErrorField; message: string };
+
+const normalizeSynchronizerUpgradeFields = (upgradeTime: string, migrationId: string) => ({
+  upgradeTime: upgradeTime.trim(),
+  migrationId: migrationId.trim(),
+});
+
+const validateNextScheduledSynchronizerUpgradeResult = (
   upgradeTime: string,
   migrationId: string,
-  effectiveDate: string | undefined
-): string | false => {
-  const onlyOneIsProvided = (upgradeTime === '') !== (migrationId === '');
-  const bothEmpty = upgradeTime === '' && migrationId === '';
+  effectiveDate: string | undefined,
+  currentMigrationId: number | undefined
+): SynchronizerUpgradeValidationResult => {
+  // Physical synchronizer upgrade fields are disabled for effective-at-threshold proposals.
+  if (effectiveDate === undefined) {
+    return false;
+  }
+
+  const { upgradeTime: normalizedUpgradeTime, migrationId: normalizedMigrationId } =
+    normalizeSynchronizerUpgradeFields(upgradeTime, migrationId);
+  const onlyOneIsProvided = (normalizedUpgradeTime === '') !== (normalizedMigrationId === '');
+  const bothEmpty = normalizedUpgradeTime === '' && normalizedMigrationId === '';
 
   if (bothEmpty) {
     return false;
   }
 
   if (onlyOneIsProvided) {
-    return 'Upgrade Time and Migration ID are required for a Scheduled Synchronizer Upgrade';
+    return { field: 'both', message: SYNCHRONIZER_UPGRADE_MUTUAL_REQUIREMENT_MESSAGE };
   }
 
-  const upgradeTimeDate = dayjs.utc(upgradeTime);
+  if (!isValidSynchronizerUpgradeTimeFormat(normalizedUpgradeTime)) {
+    return {
+      field: 'upgradeTime',
+      message: `Upgrade Time must be in ${nextScheduledSynchronizerUpgradeFormat} format`,
+    };
+  }
+
+  const migrationIdError = validateMigrationIdAgainstCurrent(
+    normalizedMigrationId,
+    currentMigrationId
+  );
+  if (migrationIdError) {
+    return { field: 'migrationId', message: migrationIdError };
+  }
+
+  const upgradeTimeDate = dayjs.utc(normalizedUpgradeTime);
   const effectivity = dayjs(effectiveDate);
 
   const upgradeTimeIsAfterEffectiveDate = upgradeTimeDate.isAfter(effectivity.add(1, 'hour'));
   if (!upgradeTimeIsAfterEffectiveDate) {
-    return 'Upgrade Time must be at least 1 hour after the Effective Date';
+    return {
+      field: 'upgradeTime',
+      message: 'Upgrade Time must be at least 1 hour after the Effective Date',
+    };
   }
+
+  return false;
+};
+
+export const validateNextScheduledSynchronizerUpgrade = (
+  upgradeTime: string,
+  migrationId: string,
+  effectiveDate: string | undefined,
+  currentMigrationId: number | undefined
+): string | false => {
+  const result = validateNextScheduledSynchronizerUpgradeResult(
+    upgradeTime,
+    migrationId,
+    effectiveDate,
+    currentMigrationId
+  );
+
+  return result ? result.message : false;
+};
+
+type SynchronizerUpgradeField = 'migrationId' | 'upgradeTime';
+
+export const getSynchronizerUpgradeFieldError = (
+  field: SynchronizerUpgradeField,
+  upgradeTime: string,
+  migrationId: string,
+  effectiveDate: string | undefined,
+  currentMigrationId: number | undefined
+): string | false => {
+  if (effectiveDate === undefined) {
+    return false;
+  }
+
+  const { upgradeTime: normalizedUpgradeTime, migrationId: normalizedMigrationId } =
+    normalizeSynchronizerUpgradeFields(upgradeTime, migrationId);
+
+  if (normalizedMigrationId === '' && normalizedUpgradeTime === '') {
+    return false;
+  }
+
+  if (field === 'migrationId' && normalizedMigrationId !== '') {
+    const migrationIdError = validateMigrationIdAgainstCurrent(
+      normalizedMigrationId,
+      currentMigrationId
+    );
+    if (migrationIdError) {
+      return migrationIdError;
+    }
+  }
+
+  const result = validateNextScheduledSynchronizerUpgradeResult(
+    normalizedUpgradeTime,
+    normalizedMigrationId,
+    effectiveDate,
+    currentMigrationId
+  );
+  if (!result) {
+    return false;
+  }
+
+  if (field === 'migrationId') {
+    return result.field === 'migrationId' || result.field === 'both' ? result.message : false;
+  }
+
+  if (result.field === 'upgradeTime') {
+    return result.message;
+  }
+
+  return result.field === 'both' && normalizedUpgradeTime !== '' ? result.message : false;
+};
+
+export const validateSetDsoConfigRulesFormFields = (
+  formData: { common: CommonProposalFormData; config: ConfigFormData },
+  currentMigrationId: number | undefined
+): string | false => {
+  const expiryError = validateExpiryEffectiveDate({
+    expiration: formData.common.expiryDate,
+    effectiveDate: formData.common.effectiveDate.effectiveDate,
+  });
+
+  if (expiryError) return expiryError;
+
+  const effectiveDate = formData.common.effectiveDate.effectiveDate;
+  const syncUpgradeTime = formData.config.nextScheduledSynchronizerUpgradeTime?.value ?? '';
+  const syncMigrationId = formData.config.nextScheduledSynchronizerUpgradeMigrationId?.value ?? '';
+
+  const synchronizerUpgradeError = validateNextScheduledSynchronizerUpgrade(
+    syncUpgradeTime,
+    syncMigrationId,
+    effectiveDate,
+    currentMigrationId
+  );
+  if (synchronizerUpgradeError) return synchronizerUpgradeError;
+
+  const logicalSynchronizerUpgradeError = validateNextScheduledLogicalSynchronizerUpgrade(
+    formData.config.nextScheduledLogicalSynchronizerUpgradeTopologyFreezeTime?.value ?? '',
+    formData.config.nextScheduledLogicalSynchronizerUpgradeUpgradeTime?.value ?? '',
+    formData.config.nextScheduledLogicalSynchronizerUpgradeNewPhysicalSynchronizerSerial?.value ??
+      '',
+    formData.config.nextScheduledLogicalSynchronizerUpgradeNewPhysicalSynchronizerProtocolVersion
+      ?.value ?? '',
+    effectiveDate
+  );
+  if (logicalSynchronizerUpgradeError) return logicalSynchronizerUpgradeError;
 
   return false;
 };

--- a/apps/sv/frontend/src/utils/buildDsoRulesConfigFromChanges.ts
+++ b/apps/sv/frontend/src/utils/buildDsoRulesConfigFromChanges.ts
@@ -48,6 +48,7 @@ export function buildDsoRulesConfigFromChanges(dsoConfigChanges: ConfigChange[])
   }
 
   const upgradeTime = getValue('nextScheduledSynchronizerUpgradeTime', true);
+  const upgradeMigrationId = getValue('nextScheduledSynchronizerUpgradeMigrationId', true);
   const logicalSyncUpgradeTopologyFreezeTime = getValue(
     'nextScheduledLogicalSynchronizerUpgradeTopologyFreezeTime',
     true
@@ -98,11 +99,11 @@ export function buildDsoRulesConfigFromChanges(dsoConfigChanges: ConfigChange[])
     },
 
     nextScheduledSynchronizerUpgrade:
-      upgradeTime === null
+      upgradeTime === null || upgradeMigrationId === null
         ? null
         : {
             time: upgradeTime,
-            migrationId: getValue('nextScheduledSynchronizerUpgradeMigrationId', false),
+            migrationId: upgradeMigrationId,
           },
     nextScheduledLogicalSynchronizerUpgrade:
       logicalSyncUpgradeTopologyFreezeTime === null

--- a/apps/sv/frontend/src/utils/migrationId.ts
+++ b/apps/sv/frontend/src/utils/migrationId.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DsoInfo } from '@canton-network/splice-common-frontend';
+
+const collectMigrationIds = (dsoInfo: DsoInfo): number[] => {
+  const localNodeState =
+    dsoInfo.nodeStates.find(nodeState => nodeState.payload.sv === dsoInfo.svPartyId) ??
+    dsoInfo.nodeStates[0];
+
+  if (!localNodeState) {
+    return [];
+  }
+
+  return localNodeState.payload.state.synchronizerNodes
+    .entriesArray()
+    .flatMap(([, config]) => {
+      const ids: number[] = [];
+      if (config.sequencer) {
+        ids.push(Number(config.sequencer.migrationId));
+      }
+      if (config.legacySequencerConfig) {
+        ids.push(Number(config.legacySequencerConfig.migrationId));
+      }
+      return ids;
+    })
+    .filter(id => Number.isInteger(id) && id >= 0);
+};
+
+export const getCurrentMigrationIdFromDsoInfo = (dsoInfo: DsoInfo): number | undefined => {
+  const migrationIds = collectMigrationIds(dsoInfo);
+  if (migrationIds.length === 0) {
+    return undefined;
+  }
+
+  return Math.max(...migrationIds);
+};
+
+export const getConfigFieldCurrentConfigurationValue = (
+  fieldName: string,
+  configCurrentValue: string,
+  currentMigrationId: number | undefined
+): string => {
+  if (fieldName === 'nextScheduledSynchronizerUpgradeMigrationId' && configCurrentValue === '') {
+    return currentMigrationId !== undefined ? String(currentMigrationId) : '';
+  }
+
+  return configCurrentValue;
+};
+
+export const MIGRATION_ID_WHOLE_NUMBER_ERROR = 'Migration ID must be a whole number';
+
+export const isValidMigrationIdFormat = (value: string): boolean =>
+  /^(0|[1-9]\d*)$/.test(value) && Number.isSafeInteger(Number(value));
+
+export const validateMigrationIdAgainstCurrent = (
+  migrationId: string,
+  currentMigrationId: number | undefined
+): string | false => {
+  if (!isValidMigrationIdFormat(migrationId)) {
+    return MIGRATION_ID_WHOLE_NUMBER_ERROR;
+  }
+
+  if (currentMigrationId === undefined) {
+    return 'Unable to determine current migration ID';
+  }
+
+  const expected = String(currentMigrationId + 1);
+  if (migrationId !== expected) {
+    return `Migration ID must be ${expected} (current migration ID + 1)`;
+  }
+
+  return false;
+};


### PR DESCRIPTION
### Summary

Fixes #2451 

- Derive current migration ID from DSO node state (highest sequencer migrationId) via `getCurrentMigrationIdFromDsoInfo`
- Add migration ID format and increment validation with mutual-presence rules for upgrade time and migration ID
- Extend `ConfigField` / `SetDsoConfigRulesForm` with Current migration ID and Current Configuration subtext
- Only submit `nextScheduledSynchronizerUpgrade` when both upgrade fields are non-empty


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
