### PR TITLE
Support configuring API request logging per app-type

### DIFF
--- a/cluster/pulumi/common-sv/src/singleSvConfig.ts
+++ b/cluster/pulumi/common-sv/src/singleSvConfig.ts
@@ -167,7 +167,11 @@ const SingleSvConfigSchema = z
         appsAsync: z.boolean().default(false),
         cantonLogLevel: LogLevelSchema,
         cantonStdoutLogLevel: LogLevelSchema.optional(),
+        // Log level for the Splice apps' HTTP request logging (org.lfdecentralizedtrust.splice.admin.api)
         apiRequestLogLevel: LogLevelSchema.optional(),
+        // Log level for the Canton nodes' Ledger-API audit logging (com.digitalasset.canton.logging.audit)
+        // Falls back to `apiRequestLogLevel` when not specified
+        cantonApiRequestLogLevel: LogLevelSchema.optional(),
         cantonAsync: z.boolean().default(false),
         cometbftLogLevel: CometbftLogLevelSchema.optional(),
         cometbftExtraLogLevelFlags: z.string().optional(),

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -90,7 +90,11 @@ export const ValidatorNodeConfigSchema = z.object({
   logging: z
     .object({
       level: LogLevelSchema.optional(),
+      // Log level for the Splice apps' HTTP request logging (org.lfdecentralizedtrust.splice.admin.api)
       apiRequestLogLevel: LogLevelSchema.optional(),
+      // Log level for the Canton nodes' Ledger-API audit logging (com.digitalasset.canton.logging.audit)
+      // Falls back to `apiRequestLogLevel` when not specified
+      cantonApiRequestLogLevel: LogLevelSchema.optional(),
       async: z.boolean().optional(),
     })
     .default({}),

--- a/cluster/pulumi/common-validator/src/participant.ts
+++ b/cluster/pulumi/common-validator/src/participant.ts
@@ -81,7 +81,9 @@ export async function installParticipant(
     {
       ...participantValuesWithSpecifiedAud,
       logLevel: validatorConfig.logging?.level,
-      apiRequestLogLevel: validatorConfig.logging?.apiRequestLogLevel,
+      apiRequestLogLevel:
+        validatorConfig.logging?.cantonApiRequestLogLevel ??
+        validatorConfig.logging?.apiRequestLogLevel,
       logAsyncFlush: validatorConfig.logging?.async,
       persistence: {
         databaseName: pgName,

--- a/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
+++ b/cluster/pulumi/sv-canton/src/decentralizedSynchronizerNode.ts
@@ -276,7 +276,7 @@ export class InStackCometBftDecentralizedSynchronizerNode
       version,
       svConfig.logging?.cantonLogLevel,
       svConfig.logging?.cantonStdoutLogLevel,
-      svConfig.logging?.apiRequestLogLevel,
+      svConfig.logging?.cantonApiRequestLogLevel ?? svConfig.logging?.apiRequestLogLevel,
       svConfig.logging?.cantonAsync,
       imagePullServiceAccountName,
       opts
@@ -324,7 +324,7 @@ export class InStackCantonBftDecentralizedSynchronizerNode extends InStackDecent
       version,
       svConfig.logging?.cantonLogLevel,
       svConfig.logging?.cantonStdoutLogLevel,
-      svConfig.logging?.apiRequestLogLevel,
+      svConfig.logging?.cantonApiRequestLogLevel ?? svConfig.logging?.apiRequestLogLevel,
       svConfig.logging?.cantonAsync,
       imagePullServiceAccountName,
       opts


### PR DESCRIPTION
Fixes #6337

This adds a new `cantonApiRequestLogLevel` config that controls the API request log level of the Canton apps, while the exiting `apiRequestLogLevel` config controls the API request log level of the Splice apps.

For backward compatibility, the Canton apps will fall back to using `apiRequestLogLevel` if `cantonApiRequestLogLevel` is not set.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
