### PR TITLE
SV UI: warn voters when locked config fields are altered (#5650)

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -511,6 +511,91 @@ describe('Proposal Details Content', () => {
     expect(jsonDiffsToggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByText('JSON')).not.toBeInTheDocument();
     expect(screen.getByTestId('json-diffs-details')).not.toBeVisible();
+
+    expect(
+      screen.queryByTestId('proposal-details-disabled-fields-warning')
+    ).not.toBeInTheDocument();
+  });
+
+  test('should warn when disabled fields were altered in an amulet rules config proposal', () => {
+    const amuletRulesConfigDetails = {
+      actionName: 'Set Amulet Rules Config',
+      action: 'CRARC_SetConfig',
+      proposal: {
+        configChanges: [
+          {
+            fieldName: 'transferConfigCreateFee',
+            label: 'Transfer (Create Fee)',
+            currentValue: '0.03',
+            newValue: '0.04',
+          },
+          {
+            fieldName: 'decentralizedSynchronizerActiveSynchronizer',
+            label: 'The currently active synchronizer',
+            currentValue: 'global-domain::12',
+            newValue: 'global-domain::13',
+            isId: true,
+            disabled: true,
+          },
+        ],
+      },
+    } as ProposalDetails;
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId={voteRequest.votingInformation.requester}
+          contractId={voteRequest.contractId}
+          proposalDetails={amuletRulesConfigDetails}
+          votingInformation={voteRequest.votingInformation}
+          votes={voteRequest.votes}
+        />
+      </Wrapper>
+    );
+
+    const warning = screen.getByTestId('proposal-details-disabled-fields-warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning.textContent).toMatch(/Disabled fields have been altered in this vote proposal/);
+
+    const changes = screen.getAllByTestId('config-change');
+    expect(changes[1]).toHaveAttribute('data-disabled', 'true');
+    expect(within(changes[1]).getByTestId('config-change-disabled-label')).toHaveTextContent(
+      'Disabled field'
+    );
+  });
+
+  test('should warn when disabled fields were altered in a dso rules config proposal', () => {
+    const dsoRulesConfigDetails = {
+      actionName: 'Set DSO Rules Configuration',
+      action: 'SRARC_SetConfig',
+      proposal: {
+        configChanges: [
+          {
+            fieldName: 'decentralizedSynchronizerActiveSynchronizerId',
+            label: 'Decentralized synchronizer: Active synchronizer identifier',
+            currentValue: 'global-domain::12',
+            newValue: 'global-domain::13',
+            isId: true,
+            disabled: true,
+          },
+        ],
+      },
+    } as ProposalDetails;
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId={voteRequest.votingInformation.requester}
+          contractId={voteRequest.contractId}
+          proposalDetails={dsoRulesConfigDetails}
+          votingInformation={voteRequest.votingInformation}
+          votes={voteRequest.votes}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('proposal-details-disabled-fields-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('config-change-disabled-label')).toHaveTextContent('Disabled field');
   });
 
   test('should render dso rules config changes', () => {

--- a/apps/sv/frontend/src/components/form-components/ConfigField.tsx
+++ b/apps/sv/frontend/src/components/form-components/ConfigField.tsx
@@ -77,10 +77,12 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: 'flex-start',
+          gap: 2,
+          minWidth: 0,
         }}
       >
-        <Box>
+        <Box sx={{ minWidth: 0, flex: 1, pr: 1 }}>
           <Typography variant="body1" data-testid={`config-label-${configChange.fieldName}`}>
             {configChange.label}
           </Typography>
@@ -94,9 +96,10 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
           </Typography>
         </Box>
 
-        <Box sx={{ width: 238, maxWidth: '100%' }}>
+        <Box sx={{ width: 238, maxWidth: '100%', minWidth: 0, flexShrink: 0 }}>
           <MuiTextField
             {...textFieldProps}
+            fullWidth
             // We choose empty string to represent fields that could be undefined because their values have not been set.
             value={field.state.value?.value || ''}
             onBlur={field.handleBlur}
@@ -112,7 +115,13 @@ export const ConfigField: React.FC<ConfigFieldProps> = props => {
             <Typography
               variant="caption"
               color="text.secondary"
-              sx={{ mt: 0.5, display: 'block' }}
+              title={configChange.currentValue}
+              sx={{
+                mt: 0.5,
+                display: 'block',
+                overflowWrap: 'anywhere',
+                wordBreak: 'break-word',
+              }}
               data-testid={`config-current-value-${configChange.fieldName}`}
             >
               Current Configuration: {configChange.currentValue}
@@ -145,24 +154,46 @@ export const PendingConfigDisplay: React.FC<PendingConfigDisplayProps> = ({ pend
     effectiveDate === 'Threshold' ? 'at Threshold' : dayjs(effectiveDate).fromNow();
 
   return (
-    <Typography
-      variant="caption"
-      color="text.secondary"
-      sx={{ mt: 0.5, display: 'block', textAlign: 'center' }}
+    <Box
+      sx={{ mt: 0.5, width: '100%', minWidth: 0 }}
       data-testid={`config-pending-value-${fieldName}`}
     >
-      Pending Configuration: <strong>{pendingValue}</strong> <br />
-      This{' '}
-      <RouterLink
-        to={`/governance/proposals/${proposalCid}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: 'inherit' }}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', textAlign: 'center' }}
       >
-        pending configuration
-      </RouterLink>{' '}
-      will go into effect <strong>{effectiveText}</strong>
-    </Typography>
+        Pending Configuration:{' '}
+        <Box
+          component="strong"
+          title={pendingValue}
+          sx={{
+            display: 'inline',
+            overflowWrap: 'anywhere',
+            wordBreak: 'break-word',
+            fontWeight: 700,
+          }}
+        >
+          {pendingValue}
+        </Box>
+      </Typography>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', textAlign: 'center', mt: 0.5 }}
+      >
+        This{' '}
+        <RouterLink
+          to={`/governance/proposals/${proposalCid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'inherit' }}
+        >
+          pending configuration
+        </RouterLink>{' '}
+        will go into effect <strong>{effectiveText}</strong>
+      </Typography>
+    </Box>
   );
 };
 

--- a/apps/sv/frontend/src/components/governance/ConfigValuesChanges.tsx
+++ b/apps/sv/frontend/src/components/governance/ConfigValuesChanges.tsx
@@ -31,17 +31,36 @@ export const ConfigValuesChanges: React.FC<ConfigValuesChangesProps> = props => 
         {changes.map((change, index) => (
           <Box
             key={index}
-            sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              ...(change.disabled && {
+                px: 1.5,
+                py: 1,
+                borderRadius: 1,
+                borderLeft: '3px solid',
+                borderColor: 'warning.main',
+                bgcolor: 'rgba(255, 167, 38, 0.08)',
+              }),
+            }}
             data-testid="config-change"
+            data-disabled={change.disabled ? 'true' : undefined}
           >
-            <Typography
-              variant="body1"
-              sx={{ minWidth: 200 }}
-              data-testid="config-change-field-label"
-              color={textColor}
-            >
-              {change.label}
-            </Typography>
+            <Box sx={{ minWidth: 200 }}>
+              <Typography variant="body1" data-testid="config-change-field-label" color={textColor}>
+                {change.label}
+              </Typography>
+              {change.disabled && (
+                <Typography
+                  variant="caption"
+                  color="warning.main"
+                  data-testid="config-change-disabled-label"
+                >
+                  Disabled field
+                </Typography>
+              )}
+            </Box>
 
             {change.currentValue && (
               <>

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -8,7 +8,7 @@ import {
 } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
 import { ContractId } from '@daml/types';
 import { ChevronLeft, Edit } from '@mui/icons-material';
-import { Box, Button, Divider, Stack, Tab, Tabs, Typography } from '@mui/material';
+import { Alert, Box, Button, Divider, Stack, Tab, Tabs, Typography } from '@mui/material';
 import React, { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -20,6 +20,7 @@ import {
 } from '@canton-network/splice-common-frontend';
 import { Link as RouterLink } from 'react-router';
 import {
+  ConfigChange,
   ProposalDetails,
   ProposalVote,
   ProposalVotingInformation,
@@ -35,6 +36,11 @@ import { CopyableIdentifier, CopyableUrl, MemberIdentifier, VoteStats } from '..
 import { useQuery } from '@tanstack/react-query';
 import { useSvAdminClient } from '../../contexts/SvAdminServiceContext';
 import { DEFAULT_APP_ACTIVITY_WEIGHT } from '../../utils/constants';
+
+/** True when a proposal changed fields that are locked/disabled in the create UI (e.g. emergency API). */
+export function hasAlteredDisabledFields(changes: ConfigChange[]): boolean {
+  return changes.some(c => c.disabled && c.currentValue !== c.newValue);
+}
 
 dayjs.extend(relativeTime);
 
@@ -255,6 +261,15 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
 
           {proposalDetails.action === 'CRARC_SetConfig' && (
             <>
+              {hasAlteredDisabledFields(proposalDetails.proposal.configChanges) && (
+                <Alert
+                  severity="warning"
+                  variant="outlined"
+                  data-testid="proposal-details-disabled-fields-warning"
+                >
+                  Disabled fields have been altered in this vote proposal.
+                </Alert>
+              )}
               <DetailItem
                 label="Proposed Changes"
                 value={<ConfigValuesChanges changes={proposalDetails.proposal.configChanges} />}
@@ -276,6 +291,15 @@ export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = pro
 
           {proposalDetails.action === 'SRARC_SetConfig' && (
             <>
+              {hasAlteredDisabledFields(proposalDetails.proposal.configChanges) && (
+                <Alert
+                  severity="warning"
+                  variant="outlined"
+                  data-testid="proposal-details-disabled-fields-warning"
+                >
+                  Disabled fields have been altered in this vote proposal.
+                </Alert>
+              )}
               <DetailItem
                 label="Proposed Changes"
                 value={<ConfigValuesChanges changes={proposalDetails.proposal.configChanges} />}


### PR DESCRIPTION
## Summary
- Warn on proposal details when a `CRARC_SetConfig` / `SRARC_SetConfig` proposal changes UI-disabled (locked) fields — the emergency/API path from [#5650](https://github.com/canton-network/splice/issues/5650).
- Highlight those changed rows in the proposed-changes list.
- Wrap long pending/current config values in the create form so synchronizer IDs do not overflow the field column.
- Create-UI locking for existing synchronizer fields was already in place; no backend lock API in this change.

Fixes #5650

## Test plan
- [x] Unit: `proposal-details-content.test.tsx` — warning on/off (amulet + DSO)
- [x] Unit: `pending-fields.test.tsx` still passes after wrap fix
- [x] Manual: create emergency SetConfig via API, confirm warning + highlight in UI
- [x] Manual: normal editable-only SetConfig proposal has no warning
- [x] Manual: locked fields still not editable in create form
- [x] Screenshot attached for frontend review

<img width="1366" height="747" alt="Screenshot 2026-07-20 at 12 49 38" src="https://github.com/user-attachments/assets/71f456e4-62e9-48e3-a65c-68e358ac2057" />


### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
