### PR TITLE
Remove scan transactions endpoint

### DIFF
--- a/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
+++ b/apps/app/src/main/scala/org/lfdecentralizedtrust/splice/console/ScanAppReference.scala
@@ -368,20 +368,6 @@ abstract class ScanAppReference(
       httpCommand(HttpScanAppClient.GetRewardAccountingBatch(roundNumber, batchHash))
     }
 
-  import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryResponseItem
-  import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest.SortOrder
-
-  def listTransactions(
-      pageEndEventId: Option[String],
-      sortOrder: SortOrder,
-      pageSize: Int,
-  ): Seq[TransactionHistoryResponseItem] =
-    consoleEnvironment.run {
-      httpCommand(
-        HttpScanAppClient.ListTransactions(pageEndEventId, sortOrder, pageSize)
-      )
-    }
-
   def getAcsSnapshot(party: PartyId, recordTime: Option[Instant]): ByteString =
     consoleEnvironment.run {
       httpCommand(

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -29,7 +29,6 @@ import org.lfdecentralizedtrust.splice.environment.{
   SequencerAdminConnection,
 }
 import org.lfdecentralizedtrust.splice.http.v0.definitions
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
   IntegrationTest,
@@ -373,14 +372,13 @@ class LsuIntegrationTest
       initDso(includeLocal = false)
       startAllSync(aliceValidatorBackend, splitwellValidatorBackend)
       actAndCheck("Create some transaction history", sv1WalletClient.tap(1337))(
-        "Scan transaction history is recorded and wallet balance is updated",
+        "Wallet balance is updated",
         _ => {
           // buffer to account for domain fee payments
           assertInRange(
             sv1WalletClient.balance().unlockedQty,
             (walletUsdToAmulet(1000), walletUsdToAmulet(2000)),
           )
-          countTapsFromScan(sv1ScanBackend, walletUsdToAmulet(1337)) shouldBe 1
         },
       )
 
@@ -961,16 +959,6 @@ class LsuIntegrationTest
       grpcClientMetrics,
       retryProvider,
     )
-
-  private def countTapsFromScan(scan: ScanAppBackendReference, tapAmount: BigDecimal) = {
-    listTransactionsFromScan(scan).count(
-      _.tap.map(a => BigDecimal(a.amuletAmount)).contains(tapAmount)
-    )
-  }
-
-  private def listTransactionsFromScan(scan: ScanAppBackendReference) = {
-    scan.listTransactions(None, TransactionHistoryRequest.SortOrder.Asc, 100)
-  }
 
   private def getSequencerUrlsConfiguredForTheSync(
       participantConnection: ParticipantClientReference,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/MultiHostValidatorOperatorIntegrationTest.scala
@@ -1,11 +1,9 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.topology.transaction.*
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
 import org.lfdecentralizedtrust.splice.util.WalletTestUtil
-import org.lfdecentralizedtrust.splice.store.Limit
 
 import java.nio.file.Files
 import java.util.UUID
@@ -212,19 +210,8 @@ class MultiHostValidatorOperatorIntegrationTest extends IntegrationTest with Wal
     )(
       "The send succeeds despite alice's validator being disconnected and stopped",
       _ => {
-        // Fees eat up quite a bit
         splitwellWalletClient.balance().unlockedQty should be(60)
-        // Alice's wallet is stopped, so we confirm the transaction via scan
-        sv1ScanBackend
-          .listTransactions(
-            None,
-            TransactionHistoryRequest.SortOrder.Desc,
-            Limit.DefaultMaxPageSize,
-          )
-          .flatMap(_.transfer)
-          .filter(tf =>
-            tf.description == transferDescription
-          ) should not be empty withClue "transfers splitwell to alice"
+        // don't check on alice's wallet as it's stopped. the transaction going through on splitwell is enough signal.
       },
     )
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/RollForwardLsuIntegrationTest.scala
@@ -18,7 +18,6 @@ import org.lfdecentralizedtrust.splice.environment.{
   MediatorAdminConnection,
   SequencerAdminConnection,
 }
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest
 import monocle.macros.syntax.lens.*
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
@@ -164,14 +163,13 @@ class RollForwardLsuIntegrationTest
     startAllSync(allNodes*)
 
     actAndCheck("Create some transaction history", sv1WalletClient.tap(1337))(
-      "Scan transaction history is recorded and wallet balance is updated",
+      "Wallet balance is updated",
       _ => {
         // buffer to account for domain fee payments
         assertInRange(
           sv1WalletClient.balance().unlockedQty,
           (walletUsdToAmulet(1000), walletUsdToAmulet(2000)),
         )
-        countTapsFromScan(sv1ScanBackend, walletUsdToAmulet(1337)) shouldBe 1
       },
     )
 
@@ -428,16 +426,6 @@ class RollForwardLsuIntegrationTest
       grpcClientMetrics,
       retryProvider,
     )
