### PR TITLE
TBAR: Guard meta row insertion on traffic summaries

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
@@ -243,30 +243,37 @@ class ScanVerdictIngestionService(
           // Compute app activity records (before DB transaction).
           // Records have verdictRowId = DUMMY_VERDICT_ROW_ID
           // the store resolves actual row_ids during insertion.
-          (appActivityRecords, lastArchivedRoundO) <- appActivityComputationO match {
-            case Some(appActivityComputation) =>
-              for {
-                records <- appActivityComputation.computeActivities(summariesWithVerdicts).map {
-                  _.flatMap { case (summary, _, recordO) =>
-                    recordO.map(summary.sequencingTime -> _)
+          (appActivityRecords, firstActiveRoundO, lastArchivedRoundO) <-
+            appActivityComputationO match {
+              case Some(appActivityComputation) =>
+                val recordTimes =
+                  verdicts.map(v => CantonTimestamp.tryFromProtoTimestamp(v.getRecordTime))
+                for {
+                  records <- appActivityComputation.computeActivities(summariesWithVerdicts).map {
+                    _.flatMap { case (summary, _, recordO) =>
+                      recordO.map(summary.sequencingTime -> _)
+                    }
                   }
-                }
-                lastArchivedRoundO <- verdicts
-                  .map(v => CantonTimestamp.tryFromProtoTimestamp(v.getRecordTime))
-                  .maxOption match {
-                  case Some(maxRecordTime) =>
-                    appActivityComputation.lookupLatestArchivedOpenMiningRound(maxRecordTime)
-                  case None => Future.successful(None)
-                }
-              } yield (records, lastArchivedRoundO)
-            case None => Future.successful((Seq.empty, None))
-          }
+                  firstActiveRoundO <- recordTimes.minOption match {
+                    case Some(minRecordTime) =>
+                      appActivityComputation.lookupActiveOpenMiningRound(minRecordTime)
+                    case None => Future.successful(None)
+                  }
+                  lastArchivedRoundO <- recordTimes.maxOption match {
+                    case Some(maxRecordTime) =>
+                      appActivityComputation.lookupLatestArchivedOpenMiningRound(maxRecordTime)
+                    case None => Future.successful(None)
+                  }
+                } yield (records, firstActiveRoundO, lastArchivedRoundO)
+              case None => Future.successful((Seq.empty, None, None))
+            }
 
           _ <- ensureVerdictsHaveTrafficSummaries(verdicts, summaryByTime)
           _ <- store.insertVerdictsWithAppActivityRecords(
             items,
             appActivityRecords,
             hasTrafficSummaries = summaryByTime.nonEmpty,
+            firstActiveRoundO = firstActiveRoundO,
             lastArchivedRoundO = lastArchivedRoundO,
           )
         } yield {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
@@ -266,7 +266,8 @@ class ScanVerdictIngestionService(
           _ <- store.insertVerdictsWithAppActivityRecords(
             items,
             appActivityRecords,
-            lastArchivedRoundO,
+            hasTrafficSummaries = summaryByTime.nonEmpty,
+            lastArchivedRoundO = lastArchivedRoundO,
           )
         } yield {
           val lastRecordTime = verdicts.lastOption

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -49,6 +49,14 @@ class AppActivityComputation(
   )(implicit tc: TraceContext): Future[Option[Long]] =
     rewardsReferenceStore.lookupLatestArchivedOpenMiningRound(asOf)
 
+  /** The OpenMiningRound round number active at asOf, if the round data has been ingested. */
+  def lookupActiveOpenMiningRound(
+      asOf: CantonTimestamp
+  )(implicit tc: TraceContext): Future[Option[Long]] =
+    rewardsReferenceStore
+      .lookupActiveOpenMiningRounds(Seq(asOf))
+      .map(_.get(asOf).map { case (roundNumber, _) => roundNumber })
+
   /** Compute app activity records for a batch of verdicts.
     *
     * Records are returned with verdictRowId = DUMMY_VERDICT_ROW_ID as a placeholder.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/rewards/AppActivityComputation.scala
@@ -133,8 +133,12 @@ class AppActivityComputation(
                 }
               case None =>
                 // Skip activity record computation as we don't have the necessary round data ingested.
-                // This can happen for freshly onboarded SVs, but is not
-                // expected to happen once the first activity record has been computed.
+                // This can happen for freshly onboarded SVs if the reward
+                // reference store does not have the data for any of the
+                // sequencingTime(s) in this batch.
+                // OTOH this cannot happen after ingestion starts because
+                // lookupActiveOpenMiningRounds blocks until the reference store
+                // has caught up to all the sequencingTime(s) in this batch.
                 logger.debug(
                   s"No round data found for sequencingTime=${summary.sequencingTime}, skipping activity record computation"
                 )

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -300,13 +300,15 @@ class DbAppActivityRecordStore(
   /** Insert activity records and ensure the meta row exists.
     * Creates the meta row when enough information is available to
     * determine which rounds have complete activity, even when no
-    * activity records exist (e.g., no featured app providers).
+    * activity records exist (e.g., no featured app providers),
+    * but only if traffic-summaries could be obtained for this batch.
     * On a fresh firstSV with no archived rounds, bootstraps round 0
     * as complete.
     */
   def insertAppActivityRecordsDBIO(
       items: Seq[AppActivityRecordT],
       firstRecordTimeMicros: Long,
+      hasTrafficSummaries: Boolean,
       lastArchivedRoundO: Option[Long] = None,
   )(implicit tc: TraceContext): DBIO[Unit] = {
     val insertRecords =
@@ -337,10 +339,11 @@ class DbAppActivityRecordStore(
     for {
       _ <- insertRecords
       ensureResult <- earliestRound match {
-        case Some(earliest) =>
+        case Some(earliest) if hasTrafficSummaries =>
           ensureMetaDBIO((firstRecordTimeMicros, earliest), lastArchived)
-        case None =>
-          // No archived rounds and not firstSV — skip meta creation.
+        case _ =>
+          // Either no archived rounds and not firstSV, or this batch
+          // doesn't have traffic summaries yet — skip meta creation.
           // A later verdict batch will create it.
           DBIO.successful(Resume: MetaCheckResult)
       }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -309,6 +309,7 @@ class DbAppActivityRecordStore(
       items: Seq[AppActivityRecordT],
       firstRecordTimeMicros: Long,
       hasTrafficSummaries: Boolean,
+      firstActiveRoundO: Option[Long] = None,
       lastArchivedRoundO: Option[Long] = None,
   )(implicit tc: TraceContext): DBIO[Unit] = {
     val insertRecords =
@@ -318,15 +319,9 @@ class DbAppActivityRecordStore(
           logger.info(s"Inserted ${items.size} app activity records.")
         }
 
-    // earliestRound: the lowest round covered by this ingestion batch.
-    //   - From activity records when present
-    //   - From lastArchivedRound when no featured apps produced records
-    //   - From bootstrap (-1) on a fresh firstSV with no archived rounds
-    val earliestRound = items
-      .map(_.roundNumber)
-      .minOption
-      .orElse(lastArchivedRoundO)
-      .orElse(if (isFirstSv) Some(-1L) else None)
+    // earliestRound: the oldest round open at the earliest record_time of this batch.
+    // or (-1) on firstSV, as it is expected to have complete data for the first round.
+    val earliestRound = if (isFirstSv) Some(-1L) else firstActiveRoundO
 
     // lastArchived: the highest round archived as of this verdict batch.
     //   - From the caller when available

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbAppActivityRecordStore.scala
@@ -337,8 +337,9 @@ class DbAppActivityRecordStore(
         case Some(earliest) if hasTrafficSummaries =>
           ensureMetaDBIO((firstRecordTimeMicros, earliest), lastArchived)
         case _ =>
-          // Either no archived rounds and not firstSV, or this batch
-          // doesn't have traffic summaries yet — skip meta creation.
+          // Either we have no rounds info and this is not firstSV,
+          // or we have not started obtaining the traffic summaries yet
+          // — skip meta creation.
           // A later verdict batch will create it.
           DBIO.successful(Resume: MetaCheckResult)
       }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
@@ -480,6 +480,8 @@ class DbScanVerdictStore(
     * @param items verdicts with transaction view constructors
     * @param appActivityRecords activity records with placeholder verdictRowIds
     * @param hasTrafficSummaries whether traffic summaries were fetched for this batch
+    * @param firstActiveRoundO the OpenMiningRound round active at the earliest
+    *                          record time of the batch
     * @param lastArchivedRoundO the highest archived OpenMiningRound round as of the
     *                           max record time of the batch
     */
@@ -487,6 +489,7 @@ class DbScanVerdictStore(
       items: NonEmptyList[(VerdictT, Long => Seq[TransactionViewT])],
       appActivityRecords: Seq[(CantonTimestamp, AppActivityRecordT)],
       hasTrafficSummaries: Boolean,
+      firstActiveRoundO: Option[Long] = None,
       lastArchivedRoundO: Option[Long] = None,
   )(implicit tc: TraceContext): Future[Unit] = {
     import profile.api.jdbcActionExtensionMethods
@@ -501,6 +504,7 @@ class DbScanVerdictStore(
         resolvedAppActivityRecords,
         items.head._1.recordTime.toMicros,
         hasTrafficSummaries,
+        firstActiveRoundO,
         lastArchivedRoundO,
       )
     } yield ()
@@ -549,6 +553,7 @@ class DbScanVerdictStore(
       items: Seq[AppActivityRecordT],
       firstRecordTimeMicros: Long,
       hasTrafficSummaries: Boolean,
+      firstActiveRoundO: Option[Long],
       lastArchivedRoundO: Option[Long],
   )(implicit tc: TraceContext): DBIO[Unit] =
     appActivityRecordStoreO match {
@@ -558,6 +563,7 @@ class DbScanVerdictStore(
           items,
           firstRecordTimeMicros,
           hasTrafficSummaries,
+          firstActiveRoundO,
           lastArchivedRoundO,
         )
     }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
@@ -479,12 +479,14 @@ class DbScanVerdictStore(
     *
     * @param items verdicts with transaction view constructors
     * @param appActivityRecords activity records with placeholder verdictRowIds
+    * @param hasTrafficSummaries whether traffic summaries were fetched for this batch
     * @param lastArchivedRoundO the highest archived OpenMiningRound round as of the
     *                           max record time of the batch
     */
   def insertVerdictsWithAppActivityRecords(
       items: NonEmptyList[(VerdictT, Long => Seq[TransactionViewT])],
       appActivityRecords: Seq[(CantonTimestamp, AppActivityRecordT)],
+      hasTrafficSummaries: Boolean,
       lastArchivedRoundO: Option[Long] = None,
   )(implicit tc: TraceContext): Future[Unit] = {
     import profile.api.jdbcActionExtensionMethods
@@ -498,6 +500,7 @@ class DbScanVerdictStore(
       _ <- insertAppActivityRecordsDBIO(
         resolvedAppActivityRecords,
         items.head._1.recordTime.toMicros,
+        hasTrafficSummaries,
         lastArchivedRoundO,
       )
     } yield ()
@@ -545,12 +548,18 @@ class DbScanVerdictStore(
   private def insertAppActivityRecordsDBIO(
       items: Seq[AppActivityRecordT],
       firstRecordTimeMicros: Long,
+      hasTrafficSummaries: Boolean,
       lastArchivedRoundO: Option[Long],
   )(implicit tc: TraceContext): DBIO[Unit] =
     appActivityRecordStoreO match {
       case None => DBIO.successful(())
       case Some(s) =>
-        s.insertAppActivityRecordsDBIO(items, firstRecordTimeMicros, lastArchivedRoundO)
+        s.insertAppActivityRecordsDBIO(
+          items,
+          firstRecordTimeMicros,
+          hasTrafficSummaries,
+          lastArchivedRoundO,
+        )
     }
 
   private def afterFilters(

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -170,6 +170,7 @@ class DbAppActivityRecordStoreTest
           NonEmptyList.of(verdict1 -> noViews, verdict2 -> noViews),
           appActivityRecords,
           hasTrafficSummaries = true,
+          firstActiveRoundO = Some(10L),
           lastArchivedRoundO = Some(9L),
         )
 
@@ -211,6 +212,7 @@ class DbAppActivityRecordStoreTest
           NonEmptyList.of(mkVerdict(verdictStore, "update-mono-1", baseTs) -> noViews),
           Seq(baseTs -> mkRecord(0L, 10L, Seq("app1::provider"), Seq(100L))),
           hasTrafficSummaries = true,
+          firstActiveRoundO = Some(10L),
           lastArchivedRoundO = Some(9L),
         )
         // A later batch without activity records still advances the round
@@ -220,10 +222,12 @@ class DbAppActivityRecordStoreTest
           ),
           Seq.empty,
           hasTrafficSummaries = true,
+          firstActiveRoundO = Some(11L),
           lastArchivedRoundO = Some(10L),
         )
         meta <- appStore.lookupActivityRecordMeta(1, 0)
       } yield {
+        meta.value.earliestIngestedRound shouldBe 10L
         meta.value.lastArchivedRound shouldBe Some(10L)
       }
     }
@@ -237,15 +241,16 @@ class DbAppActivityRecordStoreTest
           NonEmptyList.of(mkVerdict(verdictStore, "update-no-meta", baseTs) -> noViews),
           Seq.empty,
           hasTrafficSummaries = true,
-          lastArchivedRoundO = Some(7L),
+          firstActiveRoundO = Some(7L),
+          lastArchivedRoundO = None,
         )
         meta <- appStore.lookupActivityRecordMeta(1, 0)
       } yield {
-        // Meta row is created with earliestRound = lastArchivedRound
-        // because verdict ingestion is active even without activity records
+        // Meta row is created using the firstActiveRoundO
+        // even though there are no activity records
         meta shouldBe defined
         meta.value.earliestIngestedRound shouldBe 7L
-        meta.value.lastArchivedRound shouldBe Some(7L)
+        meta.value.lastArchivedRound shouldBe None
       }
     }
 
@@ -270,29 +275,29 @@ class DbAppActivityRecordStoreTest
       }
     }
 
-    "insert verdicts without activity records when appActivityRecords is empty" in {
+    "insert verdicts without activity records, when reward reference store does not have data asOf" in {
       for {
         (appStore, verdictStore) <- newStores()
         baseTs = CantonTimestamp.now()
 
         verdict = mkVerdict(verdictStore, "update-no-activity", baseTs)
 
+        // firstActiveRoundO is None, as reward reference store began ingestion after baseTx
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(verdict -> noViews),
           Seq.empty,
           hasTrafficSummaries = true,
+          firstActiveRoundO = None,
+          lastArchivedRoundO = None,
         )
 
         v <- verdictStore.getVerdictByUpdateId("update-no-activity")
         countAfter <- countRecords()
-        // No meta row should be created when there are no activity records
         meta <- appStore.lookupActivityRecordMeta(1, 0)
       } yield {
         v shouldBe defined
         countAfter shouldBe 0L
-        // Non-firstSV with no lastArchivedRound: meta row is not created
-        // because it would have last_archived_round = NULL, making no
-        // rounds complete.
+        // Non-firstSV with no firstActiveRoundO: meta row is not created
         meta shouldBe None
       }
     }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -169,6 +169,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(verdict1 -> noViews, verdict2 -> noViews),
           appActivityRecords,
+          hasTrafficSummaries = true,
           lastArchivedRoundO = Some(9L),
         )
 
