### PR TITLE
Support different sets of `additionalJvmOptions` for the sequencer and mediator

### DIFF
--- a/cluster/expected/sv-canton/expected.json
+++ b/cluster/expected/sv-canton/expected.json
@@ -1910,7 +1910,6 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -1954,6 +1953,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_10_mediator",
             "port": 5432,
@@ -1987,6 +1987,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-10.sv-2.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
@@ -2046,7 +2047,6 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -2090,6 +2090,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_7_mediator",
             "port": 5432,
@@ -2123,6 +2124,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-7-cometbft-cometbft-rpc.sv-1.svc.cluster.local",
             "port": 26657,
@@ -2178,7 +2180,6 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -2222,6 +2223,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_8_mediator",
             "port": 5432,
@@ -2255,6 +2257,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-8-cometbft-cometbft-rpc.sv-1.svc.cluster.local",
             "port": 26657,
@@ -2310,7 +2313,6 @@
       "namespace": "sv-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -2354,6 +2356,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_9_mediator",
             "port": 5432,
@@ -2387,6 +2390,7 @@
               "value": "PS9_SEQUENCER_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-9.sv-2.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
@@ -5488,7 +5492,6 @@
       "namespace": "sv-da-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -5532,6 +5535,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_10_mediator",
             "port": 5432,
@@ -5565,6 +5569,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-10.sv-1.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
@@ -5624,7 +5629,6 @@
       "namespace": "sv-da-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -5668,6 +5672,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_7_mediator",
             "port": 5432,
@@ -5701,6 +5706,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-7-cometbft-cometbft-rpc.sv-da-1.svc.cluster.local",
             "port": 26657,
@@ -5756,7 +5762,6 @@
       "namespace": "sv-da-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -5800,6 +5805,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_8_mediator",
             "port": 5432,
@@ -5833,6 +5839,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-8-cometbft-cometbft-rpc.sv-da-1.svc.cluster.local",
             "port": 26657,
@@ -5888,7 +5895,6 @@
       "namespace": "sv-da-1",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -5932,6 +5938,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "global_domain_9_mediator",
             "port": 5432,
@@ -5965,6 +5972,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-9.sv-1.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
@@ -8352,7 +8360,6 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -8396,6 +8403,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "mediator_10",
             "port": 5432,
@@ -8429,6 +8437,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-10.sv.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,
@@ -8488,7 +8497,6 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -8532,6 +8540,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "mediator_7",
             "port": 5432,
@@ -8565,6 +8574,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-7-cometbft-cometbft-rpc.sv.svc.cluster.local",
             "port": 26657,
@@ -8620,7 +8630,6 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -8664,6 +8673,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "mediator_8",
             "port": 5432,
@@ -8697,6 +8707,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "host": "global-domain-8-cometbft-cometbft-rpc.sv.svc.cluster.local",
             "port": 26657,
@@ -8752,7 +8763,6 @@
       "namespace": "sv",
       "timeout": 600,
       "values": {
-        "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
         "affinity": {
           "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -8796,6 +8806,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomMediatorJvmFlag",
           "persistence": {
             "databaseName": "mediator_9",
             "port": 5432,
@@ -8829,6 +8840,7 @@
               "value": "CUSTOM_MOCK_ENV_VAR_VALUE"
             }
           ],
+          "additionalJvmOptions": "-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.rmi.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -DcustomSequencerJvmFlag",
           "driver": {
             "externalAddress": "sequencer-p2p-9.sv.mock.global.canton.network.digitalasset.com",
             "externalPort": 443,

--- a/cluster/helm/splice-global-domain/templates/mediator.yaml
+++ b/cluster/helm/splice-global-domain/templates/mediator.yaml
@@ -57,7 +57,7 @@ spec:
         image: {{ .Values.imageRepo }}/{{ .Values.mediator.imageName}}:{{ .Chart.AppVersion }}{{ ((.Values.imageDigests).canton_mediator) }}
         env:
         - name: JAVA_TOOL_OPTIONS
-          value: "{{ .Values.defaultJvmOptions }} {{ .Values.additionalJvmOptions }} -Dlogback.configurationFile=/app/logback/logback.xml"
+          value: "{{ .Values.defaultJvmOptions }} {{ .Values.mediator.additionalJvmOptions }} -Dlogback.configurationFile=/app/logback/logback.xml"
         - name: CANTON_DOMAIN_POSTGRES_SERVER
           value: {{ .Values.mediator.persistence.host }}
         - name: CANTON_DOMAIN_POSTGRES_PORT

--- a/cluster/helm/splice-global-domain/templates/sequencer.yaml
+++ b/cluster/helm/splice-global-domain/templates/sequencer.yaml
@@ -53,7 +53,7 @@ spec:
         {{- end}}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "{{ .Values.defaultJvmOptions }} {{ .Values.additionalJvmOptions }} -Dlogback.configurationFile=/app/logback/logback.xml"
+              value: "{{ .Values.defaultJvmOptions }} {{ .Values.sequencer.additionalJvmOptions }} -Dlogback.configurationFile=/app/logback/logback.xml"
             - name: CANTON_DOMAIN_POSTGRES_SERVER
               value: {{ .Values.sequencer.persistence.host }}
             - name: CANTON_DOMAIN_POSTGRES_PORT

--- a/cluster/helm/splice-global-domain/tests/mediator_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/mediator_test.yaml
@@ -196,6 +196,21 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: "custom-domain-sa"
 
+  - it: "applies mediator-specific JVM options"
+    set:
+      mediator.additionalJvmOptions: "-Dmediator.option=true"
+      sequencer.additionalJvmOptions: "-Dsequencer.option=true"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=='mediator')].env[?(@.name=='JAVA_TOOL_OPTIONS')].value
+          pattern: '-Dmediator\.option=true'
+      - notMatchRegex:
+          path: spec.template.spec.containers[?(@.name=='mediator')].env[?(@.name=='JAVA_TOOL_OPTIONS')].value
+          pattern: '-Dsequencer\.option=true'
+
   - it: "sets default security contexts for pods and containers"
     documentSelector:
       path: kind

