### PR TITLE
Move LSU cancellation endpoint behind operator auth

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/SvAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/SvAppReference.scala
@@ -134,7 +134,7 @@ abstract class SvAppReference(
   @Help.Summary("Cancel a running logical synchronizer upgrade by removing its LSU announcement")
   def cancelLogicalSynchronizerUpgrade(): Unit =
     consoleEnvironment.run {
-      httpCommand(HttpSvAdminAppClient.CancelLogicalSynchronizerUpgrade())
+      httpCommand(HttpSvOperatorAppClient.CancelLogicalSynchronizerUpgrade())
     }
 
   @Help.Summary("Get identities of all domain node components")

--- a/apps/sv/src/main/openapi/sv-internal.yaml
+++ b/apps/sv/src/main/openapi/sv-internal.yaml
@@ -176,7 +176,7 @@ paths:
   /v0/admin/synchronizer/lsu/cancel:
     post:
       tags: [sv]
-      x-jvm-package: sv_admin
+      x-jvm-package: sv_operator
       operationId: "cancelLogicalSynchronizerUpgrade"
       responses:
         "200":

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/SvApp.scala
@@ -498,6 +498,7 @@ class SvApp(
         timeouts,
         loggerFactory,
         amuletAppParameters.upgradesConfig,
+        participantAdminConnection,
       )
 
       adminHandler = new HttpSvAdminHandler(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/api/client/commands/HttpSvAdminAppClient.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/api/client/commands/HttpSvAdminAppClient.scala
@@ -40,22 +40,4 @@ object HttpSvAdminAppClient {
     }
   }
 
-  case class CancelLogicalSynchronizerUpgrade()
-      extends BaseCommand[http.CancelLogicalSynchronizerUpgradeResponse, Unit] {
-
-    override def submitRequest(
-        client: Client,
-        headers: List[HttpHeader],
-    ): EitherT[Future, Either[
-      Throwable,
-      HttpResponse,
-    ], http.CancelLogicalSynchronizerUpgradeResponse] =
-      client.cancelLogicalSynchronizerUpgrade(headers = headers)
-
-    override def handleOk()(implicit
-        decoder: TemplateJsonDecoder
-    ) = { case http.CancelLogicalSynchronizerUpgradeResponse.OK =>
-      Right(())
-    }
-  }
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/api/client/commands/HttpSvOperatorAppClient.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/api/client/commands/HttpSvOperatorAppClient.scala
@@ -468,4 +468,23 @@ object HttpSvOperatorAppClient {
         Left(response.error)
     }
   }
+
+  case class CancelLogicalSynchronizerUpgrade()
+      extends BaseCommand[http.CancelLogicalSynchronizerUpgradeResponse, Unit] {
+
+    override def submitRequest(
+        client: Client,
+        headers: List[HttpHeader],
+    ): EitherT[Future, Either[
+      Throwable,
+      HttpResponse,
+    ], http.CancelLogicalSynchronizerUpgradeResponse] =
+      client.cancelLogicalSynchronizerUpgrade(headers = headers)
+
+    override def handleOk()(implicit
+        decoder: TemplateJsonDecoder
+    ) = { case http.CancelLogicalSynchronizerUpgradeResponse.OK =>
+      Right(())
+    }
+  }
 }

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvAdminHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvAdminHandler.scala
@@ -37,21 +37,6 @@ class HttpSvAdminHandler(
   protected val workflowId: String = this.getClass.getSimpleName
   private val dsoStore = dsoStoreWithIngestion.store
 
-  override def cancelLogicalSynchronizerUpgrade(
-      respond: r0.CancelLogicalSynchronizerUpgradeResponse.type
-  )()(
-      extracted: AdminUserRequest
-  ): Future[r0.CancelLogicalSynchronizerUpgradeResponse] = {
-    implicit val AdminUserRequest(traceContext) = extracted
-    withSpan(s"$workflowId.cancelLogicalSynchronizerUpgrade") { _ => _ =>
-      for {
-        decentralizedSynchronizer <- dsoStore.getDsoRules().map(_.domain)
-        _ <- participantAdminConnection
-          .removeLsuAnnouncement(decentralizedSynchronizer)
-      } yield r0.CancelLogicalSynchronizerUpgradeResponseOK
-    }
-  }
-
   override def getSynchronizerNodeIdentitiesDump(
       respond: r0.GetSynchronizerNodeIdentitiesDumpResponse.type
   )()(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvOperatorHandler.scala
@@ -62,6 +62,7 @@ class HttpSvOperatorHandler(
     override protected val timeouts: ProcessingTimeout,
     protected val loggerFactory: NamedLoggerFactory,
     upgradesConfig: UpgradesConfig,
+    participantAdminConnection: ParticipantAdminConnection,
 )(implicit
     ec: ExecutionContextExecutor,
     protected val tracer: Tracer,
@@ -594,6 +595,21 @@ class HttpSvOperatorHandler(
             )
           )
       }
+    }
+  }
+
+  override def cancelLogicalSynchronizerUpgrade(
+      respond: r0.CancelLogicalSynchronizerUpgradeResponse.type
+  )()(
+      extracted: ActAsKnownUserRequest
+  ): Future[r0.CancelLogicalSynchronizerUpgradeResponse] = {
+    implicit val ActAsKnownUserRequest(traceContext) = extracted
+    withSpan(s"$workflowId.cancelLogicalSynchronizerUpgrade") { _ => _ =>
+      for {
+        decentralizedSynchronizer <- dsoStore.getDsoRules().map(_.domain)
+        _ <- participantAdminConnection
+          .removeLsuAnnouncement(decentralizedSynchronizer)
+      } yield r0.CancelLogicalSynchronizerUpgradeResponseOK
     }
   }
 


### PR DESCRIPTION
No need for admin auth as you can schedule a LSU without it so it doesn't really make sense

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