-
-  private def countTapsFromScan(scan: ScanAppBackendReference, tapAmount: BigDecimal) = {
-    listTransactionsFromScan(scan).count(
-      _.tap.map(a => BigDecimal(a.amuletAmount)).contains(tapAmount)
-    )
-  }
-
-  private def listTransactionsFromScan(scan: ScanAppBackendReference) = {
-    scan.listTransactions(None, TransactionHistoryRequest.SortOrder.Asc, 100)
-  }
 
   private def getSequencerUrlSet(
       participantConnection: ParticipantClientReference,

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanHistoryBackfillingIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanHistoryBackfillingIntegrationTest.scala
@@ -1,6 +1,9 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.daml.ledger.javaapi.data.Transaction
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.*
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.actionrequiringconfirmation.*
+import org.lfdecentralizedtrust.splice.codegen.java.splice.dsorules.dsorules_actionrequiringconfirmation.*
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   ConfigurableApp,
@@ -20,7 +23,11 @@ import org.lfdecentralizedtrust.splice.scan.automation.{
   DeleteCorruptAcsSnapshotTrigger,
   ScanHistoryBackfillingTrigger,
 }
-import org.lfdecentralizedtrust.splice.store.{PageLimit, TreeUpdateWithMigrationId}
+import org.lfdecentralizedtrust.splice.store.{
+  PageLimit,
+  TreeUpdateWithMigrationId,
+  VoteResultsFilters,
+}
 import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.AdvanceOpenMiningRoundTrigger
 import org.lfdecentralizedtrust.splice.util.{EventId, UpdateHistoryTestUtil, WalletTestUtil}
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
@@ -29,12 +36,12 @@ import com.digitalasset.canton.data.CantonTimestamp
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 import com.digitalasset.canton.{HasActorSystem, HasExecutionContext}
 import org.lfdecentralizedtrust.splice.automation.TxLogBackfillingTrigger
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest.SortOrder
 import org.lfdecentralizedtrust.splice.scan.store.TxLogEntry
 import org.lfdecentralizedtrust.splice.store.MultiDomainAcsStore.TxLogBackfillingState
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.BackfillingState
 import org.scalactic.source.Position
 
+import java.util.Optional
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
@@ -126,6 +133,39 @@ class ScanHistoryBackfillingIntegrationTest
       _ => {
         // Amulet merging and round advancement are both paused
         aliceWalletClient.list().amulets should have length 4
+      },
+    )
+
+    // we create votes as they produce txlog entries that can be backfilled
+    actAndCheck(
+      "Create vote", {
+        val action: ActionRequiringConfirmation =
+          new ARC_DsoRules(
+            new SRARC_SetConfig(
+              new DsoRules_SetConfig(
+                sv1Backend
+                  .getDsoInfo()
+                  .dsoRules
+                  .payload
+                  .config,
+                Optional.empty(),
+              )
+            )
+          )
+
+        sv1Backend.createVoteRequest(
+          sv1Backend.getDsoInfo().svParty.toProtoPrimitive,
+          action,
+          "url",
+          "description",
+          sv1Backend.getDsoInfo().dsoRules.payload.config.voteRequestTimeout,
+          None,
+        )
+      },
+    )(
+      "Vote has been executed",
+      _ => {
+        sv1ScanBackend.listVoteRequestResults(VoteResultsFilters(), 100)._1 should have size (1)
       },
     )
 
@@ -466,18 +506,9 @@ class ScanHistoryBackfillingIntegrationTest
         .loneElement shouldBe a[TxLogBackfillingTrigger.InitializeBackfillingTask]
     }
 
-    clue("TxLog based historical queries differ") {
-      val sv1Transactions =
-        sv1ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
-      val sv2Transactions =
-        sv2ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
-
-      // We tapped 4 times before SV2 joined, and once after
-      sv1Transactions.size should be >= 5 withClue "SV1 txns"
-      sv2Transactions.size should be >= 1 withClue "SV2 txns"
-      sv1Transactions.size should be > sv2Transactions.size withClue "SV1 txns"
-      sv1Transactions should contain allElementsOf sv2Transactions withClue "sv1 transactions"
-      sv2Transactions should not contain sv1Transactions.headOption.value withClue "sv2 transactions"
+    clue("TxLog based vote result result differ") {
+      sv1ScanBackend.listVoteRequestResults(VoteResultsFilters(), 100)._1 should have size (1)
+      sv2ScanBackend.listVoteRequestResults(VoteResultsFilters(), 100)._1 should be(empty)
     }
 
     actAndCheck(
@@ -524,14 +555,13 @@ class ScanHistoryBackfillingIntegrationTest
       },
     )
 