--- a/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
+++ b/cluster/helm/splice-global-domain/tests/sequencer_test.yaml
@@ -406,6 +406,21 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: "custom-domain-sa"
 
+  - it: "applies sequencer-specific JVM options"
+    set:
+      sequencer.additionalJvmOptions: "-Dsequencer.option=true"
+      mediator.additionalJvmOptions: "-Dmediator.option=true"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='JAVA_TOOL_OPTIONS')].value
+          pattern: '-Dsequencer\.option=true'
+      - notMatchRegex:
+          path: spec.template.spec.containers[?(@.name=='sequencer')].env[?(@.name=='JAVA_TOOL_OPTIONS')].value
+          pattern: '-Dmediator\.option=true'
+
   - it: "sets default security contexts for pods and containers"
     set:
       sequencer:

--- a/cluster/helm/splice-global-domain/values-template.yaml
+++ b/cluster/helm/splice-global-domain/values-template.yaml
@@ -20,6 +20,7 @@ resources:
 
 sequencer:
   imageName: "canton-sequencer"
+  additionalJvmOptions: ""
   cometbft:
     imageName: "canton-cometbft-sequencer"
   persistence:
@@ -39,6 +40,7 @@ sequencer:
 
 mediator:
   imageName: "canton-mediator"
+  additionalJvmOptions: ""
   persistence:
     host: postgres.sv-1.svc.cluster.local
     secretName: "postgres-secrets"

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -150,6 +150,9 @@ abstract class InStackDecentralizedSynchronizerNode
               : []
             ).concat(physicalSynchronizerConfig.sequencer.additionalEnvVars),
             resources: physicalSynchronizerConfig.sequencer.resources,
+            additionalJvmOptions: getAdditionalJvmOptions(
+              physicalSynchronizerConfig.sequencer.additionalJvmOptions
+            ),
           },
           mediator: {
             ...decentralizedSynchronizerValues.mediator,
@@ -162,6 +165,9 @@ abstract class InStackDecentralizedSynchronizerNode
             },
             additionalEnvVars: physicalSynchronizerConfig.mediator.additionalEnvVars,
             resources: physicalSynchronizerConfig.mediator.resources,
+            additionalJvmOptions: getAdditionalJvmOptions(
+              physicalSynchronizerConfig.mediator.additionalJvmOptions
+            ),
           },
           enablePostgresMetrics: true,
           metrics: {
@@ -171,10 +177,6 @@ abstract class InStackDecentralizedSynchronizerNode
             },
           },
           livenessProbeInitialDelaySeconds: domainLivenessProbeInitialDelaySeconds,
-          // TODO(#5805): These are used both for sequencer and mediator while the mediator config is ignored.
-          additionalJvmOptions: getAdditionalJvmOptions(
-            physicalSynchronizerConfig.sequencer.additionalJvmOptions
-          ),
           pvc: persistentHeapDumpsPvc(),
           serviceAccountName: imagePullServiceAccountName,
           enableAntiAffinity: physicalSynchronizerConfig.sequencer.enableAntiAffinity,

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -28,3 +28,7 @@
           functionality is expected to be fully removed in 0.8.0 so
           this only provides a bit more time to migrate but you must
           complete the migration.
+
+    - Deployment
+
+        - The sequencer and mediator can now be configured with independent ``additionalJvmOptions`` via the new ``sequencer.additionalJvmOptions`` and ``mediator.additionalJvmOptions`` values in the ``splice-global-domain`` helm chart.


### PR DESCRIPTION
Fixes #5805

This updates the `splice-global-domain` helm chart to support different sets of `additionalJvmOptions` for the sequencer and mediator, and updates the Pulumi code to wire each component's options into the correct values block instead of applying the sequencer's options to both.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).