### PR TITLE
[ci] Recover accepted DUPLICATE_COMMAND in SpliceLedgerConnection ded…

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTransferIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardTransferIntegrationTest.scala
@@ -1,7 +1,6 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.concurrent.Threading
-import com.digitalasset.canton.console.CommandFailure
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.{HasActorSystem, HasExecutionContext}
 import org.lfdecentralizedtrust.splice.codegen.java.splice.api.token.metadatav1
@@ -428,25 +427,28 @@ class TokenStandardTransferIntegrationTest
         trackingId,
       )
 
-      assertThrows[CommandFailure](
-        loggerFactory.assertLogs(
-          aliceWalletClient.createTokenStandardTransfer(
-            bobUserParty,
-            10,
-            "not ok, resubmitted same trackingId so should be rejected",
-            expiration,
-            trackingId,
-          ),
-          _.errorMessage should include("Command submission already exists"),
-        )
-      )
+      val createdCid = created.output match {
+        case members.TransferInstructionPending(value) => value.transferInstructionCid
+        case x => fail(s"Expected pending transfer, got $x")
+      }
 
+      // Resubmitting the same trackingId is deduplicated idempotently: the accepted duplicate is
+      // recovered centrally and returns the original result instead of failing.
+      val resubmitted = aliceWalletClient.createTokenStandardTransfer(
+        bobUserParty,
+        10,
+        "resubmitted with the same trackingId",
+        expiration,
+        trackingId,
+      )
+      inside(resubmitted.output) { case members.TransferInstructionPending(value) =>
+        value.transferInstructionCid shouldBe createdCid
+      }
+
+      // Still exactly one transfer instruction, i.e. no duplicate was created.
       eventually() {
         inside(aliceWalletClient.listTokenStandardTransfers()) { case Seq(t) =>
-          t.contractId.contractId should be(created.output match {
-            case members.TransferInstructionPending(value) => value.transferInstructionCid
-            case x => fail(s"Expected pending transfer, got $x")
-          })
+          t.contractId.contractId should be(createdCid)
         }
       }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardV2TransferIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TokenStandardV2TransferIntegrationTest.scala
@@ -1,7 +1,6 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
 import com.digitalasset.canton.concurrent.Threading
-import com.digitalasset.canton.console.CommandFailure
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.{HasActorSystem, HasExecutionContext}
 import org.lfdecentralizedtrust.splice.codegen.java.splice.api.token.transferinstructionv2.transferinstructionresult_output.TransferInstructionResult_Completed
@@ -381,25 +380,28 @@ class TokenStandardV2TransferIntegrationTest
         trackingId,
       )
 
-      assertThrows[CommandFailure](
-        loggerFactory.assertLogs(
-          aliceWalletClient.createTokenStandardTransferV2(
-            bobUserParty,
-            10,
-            "not ok, resubmitted same trackingId so should be rejected",
-            expiration,
-            trackingId,
-          ),
-          _.errorMessage should include("Command submission already exists"),
-        )
-      )
+      val createdCid = created.output match {
+        case members.TransferInstructionPending(value) => value.transferInstructionCid
+        case x => fail(s"Expected pending transfer, got $x")
+      }
 
+      // Resubmitting the same trackingId is deduplicated idempotently: the accepted duplicate is
+      // recovered centrally and returns the original result instead of failing.
+      val resubmitted = aliceWalletClient.createTokenStandardTransferV2(
+        bobUserParty,
+        10,
+        "resubmitted with the same trackingId",
+        expiration,
+        trackingId,
+      )
+      inside(resubmitted.output) { case members.TransferInstructionPending(value) =>
+        value.transferInstructionCid shouldBe createdCid
+      }
+
+      // Still exactly one transfer instruction, i.e. no duplicate was created.
       eventually() {
         inside(aliceWalletClient.listTokenStandardTransfers()) { case Seq(t) =>
-          t.contractId.contractId should be(created.output match {
-            case members.TransferInstructionPending(value) => value.transferInstructionCid
-            case x => fail(s"Expected pending transfer, got $x")
-          })
+          t.contractId.contractId should be(createdCid)
         }
       }
     }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletBuyTrafficRequestIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletBuyTrafficRequestIntegrationTest.scala