-    clue("TxLog based historical queries return same results") {
-      val sv1Transactions =
-        sv1ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
-      val sv2Transactions =
-        sv2ScanBackend.listTransactions(None, SortOrder.Asc, 1000).map(shortDebugDescription)
-
-      // TODO(#666): switch to theSameElementsInOrderAs once the endpoint sorts by record time instead of row id.
-      sv1Transactions should contain theSameElementsAs sv2Transactions withClue "SV1/2 txns"
+    clue("TxLog based vote result queries return same results") {
+      // Not quite sure why we need the eventually given that we sync on backfilling completing but without that sv2ScanBackend can still return an empty list.
+      eventually() {
+        sv1ScanBackend.listVoteRequestResults(VoteResultsFilters(), 100)._1 shouldBe sv2ScanBackend
+          .listVoteRequestResults(VoteResultsFilters(), 100)
+          ._1
+      }
     }
 
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
@@ -3,9 +3,7 @@ package org.lfdecentralizedtrust.splice.integration.tests
 import com.digitalasset.canton.concurrent.Threading
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.config.RequireTypes.NonNegativeInt
-import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.discard.Implicits.DiscardOps
-import com.digitalasset.canton.topology.PartyId
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.client.RequestBuilding.{Get, Post}
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
@@ -18,10 +16,6 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   updateAutomationConfig,
   ConfigurableApp,
-}
-import org.lfdecentralizedtrust.splice.http.v0.definitions.{
-  TransactionHistoryRequest,
-  TransactionHistoryResponseItem,
 }
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
@@ -164,107 +158,6 @@ class ScanIntegrationTest
     spliceInstanceNames.amuletNameAcronym should be("AMT")
     spliceInstanceNames.nameServiceName should be("Amulet Name Service")
     spliceInstanceNames.nameServiceNameAcronym should be("ANS")
-  }
-
-  "list transaction pages in ascending and descending order" in { implicit env =>
-    val aliceWalletUser = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
-    def tapsForAlice = (t: TransactionHistoryResponseItem) =>
-      t.tap.exists { tap =>
-        PartyId.tryFromProtoPrimitive(tap.amuletOwner) == aliceWalletUser
-      }
-
-    val nrTaps = 10
-    val amuletAmounts = (1 to nrTaps).map(walletUsdToAmulet(_))
-    val pageSize = nrTaps / 2
-    // filtering for Alice to avoid interference by the top up taps
-    def collectAllTapPagesForAlice(sortOrder: TransactionHistoryRequest.SortOrder) = {
-      LazyList
-        .iterate(sv1ScanBackend.listTransactions(None, sortOrder, pageSize)) { page =>
-          sv1ScanBackend.listTransactions(page.lastOption.map(_.eventId), sortOrder, pageSize)
-        }
-        .takeWhile(_.nonEmpty)
-        .foldLeft(Seq.empty[TransactionHistoryResponseItem])(_ ++ _)
-        .filter(tapsForAlice)
-    }
-
-    def toAmuletAmounts(page: Seq[TransactionHistoryResponseItem]) =
-      page.flatMap(_.tap.map(t => BigDecimal(t.amuletAmount)))
-
-    actAndCheck(
-      "Tap amulets for Alice", {
-        (1 to nrTaps).foreach { i =>
-          aliceWalletClient.tap(BigDecimal(i))
-        }
-      },
-    )(
-      "Amulets should appear in Alice's wallet",
-      _ => {
-        aliceWalletClient.list().amulets should have length nrTaps.toLong
-      },
-    )
-
-    eventually() {
-      val latestRound =
-        sv1ScanBackend.getLatestOpenMiningRound(CantonTimestamp.now()).contract.payload.round.number
-      val asc = TransactionHistoryRequest.SortOrder.Asc
-      val desc = TransactionHistoryRequest.SortOrder.Desc
-      val allPagesAsc = collectAllTapPagesForAlice(asc)
-      val allPagesDesc = collectAllTapPagesForAlice(desc)
-      allPagesAsc.map(_.round) should contain only Some(
-        latestRound
-      ) withClue "alice tap pages' rounds"
-
-      val tapsFirstPageAscending = allPagesAsc.take(pageSize)
-
-      toAmuletAmounts(tapsFirstPageAscending) should be(
-        amuletAmounts.take(pageSize)
-      )
-
-      val firstPageEndEventId = tapsFirstPageAscending.last.eventId
-      val tapsSecondPageAscending = allPagesAsc.slice(pageSize, pageSize + pageSize)
-      sv1ScanBackend
-        .listTransactions(
-          Some(firstPageEndEventId),
-          TransactionHistoryRequest.SortOrder.Asc,
-          pageSize.toInt,
-        )
-        .filter(tapsForAlice)
-
-      toAmuletAmounts(tapsSecondPageAscending) should be(
-        amuletAmounts.slice(pageSize, pageSize + pageSize)
-      )
-
-      sv1ScanBackend
-        .listTransactions(
-          Some(tapsSecondPageAscending.last.eventId),
-          asc,
-          pageSize.toInt,
-        )
-        .filter(tapsForAlice) should be(empty)
-
-      val tapsFirstPageDescending = allPagesDesc.take(pageSize)
-      toAmuletAmounts(tapsFirstPageDescending) should be(
-        amuletAmounts.reverse.take(pageSize)
-      )
-
-      val tapsSecondPageDescending =
-        allPagesDesc.slice(pageSize, pageSize + pageSize)
-
-      sv1ScanBackend
-        .listTransactions(
-          Some(tapsSecondPageDescending.last.eventId),
-          TransactionHistoryRequest.SortOrder.Desc,
-          pageSize.toInt,
-        )
-        .filter(tapsForAlice) should be(empty)
-
-      toAmuletAmounts(tapsSecondPageDescending) should be(
-        amuletAmounts.reverse.slice(pageSize, pageSize + pageSize)
-      )
-      toAmuletAmounts(
-        tapsFirstPageAscending ++ tapsSecondPageAscending
-      ) should be(toAmuletAmounts((tapsFirstPageDescending ++ tapsSecondPageDescending).reverse))
-    }
   }
 
   "getUpdateHistory should return 400 for invalid after timestamp" in { implicit env =>

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvTimeBasedRewardCouponIntegrationTest.scala
@@ -6,7 +6,6 @@ import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   ConfigurableApp,
   updateAutomationConfig,
 }
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryRequest
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.{
   IntegrationTest,
@@ -221,38 +220,7 @@ class SvTimeBasedRewardCouponIntegrationTest
         )
       }
 
