### PR TITLE
Remove retries for node initialized

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SequencerAdminConnection.scala
@@ -544,7 +544,7 @@ class SequencerAdminConnection(
     getSequencerId
 
   override def isNodeInitialized()(implicit traceContext: TraceContext): Future[Boolean] = {
-    getStatus.map {
+    getStatusWithoutRetries.map {
       case NodeStatus.Failure(_) => false
       case NodeStatus.NotInitialized(_, _, _) => false
       case NodeStatus.Success(_) => true

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/StatusAdminConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/StatusAdminConnection.scala
@@ -15,14 +15,18 @@ trait StatusAdminConnection {
   type Status <: NodeStatus.Status
   protected def getStatusRequest: GrpcAdminCommand[?, ?, NodeStatus[Status]]
 
-  def getStatus(implicit traceContext: TraceContext): Future[NodeStatus[Status]] =
+  def getStatus(implicit traceContext: TraceContext): Future[NodeStatus[Status]] = {
     retryProvider.retryForClientCalls(
       "status",
       "Get node status",
-      runCmd(
-        getStatusRequest
-      ),
+      getStatusWithoutRetries,
       logger,
     )
+  }
 
+  def getStatusWithoutRetries(implicit traceContext: TraceContext): Future[NodeStatus[Status]] = {
+    runCmd(
+      getStatusRequest
+    )
+  }
 }


### PR DESCRIPTION
We already retry everywhere where we call that

This was interefering with the check for active synchronzier which is used in a lot of places and making things timeout because we had those implicit retries

In most places we had nested retries in this case

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
