### PR TITLE
[ci] Widen rate limit window in ScanIntegrationTest

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ScanIntegrationTest.scala
@@ -234,7 +234,11 @@ class ScanIntegrationTest
         // then 5 every second
         // first second is 5 (full capacity) + 5 (capacity added after consumption)
         // then 5 every second
-        val maxAccepted = 30
+        // The 50 calls are emitted at 10/s, so ~5s of refill gives 30 in the ideal case. Allow one
+        // more second of refill: throttle jitter or a slow first call stretches the window past 5s
+        // and lets a further batch through (seen accepting 31). This is still far below the 50
+        // attempted, so the assertion keeps proving that the limiter rejects.
+        val maxAccepted = 35
         // account for bursts in the stream used to rate limit the calls in `runRateLimited`
         val minAccepted = 10
         results.count(identity) should (be >= minAccepted and be <= maxAccepted)


### PR DESCRIPTION
maxAccepted was the exact theoretical ceiling with no slack, so any timing jitter that stretches the 5s emission window lets one more refill batch through (seen accepting 31).

Fixes https://github.com/DACH-NY/cn-test-failures/issues/9442

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
