### PR TITLE
Specify set of valid response content types

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpClient.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpClient.scala
@@ -17,6 +17,8 @@ import org.apache.pekko.http.scaladsl.model.{
   HttpHeader,
   HttpRequest,
   HttpResponse,
+  MediaType,
+  MediaTypes,
   StatusCode,
   StatusCodes,
 }
@@ -50,6 +52,27 @@ trait HttpClient {
 }
 
 object HttpClient {
+  private object ResponseErrorByStatus {
+    def unapply(resp: HttpResponse): Option[StatusCode] =
+      resp.status match {
+        case code @ (StatusCodes.ServerError(_) | StatusCodes.ClientError(_)) => Some(code)
+        case _ => None
+      }
+  }
+
+  private val validContentTypes: Set[MediaType] = Set(
+    MediaTypes.`application/json`,
+    MediaTypes.`application/octet-stream`,
+    MediaTypes.`text/plain`,
+  )
+
+  private def httpFnErrors(
+      nonErrorStatusCode: Set[StatusCode]
+  ): PartialFunction[HttpResponse, Unit] = {
+    case ResponseErrorByStatus(code) if !nonErrorStatusCode.contains(code) =>
+    case resp if !validContentTypes.contains(resp.entity.contentType.mediaType) =>
+  }
+
   def createHttpFn(
       clientName: String,
       operationName: String,
@@ -61,10 +84,7 @@ object HttpClient {
   ): HttpRequest => Future[HttpResponse] = {
     httpClientWithErrors(
       httpClient.executeRequest(clientName, operationName),
-      {
-        case code @ (StatusCodes.ServerError(_) | StatusCodes.ClientError(_))
-            if !nonErrorStatusCode.contains(code) =>
-      },
+      httpFnErrors(nonErrorStatusCode),
     )
   }
 
@@ -91,7 +111,7 @@ object HttpClient {
 
   private def httpClientWithErrors(
       nextClient: HttpRequest => Future[HttpResponse],
-      errors: PartialFunction[StatusCode, Unit],
+      errors: PartialFunction[HttpResponse, Unit],
   )(
       req: HttpRequest
   )(implicit ec: ExecutionContext, mat: Materializer) = {
@@ -102,7 +122,7 @@ object HttpClient {
             Future.failed[HttpResponse](error)
           }
         )
-        .applyOrElse(_resp.status, (_: StatusCode) => Future.successful(_resp))
+        .applyOrElse(_resp, Future.successful(_: HttpResponse))
     }
   }
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpClient.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/http/HttpClient.scala
@@ -60,17 +60,27 @@ object HttpClient {
       }
   }
 
