### PR TITLE
helm, info, status: Updates and fixes

### DIFF
--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+set -E
+trap 'echo "ERROR: On line $LINENO in function \"${FUNCNAME[0]}\". Exit code is $?." >&2' ERR
+
 SV_METRICS_URL="${SV_METRICS_URL:-http://sv-app:10013/metrics}"
 SCAN_URL="${SCAN_URL:-http://scan-app:5012}"
 

--- a/cluster/helm/splice-info/scripts/get-status.sh
+++ b/cluster/helm/splice-info/scripts/get-status.sh
@@ -494,7 +494,7 @@ cantonbft_get_status_reachability() {
       run_parallel "$get_cantonbfts_info_cmds" |
         json_object_values_fromjson || echo '{}'
     } |
-    jq '{ bftSequencers: [.[] | .bftSequencers[]] }'
+    jq '{ bftSequencers: map(.bftSequencers[]?) }'
   )
 
   local cantonbfts_info_for_serial; cantonbfts_info_for_serial=$(


### PR DESCRIPTION
- Print position and exit code on error
- Ignore CantonBFT node when unable to fetch URL
  - Before: If the URL for a single CantonBFT node can't be fetched no results for all CantonBFT nodes are generated
  - After: If the URL for a single CantonBFT node can't be fetched the result only for this node is missing