### PR TITLE
Suppress logback status logging in tests

### DIFF
--- a/canton/community/util-observability/src/test/resources/logback-test.xml
+++ b/canton/community/util-observability/src/test/resources/logback-test.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <!-- propagate logback changes to jul handlers -->
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>

--- a/project/ignore-patterns/sbt-output.ignore.txt
+++ b/project/ignore-patterns/sbt-output.ignore.txt
@@ -133,11 +133,6 @@ WARN: InvalidDefaultArgInFrom
 # the script does not try to be secure
 .*api_jwt\.py:153: InsecureKeyLengthWarning:.*
 
-# com.daml.testing-utils seems to bring its own logback-test.xml, but it doesn't seem to break anything so we just ignore it
-Resource.*logback-test.xml.*occurs
-Setting level of logger.*to WARN
-Propagating WARN level on Logger
-
 # rolldown/vite emits a PLUGIN_TIMINGS performance advisory (e.g. for the built-in
 # `rolldown:vite-resolve` resolver) on otherwise-successful builds. Not an error.
 .*\[PLUGIN_TIMINGS\] Warning:.*


### PR DESCRIPTION
Fixes #5942

https://github.com/digital-asset/canton/pull/535 moved `community/util-observability/src/test/resources/logback-test.xml` to `base/testing-utils/src/main/resources/logback-test.xml`, resulting in `logback-test.xml` being bundled in the `com.daml::testing-utils` JAR file. This conflicts with the `logback-test.xml` in this repo (at `canton/community/util-observability/src/test/resources/logback-test.xml`) and causes logback to log warnings:

```
Resource [logback-test.xml] occurs multiple times on the classpath.
Resource [logback-test.xml] occurs at [jar:file:/home/matt/.cache/coursier/v1/https/repo1.maven.org/maven2/com/daml/testing-utils_2.13/3.5.3/testing-utils_2.13-3.5.3.jar!/logback-test.xml]
Resource [logback-test.xml] occurs at [file:/home/matt/Projects/splice/canton/community/util-observability/target/scala-2.13/test-classes/logback-test.xml]
```

This adds a `statusListener` of `ch.qos.logback.core.status.NopStatusListener` to the config to suppress the logs, but it doesn't actually fix the issue of there being two `logback-test.xml` files on the classpath.

If that's not a sufficient fix, there are a couple other alternatives:

1. Specify the correct config file via `Test / javaOptions += "-Dlogback.configurationFile=.../logback-test.xml"` -- this would need to be set on every affected sbt project
2. Move `logback-test.xml` in the canton repo to `src/test/resources` (instead of `src/main/resources`) so it's not bundled in the JAR -- this would then require an update to `com.daml::testing-utils` once the upstream change is released

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
