### PR TITLE
[ci] Ignore background warnings in actAs-dso log assertion

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingAddlIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingAddlIntegrationTest.scala
@@ -13,6 +13,7 @@ import org.lfdecentralizedtrust.splice.sv.util.{SvOnboardingToken, SvUtil}
 import scala.jdk.OptionConverters.*
 import org.lfdecentralizedtrust.splice.sv.admin.api.client.commands.HttpSvPublicAppClient.SvOnboardingStatus
 import org.lfdecentralizedtrust.splice.util.{SvTestUtil, WalletTestUtil}
+import com.digitalasset.canton.console.CommandFailure
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.topology.transaction.ParticipantPermission
 import org.slf4j.event.Level
@@ -349,7 +350,11 @@ class SvOnboardingAddlIntegrationTest
       }
       clue("create a amulet again with actAs = DSO") {
         withCommandRetryPolicy(_ => _ => false) {
-          assertThrowsAndLogsCommandFailures(
+          // Suppress at ERROR level only: background WARNs (e.g. the SV app failing to read the
+          // bft sequencers list while sv2's scan is unavailable) must not fail the log assertion.
+          loggerFactory.assertThrowsAndLogsSuppressing[CommandFailure](
+            SuppressionRule.LevelAndAbove(Level.ERROR)
+          )(
             createAmulet(
               sv1ValidatorBackend.participantClientWithAdminToken,
               sv1UserId,


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9432

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