-  private val validContentTypes: Set[MediaType] = Set(
-    MediaTypes.`application/json`,
-    MediaTypes.`application/octet-stream`,
-    MediaTypes.`text/plain`,
-  )
+  private object ResponseErrorByContentType {
+    private val validContentTypes: Set[MediaType] = Set(
+      MediaTypes.`application/json`,
+      MediaTypes.`application/octet-stream`,
+      MediaTypes.`text/plain`,
+    )
+
+    def unapply(resp: HttpResponse): Boolean =
+      resp.entity.contentType match {
+        // Responses with `NoContentType` are always considered valid
+        case ContentTypes.NoContentType => false
+        // Otherwise a response is valid if its content type is contained in `validContentTypes`
+        case contentType => !validContentTypes.contains(contentType.mediaType)
+      }
+  }
 
   private def httpFnErrors(
       nonErrorStatusCode: Set[StatusCode]
   ): PartialFunction[HttpResponse, Unit] = {
     case ResponseErrorByStatus(code) if !nonErrorStatusCode.contains(code) =>
-    case resp if !validContentTypes.contains(resp.entity.contentType.mediaType) =>
+    case ResponseErrorByContentType() =>
   }
 
   def createHttpFn(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/InvalidResponseContentTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/InvalidResponseContentTest.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.http
 
+import cats.data.EitherT
 import com.digitalasset.canton.{BaseTest, HasActorSystem, HasExecutionContext}
 import com.digitalasset.canton.config.NonNegativeDuration
 import io.circe.syntax.*
@@ -14,6 +15,7 @@ import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.http.v0.external.common_admin.{
   CommonAdminClient,
   GetVersionResponse,
+  IsReadyResponse,
 }
 import org.scalatest.compatible.Assertion
 import org.scalatest.wordspec.AnyWordSpec
@@ -22,7 +24,7 @@ import java.time.{OffsetDateTime, ZoneOffset}
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
-class NonJsonResponseTest
+class InvalidResponseContentTest
     extends AnyWordSpec
     with BaseTest
     with HasActorSystem
@@ -30,8 +32,11 @@ class NonJsonResponseTest
 
   private implicit val mat: Materializer = Materializer(actorSystem)
 
-  private def runGetVersion(resp: ResponseEntity)(
-      expectation: Either[Either[Throwable, HttpResponse], GetVersionResponse] => Assertion
+  private def runEndpoint[A](
+      endpoint: CommonAdminClient => EitherT[Future, Either[Throwable, HttpResponse], A],
+      resp: ResponseEntity,
+  )(
+      expectation: Either[Either[Throwable, HttpResponse], A] => Assertion,
   ): Assertion = {
     implicit val httpClient: HttpClient = new HttpClient {
       val requestParameters = HttpClient.HttpRequestParameters(NonNegativeDuration(Duration.Zero))
@@ -44,21 +49,22 @@ class NonJsonResponseTest
     }
 
     val client = CommonAdminClient.httpClient(HttpClient.createHttpFn("", ""), "http://localhost")
-    expectation(client.getVersion().value.futureValue)
+    expectation(endpoint(client).value.futureValue)
   }
 
-  private val testHtmlBody = "<html><body>test</body></html>"
 
   "CommonAdminClient.getVersion" should {
-    "include the response body in the error when the response is not JSON" in {
-      runGetVersion(HttpEntity(ContentTypes.`text/html(UTF-8)`, testHtmlBody)) {
-        case Left(Left(err)) => err.getMessage should endWith(testHtmlBody)
+    "include the response body in the error when the content type is invalid" in {
+      val testBody = "<html><body>test</body></html>"
+      runEndpoint(_.getVersion(), HttpEntity(ContentTypes.`text/html(UTF-8)`, testBody)) {
+        case Left(Left(err)) => err.getMessage should endWith(testBody)
         case other => fail(s"expected Left(Left(throwable)), got: $other")
       }
     }
 
     "decode a well-formed application/json response" in {
-      runGetVersion(
+      runEndpoint(
+        _.getVersion(),
         HttpEntity(
           ContentTypes.`application/json`,
           Version(
@@ -69,6 +75,15 @@ class NonJsonResponseTest
       ) {
         case Right(_: GetVersionResponse.OK) => succeed
         case other => fail(s"expected GetVersionResponse.OK, got: $other")
+      }
+    }
+  }
+
+  "CommonAdminClient.isReady" should {
+    "handle an empty response with no content type" in {
+      runEndpoint(_.isReady(), HttpEntity.Empty) {
+        case Right(IsReadyResponse.OK) => succeed
+        case other => fail(s"expected IsReadyResponse.OK, got: $other")
       }
     }
   }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/InvalidResponseContentTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/InvalidResponseContentTest.scala
@@ -36,7 +36,7 @@ class InvalidResponseContentTest
       endpoint: CommonAdminClient => EitherT[Future, Either[Throwable, HttpResponse], A],
       resp: ResponseEntity,
   )(
-      expectation: Either[Either[Throwable, HttpResponse], A] => Assertion,
+      expectation: Either[Either[Throwable, HttpResponse], A] => Assertion
   ): Assertion = {
     implicit val httpClient: HttpClient = new HttpClient {
       val requestParameters = HttpClient.HttpRequestParameters(NonNegativeDuration(Duration.Zero))
@@ -51,7 +51,6 @@ class InvalidResponseContentTest
     val client = CommonAdminClient.httpClient(HttpClient.createHttpFn("", ""), "http://localhost")
     expectation(endpoint(client).value.futureValue)
   }
-
 
   "CommonAdminClient.getVersion" should {
     "include the response body in the error when the content type is invalid" in {
@@ -71,7 +70,7 @@ class InvalidResponseContentTest
             "1.2.3",
             OffsetDateTime.of(2026, 7, 23, 0, 0, 0, 0, ZoneOffset.UTC),
           ).asJson.noSpaces,
-        )
+        ),
       ) {
         case Right(_: GetVersionResponse.OK) => succeed
         case other => fail(s"expected GetVersionResponse.OK, got: $other")

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/NonJsonResponseTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/http/NonJsonResponseTest.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.http
+
+import com.digitalasset.canton.{BaseTest, HasActorSystem, HasExecutionContext}
+import com.digitalasset.canton.config.NonNegativeDuration
+import io.circe.syntax.*
+import org.lfdecentralizedtrust.splice.auth.AuthToken
+import org.lfdecentralizedtrust.splice.config.AuthTokenSourceConfig
+import org.lfdecentralizedtrust.splice.http.v0.definitions.Version
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.stream.Materializer
+import org.lfdecentralizedtrust.splice.http.v0.external.common_admin.{
+  CommonAdminClient,
+  GetVersionResponse,
+}
+import org.scalatest.compatible.Assertion
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.{OffsetDateTime, ZoneOffset}
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class NonJsonResponseTest
+    extends AnyWordSpec
+    with BaseTest
+    with HasActorSystem
+    with HasExecutionContext {
+
+  private implicit val mat: Materializer = Materializer(actorSystem)
+
+  private def runGetVersion(resp: ResponseEntity)(
+      expectation: Either[Either[Throwable, HttpResponse], GetVersionResponse] => Assertion
+  ): Assertion = {
+    implicit val httpClient: HttpClient = new HttpClient {
+      val requestParameters = HttpClient.HttpRequestParameters(NonNegativeDuration(Duration.Zero))
+      def withOverrideParameters(newParameters: HttpClient.HttpRequestParameters): HttpClient = this
+      def executeRequest(client: String, operation: String)(
+          request: HttpRequest
+      ): Future[HttpResponse] = Future.successful(HttpResponse(StatusCodes.OK, entity = resp))
+      def getToken(authConfig: AuthTokenSourceConfig): Future[Option[AuthToken]] =
+        Future.successful(None)
+    }
+
+    val client = CommonAdminClient.httpClient(HttpClient.createHttpFn("", ""), "http://localhost")
+    expectation(client.getVersion().value.futureValue)
+  }
+
+  private val testHtmlBody = "<html><body>test</body></html>"
+
+  "CommonAdminClient.getVersion" should {
+    "include the response body in the error when the response is not JSON" in {
+      runGetVersion(HttpEntity(ContentTypes.`text/html(UTF-8)`, testHtmlBody)) {
+        case Left(Left(err)) => err.getMessage should endWith(testHtmlBody)
+        case other => fail(s"expected Left(Left(throwable)), got: $other")
+      }
+    }
+
+    "decode a well-formed application/json response" in {
+      runGetVersion(
+        HttpEntity(
+          ContentTypes.`application/json`,
+          Version(
+            "1.2.3",
+            OffsetDateTime.of(2026, 7, 23, 0, 0, 0, 0, ZoneOffset.UTC),
+          ).asJson.noSpaces,
+        )
+      ) {
+        case Right(_: GetVersionResponse.OK) => succeed
+        case other => fail(s"expected GetVersionResponse.OK, got: $other")
+      }
+    }
+  }
+}

--- a/test-full-class-names-non-integration.log
+++ b/test-full-class-names-non-integration.log
@@ -11,6 +11,7 @@ org.lfdecentralizedtrust.splice.environment.ActiveContractsRestartTest
 org.lfdecentralizedtrust.splice.environment.CommandCircuitBreakerTest
 org.lfdecentralizedtrust.splice.environment.CommandIdDedupTest
 org.lfdecentralizedtrust.splice.environment.TopologyAwarePackageVersionSupportTest
+org.lfdecentralizedtrust.splice.http.NonJsonResponseTest
 org.lfdecentralizedtrust.splice.http.NonProxyHostsTest
 org.lfdecentralizedtrust.splice.http.UrlValidatorTest
 org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnectionTest

--- a/test-full-class-names-non-integration.log
+++ b/test-full-class-names-non-integration.log
@@ -11,7 +11,7 @@ org.lfdecentralizedtrust.splice.environment.ActiveContractsRestartTest
 org.lfdecentralizedtrust.splice.environment.CommandCircuitBreakerTest
 org.lfdecentralizedtrust.splice.environment.CommandIdDedupTest
 org.lfdecentralizedtrust.splice.environment.TopologyAwarePackageVersionSupportTest
-org.lfdecentralizedtrust.splice.http.NonJsonResponseTest
+org.lfdecentralizedtrust.splice.http.InvalidResponseContentTest
 org.lfdecentralizedtrust.splice.http.NonProxyHostsTest
 org.lfdecentralizedtrust.splice.http.UrlValidatorTest
 org.lfdecentralizedtrust.splice.scan.admin.api.client.BftScanConnectionTest


### PR DESCRIPTION
Fixes #6483

This updates `HttpClient.createHttpFn` to consider a response invalid if its content type is not `ContentTypes.NoContentType`, `application/json`, `application/octet-stream`, or `text/plain`. This results in `httpClientWithErrors` calling `getApiErrorFromResponse`, which produces an `HttpCommandException` and includes the raw response body in its error message.

`ContentType.NoContentType` is used for responses with no content type specified, like [this](https://github.com/canton-network/splice/blob/ba2b7eec6de146f639c2a353d022d6fa6faae873/apps/sv/src/main/openapi/sv-internal.yaml#L421-L423), and the other three content types are the only ones used across all the OpenAPI specs in the repo. `text/plain` is used by [`devNetOnboardValidatorPrepare`](https://github.com/canton-network/splice/blob/main/apps/sv/src/main/openapi/sv-internal.yaml#L506-L508), and `application/octet-stream` is used by [`bulkStorageDownload`](https://github.com/canton-network/splice/blob/main/apps/scan/src/main/openapi/scan-stream-server.yaml#L46-L50).

Note that this allowlist approach does present a risk of future issues if a new endpoint is added using a different content type. A blocklist approach (e.g. only considering `text/html` invalid) would prevent this issue, but would capture fewer invalid responses.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
