### PR TITLE
Prevent NAT alerts from triggering on temporary spikes

### DIFF
--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -951,7 +951,7 @@
       "conditions": [
         {
           "conditionPrometheusQueryLanguage": {
-            "duration": "0s",
+            "duration": "20m",
             "evaluationInterval": "30s",
             "query": "sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource=\"nat_gateway\"}) > 30"
           },

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -493,6 +493,10 @@ export function installNatAlerts(
         conditionPrometheusQueryLanguage: {
           query: `sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > ${natConfig.droppedSentPacketsThreshold}`,
           ...prometheusDefaults,
+          // Ignore temporary spikes (likely caused by dynamic port allocation).
+          // We mostly care about sustained dropped sent packets,
+          // which most often indicates that we don't have enough ports available to the VMs.
+          duration: '20m',
         },
       },
     ],


### PR DESCRIPTION
20m from [the last 2d on devnet after the max port change](https://console.cloud.google.com/monitoring/alerting/policies/10741823529974319548?project=da-cn-devnet)

Loosely based on what we do for quotas, except those are `inputs.monitoring.AlertPolicyConditionConditionThreshold` and these are `inputs.monitoring.AlertPolicyConditionConditionPrometheusQueryLanguage`.
The docs of `duration` say:

> ***Alerts are considered firing once their PromQL expression evaluated to be "true" for this long***. Alerts whose PromQL expression was not evaluated to be "true" for long enough are considered pending. The default value is zero. Must be zero or positive.

With a default `evaluationInterval` of 30s that should work as expected afaict.