### PR TITLE
Switch daml compat tests to pv 35

### DIFF
--- a/.github/workflows/daml_compat_test.yml
+++ b/.github/workflows/daml_compat_test.yml
@@ -33,6 +33,4 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       daml_base_version: ${{ needs.get_mainnet_version.outputs.version }}
-      # TODO(#5433) - remove after adopted on mainnet
-      protocol_version: "34"
     secrets: inherit

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ReconcileBftSequencingParametersIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ReconcileBftSequencingParametersIntegrationTest.scala
@@ -79,10 +79,10 @@ class SvReconcileBftSequencingParametersIntegrationTest
       ]
       sv1Backend.stop()
       actAndCheck(
-        "Restart with modified bft sequencing parameters unset",
+        "Restart with modified bft sequencing parameters",
         sv1LocalBackend.startSync(),
       )(
-        "sequencing parameters are unset",
+        "sequencing parameters are modified",
         _ => {
           val parameters = sv1Backend.participantClient.topology.sequencing_parameters
             .list(decentralizedSynchronizerId)


### PR DESCRIPTION
And along the way fix some buggy scalatest clue strings.

fixes https://github.com/DACH-NY/cn-test-failures/issues/9354

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
