### PR TITLE
Fix SV UI crash when CometBFT is not configured

### DIFF
--- a/apps/common/frontend/src/__tests__/dso.test.tsx
+++ b/apps/common/frontend/src/__tests__/dso.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DsoInfo, theme } from '@canton-network/splice-common-frontend';
+import { Contract } from '@canton-network/splice-common-frontend-utils';
+import { dsoInfo } from '@canton-network/splice-common-test-handlers';
+import { QueryClient, QueryClientProvider, onlineManager, useQuery } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { CometBftNodeDumpOrErrorResponse } from '@canton-network/sv-openapi';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { ThemeProvider } from '@mui/material';
+
+import { AmuletRules } from '@daml.js/splice-amulet/lib/Splice/AmuletRules';
+import { DsoRules } from '@daml.js/splice-dso-governance/lib/Splice/DsoRules';
+
+import DsoViewPrettyJSON from '../components/Dso';
+
+const makeDsoInfo = (): DsoInfo => ({
+  svUser: dsoInfo.sv_user,
+  svPartyId: dsoInfo.sv_party_id,
+  dsoPartyId: dsoInfo.dso_party_id,
+  votingThreshold: BigInt(dsoInfo.voting_threshold),
+  amuletRules: Contract.decodeOpenAPI(dsoInfo.amulet_rules.contract, AmuletRules),
+  dsoRules: Contract.decodeOpenAPI(dsoInfo.dso_rules.contract, DsoRules),
+  nodeStates: [],
+});
+
+const TestDso: React.FC = () => {
+  const dsoInfoQuery = useQuery({
+    queryKey: ['dsoInfo'],
+    queryFn: async () => makeDsoInfo(),
+    initialData: makeDsoInfo(),
+  });
+  const cometBftNodeDebugQuery = useQuery<CometBftNodeDumpOrErrorResponse>({
+    queryKey: ['cometBftDebug'],
+    queryFn: async () => {
+      throw new Error('unreachable: query is paused while offline');
+    },
+  });
+  return (
+    <DsoViewPrettyJSON
+      dsoInfoQuery={dsoInfoQuery}
+      cometBftNodeDebugQuery={cometBftNodeDebugQuery}
+    />
+  );
+};
+
+describe('DsoViewPrettyJSON', () => {
+  afterEach(() => {
+    onlineManager.setOnline(true);
+  });
+
+  // With CantonBFT the cometbft debug endpoint 404s forever, so the query never
+  // reaches success; when it pauses (browser offline / tab backgrounded during
+  // retry backoff), status is 'pending' but isLoading is false and data is
+  // undefined. Rendering must not crash in that state.
+  test('does not crash when the cometBFT debug query is paused without data', () => {
+    window.splice_config = {
+      spliceInstanceNames: { amuletName: 'Amulet' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    onlineManager.setOnline(false);
+
+    render(
+      <ThemeProvider theme={theme}>
+        <QueryClientProvider client={new QueryClient()}>
+          <TestDso />
+        </QueryClientProvider>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByText('Super Validator Information')).toBeDefined();
+  });
+});

--- a/apps/common/frontend/src/components/Dso.tsx
+++ b/apps/common/frontend/src/components/Dso.tsx
@@ -118,7 +118,9 @@ const TabPanel = (props: TabPanelProps) => {
 function getCometBftDebugData(
   cometBftNodeDebugQuery: UseQueryResult<CometBftNodeDumpOrErrorResponse>
 ) {
-  if (cometBftNodeDebugQuery.isLoading) {
+  // isPending, not isLoading: a paused query (e.g. offline during retry backoff)
+  // has isLoading false while data is still undefined.
+  if (cometBftNodeDebugQuery.isPending) {
     return <Loading />;
   }
 

--- a/apps/common/frontend/src/components/Dso.tsx
+++ b/apps/common/frontend/src/components/Dso.tsx
@@ -118,8 +118,6 @@ const TabPanel = (props: TabPanelProps) => {
 function getCometBftDebugData(
   cometBftNodeDebugQuery: UseQueryResult<CometBftNodeDumpOrErrorResponse>
 ) {
-  // isPending, not isLoading: a paused query (e.g. offline during retry backoff)
-  // has isLoading false while data is still undefined.
   if (cometBftNodeDebugQuery.isPending) {
     return <Loading />;
   }


### PR DESCRIPTION
Fixes #6540

Verified with a new vitest that reproduces the paused-pending state via onlineManager.setOnline(false); it fails on the old code with the exact production error.

I'm happy to remove that test from the PR before merging; leaning towards keeping but 1. not sure if it matches our testing style and 2. I can see the point that it's a slightly too exotic thing to test with a dedicated test suite.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
