### PR TITLE
PostgreSQL 18 release notes

### DIFF
--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -7,6 +7,12 @@
 
 .. release-notes:: Upcoming
 
+    - PostgreSQL 18
+
+        - Splice now officially supports PostgreSQL 18.
+          ⚠️ Note that that PostgreSQL 14, which was the default until now, will reach End of Life on November 12, 2026.
+          You should upgrade before that date.
+
     - Scan app
 
         - Remove deprecated ``/transactions`` endpoint.


### PR DESCRIPTION
Using ⚠️ because we have different syntax from cf-docs