@@ -209,6 +210,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(mkVerdict(verdictStore, "update-mono-1", baseTs) -> noViews),
           Seq(baseTs -> mkRecord(0L, 10L, Seq("app1::provider"), Seq(100L))),
+          hasTrafficSummaries = true,
           lastArchivedRoundO = Some(9L),
         )
         // A later batch without activity records still advances the round
@@ -217,6 +219,7 @@ class DbAppActivityRecordStoreTest
             mkVerdict(verdictStore, "update-mono-2", baseTs.plusSeconds(1L)) -> noViews
           ),
           Seq.empty,
+          hasTrafficSummaries = true,
           lastArchivedRoundO = Some(10L),
         )
         meta <- appStore.lookupActivityRecordMeta(1, 0)
@@ -233,6 +236,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(mkVerdict(verdictStore, "update-no-meta", baseTs) -> noViews),
           Seq.empty,
+          hasTrafficSummaries = true,
           lastArchivedRoundO = Some(7L),
         )
         meta <- appStore.lookupActivityRecordMeta(1, 0)
@@ -242,6 +246,27 @@ class DbAppActivityRecordStoreTest
         meta shouldBe defined
         meta.value.earliestIngestedRound shouldBe 7L
         meta.value.lastArchivedRound shouldBe Some(7L)
