### PR TITLE
Upload protobuf encoding of snapshot/updates to bulk storage.

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -22,7 +22,7 @@ import org.lfdecentralizedtrust.splice.http.v0.definitions.DamlValueEncoding.mem
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTestWithIsolatedEnvironment
 import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
-import org.lfdecentralizedtrust.splice.scan.config.BulkStorageConfig
+import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
 import org.lfdecentralizedtrust.splice.scan.config.ScanStorageConfigs.scanStorageConfigV1
 import org.lfdecentralizedtrust.splice.store.{HasS3Mock, S3BucketConnectionForTests}
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.BackfillingState
@@ -446,7 +446,8 @@ class ScanTimeBasedIntegrationTest
     val endTime = getLedgerTime
     val lastMidnight = endTime.toInstant.truncatedTo(ChronoUnit.DAYS);
     val nextMidnight = lastMidnight.plus(1, ChronoUnit.DAYS)
-    val expectedAcsSnapshotKey = s"$lastMidnight~$nextMidnight/ACS_0.zstd"
+    val expectedAcsSnapshotKey =
+      s"$lastMidnight~$nextMidnight/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", 0)}"
 
     val committedBucketConnection =
       new S3BucketConnectionForTests(s3ConfigMock("committed"), loggerFactory)
@@ -474,7 +475,11 @@ class ScanTimeBasedIntegrationTest
       // at last midnight
       committedS3Objs
         .map(_.key())
-        .filter(_.endsWith(s"~$lastMidnight/updates_0.zstd")) should not be empty
+        .filter(
+          _.endsWith(
+            s"~$lastMidnight/${ScanStorageConfig.Encoding.CompactJson.storageKey("updates", 0)}"
+          )
+        ) should not be empty
 
       // Compare bulk storage data to hot storage data from scan
       // TODO(#4788): for now, bulk storage still uses v0, so we use that here as well

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/HistoryMetrics.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/HistoryMetrics.scala
@@ -438,11 +438,11 @@ class HistoryMetrics(metricsFactory: LabeledMetricsFactory)(implicit
         )
       )(metricsContext)
 
-    def incAcsSnapshotObjects(): Unit =
-      objectsCount.inc()(MetricsContext("object_type" -> "ACS_snapshots"))
+    def incAcsSnapshotObjects(encoding: String): Unit =
+      objectsCount.inc()(MetricsContext("object_type" -> "ACS_snapshots", "encoding" -> encoding))
 
-    def incUpdateObjects(): Unit =
-      objectsCount.inc()(MetricsContext("object_type" -> "updates"))
+    def incUpdateObjects(encoding: String): Unit =
+      objectsCount.inc()(MetricsContext("object_type" -> "updates", "encoding" -> encoding))
 
     def incUpdatesCount(count: Int): Unit =
       updatesCount.inc(count.toLong)(MetricsContext.Empty)

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/ScanHttpEncodings.scala
@@ -636,6 +636,12 @@ object ScanHttpEncodings {
     )
   }
 
+  def fromDamlValueEncoding(encoding: definitions.DamlValueEncoding): ScanHttpEncodings =
+    encoding match {
+      case definitions.DamlValueEncoding.members.CompactJson => CompactJsonScanHttpEncodings()
+      case definitions.DamlValueEncoding.members.ProtobufJson => ProtobufJsonScanHttpEncodings
+    }
+
   def encodeUpdate(
       update: TreeUpdateWithMigrationId,
       encoding: definitions.DamlValueEncoding,
@@ -656,10 +662,7 @@ object ScanHttpEncodings {
           externalTransactionHashThresholdTime,
         )
     }