-      clue("The claims appear in the scan history") {
-        eventually() {
-          val txs = sv1ScanBackend
-            .listTransactions(
-              None,
-              TransactionHistoryRequest.SortOrder.Desc,
-              Limit.DefaultMaxPageSize,
-            )
-            .flatMap(_.transfer)
-            .filter(tf =>
-              tf.sender.inputSvRewardAmount.nonEmpty &&
-                Seq(sv1Party.toProtoPrimitive, aliceValidatorParty.toProtoPrimitive)
-                  .contains(tf.sender.party)
-            )
-            .map(tf => tf.sender.party -> tf.sender.inputSvRewardAmount.value)
-            .toMap
-          BigDecimal(txs(sv1Party.toProtoPrimitive)) should beWithin(
-            // The expected SV reward calculated here does not match exactly the reward calculated in daml,
-            // presumably because of rounding differences in the reward calculation.
-            BigDecimal(eachSvGetInRound0) - 0.001,
-            BigDecimal(eachSvGetInRound0) + 0.001,
-          )
-          BigDecimal(txs(aliceValidatorParty.toProtoPrimitive)) should beWithin(
-            // The expected SV reward calculated here does not match exactly the reward calculated in daml,
-            // presumably because of rounding differences in the reward calculation.
-            BigDecimal(expectedAliceAmount) - 0.001,
-            BigDecimal(expectedAliceAmount) + 0.001,
-          )
-        }
-      }
-
-      clue("The claims appear in the wallet history") {
+      clue("The claims appear in the SV wallet history") {
         eventually() {
           val txs = withoutDevNetTopups(
             sv1WalletClient

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/UpdateHistoryTestUtil.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/util/UpdateHistoryTestUtil.scala
@@ -45,7 +45,6 @@ import com.digitalasset.canton.config.RequireTypes.PositiveInt
 import com.digitalasset.canton.console.LocalInstanceReference
 import com.digitalasset.canton.metrics.MetricValue
 import com.digitalasset.canton.topology.{PartyId, SynchronizerId}
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryResponseItem
 import org.scalatest.Assertion
 
 import scala.jdk.CollectionConverters.*
@@ -442,22 +441,6 @@ trait UpdateHistoryTestUtil extends TestCommon {
   }
   def shortDebugDescription(u: Seq[definitions.UpdateHistoryItem]): String = {
     u.map(shortDebugDescription).mkString("[\n", ",\n", "\n]")
-  }
-  def shortDebugDescription(u: TransactionHistoryResponseItem): String = {
-    // Minimal, human-readable description.
-    // Only contains data that is consistent across SVs (in particular, no offset).
-    u.transactionType match {
-      case TransactionHistoryResponseItem.TransactionType.members.Transfer =>
-        s"Transfer(${u.date}, ${u.transfer.value.sender}, ${u.transfer.value.receivers
-            .map(r => s"${r.party} -> ${r.amount}")
-            .mkString(", ")})"
-      case TransactionHistoryResponseItem.TransactionType.members.Mint =>
-        s"Mint(${u.date}, ${u.mint.value.amuletOwner}, ${u.mint.value.amuletAmount})"
-      case TransactionHistoryResponseItem.TransactionType.members.DevnetTap =>
-        s"DevnetTap(${u.date}, ${u.tap.value.amuletOwner}, ${u.tap.value.amuletAmount})"
-      case TransactionHistoryResponseItem.TransactionType.members.AbortTransferInstruction =>
-        s"AbortTransferInstruction(${u.date}, ${u.abortTransferInstruction.value.transferInstructionCid})"
-    }
   }
 
   def dropTrailingNones(u: UpdateHistoryResponse): UpdateHistoryResponse =

--- a/apps/scan/src/main/openapi/scan.yaml
+++ b/apps/scan/src/main/openapi/scan.yaml
@@ -1448,36 +1448,6 @@ paths:
         "404":
           $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
 
-  /v0/transactions:
-    post:
-      deprecated: true
-      tags: [deprecated]
-      x-jvm-package: scan
-      operationId: "listTransactionHistory"
-      description: |
-        **Deprecated with known bugs that will not be fixed, use /v2/updates instead**.
-
-        Lists transactions, by default in ascending order, paged, from ledger begin or optionally starting after a provided event id.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/TransactionHistoryRequest"
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TransactionHistoryResponse"
-        "400":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/400"
-        "404":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/404"
-        "500":
-          $ref: "../../../../common/src/main/openapi/common-external.yaml#/components/responses/500"
-
   /v0/updates:
     post:
       deprecated: true
@@ -2205,97 +2175,6 @@ components:
         svName:
           description: The sequencer's operating SV name.
           type: string
-    TransactionHistoryRequest:
-      type: object
-      required:
-        - page_size
-      properties:
-        page_end_event_id:
-          type: string
-          description: |
-            Note that all transactions carry some monotonically-increasing event_id.
-            Omit this page_end_event_id to start reading the first page, from the beginning or the end of the ledger, depending on the sort_order column.
-            A subsequent request can fill the page_end_event_id with the last event_id of the TransactionHistoryResponse to continue reading in the same sort_order.
-            The transaction with event_id == page_end_event_id will be skipped in the next response, making it possible to continuously read pages in the same sort_order.
-        sort_order:
-          description: |
-            Sort order for the transactions. For ascending order, from beginning to the end of the ledger, use "asc".
-            For descending order, from end to beginning of the ledger, use "desc".
-            "asc" is used if the sort_order is omitted.
-          type: string
-          enum:
-            - "asc"
-            - "desc"
-        page_size:
-          description: |
-            The maximum number of transactions returned for this request.
-          type: integer
-          format: int64
-    TransactionHistoryResponse:
-      type: object
-      required:
-        - transactions
-      properties:
-        transactions:
-          type: array
-          items:
-            $ref: "#/components/schemas/TransactionHistoryResponseItem"
-    TransactionHistoryResponseItem:
-      type: object
-      required:
-        - transaction_type
-        - event_id
-        - date
-        - domain_id
-      properties:
-        transaction_type:
-          description: |
-            Describes the type of activity that occurred.
-            Determines if the data for the transaction should be read
-            from the `transfer`, `mint`, or `tap` property.
-          type: string
-          enum:
-            - "transfer"
-            - "mint"
-            - "devnet_tap"
-            - "abort_transfer_instruction"
-        event_id:
-          description: |
-            The event id.
-          type: string
-        offset:
-          description: |
-            The ledger offset of the event.
-            Note that this field may not be the same across nodes, and therefore should not be compared between SVs.
-          type: string
-        date:
-          description: |
-            The effective date of the event.
-          type: string
-          format: date-time
-        domain_id:
-          description: |
-            The id of the domain through which this transaction was sequenced.
-          type: string
-        round:
-          description: |
-            The round for which this transaction was registered.
-          type: integer
-          format: int64
-        transfer:
-          description: |
-            A (batch) transfer from sender to receivers.
-          $ref: "#/components/schemas/Transfer"
-        mint:
-          description: |
-            The DSO mints amulet for the cases where the DSO rules allow for that.
-          $ref: "#/components/schemas/AmuletAmount"
-        tap:
-          description: |
-            A tap creates a Amulet, only used for development purposes, and enabled only on DevNet.
-          $ref: "#/components/schemas/AmuletAmount"
-        abort_transfer_instruction:
-          $ref: "#/components/schemas/AbortTransferInstruction"
     UpdateHistoryRequestAfter:
       type: object
       required:

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/api/client/commands/HttpScanAppClient.scala
@@ -894,33 +894,6 @@ object HttpScanAppClient {
 
   final case class DsoScan(publicUrl: Uri, svName: String)
 
-  case class ListTransactions(
-      pageEndEventId: Option[String],
-      sortOrder: definitions.TransactionHistoryRequest.SortOrder,
-      pageSize: Int,
-  ) extends InternalBaseCommand[http.ListTransactionHistoryResponse, Seq[
-        definitions.TransactionHistoryResponseItem
-      ]] {
-    override def submitRequest(
-        client: http.ScanClient,
-        headers: List[HttpHeader],
-    ): EitherT[Future, Either[
-      Throwable,
-      HttpResponse,
-    ], http.ListTransactionHistoryResponse] = {
-      client.listTransactionHistory(
-        definitions
-          .TransactionHistoryRequest(pageEndEventId, Some(sortOrder), pageSize.toLong),
-        headers,
-      )
-    }
-
-    override def handleOk()(implicit decoder: TemplateJsonDecoder) = {
-      case http.ListTransactionHistoryResponse.OK(response) =>
-        Right(response.transactions)
-    }
-  }
-
   case class GetAcsSnapshot(
       party: PartyId,
       recordTime: Option[Instant],

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -107,7 +107,6 @@ import org.lfdecentralizedtrust.splice.store.{
   AppStore,
   AppStoreWithIngestion,
   PageLimit,
-  SortOrder,
   VoteResultsFilters,
   VotesStore,
 }
@@ -691,33 +690,6 @@ class HttpScanHandler(
           }
         )
       }
-    }
-  }
-
-  override def listTransactionHistory(
-      respond: v0.ScanResource.ListTransactionHistoryResponse.type
-  )(
-      request: definitions.TransactionHistoryRequest
-  )(extracted: TraceContext): Future[v0.ScanResource.ListTransactionHistoryResponse] = {
-    implicit val tc = extracted
-    withSpan(s"$workflowId.listTransactions") { _ => _ =>
-      val pageEndEventId =
-        if (request.pageEndEventId.exists(_.isEmpty)) None else request.pageEndEventId
-      val sortOrder = request.sortOrder
-        .fold[SortOrder](SortOrder.Ascending) {
-          case definitions.TransactionHistoryRequest.SortOrder.members.Asc => SortOrder.Ascending
-          case definitions.TransactionHistoryRequest.SortOrder.members.Desc => SortOrder.Descending
-        }
-
-      for {
-        txs <- store.listTransactions(
-          pageEndEventId,
-          sortOrder,
-          PageLimit.tryCreate(request.pageSize.intValue()),
-        )
-      } yield definitions.TransactionHistoryResponse(
-        txs.map(TxLogEntry.Http.toResponseItem).toVector
-      )
     }
   }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/TxLogEntry.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/TxLogEntry.scala
