### PR TITLE
Parse p2p url as uri instead of string

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
@@ -300,10 +300,14 @@ class ScanIntegrationTest
     bftSequencers should have size 2
     val expectedSequencerId =
       sv1Backend.appState.localSynchronizerNodes.current.sequencerAdminConnection.getSequencerId.futureValue
-    val currentSequencer = bftSequencers.find(_.url == "http://testUrl:8081").value
-    currentSequencer.id shouldBe expectedSequencerId
-    val legacySequencer = bftSequencers.find(_.url == "http://legacyUrl:8082").value
-    legacySequencer.id shouldBe expectedSequencerId
+    forExactly(1, bftSequencers) { sequencer =>
+      sequencer.url shouldBe "http://testurl:8081"
+      sequencer.id shouldBe expectedSequencerId
+    }
+    forExactly(1, bftSequencers) { sequencer =>
+      sequencer.url shouldBe "http://legacyurl:8082"
+      sequencer.id shouldBe expectedSequencerId
+    }
   }
 
   "respect rate limit" in { implicit env =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -2526,7 +2526,7 @@ class HttpScanHandler(
                         val entry = definitions.SynchronizerBftSequencer(
                           psid.serial.unwrap.toLong,
                           id.toProtoPrimitive,
-                          bftSequencer.p2pUrl,
+                          bftSequencer.p2pUrl.toString,
                         )
                         initializedBftSequencersCache.put(idx, entry).discard
                         Some(entry)

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/CantonBftPeerConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/CantonBftPeerConfig.scala
@@ -3,6 +3,8 @@
 
 package org.lfdecentralizedtrust.splice.scan.config
 
+import org.apache.pekko.http.scaladsl.model.Uri
+
 case class CantonBftPeerConfig(
-    p2pUrl: String
+    p2pUrl: Uri
 )


### PR DESCRIPTION
Should avoid people forgetting an https:// in front.

fixes #6492

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