+      }
+    }
+
+    "Does not create meta row when traffic summaries are absent" in {
+      for {
+        (appStore, verdictStore) <- newStores()
+        baseTs = CantonTimestamp.now()
+
+        _ <- verdictStore.insertVerdictsWithAppActivityRecords(
+          NonEmptyList.of(mkVerdict(verdictStore, "update-no-meta", baseTs) -> noViews),
+          Seq.empty,
+          hasTrafficSummaries = false,
+          lastArchivedRoundO = Some(7L),
+        )
+        v <- verdictStore.getVerdictByUpdateId("update-no-meta")
+        countAfter <- countRecords()
+        meta <- appStore.lookupActivityRecordMeta(1, 0)
+      } yield {
+        v shouldBe defined
+        countAfter shouldBe 0L
+        meta shouldBe None
       }
     }
 
@@ -255,6 +280,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(verdict -> noViews),
           Seq.empty,
+          hasTrafficSummaries = true,
         )
 
         v <- verdictStore.getVerdictByUpdateId("update-no-activity")
@@ -289,6 +315,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(verdict1 -> noViews, verdict2 -> noViews, verdict3 -> noViews),
           appActivityRecords,
+          hasTrafficSummaries = true,
         )
 
         v1 <- verdictStore.getVerdictByUpdateId("update-with-1")