@@ -274,6 +274,11 @@ class WalletBuyTrafficRequestIntegrationTest
       onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
       aliceWalletClient.tap(100.0)
 
+      // All 10 concurrent calls share the same tracking id. Recovering an accepted duplicate
+      // needs a completed submission to read back, which concurrent submissions do not have:
+      // the losers are rejected with SUBMISSION_ALREADY_IN_FLIGHT rather than DUPLICATE_COMMAND,
+      // so only one call succeeds. Duplicates of an already-completed submission are covered by
+      // the sequential dedup tests instead.
       val successes = loggerFactory.assertLoggedWarningsAndErrorsSeq(
         {
           MonadUtil

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletBuyTrafficRequestIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletBuyTrafficRequestIntegrationTest.scala
@@ -274,11 +274,6 @@ class WalletBuyTrafficRequestIntegrationTest
       onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
       aliceWalletClient.tap(100.0)
 
-      // All 10 concurrent calls share the same tracking id. Recovering an accepted duplicate
-      // needs a completed submission to read back, which concurrent submissions do not have:
-      // the losers are rejected with SUBMISSION_ALREADY_IN_FLIGHT rather than DUPLICATE_COMMAND,
-      // so only one call succeeds. Duplicates of an already-completed submission are covered by
-      // the sequential dedup tests instead.
       val successes = loggerFactory.assertLoggedWarningsAndErrorsSeq(
         {
           MonadUtil
@@ -312,6 +307,12 @@ class WalletBuyTrafficRequestIntegrationTest
             ))
           ),
       )
+      // All 10 calls share the same tracking id, but the dedup recovery does not apply here:
+      // reading back an accepted duplicate needs a completed submission, which concurrent
+      // submissions do not have. So one call wins and the other 9 are rejected, mostly with
+      // SUBMISSION_ALREADY_IN_FLIGHT from the participant and some with 429 from the rate
+      // limiter. Duplicates of an already-completed submission are covered by the sequential
+      // dedup tests.
       successes shouldBe 1
     }
   }

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletIntegrationTest.scala
@@ -91,10 +91,8 @@ class WalletIntegrationTest
     "tap deduplicates" in { implicit env =>
       onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
       aliceWalletClient.tap(50.0, Some("dedup-test"))
-      assertThrowsAndLogsCommandFailures(
-        aliceWalletClient.tap(50.0, Some("dedup-test")),
-        _.errorMessage should include("409 Conflict"),
-      )
+      // Duplicate tap with the same command id returns the original result idempotently (200, not 409).
+      aliceWalletClient.tap(50.0, Some("dedup-test"))
     }
 
     "allow two wallet app users to connect to one wallet backend and tap" in { implicit env =>
@@ -548,10 +546,11 @@ class WalletIntegrationTest
             aliceWalletClient.balance().unlockedQty should be(40.0)
           },
         )
-        assertThrowsAndLogsCommandFailures(
-          bobWalletClient.transferPreapprovalSend(aliceUserParty, 40.0, deduplicationId),
-          _.errorMessage should include("409 Conflict"),
-        )
+        // Duplicate send with same deduplication id returns the original result idempotently (200, not 409).
+        bobWalletClient.transferPreapprovalSend(aliceUserParty, 40.0, deduplicationId)
+        // Balance is unchanged — idempotent
+        bobWalletClient.balance().unlockedQty should be(60.0)
+        aliceWalletClient.balance().unlockedQty should be(40.0)
 
         clue("Preapproval sends work if provider has a featured app right") {
           // Feature alice validator to test a transfer with a featured preapproval provider

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletPaymentIntegrationTest.scala
@@ -252,6 +252,15 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
         trackingId,
       )
 
