### PR TITLE
[ci] Release netty buffers on zstd compression failures

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/bulk/ZstdGroupedWeight.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/bulk/ZstdGroupedWeight.scala
@@ -9,6 +9,8 @@ import org.apache.pekko.stream.stage.{GraphStage, GraphStageLogic, InHandler, Ou
 import org.apache.pekko.stream.{Attributes, FlowShape, Inlet, Outlet}
 import org.apache.pekko.util.ByteString
 
+import scala.util.control.NonFatal
+
 /** A Pekko GraphStage that zstd-compresses a stream of bytestrings, and splits the output into zstd objects of size (minWeight + delta).
   * Somewhat similar to Pekko's built-in GroupedWeight, but outputs valid zstd compressed objects.
   */
@@ -47,15 +49,25 @@ case class ZstdGroupedWeight(
 
     val bufferAllocator = PooledByteBufAllocator.DEFAULT
     val tmpBuffer = bufferAllocator.directBuffer(zstdTmpBufferSize)
-    val tmpNioBuffer = tmpBuffer.nioBuffer(0, tmpBuffer.capacity())
-    val compressingStream =
-      new ZstdDirectBufferCompressingStreamNoFinalizer(tmpNioBuffer, compressionLevel)
+    val (tmpNioBuffer, compressingStream) =
+      try {
+        val nioBuffer = tmpBuffer.nioBuffer(0, tmpBuffer.capacity())
+        (nioBuffer, new ZstdDirectBufferCompressingStreamNoFinalizer(nioBuffer, compressionLevel))
+      } catch {
+        // a failed construction never reaches close(), so release the buffer here
+        case NonFatal(e) =>
+          val _ = tmpBuffer.release()
+          throw e
+      }
 
     def compress(input: ByteString): ByteString = {
       val inputBB = bufferAllocator.directBuffer(input.size)
-      inputBB.writeBytes(input.toArrayUnsafe())
-      compressingStream.compress(inputBB.nioBuffer())
-      inputBB.release()
+      try {
+        inputBB.writeBytes(input.toArrayUnsafe())
+        compressingStream.compress(inputBB.nioBuffer())
+      } finally {
+        val _ = inputBB.release()
+      }
       compressingStream.flush()
       tmpNioBuffer.flip()
       val result = ByteString.fromByteBuffer(tmpNioBuffer)
@@ -72,8 +84,11 @@ case class ZstdGroupedWeight(
     }
 
     override def close(): Unit = {
-      compressingStream.close()
-      val _ = tmpBuffer.release()
+      try {
+        compressingStream.close()
+      } finally {
+        val _ = tmpBuffer.release()
+      }
     }
   }
 


### PR DESCRIPTION

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
