### PR TITLE
Double timeout for `/api/sv/v0/onboard/sv/sequencer`

### DIFF
--- a/cluster/images/sv-app/app.conf
+++ b/cluster/images/sv-app/app.conf
@@ -103,7 +103,7 @@ canton {
         # TODO(DACH-NY/canton-network-internal#2125) Revisit timeouts on 3.4
         custom-timeouts {
           onboardSvPartyMigrationAuthorize = 20 minutes
-          onboardSvSequencer = 5 minutes
+          onboardSvSequencer = 10 minutes
         }
         rate-limiting {
           default {


### PR DESCRIPTION
[static]

On CILR we now need more than 5 minutes for `com.digitalasset.canton.sequencer.admin.v30.SequencerAdministrationService/OnboardingStateV2`.

The timing matches the switch to CantonBFT sequencers. Not fully clear how this can matter (CantonBFT only adds a ~constant amount of stuff to these, see https://github.com/DACH-NY/canton/blob/main/community/synchronizer/src/main/protobuf/com/digitalasset/canton/sequencer/admin/v30/sequencer_bft_additional_snapshot_info.proto).

I'm choosing to believe that we'll revisit the custom timeouts in https://github.com/DACH-NY/canton-network-internal/issues/2125 some day so not bothering with deeper analysis.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
