### PR TITLE
[ci] Disable update history sanity check in SvOnboardingViaNonFoundin…

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/SvOnboardingViaNonFoundingSvIntegrationTest.scala
@@ -26,6 +26,8 @@ class SvOnboardingViaNonFoundingSvIntegrationTest
     with SvTestUtil
     with StandaloneCanton {
 
+  // sv1 is stopped mid-test, so neither history check is meaningful here.
+  override protected def runUpdateHistorySanityCheck: Boolean = false
   override protected def runEventHistorySanityCheck: Boolean = false
 
   override def dbsSuffix: String = "non_sv1_svs"


### PR DESCRIPTION
…gSvIntegrationTest

sv1 is stopped mid-test; the plugin accesses sv1Scan.automation after sv1's participant is down, throwing 'Node doesn't have any app state'. This also prevents proper port release, causing three subsequent tests to fail with 'Could not create Prometheus HTTP server'.

Fixes https://github.com/DACH-NY/cn-test-failures/issues/9124

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