@@ -335,6 +362,7 @@ class DbAppActivityRecordStoreTest
         _ <- verdictStore.insertVerdictsWithAppActivityRecords(
           NonEmptyList.of(verdict -> noViews),
           appActivityRecords,
+          hasTrafficSummaries = true,
         )
 
         v <- verdictStore.getVerdictByUpdateId("update-mismatch")

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -275,6 +275,38 @@ class DbAppActivityRecordStoreTest
       }
     }
 
+    "on a fresh firstSV, does not create meta row when traffic summaries are absent" in {
+      for {
+        (appStore, verdictStore) <- newStores(isFirstSv = true)
+        baseTs = CantonTimestamp.now()
+
+        _ <- verdictStore.insertVerdictsWithAppActivityRecords(
+          NonEmptyList.of(mkVerdict(verdictStore, "update-firstsv-2", baseTs) -> noViews),
+          Seq.empty,
+          hasTrafficSummaries = false,
+        )
+        // Even on firstSV, missing traffic summaries defer meta creation
+        // to a later batch.
+        metaBefore <- appStore.lookupActivityRecordMeta(1, 0)
+
+        // A later batch with traffic summaries creates the meta row.
+        _ <- verdictStore.insertVerdictsWithAppActivityRecords(
+          NonEmptyList.of(
+            mkVerdict(verdictStore, "update-firstsv-3", baseTs.plusSeconds(1L)) -> noViews
+          ),
+          Seq.empty,
+          hasTrafficSummaries = true,
+        )
+        metaAfter <- appStore.lookupActivityRecordMeta(1, 0)
+      } yield {
+        metaBefore shouldBe None
+
+        metaAfter shouldBe defined
+        metaAfter.value.earliestIngestedRound shouldBe -1L
+        metaAfter.value.lastArchivedRound shouldBe Some(0L)
+      }
+    }
+
     "insert verdicts without activity records, when reward reference store does not have data asOf" in {
       for {
         (appStore, verdictStore) <- newStores()
@@ -1084,7 +1116,9 @@ class DbAppActivityRecordStoreTest
   /** Creates both an app activity record store and a verdict store backed by
     * the same UpdateHistory, for testing insertVerdictsWithAppActivityRecords.
     */
-  private def newStores(): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
+  private def newStores(
+      isFirstSv: Boolean = false
+  ): Future[(DbAppActivityRecordStore, DbScanVerdictStore)] = {
     val participantId = mkParticipantId("activity-test")
     val updateHistory = new UpdateHistory(
       storage.underlying,
@@ -1103,7 +1137,7 @@ class DbAppActivityRecordStoreTest
         storage.underlying,
         updateHistory,
         DbAppActivityRecordStore.IngestionVersions(1, 0),
-        isFirstSv = false,
+        isFirstSv,
         loggerFactory,
       )
       val verdictStore = new DbScanVerdictStore(


### PR DESCRIPTION
Fixes #6463 
Fixes #6499 

- Add test for first SV scenario
- Fix a comment
### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
