### PR TITLE
Update sbt to 1.12.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ lazy val root: Project = (project in file("."))
     BuildCommon.sharedSettings,
     scalacOptions ++= Seq("-Wconf:src=src_managed/.*:silent"),
     // Needed to be able to resolve scalafmt snapshot versions
-    resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
+    resolvers += Resolver.sonatypeCentralSnapshots,
     damlDarsLockCheckerFileArg := {
       val darFiles: Seq[File] = damlBuild.all(allDarsFilter).value.flatten
       val basePath = baseDirectory.value.toPath

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.12.14


### PR DESCRIPTION
Prior to v1.11.1, sbt had a memory leak (https://github.com/sbt/sbt/issues/8142) in its `update` task that caused memory usage to grow linearly with the number of `update`s performed. This affects regular development as `update` is called as part of the `compile` task dependency graph.

After upgrading to a version that includes the fix (https://github.com/coursier/sbt-coursier/pull/563, https://github.com/coursier/sbt-coursier/pull/564), I've found development with sbt, especially with long-running sbt shell sessions, to be a more pleasant experience; there's less sluggishness and a lot fewer warnings that say "X seconds of the last 10 seconds were spent in garbage collection."

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