@@ -5,18 +5,15 @@ package org.lfdecentralizedtrust.splice.scan.store
 
 import org.lfdecentralizedtrust.splice.codegen.java.splice
 import org.lfdecentralizedtrust.splice.store.StoreErrors
-import org.lfdecentralizedtrust.splice.util.Codec
 
 import scala.collection.immutable
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 import java.time.Instant
 import org.lfdecentralizedtrust.splice.http.v0.definitions as httpDef
-import org.lfdecentralizedtrust.splice.http.v0.definitions.TransactionHistoryResponseItem.TransactionType as HttpTransactionType
 import com.digitalasset.canton.config.CantonRequireTypes.String3
 import com.digitalasset.canton.topology.PartyId
 
-import java.time.ZoneOffset
 import scala.math.BigDecimal.RoundingMode
 
 trait TxLogEntry extends Product with Serializable {
@@ -117,130 +114,6 @@ object TxLogEntry extends StoreErrors {
       val Sent = "sent"
       val Failed = "failed"
     }
-
-    private def toResponse(data: SenderAmount) = httpDef.SenderAmount(
-      party = data.party.toProtoPrimitive,
-      inputAmuletAmount = Some(Codec.encode(data.inputAmuletAmount)),
-      inputAppRewardAmount = Some(Codec.encode(data.inputAppRewardAmount)),
-      inputValidatorRewardAmount = Some(Codec.encode(data.inputValidatorRewardAmount)),
-      inputSvRewardAmount = Some(Codec.encode(data.inputSvRewardAmount.getOrElse(BigDecimal(0)))),
-      inputValidatorFaucetAmount = data.inputValidatorFaucetAmount.map(fa => Codec.encode(fa)),
-      senderChangeAmount = Codec.encode(data.senderChangeAmount),
-      senderChangeFee = Codec.encode(data.senderChangeFee),
-      senderFee = Codec.encode(data.senderFee),
-      holdingFees = Codec.encode(data.holdingFees),
-    )
-
-    private def toResponse(data: ReceiverAmount) = httpDef.ReceiverAmount(
-      party = data.party.toProtoPrimitive,
-      amount = Codec.encode(data.amount),
-      receiverFee = Codec.encode(data.receiverFee),
-    )
-
-    private def toResponse(data: BalanceChange) = httpDef.BalanceChange(
-      party = data.party.toProtoPrimitive,
-      changeToInitialAmountAsOfRoundZero = Codec.encode(data.changeToInitialAmountAsOfRoundZero),
-      changeToHoldingFeesRate = Codec.encode(data.changeToHoldingFeesRate),
-    )
-
-    private def toTransferResponseItem(entry: TransferTxLogEntry) =
-      httpDef.TransactionHistoryResponseItem(
-        transactionType = HttpTransactionType.Transfer,
-        eventId = entry.eventId,
-        offset = Some(entry.offset),
-        domainId = entry.domainId.toProtoPrimitive,
-        date = java.time.OffsetDateTime
-          .ofInstant(entry.date.getOrElse(throw txMissingField()), ZoneOffset.UTC),
-        transfer = Some(
-          httpDef.Transfer(
-            sender = toResponse(entry.sender.getOrElse(throw txMissingField())),
-            receivers = entry.receivers.map(toResponse).toVector,
-            balanceChanges = entry.balanceChanges.map(toResponse).toVector,
-            description = Some(entry.description).filter(_.nonEmpty),
-            transferInstructionReceiver =
-              Some(entry.transferInstructionReceiver).filter(_.nonEmpty),
-            transferInstructionAmount = entry.transferInstructionAmount.map(Codec.encode(_)),
-            transferInstructionCid = Some(entry.transferInstructionCid).filter(_.nonEmpty),
-            transferKind = entry.transferKind match {
-              case TransferKind.Unrecognized(_) => None
-              case TransferKind.TRANSFER_KIND_OTHER => None
-              case TransferKind.TRANSFER_KIND_CREATE_TRANSFER_INSTRUCTION =>
-                Some(httpDef.Transfer.TransferKind.members.CreateTransferInstruction)
-              case TransferKind.TRANSFER_KIND_TRANSFER_INSTRUCTION_ACCEPT =>
-                Some(httpDef.Transfer.TransferKind.members.TransferInstructionAccept)
-              case TransferKind.TRANSFER_KIND_PREAPPROVAL_SEND =>
-                Some(httpDef.Transfer.TransferKind.members.PreapprovalSend)
-            },
-          )
-        ),
-        round = Some(entry.round),
-      )
-
-    private def toTapResponseItem(entry: TapTxLogEntry) = httpDef.TransactionHistoryResponseItem(
-      transactionType = HttpTransactionType.DevnetTap,
-      eventId = entry.eventId,
-      offset = Some(entry.offset),
-      domainId = entry.domainId.toProtoPrimitive,
-      date = java.time.OffsetDateTime
-        .ofInstant(entry.date.getOrElse(throw txMissingField()), ZoneOffset.UTC),
-      tap = Some(
-        httpDef.AmuletAmount(
-          amuletOwner = entry.amuletOwner.toProtoPrimitive,
-          amuletAmount = Codec.encode(entry.amuletAmount),
-        )
-      ),
-      round = Some(entry.round),
-    )
-
-    private def toMintResponseItem(entry: MintTxLogEntry) = httpDef.TransactionHistoryResponseItem(
-      transactionType = HttpTransactionType.Mint,
-      eventId = entry.eventId,
-      offset = Some(entry.offset),
-      domainId = entry.domainId.toProtoPrimitive,
-      date = java.time.OffsetDateTime
-        .ofInstant(entry.date.getOrElse(throw txMissingField()), ZoneOffset.UTC),
-      mint = Some(
-        httpDef.AmuletAmount(
-          amuletOwner = entry.amuletOwner.toProtoPrimitive,
-          amuletAmount = Codec.encode(entry.amuletAmount),
-        )
-      ),
-    )
-
-    private def toAbortTransferInstructionResponseItem(entry: AbortTransferInstructionTxLogEntry) =
-      httpDef.TransactionHistoryResponseItem(
-        transactionType = HttpTransactionType.AbortTransferInstruction,
-        eventId = entry.eventId,
-        offset = Some(entry.offset),
-        domainId = entry.domainId.toProtoPrimitive,
-        date = java.time.OffsetDateTime
-          .ofInstant(entry.date.getOrElse(throw txMissingField()), ZoneOffset.UTC),
-        abortTransferInstruction = Some(
-          httpDef.AbortTransferInstruction(
-            abortKind = entry.transferAbortKind match {
-              case TransferAbortKind.Unrecognized(_) =>
-                sys.error(s"Unexpected transfer abort kind: ${entry.transferAbortKind}")
-              case TransferAbortKind.TRANSFER_ABORT_KIND_RESERVED =>
-                sys.error(s"Unexpected transfer abort kind: ${entry.transferAbortKind}")
-              case TransferAbortKind.TRANSFER_ABORT_KIND_REJECT =>
-                httpDef.AbortTransferInstruction.AbortKind.members.Reject
-              case TransferAbortKind.TRANSFER_ABORT_KIND_WITHDRAW =>
-                httpDef.AbortTransferInstruction.AbortKind.members.Withdraw
-            },
-            transferInstructionCid = entry.transferInstructionCid,
-          )
-        ),
-      )
-
-    def toResponseItem(entry: TransactionTxLogEntry): httpDef.TransactionHistoryResponseItem =
-      entry match {
-        case entry: TransferTxLogEntry => toTransferResponseItem(entry)
-        case entry: TapTxLogEntry => toTapResponseItem(entry)
-        case entry: MintTxLogEntry => toMintResponseItem(entry)
-        case entry: AbortTransferInstructionTxLogEntry =>
-          toAbortTransferInstructionResponseItem(entry)
-        case _ => throw txLogIsOfWrongType(entry.getClass.getSimpleName)
-      }
 
     def toResponse(
         status: TransferCommandTxLogEntry.Status

--- a/cluster/configs/shared/rate-limits/unlimited.yaml
+++ b/cluster/configs/shared/rate-limits/unlimited.yaml
@@ -85,10 +85,6 @@ rateLimits:
     name: dso-party-id
     type: unlimited
 
-  /api/scan/v0/transactions:
-    name: transactions
-    type: unlimited
-
   /api/scan/v0/backfilling:
     name: backfilling
     type: unlimited

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -326,9 +326,6 @@ sv:
         /api/scan/v0/synchronizer-identities:
           name: 'synchronizer-identities'
           type: 'unlimited'
-        /api/scan/v0/transactions:
-          name: 'transactions'
-          type: 'unlimited'
         /api/scan/v0/transfer-command:
           name: 'transfer-command-status'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -326,9 +326,6 @@ sv:
         /api/scan/v0/synchronizer-identities:
           name: 'synchronizer-identities'
           type: 'unlimited'
-        /api/scan/v0/transactions:
-          name: 'transactions'
-          type: 'unlimited'
         /api/scan/v0/transfer-command:
           name: 'transfer-command-status'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -326,9 +326,6 @@ sv:
         /api/scan/v0/synchronizer-identities:
           name: 'synchronizer-identities'
           type: 'unlimited'
-        /api/scan/v0/transactions:
-          name: 'transactions'
-          type: 'unlimited'
         /api/scan/v0/transfer-command:
           name: 'transfer-command-status'
           type: 'unlimited'

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -326,9 +326,6 @@ sv:
         /api/scan/v0/synchronizer-identities:
           name: 'synchronizer-identities'
           type: 'unlimited'
-        /api/scan/v0/transactions:
-          name: 'transactions'
-          type: 'unlimited'
         /api/scan/v0/transfer-command:
           name: 'transfer-command-status'
           type: 'unlimited'

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -326,9 +326,6 @@ sv:
         /api/scan/v0/synchronizer-identities:
           name: 'synchronizer-identities'
           type: 'unlimited'
-        /api/scan/v0/transactions:
-          name: 'transactions'
-          type: 'unlimited'
         /api/scan/v0/transfer-command:
           name: 'transfer-command-status'
           type: 'unlimited'

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1772,10 +1772,6 @@
           "name": "synchronizer-identities",
           "type": "unlimited"
         },
-        "/api/scan/v0/transactions": {
-          "name": "transactions",
-          "type": "unlimited"
-        },
         "/api/scan/v0/transfer-command": {
           "name": "transfer-command-status",
           "type": "unlimited"
@@ -2153,10 +2149,6 @@
         },
         "/api/scan/v0/synchronizer-identities": {
           "name": "synchronizer-identities",
-          "type": "unlimited"
-        },
-        "/api/scan/v0/transactions": {
-          "name": "transactions",
           "type": "unlimited"
         },
         "/api/scan/v0/transfer-command": {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -997,10 +997,6 @@
           "name": "synchronizer-identities",
           "type": "unlimited"
         },
-        "/api/scan/v0/transactions": {
-          "name": "transactions",
-          "type": "unlimited"
-        },
         "/api/scan/v0/transfer-command": {
           "name": "transfer-command-status",
           "type": "unlimited"

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -6,3 +6,7 @@
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
 .. release-notes:: Upcoming
+
+    - Scan app
+
+        - Remove deprecated ``/transactions`` endpoint.


### PR DESCRIPTION
Already deprecated, we removed /activities already, metrics show basically no usage (< 1 request per day) and next release is 0.7.0 so perfect time for removing a deprecated endpoint.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