+      // Wait for the offer to be ingested, so that the resubmission hits the trackingId check
+      // instead of racing it. A duplicate that loses the race is recovered from the ledger and
+      // returns the original offer rather than failing.
+      eventually() {
+        inside(aliceWalletClient.listTransferOffers()) { case Seq(t) =>
+          t.contractId should be(offerId)
+        }
+      }
+
       assertThrows[CommandFailure](
         loggerFactory.assertLogs(
           aliceWalletClient.createTransferOffer(
@@ -261,16 +270,13 @@ class WalletPaymentIntegrationTest extends IntegrationTest with WalletTestUtil {
             expiration,
             trackingId,
           ),
-          _.errorMessage should include("Command submission already exists").or(
-            include(s"Transfer offer with trackingId ${trackingId} already exists.")
+          _.errorMessage should include(
+            s"Transfer offer with trackingId ${trackingId} already exists."
           ),
         )
       )
 
       eventually() {
-        inside(aliceWalletClient.listTransferOffers()) { case Seq(t) =>
-          t.contractId should be(offerId)
-        }
         inside(aliceWalletClient.listTransferOffers()) { case Seq(t) =>
           t.contractId should be(offerId)
         }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/PollingTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/PollingTrigger.scala
@@ -112,6 +112,8 @@ trait PollingTrigger extends Trigger with FlagCloseableAsync {
     context.metricsFactory,
     mc.labels,
     context.retryProvider,
+    // Built outside the RetryFor typeclass, so the automation default has to be restated.
+    duplicateCommandIsFatal = false,
   )
 
   override def isHealthy: Boolean = pollingLoopRef

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryFor.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryFor.scala
@@ -8,12 +8,17 @@ import scala.concurrent.duration.*
 
 /** The intended use of a retry, expressed in terms like number of retries and
   * backoff.  Use a definition in the companion rather than constructing ''ad hoc''.
+  *
+  * `duplicateCommandIsFatal` gives up on DUPLICATE_COMMAND instead of retrying. It is set
+  * for client calls, where a duplicate cannot resolve within the deduplication window, and
+  * left off for automation, which retries and then finds its task stale.
   */
 final case class RetryFor private (
     maxRetries: Int,
     initialDelay: FiniteDuration,
     maxDelay: Duration,
     resetRetriesAfter: Option[FiniteDuration],
+    duplicateCommandIsFatal: Boolean = false,
 )
 
 object RetryFor {
@@ -67,6 +72,7 @@ object RetryFor {
     initialDelay = 100.millis,
     maxDelay = 1.seconds,
     resetRetriesAfter = None,
+    duplicateCommandIsFatal = true,
   )
 
   /** A retry intended for client calls during the init phase, timing out slower compared to the regular client calls to allow for more contention that happens during initialization. */
@@ -75,5 +81,6 @@ object RetryFor {
     initialDelay = 100.millis,
     maxDelay = 3.seconds,
     resetRetriesAfter = None,
+    duplicateCommandIsFatal = true,
   )
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryProvider.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryProvider.scala
@@ -600,9 +600,18 @@ object RetryProvider {
               case _ => false
             }
 
+            val isDuplicateCommand = errorDetails.exists {
+              case detail: ErrorDetails.ErrorInfoDetail =>
+                (detail.errorCodeId: String) == "DUPLICATE_COMMAND"
+              case _ => false
+            }
+
             errorCategory match {
               // Pruning errors fall under FAILED_PRECONDITION which we usually retry but there is no chance to recover from it so we instead treat it as a fatal error.
               case _ if isPruningError => fatalError
+              // DUPLICATE_COMMAND: accepted duplicates are recovered centrally in SpliceLedgerConnection;
+              // rejected ones can never succeed within the dedup window — don't retry either.
+              case _ if isDuplicateCommand => fatalError
               case Some(cat) if cat.retryable.nonEmpty || extraRetryableCategories.contains(cat) =>
                 //  don't log the stack traces of transient gRPC exceptions to make the logs less noisy.
                 val msg =

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryProvider.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/RetryProvider.scala
@@ -472,6 +472,7 @@ final class RetryProvider(
             "operation" -> operationId
           ),
           this,
+          retryConfig.duplicateCommandIsFatal,
         ),
       )
     }
@@ -516,6 +517,7 @@ object RetryProvider {
       metricsFactory: LabeledMetricsFactory,
       additionalMetricsLabels: Map[String, String],
       flagCloseable: FlagCloseable,
+      duplicateCommandIsFatal: Boolean,
   ) extends ExceptionRetryPolicy {
     // Additional categories that are not marked as retryable but we
     // can safely retry since we know there are other apps or
@@ -609,9 +611,9 @@ object RetryProvider {
             errorCategory match {
               // Pruning errors fall under FAILED_PRECONDITION which we usually retry but there is no chance to recover from it so we instead treat it as a fatal error.
               case _ if isPruningError => fatalError
-              // DUPLICATE_COMMAND: accepted duplicates are recovered centrally in SpliceLedgerConnection;
-              // rejected ones can never succeed within the dedup window — don't retry either.
-              case _ if isDuplicateCommand => fatalError
+              // Accepted duplicates are recovered centrally in SpliceLedgerConnection; a rejected
+              // one can never succeed within the dedup window, so client calls give up here.
+              case _ if isDuplicateCommand && duplicateCommandIsFatal => fatalError
               case Some(cat) if cat.retryable.nonEmpty || extraRetryableCategories.contains(cat) =>
                 //  don't log the stack traces of transient gRPC exceptions to make the logs less noisy.
                 val msg =
@@ -812,6 +814,7 @@ object RetryProvider {
         metricsFactory: LabeledMetricsFactory,
         additionalMetricsLabels: Map[String, String],
         flagCloseable: FlagCloseable,
+        duplicateCommandIsFatal: Boolean,
     ): ExceptionRetryPolicy
   }
 
@@ -824,6 +827,7 @@ object RetryProvider {
             metricsFactory: LabeledMetricsFactory,
             additionalMetricsLabels: Map[String, String],
             flagCloseable: FlagCloseable,
+            duplicateCommandIsFatal: Boolean,
         ) = a(operationName)
       }
 
@@ -834,6 +838,7 @@ object RetryProvider {
           metricsFactory: LabeledMetricsFactory,
           additionalMetricsLabels: Map[String, String],
           flagCloseable: FlagCloseable,
+          duplicateCommandIsFatal: Boolean,
       ): RetryableError = RetryProvider.RetryableError(
         operationName,
         additionalCodes,
@@ -844,6 +849,7 @@ object RetryProvider {
         metricsFactory,
         additionalMetricsLabels,
         flagCloseable,
+        duplicateCommandIsFatal,
       )
     }
 
@@ -855,6 +861,7 @@ object RetryProvider {
             metricsFactory: LabeledMetricsFactory,
             additionalMetricsLabels: Map[String, String],
             flagCloseable: FlagCloseable,
+            duplicateCommandIsFatal: Boolean,
         ): RetryableError = RetryProvider.RetryableError(
           operationName,
           Seq.empty,
@@ -865,6 +872,7 @@ object RetryProvider {
           metricsFactory,
           additionalMetricsLabels,
           flagCloseable,
+          duplicateCommandIsFatal,
         )
       }
   }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -881,6 +881,7 @@ class SpliceLedgerConnection(
       priority: CommandPriority,
       deadline: Option[NonNegativeFiniteDuration] = None,
       preferredPackageIds: Seq[String] = Seq.empty,
+      recoverAcceptedDuplicates: Boolean = false,
   ) {
     private type DedupNotSpecifiedYet = CmdId =:= Any
     private type SynchronizerIdRequired = DomId <:< SynchronizerId
@@ -891,6 +892,7 @@ class SpliceLedgerConnection(
         disclosedContracts: DisclosedContracts = this.disclosedContracts,
         deadline: Option[NonNegativeFiniteDuration] = this.deadline,
         preferredPackageIds: Seq[String] = this.preferredPackageIds,
+        recoverAcceptedDuplicates: Boolean = this.recoverAcceptedDuplicates,
     ): submit[C, CmdId0, DomId0] =
       new submit(
         actAs,
@@ -902,7 +904,17 @@ class SpliceLedgerConnection(
         priority,
         deadline,
         preferredPackageIds,
+        recoverAcceptedDuplicates,
       )
+
+    /** Read an already-accepted duplicate back from the ledger and return its result, rather
+      * than failing the submission.
+      *
+      * For client calls, which cannot do anything useful with the failure. Automation leaves
+      * this off: a trigger needs the error so that its own retry re-runs the staleness check.
+      */
+    def recoveringAcceptedDuplicates(enabled: Boolean = true): submit[C, CmdId, DomId] =
+      copy(recoverAcceptedDuplicates = enabled)
 
     def withDedup(commandId: CommandId, deduplicationOffset: Long)(implicit
         cid: DedupNotSpecifiedYet
@@ -1018,7 +1030,8 @@ class SpliceLedgerConnection(
                 }
                 .recoverWith {
                   case ex: StatusRuntimeException
-                      if ex.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
+                      if recoverAcceptedDuplicates &&
+                        ex.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
                     parseDuplicateCommandAccepted(ex) match {
                       case Some(completionOffset) =>
                         client.recoverFromDuplicateCommand(

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/SpliceLedgerConnection.scala
@@ -12,7 +12,8 @@ import com.daml.ledger.javaapi.data.codegen.{ContractId, Created, Exercised, Has
 import com.daml.ledger.javaapi.data.{Command, CreatedEvent, ExercisedEvent, Transaction, User}
 import com.digitalasset.base.error.ErrorResource
 import com.digitalasset.base.error.utils.ErrorDetails
-import com.digitalasset.base.error.utils.ErrorDetails.ResourceInfoDetail
+import com.digitalasset.base.error.utils.ErrorDetails.{ErrorInfoDetail, ResourceInfoDetail}
+import io.grpc.protobuf.{StatusProto as GrpcStatusProto}
 import com.digitalasset.canton.SynchronizerAlias
 import com.digitalasset.canton.admin.api.client.data.parties.PartyDetails
 import com.digitalasset.canton.config.NonNegativeFiniteDuration
@@ -777,6 +778,23 @@ class SpliceLedgerConnection(
     callCallbacksOnCompletion(result)(x => (None, x))
   }
 
+  // Returns Some(completionOffset) when the exception is DUPLICATE_COMMAND with accepted=true,
+  // allowing callers to fetch the already-completed transaction instead of failing.
+  private def parseDuplicateCommandAccepted(ex: StatusRuntimeException): Option[Long] = {
+    val statusProto = GrpcStatusProto.fromThrowable(ex)
+    if (statusProto == null) None
+    else
+      ErrorDetails
+        .from(statusProto)
+        .collectFirst {
+          case ErrorInfoDetail(errorCodeId, metadata)
+              if errorCodeId == "DUPLICATE_COMMAND" &&
+                metadata.get("accepted").contains("true") =>
+            metadata.get("completion_offset").flatMap(co => Try(co.toLong).toOption)
+        }
+        .flatten
+  }
+
   private def verifyEnoughExtraTrafficRemains(
       synchronizerId: SynchronizerId,
       commandPriority: CommandPriority,
@@ -997,6 +1015,20 @@ class SpliceLedgerConnection(
                     )
                     .withCause(ex.getCause)
                     .asRuntimeException
+                }
+                .recoverWith {
+                  case ex: StatusRuntimeException
+                      if ex.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
+                    parseDuplicateCommandAccepted(ex) match {
+                      case Some(completionOffset) =>
+                        client.recoverFromDuplicateCommand(
+                          waitFor,
+                          completionOffset,
+                          actAs.map(_.toProtoPrimitive),
+                        )
+                      case None =>
+                        Future.failed(ex)
+                    }
                 }
             )(getOffsetAndResult)
 

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ledger/api/LedgerClient.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/environment/ledger/api/LedgerClient.scala
@@ -27,6 +27,7 @@ import com.daml.ledger.javaapi.data.{
   CreateUserResponse,
   ListUserRightsResponse,
   OffsetCheckpoint,
+  Transaction,
   User,
 }
 import com.daml.ledger.javaapi.data.codegen.ContractId
@@ -222,6 +223,34 @@ private[environment] class LedgerClient(
         .mapConcat(GetTreeUpdatesResponse.fromProto)
     )
   }
+
+  private[environment] def getTransactionByOffset(
+      offset: Long,
+      actAs: Seq[String],
+  )(implicit tc: TraceContext): Future[Transaction] = {
+    import lapi.update_service.GetUpdateResponse.Update as U
+    val updateFormat = LedgerClient.ledgerEffectsUpdateFormat(actAs)
+    for {
+      stub <- withCredentialsAndTraceContext(updateServiceStub)
+      response <- stub.getUpdateByOffset(
+        lapi.update_service
+          .GetUpdateByOffsetRequest(offset = offset, updateFormat = Some(updateFormat))
+      )
+    } yield response.update match {
+      case U.Transaction(tree) => LedgerClient.lapiTreeToJavaTree(tree)
+      case other =>
+        throw GrpcStatus.INTERNAL
+          .withDescription(s"Expected transaction at offset $offset but got $other")
+          .asRuntimeException()
+    }
+  }
+
+  private[environment] def recoverFromDuplicateCommand[W](
+      waitFor: SubmitAndWaitFor[W],
+      completionOffset: Long,
+      actAs: Seq[String],
+  )(implicit tc: TraceContext): Future[W] =
+    waitFor.recoverFromDuplicate(completionOffset, getTransactionByOffset(_, actAs))
 
   def submitAndWait[Z](
       synchronizerId: String,
@@ -806,6 +835,10 @@ object LedgerClient {
     private[LedgerClient] type RawResponse
     private[LedgerClient] val stubSubmit: StubSubmit[RawResponse]
     private[LedgerClient] val mapResponse: RawResponse => Z
+    private[LedgerClient] def recoverFromDuplicate(
+        completionOffset: Long,
+        fetchTransaction: Long => Future[Transaction],
+    ): Future[Z]
   }
 
   private[environment] object SubmitAndWaitFor {
@@ -823,7 +856,7 @@ object LedgerClient {
             )
             .map(r => command_service.SubmitAndWaitResponse.toJavaProto(r))(ec)
         }
-      )
+      )((offset, _) => Future.successful(offset))
 
     val TransactionTree: SubmitAndWaitFor[jdata.Transaction] =
       impl((response: CSOC.SubmitAndWaitForTransactionResponse) =>
@@ -836,7 +869,7 @@ object LedgerClient {
             )
             .map(r => command_service.SubmitAndWaitForTransactionResponse.toJavaProto(r))(ec)
         }
-      }
+      }((offset, fetch) => fetch(offset))
 
     private type StubSubmit[R] = (
         CommandServiceGrpc.CommandServiceStub,
@@ -846,16 +879,52 @@ object LedgerClient {
 
     private[this] def impl[R, Z](mapResponse0: R => Z)(
         stubSubmit0: StubSubmit[R]
+    )(
+        recover0: (Long, Long => Future[jdata.Transaction]) => Future[Z]
     ): SubmitAndWaitFor[Z] = new SubmitAndWaitFor[Z] {
       type RawResponse = R
       override val stubSubmit = stubSubmit0
       override val mapResponse = mapResponse0
+      override def recoverFromDuplicate(
+          completionOffset: Long,
+          fetchTransaction: Long => Future[jdata.Transaction],
+      ): Future[Z] = recover0(completionOffset, fetchTransaction)
     }
   }
 
   final case class GetTreeUpdatesResponse(
       updateOrCheckpoint: TreeUpdateOrOffsetCheckpoint
   )
+  private def wildcardFilter(party: String) =
+    party -> transaction_filter.Filters(
+      Seq(
+        transaction_filter.CumulativeFilter(
+          transaction_filter.CumulativeFilter.IdentifierFilter
+            .WildcardFilter(transaction_filter.WildcardFilter(false))
+        )
+      )
+    )
+
+  private[environment] def ledgerEffectsUpdateFormat(
+      actAs: Seq[String]
+  ): transaction_filter.UpdateFormat =
+    transaction_filter.UpdateFormat(
+      includeTransactions = Some(
+        transaction_filter.TransactionFormat(
+          eventFormat = Some(
+            transaction_filter.EventFormat(
+              filtersByParty = actAs.map(wildcardFilter).toMap,
+              filtersForAnyParty = None,
+              verbose = false,
+            )
+          ),
+          transactionShape = transaction_filter.TransactionShape.TRANSACTION_SHAPE_LEDGER_EFFECTS,
+        )
+      ),
+      includeReassignments = None,
+      includeTopologyEvents = None,
+    )
+
   def lapiTreeToJavaTree(
       tree: lapi.transaction.Transaction
   ): com.daml.ledger.javaapi.data.Transaction = {

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/admin/http/HttpSvPublicHandler.scala
@@ -880,6 +880,7 @@ class HttpSvPublicHandler(
                     ),
                     deduplicationOffset = offset,
                   )
+                  .recoveringAcceptedDuplicates()
                   .yieldUnit()
               }
               .value

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/admin/http/HttpValidatorAdminHandler.scala
@@ -464,6 +464,7 @@ class HttpValidatorAdminHandler(
                             BaseLedgerConnection.sanitizeUserIdToPartyString(body.userPartyId),
                           ),
                           DedupOffset(implicitly[Ordering[Long]].min(offsetESP, offsetTP)),
+                          recoverAcceptedDuplicates = true,
                         )
                       ),
                     )

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandler.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandler.scala
@@ -576,6 +576,7 @@ class HttpWalletHandler(
             AmuletOperationDedupConfig(
               commandId,
               dedupDuration,
+              recoverAcceptedDuplicates = true,
             )
           ),
         ),
