### PR TITLE
Disable BFT sequencer connections for SVs in SvOnboardingViaNonFoundingSvIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
@@ -141,9 +141,10 @@ class SvOnboardingViaNonFoundingSvIntegrationTest
                 }
               }
             endpoints.toSet shouldBe Set(
-              LocalSynchronizerNode.toEndpoint(
-                sv1Backend.config.localSynchronizerNodes.current.sequencer.internalApi
-              ),
+              // SV BFT sequencer connections are disabled
+//              LocalSynchronizerNode.toEndpoint(
+//                sv1Backend.config.localSynchronizerNodes.current.sequencer.internalApi
+//              ),
               LocalSynchronizerNode.toEndpoint(
                 sv2Backend.config.localSynchronizerNodes.current.sequencer.internalApi
               ),

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
@@ -87,6 +87,8 @@ class SvOnboardingViaNonFoundingSvIntegrationTest
         }(configuration)
       })
       .withManualStart
+      // Prevent flakes where the topology transaction gets dropped from outbox after disconnect and we're not retrying
+      .withSvBftSequencerConnectionDisabled()
 
   "A new SV can: 1) onboard via a non-sv1 while sv1 is offboarded from the DSO and " +
     "2) bootstrap using a sequencer that is not sv1's sequencer" in { implicit env =>

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
@@ -147,7 +147,7 @@ class SvOnboardingViaNonFoundingSvIntegrationTest
 //              ),
               LocalSynchronizerNode.toEndpoint(
                 sv2Backend.config.localSynchronizerNodes.current.sequencer.internalApi
-              ),
+              )
             )
             sv2Backend.participantClient.synchronizers.is_connected(
               decentralizedSynchronizerAlias


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9099