### PR TITLE
Remove double splitwell test setup

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SplitwellFrontendIntegrationTest.scala
@@ -31,10 +31,6 @@ class SplitwellFrontendIntegrationTest
     EnvironmentDefinition
       .simpleTopology1Sv(this.getClass.getSimpleName)
       .withAdditionalSetup(implicit env => {
-        EnvironmentDefinition
-          .simpleTopology1Sv(this.getClass.getSimpleName)
-          .setup(env)
-
         aliceValidatorBackend.participantClient.upload_dar_unless_exists(splitwellDarPath)
         bobValidatorBackend.participantClient.upload_dar_unless_exists(splitwellDarPath)
       })


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9285

surely if we run setup twice (which looks like a bad merge conflict resolution?), we will encounter weird flakes such as topology transactions being proposed twice as part of `withMultiSyncFeatureFlag`  running twice