### PR TITLE
fix: narrow down alerts to just the right GW

### DIFF
--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -910,7 +910,7 @@
           "conditionPrometheusQueryLanguage": {
             "duration": "0s",
             "evaluationInterval": "30s",
-            "query": "sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource=\"nat_gateway\"}) > 0"
+            "query": "sum by (gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource=\"nat_gateway\", gateway_name=~\"nat-mock-gw.*\"}) > 0"
           },
           "displayName": "NAT allocation failed in mock"
         }
@@ -953,7 +953,7 @@
           "conditionPrometheusQueryLanguage": {
             "duration": "20m",
             "evaluationInterval": "30s",
-            "query": "sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource=\"nat_gateway\"}) > 30"
+            "query": "sum by (gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource=\"nat_gateway\", gateway_name=~\"nat-mock-gw.*\"}) > 30"
           },
           "displayName": "NAT dropped sent packets in mock"
         }
@@ -996,7 +996,7 @@
           "conditionPrometheusQueryLanguage": {
             "duration": "0s",
             "evaluationInterval": "30s",
-            "query": "sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource=\"nat_gateway\"} / 64512) * 100) > 80"
+            "query": "sum by (gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource=\"nat_gateway\", gateway_name=~\"nat-mock-gw.*\"} / 64512) * 100) > 80"
           },
           "displayName": "NAT port usage high in mock"
         }

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -471,8 +471,7 @@ export function installNatAlerts(
       {
         displayName: `NAT allocation failed in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query:
-            'sum by (nat_gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway"}) > 0',
+          query: `sum by (gateway_name) (router_googleapis_com:nat_nat_allocation_failed{monitored_resource="nat_gateway", gateway_name=~"nat-${CLUSTER_BASENAME}-gw.*"}) > 0`,
           ...prometheusDefaults,
         },
       },
@@ -491,7 +490,7 @@ export function installNatAlerts(
       {
         displayName: `NAT dropped sent packets in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: `sum by (nat_gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway"}) > ${natConfig.droppedSentPacketsThreshold}`,
+          query: `sum by (gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource="nat_gateway", gateway_name=~"nat-${CLUSTER_BASENAME}-gw.*"}) > ${natConfig.droppedSentPacketsThreshold}`,
           ...prometheusDefaults,
           // Ignore temporary spikes (likely caused by dynamic port allocation).
           // We mostly care about sustained dropped sent packets,
@@ -514,7 +513,7 @@ export function installNatAlerts(
       {
         displayName: `NAT port usage high in ${CLUSTER_BASENAME}`,
         conditionPrometheusQueryLanguage: {
-          query: `sum by (nat_gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource="nat_gateway"} / 64512) * 100) > ${natConfig.thresholdPercent}`,
+          query: `sum by (gateway_name) ((router_googleapis_com:nat_port_usage{monitored_resource="nat_gateway", gateway_name=~"nat-${CLUSTER_BASENAME}-gw.*"} / 64512) * 100) > ${natConfig.thresholdPercent}`,
           // 64512 is the maximum number of ports per IP for Cloud NAT, as documented here: https://docs.cloud.google.com/nat/docs/ports-and-addresses#ports
           ...prometheusDefaults,
         },


### PR DESCRIPTION
For example: [link](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P7D?project=da-cn-devnet&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesQuery%22:%7B%22prometheusQuery%22:%22sum(rate(%7B%5C%22__name__%5C%22%3D%5C%22router.googleapis.com%2Fnat%2Fdropped_sent_packets_count%5C%22,%5C%22monitored_resource%5C%22%3D%5C%22nat_gateway%5C%22,%5C%22gateway_name%5C%22%3D~%5C%22nat-dev-gw.*%5C%22%7D%5B$%7B__interval%7D%5D))%5Cn%23This%20promql%20query%20was%20automatically%20converted%20from%20a%20builder%20query,%20and%20it%20may%20not%20be%20fully%20equivalent%20to%20the%20builder%20query.%20Manually%20verify%20the%20promql%20query%20before%20using%20it%20and%20edit%20as%20needed.%22%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22%7D%5D,%22chartOptions%22:%7B%22mode%22:%22COLOR%22,%22displayHorizontal%22:false%7D,%22thresholds%22:%5B%5D,%22yAxis%22:%7B%22scale%22:%22LINEAR%22%7D%7D%7D)
