### PR TITLE
[ci] Bump timeout on concurrent taps in wallet batch test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -34,6 +34,8 @@ import com.digitalasset.canton.discard.Implicits.DiscardOps
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import org.apache.pekko.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.{Seconds, Span}
 import org.slf4j.event.Level
 
 import java.time.Duration
@@ -225,9 +227,12 @@ class WalletIntegrationTest
 
           val tapsAfter = Range(0, 3).map(_ => Future(Try(aliceWalletClient.tap(10))))
 
-          // Wait for all futures to complete
-          val successfulTaps = (tapsBefore ++ tapsAfter).map(_.futureValue).count(_.isSuccess)
-          if (failedAcceptF.futureValue.isSuccess)
+          // Wait for all futures to complete. The stale accept forces the treasury to filter
+          // and retry batches, so under load this can exceed the default patience.
+          val patience = PatienceConfiguration.Timeout(Span(60, Seconds))
+          val successfulTaps =
+            (tapsBefore ++ tapsAfter).map(_.futureValue(patience)).count(_.isSuccess)
+          if (failedAcceptF.futureValue(patience).isSuccess)
             fail("The AcceptTransferOffer action unexpectedly succeeded")
 
           successfulTaps should be(


### PR DESCRIPTION
Improves https://github.com/DACH-NY/cn-test-failures/issues/9392

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
