### PR TITLE
Change default cantonbft config to exponential blacklisting

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ReconcileBftSequencingParametersIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ReconcileBftSequencingParametersIntegrationTest.scala
@@ -39,9 +39,8 @@ class SvReconcileBftSequencingParametersIntegrationTest
                         blacklistLeaderSelectionPolicyConfig =
                           SequencingParameters.DefaultLeaderSelectionPolicyConfig.copy(
                             howLongToBlacklist =
-                              BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Exponential(
-                                initialValue = 1L,
-                                maximumEpochBlacklisted = Some(250L),
+                              BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Linear(
+                                maximumEpochBlacklisted = Some(250L)
                               )
                           ),
                       )
@@ -75,7 +74,7 @@ class SvReconcileBftSequencingParametersIntegrationTest
       bftParameters.pbftViewChangeTimeout shouldBe com.digitalasset.canton.time.PositiveFiniteDuration
         .tryOfSeconds(5)
       bftParameters.blacklistLeaderSelectionPolicyConfig.howLongToBlacklist shouldBe a[
-        BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Linear
+        BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Exponential
       ]
       sv1Backend.stop()
       actAndCheck(
@@ -92,7 +91,7 @@ class SvReconcileBftSequencingParametersIntegrationTest
             .fromByteString(sv1Backend.config.localSynchronizerNodes.current.protocolVersion, bytes)
             .value
           bftParameters.blacklistLeaderSelectionPolicyConfig.howLongToBlacklist shouldBe a[
-            BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Exponential
+            BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Linear
           ]
         },
       )

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala
@@ -463,7 +463,13 @@ case class SvAppBackendConfig(
         pbftViewChangeTimeout = PositiveFiniteDuration.ofSeconds(5),
         segmentLength = SequencingParameters.DefaultSegmentLength.length,
         blacklistLeaderSelectionPolicyConfig =
-          SequencingParameters.DefaultLeaderSelectionPolicyConfig,
+          SequencingParameters.DefaultLeaderSelectionPolicyConfig.copy(
+            howLongToBlacklist =
+              BlacklistLeaderSelectionPolicyConfig.HowLongToBlacklist.Exponential(
+                initialValue = 1L,
+                maximumEpochBlacklisted = Some(250L),
+              )
+          ),
       )
     ),
     // Set to false to disable the DB-level exclusive lock that prevents two SV instances


### PR DESCRIPTION
To recover more quickly from nodes that are down. Not gonna do much for the cases where someone times out every X epochs but still a better default.

[ci]



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