-    val encodings: ScanHttpEncodings = encoding match {
-      case definitions.DamlValueEncoding.members.CompactJson => CompactJsonScanHttpEncodings()
-      case definitions.DamlValueEncoding.members.ProtobufJson => ProtobufJsonScanHttpEncodings
-    }
+    val encodings: ScanHttpEncodings = fromDamlValueEncoding(encoding)
     // v0 always returns the update ids as `#` prefixed,as that's the way they were encoded in canton. v1 returns it without the `#`
     encodings.lapiToHttpUpdate(
       update2,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -3,7 +3,9 @@
 
 package org.lfdecentralizedtrust.splice.scan.config
 
+import cats.data.NonEmptyList
 import com.digitalasset.canton.data.CantonTimestamp
+import org.lfdecentralizedtrust.splice.http.v0.definitions
 import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.{
   AcsSnapshot,
   IncrementalAcsSnapshot,
@@ -11,6 +13,7 @@ import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.{
 
 import java.time.{Duration, Instant, ZoneOffset}
 import java.time.temporal.{ChronoField, ChronoUnit}
+import scala.util.matching.Regex
 
 /** Note that these configurations must be kept consistent between SVs,
   *  so they are not configured via a local config file in Scan. Instead, they must be voted on.
@@ -134,6 +137,31 @@ case class ScanStorageConfig(
       segmentStartTimestamp: CantonTimestamp
   ): String = segmentStartTimestamp.toString
 
+}
+
+object ScanStorageConfig {
+  sealed abstract class Encoding(
+      val key: String,
+      val damlValueEncoding: definitions.DamlValueEncoding,
+  ) {
+    final def storageKey(prefix: String, index: Int): String = s"${prefix}_${key}_$index.zstd"
+
+    final def storageKeyRegex(prefix: String): Regex =
+      Encoding.makeStorageKeyRegex(prefix, "_" + Regex.quote(key))
+  }
+  object Encoding {
+    case object CompactJson
+        extends Encoding("compact_json", definitions.DamlValueEncoding.CompactJson)
+    case object ProtobufJson
+        extends Encoding("protobuf_json", definitions.DamlValueEncoding.ProtobufJson)
+
+    lazy val all: NonEmptyList[Encoding] = NonEmptyList.of[Encoding](CompactJson, ProtobufJson)
+
+    private def makeStorageKeyRegex(prefix: String, middle: String): Regex =
+      (".*" + Regex.quote(prefix) + middle + "_\\d+\\.zstd").r
+
+    def noEncodingRegex(prefix: String): Regex = makeStorageKeyRegex(prefix, "")
+  }
 }
 
 object ScanStorageConfigs {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanStorageConfig.scala
@@ -147,7 +147,7 @@ object ScanStorageConfig {
     final def storageKey(prefix: String, index: Int): String = s"${prefix}_${key}_$index.zstd"
 
     final def storageKeyRegex(prefix: String): Regex =
-      Encoding.makeStorageKeyRegex(prefix, "_" + Regex.quote(key))
+      (".*" + Regex.quote(prefix) + "_" + Regex.quote(key) + "_\\d+\\.zstd").r
   }
   object Encoding {
     case object CompactJson
@@ -156,11 +156,6 @@ object ScanStorageConfig {
         extends Encoding("protobuf_json", definitions.DamlValueEncoding.ProtobufJson)
 
     lazy val all: NonEmptyList[Encoding] = NonEmptyList.of[Encoding](CompactJson, ProtobufJson)
-
-    private def makeStorageKeyRegex(prefix: String, middle: String): Regex =
-      (".*" + Regex.quote(prefix) + middle + "_\\d+\\.zstd").r
-
-    def noEncodingRegex(prefix: String): Regex = makeStorageKeyRegex(prefix, "")
   }
 }
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.store.bulk
 
+import cats.data.NonEmptyList
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.tracing.TraceContext
@@ -28,7 +29,9 @@ class BulkStorageReader(
     extends NamedLogging {
 
   def getCommittedObjectsForAcsSnapshotAtOrBefore(
-      atOrBeforeTimestamp: CantonTimestamp
+      atOrBeforeTimestamp: CantonTimestamp,
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding] =
+        NonEmptyList.one(ScanStorageConfig.Encoding.CompactJson),
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[AcsSnapshotObjects] = {
     for {
       snapshotTs <-
@@ -45,7 +48,12 @@ class BulkStorageReader(
               ts.timestamp
             case Some(ts) => storageConfig.computeBulkSnapshotTimeAtOrBefore(atOrBeforeTimestamp)
           }
-      objects <- getAcsSnapshotObjects(snapshotTs, committedS3Connection, storageConfig)
+      objects <- getAcsSnapshotObjects(
+        snapshotTs,
+        committedS3Connection,
+        storageConfig,
+        storageEncodings,
+      )
     } yield {
       objects
     }
@@ -99,18 +107,26 @@ class BulkStorageReader(
   def getStagingObjectsForAcsSnapshotAt(
       timestamp: CantonTimestamp
   ): Future[AcsSnapshotObjects] = {
-    getAcsSnapshotObjects(timestamp, stagingS3Connection, storageConfig)
+    getAcsSnapshotObjects(
+      timestamp,
+      stagingS3Connection,
+      storageConfig,
+      ScanStorageConfig.Encoding.all,
+    )
   }
 
   def getStagingObjectsForUpdateHistorySegment(
       segment: UpdatesSegment
-  ): Future[UpdateHistoryObjectsResponse] = getUpdateObjectsInSegment(segment, stagingS3Connection)
+  ): Future[UpdateHistoryObjectsResponse] =
+    getUpdateObjectsInSegment(segment, stagingS3Connection, ScanStorageConfig.Encoding.all)
 
   def getCommittedUpdatesBetweenDates(
       afterRecordTime: CantonTimestamp,
       atOrBeforeRecordTime: CantonTimestamp,
       limit: PageLimit,
       nextPageTokenO: Option[String],
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding] =
+        NonEmptyList.one(ScanStorageConfig.Encoding.CompactJson),
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[UpdateHistoryObjectsResponse] =
     getUpdatesBetweenDatesFromBucket(
       afterRecordTime,
@@ -119,6 +135,7 @@ class BulkStorageReader(
       nextPageTokenO,
       committedS3Connection,
       updateHistoryCommittedProgress.readLatestProcessedSegment,
+      storageEncodings,
     )
 
   def getStagingSegmentStartingAt(
@@ -158,10 +175,26 @@ class BulkStorageReader(
         )
     }
 
+  /** Checks if a key in bulk storage has no specified encoding or matches one of the given
+    * [[storageEncodings]].
+    *
+    * The check for no encoding is to support a legacy key format, prior to the change that added
+    * support for uploading multiple encodings. Without it, pre-existing data in bulk storage would
+    * become unreadable; [[getCommittedObjectsForAcsSnapshotAtOrBefore]] and
+    * [[getCommittedUpdatesBetweenDates]] would never return objects with the old key format.
+    */
+  private def keyMatchesStorageEncodings(
+      prefix: String,
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
+  )(key: String): Boolean =
+    ScanStorageConfig.Encoding.noEncodingRegex(prefix).matches(key) ||
+      storageEncodings.exists(_.storageKeyRegex(prefix).matches(key))
+
   private def getAcsSnapshotObjects(
       timestamp: CantonTimestamp,
       s3Connection: S3BucketConnection,
       storageConfig: ScanStorageConfig,
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   ): Future[AcsSnapshotObjects] = {
     for {
       objects <- s3Connection
@@ -170,7 +203,7 @@ class BulkStorageReader(
         // (hence the HardLimit, just as a safety precaution).
         .listObjects(
           storageConfig.findSegmentFolderPrefixByStartTimestamp(timestamp),
-          _.matches(".*ACS_\\d+\\.zstd"),
+          keyMatchesStorageEncodings("ACS", storageEncodings),
           HardLimit.tryCreate(Limit.DefaultMaxPageSize),
         )
       objectsWithChecksums <- s3Connection.getChecksums(objects)
@@ -201,6 +234,7 @@ class BulkStorageReader(
       nextPageTokenO: Option[String],
       s3Connection: S3BucketConnection,
       readLatestProcessedSegment: => Future[Option[UpdatesSegment]],
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   )(implicit tc: TraceContext, ec: ExecutionContext): Future[UpdateHistoryObjectsResponse] = {
 
     def isFolderInRange(folder: String): Boolean = {
@@ -299,7 +333,7 @@ class BulkStorageReader(
               if (folderLimit <= 0) {
                 Future.successful((folderAcc, folderLimit))
               } else {
-                getUpdateObjectsInFolder(s3Connection, folder).map { folderObjs =>
+                getUpdateObjectsInFolder(s3Connection, folder, storageEncodings).map { folderObjs =>
                   if (folderObjs.size > folderLimit) {
                     // Folder would exceed the limit; omit it entirely (and stop adding more by making the limit 0)
                     if (folderAcc.isEmpty) {
@@ -338,12 +372,13 @@ class BulkStorageReader(
   private def getUpdateObjectsInSegment(
       segment: UpdatesSegment,
       s3Connection: S3BucketConnection,
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   ): Future[UpdateHistoryObjectsResponse] = {
     val folder = storageConfig.getSegmentFolder(
       segment.fromTimestamp.timestamp,
       Some(segment.toTimestamp.timestamp),
     )
-    getUpdateObjectsInFolder(s3Connection, folder)
+    getUpdateObjectsInFolder(s3Connection, folder, storageEncodings)
       .flatMap(s3Connection.getChecksums)
       .map { objectsWithChecksums =>
         if (objectsWithChecksums.isEmpty) {
@@ -366,9 +401,10 @@ class BulkStorageReader(
   private def getUpdateObjectsInFolder(
       s3Connection: S3BucketConnection,
       folder: String,
+      storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   ): Future[Seq[String]] = s3Connection.listObjects(
     prefix = folder,
-    _.matches(".*updates_\\d+\\.zstd"),
+    keyMatchesStorageEncodings("updates", storageEncodings),
     HardLimit.tryCreate(Limit.DefaultMaxPageSize),
   )
 

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/BulkStorageReader.scala
@@ -175,20 +175,12 @@ class BulkStorageReader(
         )
     }
 
-  /** Checks if a key in bulk storage has no specified encoding or matches one of the given
-    * [[storageEncodings]].
-    *
-    * The check for no encoding is to support a legacy key format, prior to the change that added
-    * support for uploading multiple encodings. Without it, pre-existing data in bulk storage would
-    * become unreadable; [[getCommittedObjectsForAcsSnapshotAtOrBefore]] and
-    * [[getCommittedUpdatesBetweenDates]] would never return objects with the old key format.
-    */
+  /** Checks if a key in bulk storage matches one of the given [[storageEncodings]]. */
   private def keyMatchesStorageEncodings(
       prefix: String,
       storageEncodings: NonEmptyList[ScanStorageConfig.Encoding],
   )(key: String): Boolean =
-    ScanStorageConfig.Encoding.noEncodingRegex(prefix).matches(key) ||
-      storageEncodings.exists(_.storageKeyRegex(prefix).matches(key))
+    storageEncodings.exists(_.storageKeyRegex(prefix).matches(key))
 
   private def getAcsSnapshotObjects(
       timestamp: CantonTimestamp,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/MultiEncodingBulkStorageFlow.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/MultiEncodingBulkStorageFlow.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.scan.store.bulk
+
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.FlowShape
+import org.apache.pekko.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge}
+import org.apache.pekko.util.ByteString
+import org.lfdecentralizedtrust.splice.scan.config.ScanStorageConfig
+
+/** Uploads every chunk of a bulk storage dump once per [[ScanStorageConfig.Encoding]].
+  *
+  * Each upstream chunk is broadcast to one branch per encoding, where it's encoded, uploaded via
+  * the given [[uploadFlow]] (an [[S3ZstdObjects]] flow), and counted in the metrics. The emitted
+  * object keys of all branches are merged into a single downstream output.
+  *
+  * Note that the `Merge` is not eager, so the resulting flow only completes once every branch has
+  * uploaded all of its objects. Callers can therefore rely on total completion before advancing a
+  * progress marker.
+  */
+object MultiEncodingBulkStorageFlow {
+  private lazy val encodings = ScanStorageConfig.Encoding.all.toList
+  private lazy val numEncodings = encodings.length
+
+  def apply[A](
+      encode: (A, ScanStorageConfig.Encoding) => ByteString,
+      uploadFlow: ScanStorageConfig.Encoding => Flow[ByteString, String, ?],
+      incObjects: ScanStorageConfig.Encoding => Unit,
+  ): Flow[A, String, NotUsed] = {
+    Flow.fromGraph(GraphDSL.create() { implicit b =>
+      import GraphDSL.Implicits.*
+
+      val broadcast = b.add(Broadcast[A](numEncodings))
+      val merge = b.add(Merge[String](numEncodings))
+
+      encodings.zipWithIndex.foreach { case (encoding, i) =>
+        val branch = Flow[A]
+          .map(encode(_, encoding))
+          .via(uploadFlow(encoding))
+          .wireTap(_ => incObjects(encoding))
+
+        broadcast.out(i) ~> branch ~> merge.in(i)
+      }
+
+      FlowShape(broadcast.in, merge.out)
+    })
+  }
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/SingleAcsSnapshotBulkStorage.scala
@@ -8,7 +8,7 @@ import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.tracing.TraceContext
 import org.apache.pekko.stream.scaladsl.{Flow, Source}
 import org.apache.pekko.util.ByteString
-import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
+import org.lfdecentralizedtrust.splice.scan.admin.http.ScanHttpEncodings
 import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore
 import org.lfdecentralizedtrust.splice.store.{
   HistoryMetrics,
@@ -16,6 +16,7 @@ import org.lfdecentralizedtrust.splice.store.{
   S3BucketConnection,
   TimestampWithMigrationId,
 }
+import org.lfdecentralizedtrust.splice.store.events.SpliceCreatedEvent
 
 import scala.concurrent.Future
 import io.circe.syntax.*
@@ -46,15 +47,10 @@ class SingleAcsSnapshotBulkStorage(
 )(implicit tc: TraceContext, ec: ExecutionContext)
     extends NamedLogging {
 
-  case class AcsSnapshotChunk(
-      chunkBytes: ByteString,
-      numContracts: Int,
-  )
-
   private def getAcsSnapshotChunk(
       timestamp: TimestampWithMigrationId,
       after: Option[Long],
-  ): Future[(Position, AcsSnapshotChunk)] = {
+  ): Future[(Position, Vector[SpliceCreatedEvent])] = {
     for {
       snapshot <- acsSnapshotStore.queryAcsSnapshot(
         timestamp.migrationId,
@@ -64,22 +60,27 @@ class SingleAcsSnapshotBulkStorage(
         Seq.empty,
         Seq.empty,
       )
-    } yield {
-      val encoded = snapshot.createdEventsInPage.map(event =>
-        CompactJsonScanHttpEncodings()
-          .javaToHttpActiveContract(event.eventId, event.recordTime, event.event)
-      )
-      val contractsStr = encoded.map(_.asJson.noSpacesSortKeys).mkString("\n") + "\n"
-      val contractsBytes = ByteString(contractsStr.getBytes(StandardCharsets.UTF_8))
-      logger.debug(
-        s"Read ${encoded.length} contracts from ACS, to a bytestring of size ${contractsBytes.length} bytes"
-      )
-      (
-        snapshot.afterToken.fold(End: Position)(Index(_)),
-        AcsSnapshotChunk(contractsBytes, encoded.length),
-      )
-    }
+    } yield (
+      snapshot.afterToken.fold(End: Position)(Index(_)),
+      snapshot.createdEventsInPage,
+    )
 
+  }
+
+  private def encodeEvents(
+      events: Vector[SpliceCreatedEvent],
+      encoding: ScanStorageConfig.Encoding,
+  ): ByteString = {
+    val encodings = ScanHttpEncodings.fromDamlValueEncoding(encoding.damlValueEncoding)
+    val encoded = events.map(event =>
+      encodings.javaToHttpActiveContract(event.eventId, event.recordTime, event.event)
+    )
+    val contractsStr = encoded.map(_.asJson.noSpacesSortKeys).mkString("\n") + "\n"
+    val contractsBytes = ByteString(contractsStr.getBytes(StandardCharsets.UTF_8))
+    logger.debug(
+      s"Read ${encoded.length} contracts from ACS, to a bytestring of size ${contractsBytes.length} bytes, with encoding ${encoding.key}"
+    )
+    contractsBytes
   }
 
   private def getSource: Source[Seq[String], NotUsed] = {
@@ -89,22 +90,26 @@ class SingleAcsSnapshotBulkStorage(
         case Index(i) => getAcsSnapshotChunk(timestamp, Some(i)).map(Some(_))
         case End => Future.successful(None)
       }
-      .map(chunk => {
-        historyMetrics.BulkStorage.incContractsCount(chunk.numContracts)
-        chunk.chunkBytes
+      .map(events => {
+        historyMetrics.BulkStorage.incContractsCount(events.length)
+        events
       })
       .via(
-        S3ZstdObjects(
-          storageConfig,
-          appConfig,
-          s3Connection,
-          { objIdx =>
-            s"${storageConfig.getSegmentFolder(timestamp.timestamp, None)}/ACS_$objIdx.zstd"
-          },
-          loggerFactory,
+        MultiEncodingBulkStorageFlow(
+          encodeEvents,
+          encoding =>
+            S3ZstdObjects(
+              storageConfig,
+              appConfig,
+              s3Connection,
+              objIdx =>
+                s"${storageConfig.getSegmentFolder(timestamp.timestamp, None)}/${encoding
+                    .storageKey("ACS", objIdx)}",
+              loggerFactory,
+            ),
+          encoding => historyMetrics.BulkStorage.incAcsSnapshotObjects(encoding.key),
         )
       )
-      .wireTap(_ => historyMetrics.BulkStorage.incAcsSnapshotObjects())
       .fold(Seq.empty[String])(_ :+ _)
   }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistorySegmentBulkStorage.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.scan.store.bulk
 
+import cats.data.NonEmptyList
 import com.digitalasset.canton.logging.{NamedLoggerFactory, NamedLogging}
 import com.digitalasset.canton.tracing.TraceContext
 import org.apache.pekko.NotUsed
@@ -10,7 +11,6 @@ import org.apache.pekko.stream.scaladsl.{Flow, Source}
 import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
 import org.apache.pekko.util.ByteString
 import org.apache.pekko.pattern.after
-import org.lfdecentralizedtrust.splice.http.v0.definitions
 import org.lfdecentralizedtrust.splice.scan.admin.http.{ScanHttpEncodings, ScanJsonSupport}
 import org.lfdecentralizedtrust.splice.store.{
   HistoryMetrics,
@@ -56,14 +56,11 @@ class UpdateHistorySegmentBulkStorage(
 )(implicit tc: TraceContext, ec: ExecutionContext)
     extends NamedLogging {
 
-  case class UpdatesChunk(
-      updateBytes: ByteString,
-      numUpdates: Int,
-  )
-
   private def getUpdatesChunk(
       afterTs: TimestampWithMigrationId
-  )(implicit actorSystem: ActorSystem): Future[Option[(TimestampWithMigrationId, UpdatesChunk)]] = {
+  )(implicit
+      actorSystem: ActorSystem
+  ): Future[Option[(TimestampWithMigrationId, Seq[TreeUpdateWithMigrationId])]] = {
     for {
       updates <- updateHistory.getUpdatesWithoutImportUpdates(
         Some((afterTs.migrationId, afterTs.timestamp)),
@@ -85,7 +82,6 @@ class UpdateHistorySegmentBulkStorage(
               s"Adding ${updatesInSegment.length} updates, between record time ${updatesInSegment.headOption
                   .map(_.update.update.recordTime)} and ${updatesInSegment.lastOption.map(_.update.update.recordTime)}"
             )
-            val updatesBytes: ByteString = encodeUpdates(updatesInSegment)
             val last = updatesInSegment.lastOption.getOrElse(
               throw new RuntimeException("Unexpected failure")
             )
@@ -93,7 +89,7 @@ class UpdateHistorySegmentBulkStorage(
               Some(
                 (
                   TimestampWithMigrationId(last.update.update.recordTime, last.migrationId),
-                  UpdatesChunk(updatesBytes, updatesInSegment.length),
+                  updatesInSegment,
                 )
               )
             )
@@ -113,7 +109,7 @@ class UpdateHistorySegmentBulkStorage(
             appConfig.updatesPollingInterval.underlying,
             actorSystem.scheduler,
           ) {
-            Future.successful(Some((afterTs, UpdatesChunk(ByteString.empty, 0))))
+            Future.successful(Some((afterTs, Nil)))
           }
         }
     } yield {
@@ -121,11 +117,14 @@ class UpdateHistorySegmentBulkStorage(
     }
   }
 
-  private def encodeUpdates(updates: Seq[TreeUpdateWithMigrationId]) = {
-    val encoded = updates.map(update =>
+  private def encodeUpdates(
+      updates: NonEmptyList[TreeUpdateWithMigrationId],
+      encoding: ScanStorageConfig.Encoding,
+  ): ByteString = {
+    val encoded = updates.toList.map(update =>
       ScanHttpEncodings.encodeUpdateV2(
         update,
-        definitions.DamlValueEncoding.CompactJson,
+        encoding.damlValueEncoding,
         ScanHttpEncodings.V1,
       )
     )
@@ -139,8 +138,7 @@ class UpdateHistorySegmentBulkStorage(
       .mkString("\n") + "\n"
     val updatesBytes = ByteString(updatesStr.getBytes(StandardCharsets.UTF_8))
     logger.debug(
-      s"Read and encoded ${encoded.length} updates from DB, to a bytestring of size ${updatesBytes.length} bytes. Timestamps are ${updates.headOption
-          .map(_.update.update.recordTime)} to ${updates.lastOption.map(_.update.update.recordTime)}"
+      s"Read and encoded ${encoded.length} updates from DB, to a bytestring of size ${updatesBytes.length} bytes, with encoding ${encoding.key}. Timestamps are ${updates.head.update.update.recordTime} to ${updates.last.update.update.recordTime}"
     )
     updatesBytes
   }
@@ -150,30 +148,35 @@ class UpdateHistorySegmentBulkStorage(
   ): Source[Seq[String], NotUsed] = {
     Source
       .unfoldAsync(segment.fromTimestamp)(ts => getUpdatesChunk(ts))
-      .map(chunk => {
-        historyMetrics.BulkStorage.incUpdatesCount(chunk.numUpdates)
-        chunk.updateBytes
+      .map(updates => {
+        historyMetrics.BulkStorage.incUpdatesCount(updates.length)
+        updates
       })
       .via(
-        // We use lazyFlow, so that in the case where no updates are emitted, we don't instantiate the S3ZstdObjects at all,
-        // since it assumes that it gets at least one chunk to write.
-        Flow.lazyFlow(() =>
-          S3ZstdObjects(
-            storageConfig,
-            appConfig,
-            s3Connection,
-            { objIdx =>
-              s"${storageConfig.getSegmentFolder(segment.fromTimestamp.timestamp, Some(segment.toTimestamp.timestamp))}/updates_$objIdx.zstd"
-            },
-            loggerFactory,
-          )
+        MultiEncodingBulkStorageFlow(
+          (updates, encoding) =>
+            NonEmptyList.fromFoldable(updates).fold(ByteString.empty)(encodeUpdates(_, encoding)),
+          encoding =>
+            // We use lazyFlow, so that in the case where no updates are emitted, we don't instantiate the S3ZstdObjects at all,
+            // since it assumes that it gets at least one chunk to write.
+            Flow.lazyFlow(() =>
+              S3ZstdObjects(
+                storageConfig,
+                appConfig,
+                s3Connection,
+                objIdx =>
+                  s"${storageConfig.getSegmentFolder(segment.fromTimestamp.timestamp, Some(segment.toTimestamp.timestamp))}/${encoding
+                      .storageKey("updates", objIdx)}",
+                loggerFactory,
+              )
+            ),
+          encoding => historyMetrics.BulkStorage.incUpdateObjects(encoding.key),
         )
       )
       .orElse(Source.lazySource { () =>
         logger.warn(s"No updates found in segment ${segment.fromTimestamp}-${segment.toTimestamp}")
         Source.empty
       })
-      .wireTap(_ => historyMetrics.BulkStorage.incUpdateObjects())
       .fold(Seq.empty[String])(_ :+ _)
   }
 }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageCommitFromStagingTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageCommitFromStagingTest.scala
@@ -137,21 +137,25 @@ class AcsSnapshotBulkStorageCommitFromStagingTest
           objectCount: Int,
       ): Unit = {
         (0 until objectCount).foreach { i =>
-          stagingConnection
-            .createObject(
-              s"${bulkStorageTestConfig.getSegmentFolder(ts(day), None)}/ACS_$i.zstd",
-              s"dummy acs snapshot at ${ts(day)} (object $i)".getBytes,
-            )
-            .futureValue
+          ScanStorageConfig.Encoding.all.toList.foreach { encoding =>
+            stagingConnection
+              .createObject(
+                s"${bulkStorageTestConfig.getSegmentFolder(ts(day), None)}/${encoding.storageKey("ACS", i)}",
+                s"dummy acs snapshot at ${ts(day)} (object $i)".getBytes,
+              )
+              .futureValue
+          }
         }
       }
 
       def assertCommittedObjectsForSnapshot(day: Int, expectedCount: Int): Assertion = {
-        val expectedKeys = (0 until expectedCount).map { i =>
-          s"${bulkStorageTestConfig.getSegmentFolder(ts(day), None)}/ACS_$i.zstd"
+        val expectedKeys = (0 until expectedCount).flatMap { i =>
+          ScanStorageConfig.Encoding.all.toList.map { encoding =>
+            s"${bulkStorageTestConfig.getSegmentFolder(ts(day), None)}/${encoding.storageKey("ACS", i)}"
+          }
         }
         reader
-          .getCommittedObjectsForAcsSnapshotAtOrBefore(ts(day))
+          .getCommittedObjectsForAcsSnapshotAtOrBefore(ts(day), ScanStorageConfig.Encoding.all)
           .futureValue
           .objects
           .map(_.key) should contain theSameElementsAs
@@ -215,7 +219,8 @@ class AcsSnapshotBulkStorageCommitFromStagingTest
       committedConnection
         .copyObject(
           "staging",
-          s"${bulkStorageTestConfig.getSegmentFolder(ts(4), None)}/ACS_0.zstd",
+          s"${bulkStorageTestConfig.getSegmentFolder(ts(4), None)}/${ScanStorageConfig.Encoding.CompactJson
+              .storageKey("ACS", 0)}",
         )
         .futureValue
 
@@ -236,12 +241,14 @@ class AcsSnapshotBulkStorageCommitFromStagingTest
         committedConnection
           .copyObject(
             "staging",
-            s"${bulkStorageTestConfig.getSegmentFolder(ts(5), None)}/ACS_$i.zstd",
+            s"${bulkStorageTestConfig
+                .getSegmentFolder(ts(5), None)}/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", i)}",
           )
           .futureValue
         stagingConnection
           .deleteObject(
-            s"${bulkStorageTestConfig.getSegmentFolder(ts(5), None)}/ACS_$i.zstd"
+            s"${bulkStorageTestConfig
+                .getSegmentFolder(ts(5), None)}/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", i)}"
           )
           .futureValue
       }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDbTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/AcsSnapshotBulkStorageWriterFromDbTest.scala
@@ -23,7 +23,11 @@ import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
 import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider, SpliceMetrics}
 import org.lfdecentralizedtrust.splice.http.v0.definitions as httpApi
-import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
+import org.lfdecentralizedtrust.splice.scan.admin.http.{
+  CompactJsonScanHttpEncodings,
+  ProtobufJsonScanHttpEncodings,
+  ScanHttpEncodings,
+}
 import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
 import org.lfdecentralizedtrust.splice.scan.store.{
   AcsSnapshotStore,
@@ -50,6 +54,7 @@ import org.slf4j.event.Level
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.*
@@ -106,49 +111,80 @@ class AcsSnapshotBulkStorageWriterFromDbTest
           )
           .map(_.createdEventsInPage)
       } yield {
-        val objectKeys = s3Objects.contents.asScala.map(_.key()).sorted
-        objectKeys should have length 7
-        objectKeys.foreach(
-          _ should startWith("2026-01-02T00:00:00Z~2026-01-03T00:00:00Z/ACS_")
-        )
-        val objectCountMetrics = metricsFactory.metrics.counters.get(
-          SpliceMetrics.MetricsPrefix :+ "history" :+ "bulk-storage" :+ "object-count"
-        )
-        val numObjectsFromMetric = objectCountMetrics.value
-          .get(MetricsContext.Empty)
-          .value
-          .markers
-          .get(MetricsContext("object_type" -> "ACS_snapshots"))
-          .value
-          .get()
-        numObjectsFromMetric shouldBe 7
-
-        val allContractsFromS3 = objectKeys.flatMap(
-          readUncompressAndDecode(
-            bucketConnection,
-            io.circe.parser.decode[httpApi.ActiveContract],
+        def checkEncoding(encoding: ScanStorageConfig.Encoding) = {
+          /* We hard-code the expected digests to enforce that the persisted data format does not change.
+             These values must not be modified unless there is a conscious decision to change the persisted format,
+             with a migration plan for how to apply it consistently across SVs. */
+          val (encodings, expectedDigests): (ScanHttpEncodings, Seq[String]) =
+            encoding match {
+              case ScanStorageConfig.Encoding.CompactJson =>
+                (
+                  new CompactJsonScanHttpEncodings(identity, identity),
+                  Seq(
+                    "n6CV6dF9zpleq66YiXmCG96hw1BBakp1I8JjC5lf5n0=",
+                    "bJDalSmiVKCk9QSc6sAWdahJNZQqVn51WmkFbQI6wkA=",
+                    "noZU+He8HnCM38MujtpEle4NNGwnE7wN8z96V+HTdK0=",
+                    "rwak+Y4JcInTiEa2yUKf8rjO3RD7ay/D2hmQG4BAa54=",
+                    "YM7SNxHrU3xYyNOjgEqowitAvgsiX1f7tq0pCaD/OhQ=",
+                    "Mb3D2ZOVQclMwuYEqLuTKhGqnUHCio6K61FBTXgt5Vs=",
+                    "+5iW2M9Vz5y9sCtEWyrS3m+EUqnD50dXRVIMQAMSgBY=",
+                  ),
+                )
+              case ScanStorageConfig.Encoding.ProtobufJson =>
+                (
+                  ProtobufJsonScanHttpEncodings,
+                  Seq(
+                    "NDdxcBFCRqz5hXHXqJkD9qqzc1C9t0PWZgHq2F9xsUA=",
+                    "hluFPPWS1V2djExfppU+aiPqYx18s/qxZe83nFjthV0=",
+                    "5D3k/XWBw/OhN5wus7XMuesHKhQwlktDFMFcO9lAI5g=",
+                    "sov3P/ekZ1CRQUPYVMcA7tn2yO4EV+XYtlWc5NF2FP0=",
+                    "tYYPDCgkg/s+dbJD9i6kxBHiMIKq2RB/D0+Fc5gzlAI=",
+                    "CjQBhKAQ+KU7it/OCAkyDtKLNHJmWu2nsU4x1TcT+us=",
+                    "ZonY8bJ5NA2b1Y/gOU2eeUF6lVsQqijKWDjP8kKWvhU=",
+                    "G7eAcDOxoCsxpC9Qwo61IZFUFD0sZnqPf3/dolF9nXQ=",
+                  ),
+                )
+            }
+          val objectKeys = s3Objects.contents.asScala
+            .map(_.key())
+            .sorted
+            .filter(
+              encoding.storageKeyRegex("ACS").matches
+            )
+          objectKeys should have length expectedDigests.length.toLong
+          objectKeys.foreach(
+            _ should startWith(s"2026-01-02T00:00:00Z~2026-01-03T00:00:00Z/ACS_${encoding.key}")
           )
-        )
-        allContracts.map(c =>
-          new CompactJsonScanHttpEncodings(identity, identity)
-            .javaToHttpActiveContract(c.eventId, c.recordTime, c.event)
-        ) should contain theSameElementsInOrderAs allContractsFromS3
+          val objectCountMetrics = metricsFactory.metrics.counters.get(
+            SpliceMetrics.MetricsPrefix :+ "history" :+ "bulk-storage" :+ "object-count"
+          )
+          val numObjectsFromMetric = objectCountMetrics.value
+            .get(MetricsContext.Empty)
+            .value
+            .markers
+            .get(MetricsContext("object_type" -> "ACS_snapshots", "encoding" -> encoding.key))
+            .value
+            .get()
+          numObjectsFromMetric shouldBe expectedDigests.length
 
-        /* We hard-code the expected digests to enforce that the persisted data format does not change.
-           These values must not be modified unless there is a conscious decision to change the persisted format,
-           with a migration plan for how to apply it consistently across SVs. */
-        bucketConnection
-          .getChecksums(objectKeys.toSeq)
-          .futureValue
-          .map(_.checksum) should contain theSameElementsInOrderAs Seq(
-          "n6CV6dF9zpleq66YiXmCG96hw1BBakp1I8JjC5lf5n0=",
-          "bJDalSmiVKCk9QSc6sAWdahJNZQqVn51WmkFbQI6wkA=",
-          "noZU+He8HnCM38MujtpEle4NNGwnE7wN8z96V+HTdK0=",
-          "rwak+Y4JcInTiEa2yUKf8rjO3RD7ay/D2hmQG4BAa54=",
-          "YM7SNxHrU3xYyNOjgEqowitAvgsiX1f7tq0pCaD/OhQ=",
-          "Mb3D2ZOVQclMwuYEqLuTKhGqnUHCio6K61FBTXgt5Vs=",
-          "+5iW2M9Vz5y9sCtEWyrS3m+EUqnD50dXRVIMQAMSgBY=",
-        )
+          val allContractsFromS3 = objectKeys.flatMap(
+            readUncompressAndDecode(
+              bucketConnection,
+              io.circe.parser.decode[httpApi.ActiveContract],
+            )
+          )
+          allContracts.map(c =>
+            encodings.javaToHttpActiveContract(c.eventId, c.recordTime, c.event)
+          ) should contain theSameElementsInOrderAs allContractsFromS3
+
+          bucketConnection
+            .getChecksums(objectKeys.toSeq)
+            .futureValue
+            .map(_.checksum) should contain theSameElementsInOrderAs expectedDigests
+        }
+
+        checkEncoding(ScanStorageConfig.Encoding.CompactJson)
+        checkEncoding(ScanStorageConfig.Encoding.ProtobufJson)
       }
     }
 
@@ -223,7 +259,8 @@ class AcsSnapshotBulkStorageWriterFromDbTest
           reader.getCommittedObjectsForAcsSnapshotAtOrBefore(queryTs).futureValue
         getObjectsResult.objects.map(_.key) should contain theSameElementsInOrderAs
           (0 until expectedNumObjects).map(i =>
-            s"$expectedTs~${expectedTs.add(1.days)}/ACS_$i.zstd"
+            s"$expectedTs~${expectedTs
+                .add(1.days)}/${ScanStorageConfig.Encoding.CompactJson.storageKey("ACS", i)}"
           )
         getObjectsResult.objects.map(_.checksum).foreach {
           // We test elsewhere that computed and persisted checksums are correct, so here we just check that they are present and not empty
@@ -403,19 +440,12 @@ class AcsSnapshotBulkStorageWriterFromDbTest
       bucketConnection: S3BucketConnection
   ): S3BucketConnection = {
     val s3BucketConnectionWithErrors = Mockito.spy(bucketConnection)
-    var failureCount = 0
+    val failedKeys = ConcurrentHashMap.newKeySet[String]()
     val _ = doAnswer { (invocation: InvocationOnMock) =>
       val args = invocation.getArguments
       args.toList match {
-        case (key: String) :: _ if key.endsWith("2.zstd") =>
-          if (failureCount < 1) {
-            failureCount += 1
-            throw new RuntimeException(s"Simulated S3 error (#$failureCount)")
-          } else {
-            failureCount = 0
-            logger.debug(s"No Simulated S3 error, resetting failureCount to 0")
-            invocation.callRealMethod().asInstanceOf[s3BucketConnectionWithErrors.AppendWriteObject]
-          }
+        case (key: String) :: _ if key.endsWith("2.zstd") && failedKeys.add(key) =>
+          throw new RuntimeException(s"Simulated S3 error for $key")
         case _ =>
           invocation.callRealMethod().asInstanceOf[s3BucketConnectionWithErrors.AppendWriteObject]
       }

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/bulk/UpdateHistoryBulkStorageTest.scala
@@ -25,7 +25,11 @@ import org.lfdecentralizedtrust.splice.config.AutomationConfig
 import org.lfdecentralizedtrust.splice.environment.{DarResources, RetryProvider, SpliceMetrics}
 import org.lfdecentralizedtrust.splice.environment.ledger.api.TransactionTreeUpdate
 import org.lfdecentralizedtrust.splice.http.v0.definitions.UpdateHistoryItemV2
-import org.lfdecentralizedtrust.splice.scan.admin.http.CompactJsonScanHttpEncodings
+import org.lfdecentralizedtrust.splice.scan.admin.http.{
+  CompactJsonScanHttpEncodings,
+  ProtobufJsonScanHttpEncodings,
+  ScanHttpEncodings,
+}
 import org.lfdecentralizedtrust.splice.scan.config.{BulkStorageConfig, ScanStorageConfig}
 import org.lfdecentralizedtrust.splice.scan.store.{ScanKeyValueProvider, ScanKeyValueStore}
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.UpdateHistoryResponse
@@ -104,22 +108,37 @@ class UpdateHistoryBulkStorageTest
         "Ingest 1000 more events. Now the last timestamp will be beyond the segment, so the source will complete and emit the object keys"
       ) {
         mockStore.mockIngestion(1000)
-        probe.expectNext(20.seconds) should contain theSameElementsInOrderAs Seq(
-          "1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/updates_0.zstd",
-          "1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/updates_1.zstd",
+        val expectedKeys = ScanStorageConfig.Encoding.all.toList.flatMap(e =>
+          Seq(
+            s"1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/${e.storageKey("updates", 0)}",
+            s"1970-01-01T00:00:00.100Z~1970-01-01T00:00:02.300Z/${e.storageKey("updates", 1)}",
+          )
+        )
+        val actualKeys = probe.expectNext(20.seconds)
+        def filterKeys(keys: Seq[String], encoding: ScanStorageConfig.Encoding) =
+          keys.filter(encoding.storageKeyRegex("updates").matches)
+        actualKeys should contain theSameElementsAs expectedKeys
+        // Confirm encoding-specific keys are in the correct order
+        ScanStorageConfig.Encoding.all.toList.foreach(e =>
+          filterKeys(actualKeys, e) should contain theSameElementsInOrderAs filterKeys(
+            expectedKeys,
+            e,
+          )
         )
         probe.expectComplete()
         val objectCountMetrics = metricsFactory.metrics.counters
           .get(SpliceMetrics.MetricsPrefix :+ "history" :+ "bulk-storage" :+ "object-count")
           .value
-        val numObjectsFromMetric = objectCountMetrics
-          .get(MetricsContext.Empty)
-          .value
-          .markers
-          .get(MetricsContext("object_type" -> "updates"))
-          .value
-          .get()
-        numObjectsFromMetric shouldBe 2
+        def numObjectsFromMetric(encoding: ScanStorageConfig.Encoding): Long =
+          objectCountMetrics
+            .get(MetricsContext.Empty)
+            .value
+            .markers
+            .get(MetricsContext("object_type" -> "updates", "encoding" -> encoding.key))
+            .value
+            .get()
+        numObjectsFromMetric(ScanStorageConfig.Encoding.CompactJson) shouldBe 2
+        numObjectsFromMetric(ScanStorageConfig.Encoding.ProtobufJson) shouldBe 2
       }
 
       clue("Check that the dumped content is correct") {
@@ -134,27 +153,50 @@ class UpdateHistoryBulkStorageTest
               update.update.update.recordTime <= toTimestamp
           )
         } yield {
-          val objectKeys = s3Objects.contents.asScala.map(_.key()).sorted
-          objectKeys should have length 2
-          s3Objects.contents().get(0).size().toInt should be >= maxFileSize.toInt
-          val allUpdatesFromS3 = objectKeys.flatMap(
-            readUncompressAndDecode(bucketConnection, io.circe.parser.decode[UpdateHistoryItemV2])
-          )
-          allUpdatesFromS3.length shouldBe segmentUpdates.length
-          allUpdatesFromS3
-            .map(
-              new CompactJsonScanHttpEncodings(identity, identity).httpToLapiUpdate
-            ) should contain theSameElementsInOrderAs segmentUpdates
-          /* We hard-code the expected digests to enforce that the persisted data format does not change.
-             These values must not be modified unless there is a conscious decision to change the persisted format,
-             with a migration plan for how to apply it consistently across SVs. */
-          bucketConnection
-            .getChecksums(objectKeys.toSeq)
-            .futureValue
-            .map(_.checksum) should contain theSameElementsInOrderAs Seq(
-            "MM+DyxPP6UgpAaSCsm99j4ZAtYIK3TIrPmxFyodBrQQ=",
-            "2oWb5Um18xwnJTMkC4yilyrcsUADYoxtV7toJi29VsI=",
-          )
+          def checkEncoding(encoding: ScanStorageConfig.Encoding) = {
+            /* We hard-code the expected digests to enforce that the persisted data format does not change.
+               These values must not be modified unless there is a conscious decision to change the persisted format,
+               with a migration plan for how to apply it consistently across SVs. */
+            val (encodings, expectedDigests): (ScanHttpEncodings, Seq[String]) = encoding match {
+              case ScanStorageConfig.Encoding.CompactJson =>
+                (
+                  new CompactJsonScanHttpEncodings(identity, identity),
+                  Seq(
+                    "MM+DyxPP6UgpAaSCsm99j4ZAtYIK3TIrPmxFyodBrQQ=",
+                    "2oWb5Um18xwnJTMkC4yilyrcsUADYoxtV7toJi29VsI=",
+                  ),
+                )
+              case ScanStorageConfig.Encoding.ProtobufJson =>
+                (
+                  ProtobufJsonScanHttpEncodings,
+                  Seq(
+                    "9QrYwnzkSce+GIh82uzY+1JHv4ukYC+llD0Idx1GDio=",
+                    "pCOz8MG6Zoxup4NGnzBx48kFPm582cWn+GxWSZFyq+E=",
+                  ),
+                )
+            }
+
+            val filteredS3Objects = s3Objects.contents.asScala
+              .filter(o => encoding.storageKeyRegex("updates").matches(o.key()))
+            val objectKeys = filteredS3Objects.map(_.key()).sorted
+            objectKeys should have length expectedDigests.length.toLong
+            filteredS3Objects(0).size().toInt should be >= maxFileSize.toInt
+            val allUpdatesFromS3 = objectKeys.flatMap(
+              readUncompressAndDecode(bucketConnection, io.circe.parser.decode[UpdateHistoryItemV2])
+            )
+            allUpdatesFromS3.length shouldBe segmentUpdates.length
+            allUpdatesFromS3
+              .map(
+                encodings.httpToLapiUpdate
+              ) should contain theSameElementsInOrderAs segmentUpdates
+            bucketConnection
+              .getChecksums(objectKeys.toSeq)
+              .futureValue
+              .map(_.checksum) should contain theSameElementsInOrderAs expectedDigests
+          }
+
+          checkEncoding(ScanStorageConfig.Encoding.CompactJson)
+          checkEncoding(ScanStorageConfig.Encoding.ProtobufJson)
         }
       }
     }
@@ -382,28 +424,28 @@ class UpdateHistoryBulkStorageTest
         loggerFactory,
       )
 
-      val d20u0 = "2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/updates_0.zstd"
-      val d20u1 = "2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/updates_1.zstd"
-      val d21u0 = "2015-10-21T00:00:00Z~2015-10-22T00:00:00Z/updates_0.zstd"
-      val d21u1 = "2015-10-21T00:00:00Z~2015-10-22T00:00:00Z/updates_1.zstd"
-      val d22u0 = "2015-10-22T00:00:00Z~2015-10-23T00:00:00Z/updates_0.zstd"
-      val d22u1 = "2015-10-22T00:00:00Z~2015-10-23T00:00:00Z/updates_1.zstd"
-      val d23u0 = "2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/updates_0.zstd"
-      val d23u1 = "2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/updates_1.zstd"
-      val d24u0 = "2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/updates_0.zstd"
-      val d24u1 = "2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/updates_1.zstd"
-      val allObjs = Seq(
-        d20u0,
-        d20u1,
-        d21u0,
-        d21u1,
-        d22u0,
-        d22u1,
-        d23u0,
-        d23u1,
-        d24u0,
-        d24u1,
-      )
+      def makeObjectKeys(dates: String, prefix: String = "updates"): Seq[String] =
+        ScanStorageConfig.Encoding.all.toList.flatMap { encoding =>
+          Seq(0, 1).map { i =>
+            s"${dates}/${encoding.storageKey(prefix, i)}"
+          }
+        }
+
+      def getCommitted(start: String, end: String, limit: Int, nextPageTokenO: Option[String]) =
+        reader.getCommittedUpdatesBetweenDates(
+          CantonTimestamp.tryFromInstant(Instant.parse(start)),
+          CantonTimestamp.tryFromInstant(Instant.parse(end)),
+          PageLimit.tryCreate(limit),
+          nextPageTokenO,
+          ScanStorageConfig.Encoding.all,
+        )
+
+      val d20 = makeObjectKeys("2015-10-20T00:00:00Z~2015-10-21T00:00:00Z")
+      val d21 = makeObjectKeys("2015-10-21T00:00:00Z~2015-10-22T00:00:00Z")
+      val d22 = makeObjectKeys("2015-10-22T00:00:00Z~2015-10-23T00:00:00Z")
+      val d23 = makeObjectKeys("2015-10-23T00:00:00Z~2015-10-24T00:00:00Z")
+      val d24 = makeObjectKeys("2015-10-24T00:00:00Z~2015-10-25T00:00:00Z")
+      val allObjs = d20 ++ d21 ++ d22 ++ d23 ++ d24
       Future
         .sequence(allObjs.map {
           bucketConnection.createObject(_)
@@ -411,108 +453,58 @@ class UpdateHistoryBulkStorageTest
         .futureValue
 
       // A wider range than the data
-      val res1 = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-10T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-30T00:00:00Z")),
-          PageLimit.tryCreate(10),
-          None,
-        )
-        .futureValue
-      res1.objects.map(_.key) should contain theSameElementsInOrderAs Seq(
-        d20u0,
-        d20u1,
-        d21u0,
-        d21u1,
-        d22u0,
-        d22u1,
-        d23u0,
-        d23u1,
-      )
+      val res1 = getCommitted("2015-10-10T00:00:00Z", "2015-10-30T00:00:00Z", 20, None).futureValue
+      res1.objects.map(_.key) should contain theSameElementsInOrderAs d20 ++ d21 ++ d22 ++ d23
       res1.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/")
-      val res1b = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-10T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-30T00:00:00Z")),
-          PageLimit.tryCreate(10),
-          res1.nextPageTokenO,
-        )
-        .futureValue
+      val res1b = getCommitted(
+        "2015-10-10T00:00:00Z",
+        "2015-10-30T00:00:00Z",
+        20,
+        res1.nextPageTokenO,
+      ).futureValue
       res1b.objects.map(_.key) shouldBe empty
       res1b.nextPageTokenO shouldBe Some("2015-10-23T00:00:00Z~2015-10-24T00:00:00Z/")
 
       // A smaller range within the data
-      val res2 = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T16:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T16:00:05Z")),
-          PageLimit.tryCreate(10),
-          None,
-        )
-        .futureValue
-      res2.objects.map(_.key) should contain theSameElementsInOrderAs Seq(d21u0, d21u1)
+      val res2 = getCommitted("2015-10-21T16:00:00Z", "2015-10-21T16:00:05Z", 20, None).futureValue
+      res2.objects.map(_.key) should contain theSameElementsInOrderAs d21
       res2.nextPageTokenO shouldBe None
 
       // pagination
-      val res3 = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-01T12:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T16:00:05Z")),
-          PageLimit.tryCreate(
-            3
-          ), // on purpose 3 even though we expect only 2 back (since the response is always full days of updates)
-          None,
-        )
-        .futureValue
-      res3.objects.map(_.key) should contain theSameElementsInOrderAs Seq(d20u0, d20u1)
+      val res3 = getCommitted(
+        "2015-10-01T12:00:00Z",
+        "2015-10-21T16:00:05Z",
+        5, // on purpose 5 even though we expect only 4 back (since the response is always full days of updates)
+        None,
+      ).futureValue
+      res3.objects.map(_.key) should contain theSameElementsInOrderAs d20
       res3.nextPageTokenO shouldBe Some("2015-10-20T00:00:00Z~2015-10-21T00:00:00Z/")
-      val res3b = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-01T12:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T16:00:05Z")),
-          PageLimit.tryCreate(3),
-          res3.nextPageTokenO,
-        )
-        .futureValue
-      res3b.objects.map(_.key) should contain theSameElementsInOrderAs Seq(d21u0, d21u1)
+      val res3b = getCommitted(
+        "2015-10-01T12:00:00Z",
+        "2015-10-21T16:00:05Z",
+        5,
+        res3.nextPageTokenO,
+      ).futureValue
+      res3b.objects.map(_.key) should contain theSameElementsInOrderAs d21
       res3b.nextPageTokenO shouldBe None
 
       // exact match with start and end of segments
-      val res4 = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-23T00:00:00Z")),
-          PageLimit.tryCreate(4),
-          None,
-        )
-        .futureValue
+      val res4 = getCommitted("2015-10-21T00:00:00Z", "2015-10-23T00:00:00Z", 8, None).futureValue
       res4.objects
-        .map(_.key) should contain theSameElementsInOrderAs Seq(d21u0, d21u1, d22u0, d22u1)
+        .map(_.key) should contain theSameElementsInOrderAs d21 ++ d22
       res4.nextPageTokenO shouldBe None
 
       // limit too low for first folder
-      val ex = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-23T00:00:00Z")),
-          PageLimit.tryCreate(1),
-          None,
-        )
-        .failed
-        .futureValue
+      val ex =
+        getCommitted("2015-10-21T00:00:00Z", "2015-10-23T00:00:00Z", 3, None).failed.futureValue
       ex shouldBe a[StatusRuntimeException]
       ex.asInstanceOf[StatusRuntimeException]
         .getStatus
         .getCode shouldBe io.grpc.Status.Code.INVALID_ARGUMENT
 
       // Test handling an empty segment: Simulate no updates in 2015-10-25 to 2015-10-26
-      val d26u0 = "2015-10-26T00:00:00Z~2015-10-27T00:00:00Z/updates_0.zstd"
-      val d26u1 = "2015-10-26T00:00:00Z~2015-10-27T00:00:00Z/updates_1.zstd"
-      val moreObjs = Seq(
-        "2015-10-25T00:00:00Z~2015-10-26T00:00:00Z/ACS_0.zstd",
-        d26u0,
-        d26u1,
-      )
+      val d26 = makeObjectKeys("2015-10-26T00:00:00Z~2015-10-27T00:00:00Z")
+      val moreObjs = makeObjectKeys("2015-10-25T00:00:00Z~2015-10-26T00:00:00Z", "ACS") ++ d26
       Future
         .sequence(moreObjs.map {
           bucketConnection.createObject(_)
@@ -546,25 +538,16 @@ class UpdateHistoryBulkStorageTest
         )
       )
       // Query up to the middle of the empty segment
-      val res5 = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-20T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-25T12:00:00Z")),
-          PageLimit.tryCreate(20),
-          None,
-        )
-        .futureValue
+      val res5 = getCommitted("2015-10-20T00:00:00Z", "2015-10-25T12:00:00Z", 20, None).futureValue
       // First response contains all data, but with a next page token
       res5.objects.map(_.key) should contain theSameElementsInOrderAs allObjs
       res5.nextPageTokenO shouldBe Some("2015-10-24T00:00:00Z~2015-10-25T00:00:00Z/")
-      val res5b = reader
-        .getCommittedUpdatesBetweenDates(
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-21T00:00:00Z")),
-          CantonTimestamp.tryFromInstant(Instant.parse("2015-10-25T12:00:00Z")),
-          PageLimit.tryCreate(20),
-          res5.nextPageTokenO,
-        )
-        .futureValue
+      val res5b = getCommitted(
+        "2015-10-21T00:00:00Z",
+        "2015-10-25T12:00:00Z",
+        20,
+        res5.nextPageTokenO,
+      ).futureValue
       // Second page should be empty, with no nextPageToken
       res5b.objects.map(_.key) shouldBe empty
       res5b.nextPageTokenO shouldBe None


### PR DESCRIPTION
Fixes #6497

This updates `SingleAcsSnapshotBulkStorage.getSource` and `UpdateHistorySegmentBulkStorage.getSource` to upload both the API and protobuf encoding of the relevant data to bulk storage.

After incrementing the contracts/updates count metrics, each class:

- Fans out for both encodings
- For each encoding, encodes and uploads the data, then increments object count metrics
- Fans back in so the resulting `Source` contains the keys of all uploaded objects for both encodings

This Pekko logic is handled by a new generic `MultiEncodingBulkStorageFlow`, which uses Pekko's `Broadcast` and `Merge` to handle the fan-out and fan-in behavior.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).