@@ -687,6 +688,7 @@ class HttpWalletHandler(
                 AmuletOperationDedupConfig(
                   commandId,
                   dedupDuration,
+                  recoverAcceptedDuplicates = true,
                 )
               ),
             )
@@ -809,6 +811,7 @@ class HttpWalletHandler(
           ),
           deduplicationOffset = dedupOffset,
         )
+        .recoveringAcceptedDuplicates()
         .withSynchronizerId(domain)
         .yieldResult()
         .map(_.contractId)
@@ -864,6 +867,7 @@ class HttpWalletHandler(
                     body.deduplicationId,
                   ),
                   dedupDuration,
+                  recoverAcceptedDuplicates = true,
                 )
               ),
             )
@@ -887,6 +891,7 @@ class HttpWalletHandler(
       val dedupConfig = AmuletOperationDedupConfig(
         commandId,
         dedupDuration,
+        recoverAcceptedDuplicates = true,
       )
       (for {
         result <- userWallet.treasury.enqueueTokenStandardTransferOperationV1(
@@ -1072,6 +1077,7 @@ class HttpWalletHandler(
       val dedupConfig = AmuletOperationDedupConfig(
         commandId,
         dedupDuration,
+        recoverAcceptedDuplicates = true,
       )
       (for {
         result <- userWallet.treasury.enqueueTokenStandardTransferOperationV2(
@@ -1235,6 +1241,7 @@ class HttpWalletHandler(
       val dedupConfig = AmuletOperationDedupConfig(
         commandId,
         dedupDuration,
+        recoverAcceptedDuplicates = true,
       )
       for {
         result <- userWallet.treasury.enqueueAmuletAllocationOperation(
@@ -1311,6 +1318,7 @@ class HttpWalletHandler(
         commandId,
         // Overriden to be low enough (5m) that we allow the same allocation to be re-created after being withdrawn
         DedupDuration(com.google.protobuf.Duration.newBuilder().setSeconds(5L * 60L).build()),
+        recoverAcceptedDuplicates = true,
       )
       for {
         result <- userWallet.treasury.enqueueAmuletAllocationOperation(
@@ -1824,6 +1832,7 @@ class HttpWalletHandler(
               ),
             deduplicationConfig = dedupDuration,
           )
+          .recoveringAcceptedDuplicates()
           .withDisclosedContracts(
             userWallet.connection
               .disclosedContracts(amuletRules, unclaimedDevelopmentFundCouponsToAllocate*)

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandlerUtil.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/admin/http/HttpWalletHandlerUtil.scala
@@ -91,6 +91,7 @@ trait HttpWalletHandlerUtil extends Spanning with NamedLogging {
               priority = priority,
             )
             .withDedup(commandId, dedupConfig)
+            .recoveringAcceptedDuplicates()
             .withDisclosedContracts(disclosedContracts(userWallet.connection))
             .yieldResult()
       }

--- a/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
+++ b/apps/wallet/src/main/scala/org/lfdecentralizedtrust/splice/wallet/treasury/TreasuryService.scala
@@ -648,7 +648,10 @@ class TreasuryService(
       (offset, result) <- batch.dedup match {
         case None => baseSubmission.noDedup.yieldResultAndOffset()
         case Some(dedup) =>
-          baseSubmission.withDedup(dedup.commandId, dedup.config).yieldResultAndOffset()
+          baseSubmission
+            .withDedup(dedup.commandId, dedup.config)
+            .recoveringAcceptedDuplicates(dedup.recoverAcceptedDuplicates)
+            .yieldResultAndOffset()
       }
 
       // wait for store to ingest the new amulet holdings, then return all outcomes to the callers
@@ -813,7 +816,10 @@ class TreasuryService(
       (offset, result) <- operation.dedup match {
         case None => baseSubmission.noDedup.yieldResultAndOffset()
         case Some(dedup) =>
-          baseSubmission.withDedup(dedup.commandId, dedup.config).yieldResultAndOffset()
+          baseSubmission
+            .withDedup(dedup.commandId, dedup.config)
+            .recoveringAcceptedDuplicates(dedup.recoverAcceptedDuplicates)
+            .yieldResultAndOffset()
       }
       _ <- userStore.signalWhenIngestedOrShutdown(offset)
     } yield {
@@ -1559,9 +1565,14 @@ object TreasuryService {
       }
   }
 
+  /** @param recoverAcceptedDuplicates
+    *   set by client calls, so that a duplicate of an already-accepted submission returns the
+    *   original result. Automation leaves it off and lets its own retry handle the duplicate.
+    */
   final case class AmuletOperationDedupConfig(
       commandId: CommandId,
       config: DedupConfig,
+      recoverAcceptedDuplicates: Boolean = false,
   ) extends PrettyPrinting {
     override def pretty: Pretty[AmuletOperationDedupConfig.this.type] =
       prettyNode("DedupConfig", param("commandId", _.commandId), param("config", _.config))

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -6,3 +6,11 @@
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
 .. release-notes:: Upcoming
+
+    - Wallet app
+
+        - Duplicate wallet operations submitted with the same command id (e.g. tap, transfer,
+          token standard transfers) now return the original result idempotently instead of HTTP 409.
+          This aligns with standard idempotency-key semantics: a second request with a previously
+          accepted command id receives a 200 response with the same result as the first.
+          Concurrent duplicates, where no submission has completed yet, are still rejected.


### PR DESCRIPTION
…up path

A dedup'd submission that times out client-side but succeeds on the ledger returns
`ALREADY_EXISTS`/`DUPLICATE_COMMAND` with `accepted=true` on retry. `RetryProvider` classified that
as retryable, so the call retried until its budget ran out inside the 24h dedup window and surfaced
as HTTP 409.

**Recovery.** `SpliceLedgerConnection.clientSubmit` now reads the completed transaction back by its
`completion_offset` and returns the original result. Opt-in per submission and set only by the HTTP
handlers: automation needs the duplicate to surface so its own retry re-runs the staleness check.

**Retry classification.** `RetryFor` gains `duplicateCommandIsFatal`, set on `ClientCalls` and
`InitializingClientCalls`. This is a latency improvement rather than a correctness fix, an
`accepted=true` duplicate no longer reaches the classifier at all, so it only affects `accepted=false`,
where the command genuinely never ran and 409 is the right answer, now returned at once instead of
after 12 retries.

**Not covered:** concurrent duplicates, where nothing has completed yet. Those fail with
`SUBMISSION_ALREADY_IN_FLIGHT`, which carries no offset to read back, so one call wins as before.

Fixes a real failure on main: post-merge run 30567495326 (`RollForwardLsuIntegrationTest`) shows a tap
going DEADLINE_EXCEEDED → `SUBMISSION_ALREADY_IN_FLIGHT` → `DUPLICATE_COMMAND accepted=true,
completion_offset=245` → 409 after 20.4s. Also see https://github.com/DACH-NY/cn-test-failures/issues/9435

Duplicate wallet operations with the same command id now return 200 with the original result. Release
note included; four integration tests that asserted the old failure were updated.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
