### PR TITLE
feat: ensure pure gha can build images

### DIFF
--- a/cluster/images/local.mk
+++ b/cluster/images/local.mk
@@ -43,7 +43,13 @@ sequencer-image := cluster/images/canton-sequencer
 splice-ui-image := cluster/images/splice-web-ui
 images_file := cluster/images/.images
 
-ifdef CI
+ifdef GITHUB_ACTIONS
+    # never use the cache in CI on the master branch
+    cache_opt := --no-cache
+    platform_opt := --platform=linux/amd64,linux/arm64
+    repo = $(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY)
+    commit_sha = $(GITHUB_SHA)
+else ifdef CI # CCI
     # never use the cache in CI on the master branch
     cache_opt := --no-cache
     platform_opt := --platform=linux/amd64,linux/arm64


### PR DESCRIPTION
Needed because of [this](https://github.com/DACH-NY/canton-network-internal/actions/runs/29989531372/job/89149045156?pr=5114#step:10:5405) build

And cluster tests [still work on CCI](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/75621/details?workflowId=9e07df60-8269-4eb3-a0b9-8d65325551fb&job=f4d987a4-282e-4e28-879d-50b87780df9d&buildNumber=452210&jobType=build) 🎉 

Part of https://github.com/DACH-NY/canton-network-internal/issues/4570