### PR TITLE
[ci] Pin as_of_round in ScanTimeBasedIntegrationTest holdings summary

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanTimeBasedIntegrationTest.scala
@@ -412,6 +412,10 @@ class ScanTimeBasedIntegrationTest
         migrationId,
         ownerPartyIds = Vector(aliceUserParty),
         recordTimeMatch = Some(definitions.HoldingsSummaryRequest.RecordTimeMatch.AtOrBefore),
+        // as_of_round defaults to the earliest open mining round at request time, and the
+        // advanceTime above lets the rounds advance, so pin it to the round the exact query
+        // resolved. Otherwise the holding fees derived from it differ by one round's worth.
+        asOfRound = holdingsSummary.map(_.computedAsOfRound),
       )
       holdingsSummaryAtOrBefore shouldBe holdingsSummary
 


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9441

The at_or_before query ran after advanceTime, so it resolved a different earliest open mining round than the exact query and the holding fees differed by one round.

`ScanTimeBasedIntegrationTest.snapshotting` flakes on the assertion that the
`at_or_before` holdings summary equals the `exact` one for the same snapshot:
`computed_as_of_round` came back 4817 vs 4816, and with it the holding fees
(`0.0000000000` vs `-0.0038051800`).

`as_of_round` defaults to the earliest open mining round *at request time*
(documented in `scan.yaml`), and neither query passes it. The
`advanceTime(10.minutes)` between the two lets `AdvanceOpenMiningRoundTrigger`
archive round 4816 in the gap, so the fees derived from it differ by one round.

Fix: pin `as_of_round` on the `at_or_before` query to the round the `exact`
query resolved, so the assertion tests record-time matching — which is what
it is there for. Test-only, no change to scan behaviour.

Seen in https://github.com/canton-network/splice/actions/runs/30539688988/job/90861428903

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
