### PR TITLE
Specify duration in seconds in GCP alert

### DIFF
--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -951,7 +951,7 @@
       "conditions": [
         {
           "conditionPrometheusQueryLanguage": {
-            "duration": "20m",
+            "duration": "1200s",
             "evaluationInterval": "30s",
             "query": "sum by (gateway_name, reason) (router_googleapis_com:nat_dropped_sent_packets_count{monitored_resource=\"nat_gateway\", gateway_name=~\"nat-mock-gw.*\"}) > 30"
           },

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -495,7 +495,7 @@ export function installNatAlerts(
           // Ignore temporary spikes (likely caused by dynamic port allocation).
           // We mostly care about sustained dropped sent packets,
           // which most often indicates that we don't have enough ports available to the VMs.
-          duration: '20m',
+          duration: '1200s',
         },
       },
     ],


### PR DESCRIPTION
To make GCP happy [static]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
