### PR TITLE
Fix curl retry piped into jq in skip_on_static and daml_comp…

### DIFF
--- a/.github/actions/tests/skip_on_static/action.yml
+++ b/.github/actions/tests/skip_on_static/action.yml
@@ -24,10 +24,17 @@ runs:
           # as the latter is fixed when the job starts which for `env_hold` jobs
           # is _before_ the approval already e.g. when an external contributor
           # created the PR and not when the maintainer approved it after adding the static label.
-          pr_labels=$(curl -sSL --fail-with-body -H "Authorization: Bearer ${{ inputs.gh_token }}" \
-                             --retry 10 --retry-delay 10 --retry-all-errors \
-                             -H "Accept: application/vnd.github.v3+json" \
-                             "${{ github.event.pull_request.url }}" | jq '.labels')
+          # Write the response to a file instead of piping into jq: curl resets an
+          # -o output file between retries, but a pipe keeps the failed-attempt
+          # bodies (breaking jq) and dies once jq exits (curl error 23).
+          pr_json="$RUNNER_TEMP/pr.json"
+          curl -sSL --fail-with-body -o "$pr_json" \
+               -H "Authorization: Bearer ${{ inputs.gh_token }}" \
+               --retry 10 --retry-delay 10 --retry-all-errors \
+               -H "Accept: application/vnd.github.v3+json" \
+               "${{ github.event.pull_request.url }}" \
+            || { echo "PR fetch failed; last response body:"; cat "$pr_json"; exit 1; }
+          pr_labels=$(jq '.labels' "$pr_json")
           echo "Pull request labels: $pr_labels"
           static_label=$(echo "$pr_labels" | jq -r '.[] | select(.name == "static") | .name' | grep -c 'static' || true)
           if [[ "$last_commit_msg" == *"[static]"* ]] || [[ "$static_label" -gt 0 ]]; then

--- a/.github/workflows/daml_compat_test.yml
+++ b/.github/workflows/daml_compat_test.yml
@@ -24,7 +24,10 @@ jobs:
         id: get_mainnet_version
         run: |
           set -eou pipefail
-          version="$(curl -sSL --fail-with-body https://docs.global.canton.network.sync.global/info | jq -r '.sv.version')"
+          info_json="$RUNNER_TEMP/info.json"
+          curl -sSL --fail-with-body -o "$info_json" https://docs.global.canton.network.sync.global/info \
+            || { echo "Fetch failed; response body:"; cat "$info_json"; exit 1; }
+          version="$(jq -r '.sv.version' "$info_json")"
           echo "MainNet version is $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
…at_test

Failed-attempt bodies from --fail-with-body corrupt the pipe into jq (parse error, then EPIPE storm). Write to a file instead: curl resets an -o output file between retries.

Fixes #7443

## Testing

Reproduced end-to-end against a local mock of the GitHub API that returns a plain-text 503 for the
first two requests and valid JSON afterwards:

<details>
<summary>mock_gh.py</summary>

```python
"""Mock GitHub API: first FAILS requests get a 503 with a plain-text body, then 200 JSON."""
import http.server
import json
import sys

FAILS = int(sys.argv[1]) if len(sys.argv) > 1 else 2
PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 8931
count = {"n": 0}


class Handler(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        count["n"] += 1
        if count["n"] <= FAILS:
            body = b"upstream connect error or disconnect/reset before headers"
            self.send_response(503)
        else:
            body = json.dumps(
                {"number": 1, "labels": [{"name": "static"}, {"name": "other"}]}
            ).encode()
            self.send_response(200)
        self.send_header("Content-Type", "application/json" if count["n"] > FAILS else "text/plain")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, fmt, *args):
        print(f"[mock] attempt {count['n']}: {fmt % args}", file=sys.stderr)


http.server.HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
```

</details>

**1. Old pattern reproduces the CI failure** — and fails even though the third attempt succeeds,
because the two 503 bodies are concatenated ahead of the JSON in the pipe:

```console
$ python3 mock_gh.py 2 8931 &   # 2 failures, then success
$ pr_labels=$(curl -sSL --fail-with-body --retry 10 --retry-delay 1 --retry-all-errors \
      -H "Accept: application/vnd.github.v3+json" "http://127.0.0.1:8931/pr" | jq '.labels')
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
jq: parse error: Invalid numeric literal at line 1, column 9
```

**2. New pattern recovers across retries** (same mock, 2 failures then success), including the
downstream `static_label` logic:

```console
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
SUCCESS pr_labels=[
  {
    "name": "static"
  },
  {
    "name": "other"
  }
]
static_label=1
```

**3. New pattern with all retries exhausted** fails the step cleanly and shows the response body:

```console
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
PR fetch failed; last response body:
upstream connect error or disconnect/reset before headers
step exit code: 1
```

In-CI validation: `skip_on_static` runs on this PR itself — the "Check if static only" step log
shows the new code path fetching and parsing the labels. Adding the `static` label and re-running
exercises the label-detection branch (`skip=true`).

### Verified in this PR's own CI runs

- `[ci]` commit → labels fetched & parsed, `skip=false`:
  [`Pull request labels: []` → `Not static-test-only`](https://github.com/canton-network/splice/actions/runs/30349562049/job/90243775064#step:3:48)
- `[static]` commit (earlier push) → same fetch, `skip=true`:
  [`Only static tests should be running`, `Static label count: 0`](https://github.com/canton-network/splice/actions/runs/30349374207/job/90242984997#step:3:48)

Both links point at the "Check if static only" step (step 3) of the "Cancel if not opted in" job, landing on the Pull request labels: [] line — the direct evidence that the new file-based curl+jq path fetched and parsed the live GitHub API response.