### PR TITLE
Monitor BFT in catchup test

### DIFF
--- a/cluster/scripts/monitor-sv-catchup.sh
+++ b/cluster/scripts/monitor-sv-catchup.sh
@@ -34,26 +34,21 @@ else
   PROM="https://prometheus.${GCP_CLUSTER_BASENAME}.global.canton.network.digitalasset.com"
 fi
 
-outcome="timed_out"
-poll_interval=60
-start=$(date +%s)
-start_time=$(date -u -d @"$start" '+%Y-%m-%dT%H:%M:%S.%3NZ')
-timeout_hours="8"
-timeout_secs=$(( timeout_hours * 3600 ))
-stall_start=$(date +%s)
-stall_timeout_secs=3600
-
 # Helper to query Prometheus for a single value
 # Fetch data from 2 minutes ago
 # Default to value higher than threshold but less than expected max
 function query_prom() {
-  local default=${2:-"180"}
-  local ts
+  local default ts
+  default=${2:-"180"}
   ts=$(date -d '2 minutes ago' +%s)
   curl -ksf "${PROM}/api/v1/query" \
     --data-urlencode "query=${1}" \
     --data-urlencode "time=${ts}" \
  | jq -r ".data.result[0].value[1] // \"${default}\""
+}
+
+function query_bft_delay() {
+  query_prom "histogram_quantile(0.95, sum by(namespace) (rate(daml_sequencer_bftordering_output_block_delay_duration_seconds{namespace=\"${namespace}\"}[1m])))" "999"
 }
 
 function query_seq_delay() {
@@ -76,118 +71,159 @@ function query_med_rate() {
   query_prom "sum by (namespace) (rate(daml_sequencer_client_handler_sequencer_events{namespace=\"${namespace}\",component=\"mediator\",job=~\"global-domain-.*-mediator\"}[1m]))" "0"
 }
 
-# Accumulators inside the loop
-seq_rate_sum=0
-part_rate_sum=0
-med_rate_sum=0
-rate_sample_count=0
-
-_info "Monitoring catchup for ${namespace}"
-_info "Thresholds: seq>=${seq_min_eps} eps, participant>=${part_min_eps} eps, mediator>=${med_min_eps} eps"
-_info "Caught-up when: seq<=${seq_delay_ok}s, participant<=${part_delay_ok}s, mediator<=${med_delay_ok}s"
-_info "Test timeout: ${timeout_hours}h | Stall timeout: 1h of zero progress"
-
-while true; do
-  elapsed=$(( $(date +%s) - start ))
-  if [ "$elapsed" -ge "$timeout_secs" ]; then
-    _error_msg "Catchup timed out after ${timeout_hours}h"
-    break
-  fi
-
-  # Track delays to determine if caught up
-  seq_delay=$(query_seq_delay)
-  part_delay=$(query_part_delay)
-  med_delay=$(query_med_delay)
-
-  seq_caught=$(echo "$seq_delay  < $seq_delay_ok" | bc -l)
-  part_caught=$(echo "$part_delay < $part_delay_ok" | bc -l)
-  med_caught=$(echo "$med_delay  < $med_delay_ok" | bc -l)
-
-  _info "Delays — seq: ${seq_delay}s, participant: ${part_delay}s, mediator: ${med_delay}s (elapsed: ${elapsed}s)"
-
-  if [ "$seq_caught" = "1" ] && [ "$part_caught" = "1" ] && [ "$med_caught" = "1" ]; then
-    _info "All components caught up"
-    outcome="success"
-    break
-  fi
-
-  # Track peak rates during catchup
-  seq_rate=$(query_seq_rate)
-  part_rate=$(query_part_rate)
-  med_rate=$(query_med_rate)
-
-  seq_rate_sum=$(echo "$seq_rate_sum + $seq_rate" | bc -l)
-  part_rate_sum=$(echo "$part_rate_sum + $part_rate" | bc -l)
-  med_rate_sum=$(echo "$med_rate_sum + $med_rate" | bc -l)
-  rate_sample_count=$((rate_sample_count + 1))
-
-  _info "Mean rates so far> seq: $(echo "scale=1; $seq_rate_sum / $rate_sample_count" | bc) eps, participant: $(echo "scale=1; $part_rate_sum / $rate_sample_count" | bc) eps, mediator: $(echo "scale=1; $med_rate_sum / $rate_sample_count" | bc) eps"
-
-  # Check that the catchup is making progress, otherwise abort after 1h of zero progress
-  all_zero=$(echo "$seq_rate == 0 && $part_rate == 0 && $med_rate == 0" | bc -l)
-  if [ "$all_zero" = "1" ]; then
-    stall_elapsed=$(( $(date +%s) - stall_start ))
-    _info "Zero progress for ${stall_elapsed}s / ${stall_timeout_secs}s before giving up"
-    if [ "$stall_elapsed" -ge "$stall_timeout_secs" ]; then
-      _error_msg "No progress for over 1 hour, aborting catchup test"
-      outcome="stalled"
+# Wait for BFT ordering to catch up (block delay < 2 min) before measuring catchup rates.
+function wait_for_bft_ordering() {
+  local bft_delay_threshold bft_poll_interval bft_wait_start bft_wait_secs
+  bft_delay_threshold=120
+  bft_poll_interval=30
+  bft_wait_start=$(date +%s)
+  _info "Waiting for BFT ordering block delay to drop below ${bft_delay_threshold}s..."
+  while true; do
+    bft_delay=$(query_bft_delay)
+    _info "BFT ordering block delay: ${bft_delay}s (threshold: ${bft_delay_threshold}s)"
+    if (( $(echo "$bft_delay < $bft_delay_threshold" | bc -l) )); then
+      _info "BFT ordering caught up"
       break
     fi
+    sleep "$bft_poll_interval"
+  done
+  bft_wait_secs=$(( $(date +%s) - bft_wait_start ))
+  bft_wait_mins=$(( bft_wait_secs / 60 ))
+  _info "BFT ordering wait took ${bft_wait_mins}m, starting catchup monitoring"
+}
+
+function monitor_catchup() {
+  outcome="timed_out"
+  poll_interval=60
+  start=$(date +%s)
+  start_time=$(date -u -d @"$start" '+%Y-%m-%dT%H:%M:%S.%3NZ')
+  timeout_hours="8"
+  timeout_secs=$(( timeout_hours * 3600 ))
+  stall_start=$(date +%s)
+  stall_timeout_secs=3600
+
+  # Accumulators inside the loop
+  seq_rate_sum=0
+  part_rate_sum=0
+  med_rate_sum=0
+  rate_sample_count=0
+
+  _info "Monitoring catchup for ${namespace}"
+  _info "Thresholds: seq>=${seq_min_eps} eps, participant>=${part_min_eps} eps, mediator>=${med_min_eps} eps"
+  _info "Caught-up when: seq<=${seq_delay_ok}s, participant<=${part_delay_ok}s, mediator<=${med_delay_ok}s"
+  _info "Test timeout: ${timeout_hours}h | Stall timeout: 1h of zero progress"
+
+  while true; do
+    elapsed=$(( $(date +%s) - start ))
+    if [ "$elapsed" -ge "$timeout_secs" ]; then
+      _error_msg "Catchup timed out after ${timeout_hours}h"
+      break
+    fi
+
+    # Track delays to determine if caught up
+    seq_delay=$(query_seq_delay)
+    part_delay=$(query_part_delay)
+    med_delay=$(query_med_delay)
+
+    seq_caught=$(echo "$seq_delay  < $seq_delay_ok" | bc -l)
+    part_caught=$(echo "$part_delay < $part_delay_ok" | bc -l)
+    med_caught=$(echo "$med_delay  < $med_delay_ok" | bc -l)
+
+    _info "Delays — seq: ${seq_delay}s, participant: ${part_delay}s, mediator: ${med_delay}s (elapsed: ${elapsed}s)"
+
+    if [ "$seq_caught" = "1" ] && [ "$part_caught" = "1" ] && [ "$med_caught" = "1" ]; then
+      _info "All components caught up"
+      outcome="success"
+      break
+    fi
+
+    # Track rates during catchup for mean calculation
+    seq_rate=$(query_seq_rate)
+    part_rate=$(query_part_rate)
+    med_rate=$(query_med_rate)
+
+    seq_rate_sum=$(echo "$seq_rate_sum + $seq_rate" | bc -l)
+    part_rate_sum=$(echo "$part_rate_sum + $part_rate" | bc -l)
+    med_rate_sum=$(echo "$med_rate_sum + $med_rate" | bc -l)
+    rate_sample_count=$((rate_sample_count + 1))
+
+    _info "Mean rates so far> seq: $(echo "scale=1; $seq_rate_sum / $rate_sample_count" | bc) eps, participant: $(echo "scale=1; $part_rate_sum / $rate_sample_count" | bc) eps, mediator: $(echo "scale=1; $med_rate_sum / $rate_sample_count" | bc) eps"
+
+    # Check that the catchup is making progress, otherwise abort after 1h of zero progress
+    all_zero=$(echo "$seq_rate == 0 && $part_rate == 0 && $med_rate == 0" | bc -l)
+    if [ "$all_zero" = "1" ]; then
+      stall_elapsed=$(( $(date +%s) - stall_start ))
+      _info "Zero progress for ${stall_elapsed}s / ${stall_timeout_secs}s before giving up"
+      if [ "$stall_elapsed" -ge "$stall_timeout_secs" ]; then
+        _error_msg "No progress for over 1 hour, aborting catchup test"
+        outcome="stalled"
+        break
+      fi
+    else
+      stall_start=$(date +%s)
+    fi
+
+    sleep "$poll_interval"
+  done
+}
+
+function compute_results() {
+  elapsed=$(( $(date +%s) - start ))
+  elapsed_mins=$(( elapsed / 60 ))
+  end_time=$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')
+
+  if [ "$rate_sample_count" -gt 0 ]; then
+    seq_rate_mean=$(echo "$seq_rate_sum / $rate_sample_count" | bc -l)
+    part_rate_mean=$(echo "$part_rate_sum / $rate_sample_count" | bc -l)
+    med_rate_mean=$(echo "$med_rate_sum / $rate_sample_count" | bc -l)
   else
-    stall_start=$(date +%s)
+    seq_rate_mean=0
+    part_rate_mean=0
+    med_rate_mean=0
+  fi
+  seq_ok=$(echo  "$seq_rate_mean  >= $seq_min_eps"| bc -l)
+  part_ok=$(echo "$part_rate_mean >= $part_min_eps" | bc -l)
+  med_ok=$(echo  "$med_rate_mean  >= $med_min_eps"  | bc -l)
+}
+
+function post_results() {
+  if [ "$outcome" = "success" ]; then
+    icon="✅"
+    exit_code=0
+  elif [ "$outcome" = "stalled" ]; then
+    icon="🚨"
+    exit_code=1
+  else
+    icon="❌"
+    exit_code=1
   fi
 
-  sleep "$poll_interval"
-done
+  grafana_base="https://grafana.${GCP_CLUSTER_BASENAME}.global.canton.network.digitalasset.com"
+  grafana_domain_link="${grafana_base}/d/ca9df344-c699-4efe-83c2-5fb2639d96d9/global-domain-catchup?orgId=1&timezone=UTC&var-DS=prometheus&var-namespace=${namespace}&var-migration=All&viewPanel=panel-11&from=${start_time}&to=${end_time}"
+  grafana_participant_link="${grafana_base}/d/edkzo5ukgeqyoc/participant?orgId=1&timezone=UTC&var-namespace=${namespace}&var-job=All&var-participant=All&viewPanel=panel-13&from=${start_time}&to=${end_time}"
 
-elapsed=$(( $(date +%s) - start ))
-elapsed_mins=$(( elapsed / 60 ))
-end_time=$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')
+  message="${icon} *SV Catchup Test — \`${namespace}\` on \`${GCP_CLUSTER_BASENAME}\`*
+  Outcome: ${outcome}$([ "$outcome" = "stalled" ] && echo " — no events processed for 1h, aborting test, node may be stuck") | Duration: ${elapsed_mins}m (+ ${bft_wait_mins}m BFT ordering wait) | Started: ${start_time} | Ended: ${end_time}
 
-if [ "$rate_sample_count" -gt 0 ]; then
-  seq_rate_mean=$(echo "$seq_rate_sum / $rate_sample_count" | bc -l)
-  part_rate_mean=$(echo "$part_rate_sum / $rate_sample_count" | bc -l)
-  med_rate_mean=$(echo "$med_rate_sum / $rate_sample_count" | bc -l)
-else
-  seq_rate_mean=0
-  part_rate_mean=0
-  med_rate_mean=0
-fi
+  *Per-component mean rates over catchup window (${rate_sample_count} samples):*
+  • Sequencer: \`$(printf "%.1f" "$seq_rate_mean")\` events/s  (expected ≥ ${seq_min_eps})  $([ "$seq_ok" = "1" ] && echo "✅" || echo "❌")
+  • Participant: \`$(printf "%.1f" "$part_rate_mean")\` events/s  (expected ≥ ${part_min_eps})  $([ "$part_ok" = "1" ] && echo "✅" || echo "❌")
+  • Mediator: \`$(printf "%.1f" "$med_rate_mean")\` events/s  (expected ≥ ${med_min_eps})  $([ "$med_ok" = "1" ] && echo "✅" || echo "❌")
 
-seq_ok=$(echo  "$seq_rate_mean  >= $seq_min_eps"| bc -l)
-part_ok=$(echo "$part_rate_mean >= $part_min_eps" | bc -l)
-med_ok=$(echo  "$med_rate_mean  >= $med_min_eps"  | bc -l)
+  *Links:*
+  • <${CIRCLE_BUILD_URL:-"#"}|CircleCI Job>
+  • <${grafana_domain_link}|Sequencer Dashboard>
+  • <${grafana_participant_link}|Participant and Mediator Dashboards>"
 
-if [ "$outcome" = "success" ]; then
-  icon="✅"
-  exit_code=0
-elif [ "$outcome" = "stalled" ]; then
-  icon="🚨"
-  exit_code=1
-else
-  icon="❌"
-  exit_code=1
-fi
+  _info "$message"
 
-grafana_base="https://grafana.${GCP_CLUSTER_BASENAME}.global.canton.network.digitalasset.com"
-grafana_domain_link="${grafana_base}/d/ca9df344-c699-4efe-83c2-5fb2639d96d9/global-domain-catchup?orgId=1&timezone=UTC&var-DS=prometheus&var-namespace=${namespace}&var-migration=All&viewPanel=panel-11&from=${start_time}&to=${end_time}"
-grafana_participant_link="${grafana_base}/d/edkzo5ukgeqyoc/participant?orgId=1&timezone=UTC&var-namespace=${namespace}&var-job=All&var-participant=All&viewPanel=panel-13&from=${start_time}&to=${end_time}"
+  "${DA_REPO_ROOT}/.circleci/scripts/slack/post-slack-message.sh" \
+    "$message" "$slack_channel"
+}
 
-message="${icon} *SV Catchup Test — \`${namespace}\` on \`${GCP_CLUSTER_BASENAME}\`*
-Outcome: ${outcome}$([ "$outcome" = "stalled" ] && echo " — no events processed for 1h, aborting test, node may be stuck") | Duration: ${elapsed_mins}m | Started: ${start_time} | Ended: ${end_time}
-
-*Per-component mean rates over catchup window (${rate_sample_count} samples):*
-• Sequencer: \`$(printf "%.1f" "$seq_rate_mean")\` events/s  (expected ≥ ${seq_min_eps})  $([ "$seq_ok" = "1" ] && echo "✅" || echo "❌")
-• Participant: \`$(printf "%.1f" "$part_rate_mean")\` events/s  (expected ≥ ${part_min_eps})  $([ "$part_ok" = "1" ] && echo "✅" || echo "❌")
-• Mediator: \`$(printf "%.1f" "$med_rate_mean")\` events/s  (expected ≥ ${med_min_eps})  $([ "$med_ok" = "1" ] && echo "✅" || echo "❌")
-
-*Dashboards:*
-• <${grafana_domain_link}|Sequencer>
-• <${grafana_participant_link}|Participant and Mediator>"
-
-_info "$message"
-
-"${DA_REPO_ROOT}/.circleci/scripts/slack/post-slack-message.sh" \
-  "$message" "$slack_channel"
-
+# main
+wait_for_bft_ordering
+monitor_catchup
+compute_results
+post_results
 exit $exit_code

--- a/cluster/scripts/monitor-sv-catchup.sh
+++ b/cluster/scripts/monitor-sv-catchup.sh
@@ -73,17 +73,23 @@ function query_med_rate() {
 
 # Wait for BFT ordering to catch up (block delay < 2 min) before measuring catchup rates.
 function wait_for_bft_ordering() {
-  local bft_delay_threshold bft_poll_interval bft_wait_start bft_wait_secs
+  local bft_delay_threshold bft_poll_interval bft_wait_start bft_wait_secs bft_timeout_secs
   bft_delay_threshold=120
   bft_poll_interval=30
+  bft_timeout_secs=$((3600 * 4)) # 4 hours
   bft_wait_start=$(date +%s)
   _info "Waiting for BFT ordering block delay to drop below ${bft_delay_threshold}s..."
   while true; do
     bft_delay=$(query_bft_delay)
+    bft_wait_secs=$(( $(date +%s) - bft_wait_start ))
     _info "BFT ordering block delay: ${bft_delay}s (threshold: ${bft_delay_threshold}s)"
     if (( $(echo "$bft_delay < $bft_delay_threshold" | bc -l) )); then
       _info "BFT ordering caught up"
       break
+    fi
+    if [ "$bft_wait_secs" -ge "$bft_timeout_secs" ]; then
+      _error_msg "BFT ordering did not catch up within $((bft_timeout_secs / 60))m (last delay: ${bft_delay}s)"
+      exit 1
     fi
     sleep "$bft_poll_interval"
   done


### PR DESCRIPTION
fixes https://github.com/DACH-NY/canton-network-internal/issues/6185

This test will likely be bound by CCI job timeout of 5 hours if we restore from old backups. We might consider switching it sooner to using self-hosted runners cc. @krzysztofczyz-da 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
