### PR TITLE
add per ip rate limits

### DIFF
--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -34,18 +34,6 @@ multiValidator:
 sv:
   synchronizer:
     skipInitialization: true
-  scan:
-    externalRateLimits:
-      rateLimits:
-        /registry/metadata/v1/info:
-          perIpLimits:
-            overrides:
-              test:
-                ips:
-                  - 192.68.78.50
-                maxTokens: 250
-                tokensPerFill: 250
-                fillInterval: 60s
 splitwell:
   maxDarVersion: '0.1.8'
   participantPruningSchedule:

--- a/cluster/deployment/mock/config.yaml
+++ b/cluster/deployment/mock/config.yaml
@@ -34,6 +34,18 @@ multiValidator:
 sv:
   synchronizer:
     skipInitialization: true
+  scan:
+    externalRateLimits:
+      rateLimits:
+        /registry/metadata/v1/info:
+          perIpLimits:
+            overrides:
+              test:
+                ips:
+                  - 192.68.78.50
+                maxTokens: 250
+                tokensPerFill: 250
+                fillInterval: 60s
 splitwell:
   maxDarVersion: '0.1.8'
   participantPruningSchedule:

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1907,6 +1907,16 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
+            "overrides": {
+              "test": {
+                "fillInterval": "60s",
+                "ips": [
+                  "192.68.78.50"
+                ],
+                "maxTokens": 250,
+                "tokensPerFill": 250
+              }
+            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -2286,6 +2296,16 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
+            "overrides": {
+              "test": {
+                "fillInterval": "60s",
+                "ips": [
+                  "192.68.78.50"
+                ],
+                "maxTokens": 250,
+                "tokensPerFill": 250
+              }
+            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -3516,6 +3536,23 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
+                        }
+                      },
+                      {
+                        "entries": [
+                          {
+                            "key": "header_match",
+                            "value": "registry-metadata-info"
+                          },
+                          {
+                            "key": "client_ip",
+                            "value": "192.68.78.50"
+                          }
+                        ],
+                        "token_bucket": {
+                          "fill_interval": "60s",
+                          "max_tokens": 250,
+                          "tokens_per_fill": 250
                         }
                       },
                       {
@@ -5659,6 +5696,23 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
+                        }
+                      },
+                      {
+                        "entries": [
+                          {
+                            "key": "header_match",
+                            "value": "registry-metadata-info"
+                          },
+                          {
+                            "key": "client_ip",
+                            "value": "192.68.78.50"
+                          }
+                        ],
+                        "token_bucket": {
+                          "fill_interval": "60s",
+                          "max_tokens": 250,
+                          "tokens_per_fill": 250
                         }
                       },
                       {

--- a/cluster/expected/canton-network/expected.json
+++ b/cluster/expected/canton-network/expected.json
@@ -1907,16 +1907,6 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
-            "overrides": {
-              "test": {
-                "fillInterval": "60s",
-                "ips": [
-                  "192.68.78.50"
-                ],
-                "maxTokens": 250,
-                "tokensPerFill": 250
-              }
-            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -2296,16 +2286,6 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
-            "overrides": {
-              "test": {
-                "fillInterval": "60s",
-                "ips": [
-                  "192.68.78.50"
-                ],
-                "maxTokens": 250,
-                "tokensPerFill": 250
-              }
-            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -3536,23 +3516,6 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
-                        }
-                      },
-                      {
-                        "entries": [
-                          {
-                            "key": "header_match",
-                            "value": "registry-metadata-info"
-                          },
-                          {
-                            "key": "client_ip",
-                            "value": "192.68.78.50"
-                          }
-                        ],
-                        "token_bucket": {
-                          "fill_interval": "60s",
-                          "max_tokens": 250,
-                          "tokens_per_fill": 250
                         }
                       },
                       {
@@ -5696,23 +5659,6 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
-                        }
-                      },
-                      {
-                        "entries": [
-                          {
-                            "key": "header_match",
-                            "value": "registry-metadata-info"
-                          },
-                          {
-                            "key": "client_ip",
-                            "value": "192.68.78.50"
-                          }
-                        ],
-                        "token_bucket": {
-                          "fill_interval": "60s",
-                          "max_tokens": 250,
-                          "tokens_per_fill": 250
                         }
                       },
                       {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1132,6 +1132,16 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
+            "overrides": {
+              "test": {
+                "fillInterval": "60s",
+                "ips": [
+                  "192.68.78.50"
+                ],
+                "maxTokens": 250,
+                "tokensPerFill": 250
+              }
+            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -2314,6 +2324,23 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
+                        }
+                      },
+                      {
+                        "entries": [
+                          {
+                            "key": "header_match",
+                            "value": "registry-metadata-info"
+                          },
+                          {
+                            "key": "client_ip",
+                            "value": "192.68.78.50"
+                          }
+                        ],
+                        "token_bucket": {
+                          "fill_interval": "60s",
+                          "max_tokens": 250,
+                          "tokens_per_fill": 250
                         }
                       },
                       {

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -1132,16 +1132,6 @@
           "perIpLimits": {
             "fillInterval": "60s",
             "maxTokens": 120,
-            "overrides": {
-              "test": {
-                "fillInterval": "60s",
-                "ips": [
-                  "192.68.78.50"
-                ],
-                "maxTokens": 250,
-                "tokensPerFill": 250
-              }
-            },
             "tokensPerFill": 120
           },
           "tokensPerFill": 720,
@@ -2324,23 +2314,6 @@
                           "fill_interval": "60s",
                           "max_tokens": 720,
                           "tokens_per_fill": 720
-                        }
-                      },
-                      {
-                        "entries": [
-                          {
-                            "key": "header_match",
-                            "value": "registry-metadata-info"
-                          },
-                          {
-                            "key": "client_ip",
-                            "value": "192.68.78.50"
-                          }
-                        ],
-                        "token_bucket": {
-                          "fill_interval": "60s",
-                          "max_tokens": 250,
-                          "tokens_per_fill": 250
                         }
                       },
                       {

--- a/cluster/pulumi/common/src/ratelimit/envoyRateLimiter.test.ts
+++ b/cluster/pulumi/common/src/ratelimit/envoyRateLimiter.test.ts
@@ -1,0 +1,259 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, jest, test } from '@jest/globals';
+
+import {
+  buildRateLimitActions,
+  buildRateLimitDescriptors,
+  validateIpLimits,
+} from './envoyRateLimiter';
+
+jest.mock('@canton-network/splice-pulumi-common/src/config/envConfig', () => ({
+  __esModule: true,
+  spliceEnvConfig: {
+    requireEnv() {
+      return 'dummy';
+    },
+  },
+}));
+
+const baseLimits = {
+  maxTokens: 720,
+  tokensPerFill: 720,
+  fillInterval: '60s',
+};
+
+const perIpLimits = {
+  maxTokens: 120,
+  tokensPerFill: 120,
+  fillInterval: '60s',
+};
+
+test('buildRateLimitDescriptors generates per-endpoint and generic per-IP descriptors', () => {
+  const descriptors = buildRateLimitDescriptors({
+    '/registry/metadata/v1/info': {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits,
+    },
+  });
+
+  expect(descriptors).toHaveLength(2);
+  expect(descriptors[0]).toEqual({
+    entries: [{ key: 'header_match', value: 'registry-metadata-info' }],
+    token_bucket: {
+      max_tokens: 720,
+      tokens_per_fill: 720,
+      fill_interval: '60s',
+    },
+  });
+  expect(descriptors[1]).toEqual({
+    entries: [{ key: 'header_match', value: 'registry-metadata-info' }, { key: 'client_ip' }],
+    token_bucket: {
+      max_tokens: 120,
+      tokens_per_fill: 120,
+      fill_interval: '60s',
+    },
+  });
+});
+
+test('buildRateLimitDescriptors emits named IP overrides before generic per-IP descriptor', () => {
+  const descriptors = buildRateLimitDescriptors({
+    '/registry/metadata/v1/info': {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits: {
+        ...perIpLimits,
+        overrides: {
+          'single-validator': {
+            ips: ['192.68.78.50'],
+            maxTokens: 220,
+            tokensPerFill: 220,
+            fillInterval: '60s',
+          },
+        },
+      },
+    },
+  });
+
+  expect(descriptors).toHaveLength(3);
+  expect(descriptors[0]).toEqual(
+    expect.objectContaining({
+      entries: [{ key: 'header_match', value: 'registry-metadata-info' }],
+    })
+  );
+  expect(descriptors[1]).toEqual({
+    entries: [
+      { key: 'header_match', value: 'registry-metadata-info' },
+      { key: 'client_ip', value: '192.68.78.50' },
+    ],
+    token_bucket: {
+      max_tokens: 220,
+      tokens_per_fill: 220,
+      fill_interval: '60s',
+    },
+  });
+  expect(descriptors[2]).toEqual(
+    expect.objectContaining({
+      entries: [{ key: 'header_match', value: 'registry-metadata-info' }, { key: 'client_ip' }],
+    })
+  );
+});
+
+test('buildRateLimitDescriptors emits descriptors for named overrides with multiple ips', () => {
+  const descriptors = buildRateLimitDescriptors({
+    '/registry/metadata/v1/info': {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits: {
+        ...perIpLimits,
+        overrides: {
+          'multi-validators': {
+            ips: ['192.68.78.51', '192.68.78.52'],
+            maxTokens: 250,
+            tokensPerFill: 250,
+            fillInterval: '60s',
+          },
+        },
+      },
+    },
+  });
+
+  expect(descriptors).toHaveLength(4);
+  expect(descriptors[1]).toEqual({
+    entries: [
+      { key: 'header_match', value: 'registry-metadata-info' },
+      { key: 'client_ip', value: '192.68.78.51' },
+    ],
+    token_bucket: {
+      max_tokens: 250,
+      tokens_per_fill: 250,
+      fill_interval: '60s',
+    },
+  });
+  expect(descriptors[2]).toEqual({
+    entries: [
+      { key: 'header_match', value: 'registry-metadata-info' },
+      { key: 'client_ip', value: '192.68.78.52' },
+    ],
+    token_bucket: {
+      max_tokens: 250,
+      tokens_per_fill: 250,
+      fill_interval: '60s',
+    },
+  });
+});
+
+test('buildRateLimitActions emits per-endpoint and per-IP actions', () => {
+  const actions = buildRateLimitActions({
+    '/registry/metadata/v1/info': {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits,
+    },
+  });
+
+  expect(actions).toHaveLength(2);
+  expect(actions[0]).toEqual({
+    actions: [
+      {
+        header_value_match: {
+          descriptor_value: 'registry-metadata-info',
+          expect_match: true,
+          headers: [
+            {
+              name: ':path',
+              string_match: {
+                prefix: '/registry/metadata/v1/info',
+                ignore_case: true,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  expect(actions[1]).toEqual({
+    actions: [
+      {
+        header_value_match: {
+          descriptor_value: 'registry-metadata-info',
+          expect_match: true,
+          headers: [
+            {
+              name: ':path',
+              string_match: {
+                prefix: '/registry/metadata/v1/info',
+                ignore_case: true,
+              },
+            },
+          ],
+        },
+      },
+      {
+        request_headers: {
+          descriptor_key: 'client_ip',
+          header_name: 'x-forwarded-for',
+        },
+      },
+    ],
+  });
+});
+
+test('validateIpLimits throws on duplicate IP between two named overrides', () => {
+  expect(() =>
+    validateIpLimits('/registry/metadata/v1/info', {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits: {
+        ...perIpLimits,
+        overrides: {
+          'group-a': {
+            ips: ['192.68.78.50', '192.68.78.51'],
+            maxTokens: 250,
+            tokensPerFill: 250,
+            fillInterval: '60s',
+          },
+          'group-b': {
+            ips: ['192.68.78.51'],
+            maxTokens: 250,
+            tokensPerFill: 250,
+            fillInterval: '60s',
+          },
+        },
+      },
+    })
+  ).toThrow("192.68.78.51 (in override 'group-b')");
+});
+
+test('validateIpLimits accepts unique IPs across named overrides', () => {
+  expect(() =>
+    validateIpLimits('/registry/metadata/v1/info', {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      ...baseLimits,
+      perIpLimits: {
+        ...perIpLimits,
+        overrides: {
+          'single-validator': {
+            ips: ['192.68.78.50'],
+            maxTokens: 220,
+            tokensPerFill: 220,
+            fillInterval: '60s',
+          },
+          'multi-validators': {
+            ips: ['192.68.78.51', '192.68.78.52'],
+            maxTokens: 250,
+            tokensPerFill: 250,
+            fillInterval: '60s',
+          },
+        },
+      },
+    })
+  ).not.toThrow();
+});

--- a/cluster/pulumi/common/src/ratelimit/envoyRateLimiter.ts
+++ b/cluster/pulumi/common/src/ratelimit/envoyRateLimiter.ts
@@ -11,9 +11,13 @@ interface Limits {
   fillInterval: string;
 }
 
+interface PerIpLimits extends Limits {
+  overrides?: Record<string, { ips: string[] } & Limits>;
+}
+
 interface MatchedLimits extends Limits {
   type: 'limited';
-  perIpLimits?: Limits;
+  perIpLimits?: PerIpLimits;
 }
 
 interface Banned {
@@ -96,6 +100,29 @@ function validateEndpointCoverage(
   return { missing, orphaned };
 }
 
+export function validateIpLimits(pathPrefix: string, rateLimit: LocalLimit<MatchedLimits>): void {
+  if (!rateLimit.perIpLimits) {
+    return;
+  }
+
+  const seenIps = new Set<string>();
+  const duplicates: string[] = [];
+
+  Object.entries(rateLimit.perIpLimits.overrides || {}).forEach(([overrideKey, override]) => {
+    override.ips.forEach(ip => {
+      if (seenIps.has(ip)) {
+        duplicates.push(`${ip} (in override '${overrideKey}')`);
+      } else {
+        seenIps.add(ip);
+      }
+    });
+  });
+
+  if (duplicates.length > 0) {
+    throw new Error(`${pathPrefix}: duplicate IPs in per-IP rate limits: ${duplicates.join(', ')}`);
+  }
+}
+
 function validateEffectiveRateLimits(
   args: RateLimitEnvoyFilterArgs
 ): LocalLimits<MatchedLimits> | undefined {
@@ -145,7 +172,7 @@ function validateEffectiveRateLimits(
   }
 
   // Filter out banned and unlimited entries
-  return Object.fromEntries(
+  const effectiveRateLimits = Object.fromEntries(
     Object.entries(args.rateLimits || {}).filter(
       (ent): ent is [string, LocalLimit<MatchedLimits>] => {
         // TODO (#4201): in banned case, implement actual banning with special short-circuit for whitelisted IPs
@@ -156,6 +183,104 @@ function validateEffectiveRateLimits(
       }
     )
   );
+
+  Object.entries(effectiveRateLimits).forEach(([pathPrefix, rateLimit]) => {
+    validateIpLimits(pathPrefix, rateLimit);
+  });
+
+  return effectiveRateLimits;
+}
+
+export function buildRateLimitActions(effectiveRateLimits: LocalLimits<MatchedLimits>): unknown[] {
+  return Object.entries(effectiveRateLimits).flatMap(([pathPrefix, rateLimit]) => {
+    const actions = [];
+
+    // Action 1: generate the per-endpoint action
+    const baseAction = {
+      header_value_match: {
+        descriptor_value: rateLimit.name,
+        expect_match: true,
+        headers: [
+          {
+            name: ':path',
+            string_match: {
+              prefix: pathPrefix,
+              ignore_case: true,
+            },
+          },
+        ],
+      },
+    };
+
+    actions.push({ actions: [baseAction] });
+
+    // Action 2: generate the per-IP action if perIpLimits exists
+    if (rateLimit.perIpLimits) {
+      actions.push({
+        actions: [
+          baseAction,
+          {
+            request_headers: {
+              descriptor_key: clientIpEntryKey,
+              header_name: 'x-forwarded-for',
+            },
+          },
+        ],
+      });
+    }
+
+    return actions;
+  });
+}
+
+export function buildRateLimitDescriptors(
+  effectiveRateLimits: LocalLimits<MatchedLimits>
+): unknown[] {
+  return Object.values(effectiveRateLimits).flatMap(rateLimit => {
+    const descs = [];
+
+    // per-endpoint bucket
+    descs.push({
+      entries: [{ key: 'header_match', value: rateLimit.name }],
+      token_bucket: {
+        max_tokens: rateLimit.maxTokens,
+        tokens_per_fill: rateLimit.tokensPerFill,
+        fill_interval: rateLimit.fillInterval,
+      },
+    });
+
+    // generate the per-IP buckets if configured
+    if (rateLimit.perIpLimits) {
+      // IP-specific overrides first, so they take precedence over the generic per-IP bucket
+      Object.entries(rateLimit.perIpLimits.overrides || {}).forEach(([, override]) => {
+        override.ips.forEach(ip => {
+          descs.push({
+            entries: [
+              { key: 'header_match', value: rateLimit.name },
+              { key: clientIpEntryKey, value: ip },
+            ],
+            token_bucket: {
+              max_tokens: override.maxTokens,
+              tokens_per_fill: override.tokensPerFill,
+              fill_interval: override.fillInterval,
+            },
+          });
+        });
+      });
+
+      // Generic per-IP fallback last
+      descs.push({
+        entries: [{ key: 'header_match', value: rateLimit.name }, { key: clientIpEntryKey }],
+        token_bucket: {
+          max_tokens: rateLimit.perIpLimits.maxTokens,
+          tokens_per_fill: rateLimit.perIpLimits.tokensPerFill,
+          fill_interval: rateLimit.perIpLimits.fillInterval,
+        },
+      });
+    }
+
+    return descs;
+  });
 }
 
 export class RateLimitEnvoyFilter extends pulumi.ComponentResource {
@@ -169,46 +294,7 @@ export class RateLimitEnvoyFilter extends pulumi.ComponentResource {
     super('splice:RateLimit', `splice-${args.namespace}-${name}`, args, opts);
     const effectiveRateLimits = validateEffectiveRateLimits(args);
 
-    const rateLimitActions: unknown[] =
-      Object.entries(effectiveRateLimits || {}).flatMap(([pathPrefix, rateLimit]) => {
-        const actions = [];
-
-        // Action 1: generate the per-endpoint action
-        const baseAction = {
-          header_value_match: {
-            descriptor_value: rateLimit.name,
-            expect_match: true,
-            headers: [
-              {
-                name: ':path',
-                string_match: {
-                  prefix: pathPrefix,
-                  ignore_case: true,
-                },
-              },
-            ],
-          },
-        };
-
-        actions.push({ actions: [baseAction] });
-
-        // Action 2: generate the per-IP action if perIpLimits exists
-        if (rateLimit.perIpLimits) {
-          actions.push({
-            actions: [
-              baseAction,
-              {
-                request_headers: {
-                  descriptor_key: 'client_ip',
-                  header_name: 'x-forwarded-for',
-                },
-              },
-            ],
-          });
-        }
-
-        return actions;
-      }) || [];
+    const rateLimitActions = buildRateLimitActions(effectiveRateLimits || {});
 
     const enableEnvoyRateLimitMetricsAnnotation = `
 proxyStatsMatcher:
@@ -317,45 +403,7 @@ proxyStatsMatcher:
                       // simplified descriptors by combining with actions and requiring all the tokens of an action to be set
                       // a descriptor in practice is a subset of tags from a rate limit
                       // but important to note that for each rate limit only one descriptor can match, if multiple descriptors match, the first one is used
-                      descriptors: Object.values(effectiveRateLimits || {}).flatMap(rateLimit => {
-                        const descs = [];
-
-                        // per-endpoint bucket
-
-                        descs.push({
-                          entries: [
-                            {
-                              key: 'header_match',
-                              value: rateLimit.name,
-                            },
-                          ],
-                          token_bucket: {
-                            max_tokens: rateLimit.maxTokens,
-                            tokens_per_fill: rateLimit.tokensPerFill,
-                            fill_interval: rateLimit.fillInterval,
-                          },
-                        });
-
-                        // generate the per-IP bucket if configured
-                        if (rateLimit.perIpLimits) {
-                          descs.push({
-                            entries: [
-                              {
-                                key: 'header_match',
-                                value: rateLimit.name,
-                              },
-                              { key: clientIpEntryKey },
-                            ],
-                            token_bucket: {
-                              max_tokens: rateLimit.perIpLimits.maxTokens,
-                              tokens_per_fill: rateLimit.perIpLimits.tokensPerFill,
-                              fill_interval: rateLimit.perIpLimits.fillInterval,
-                            },
-                          });
-                        }
-
-                        return descs;
-                      }),
+                      descriptors: buildRateLimitDescriptors(effectiveRateLimits || {}),
                     },
                   },
                 },

--- a/cluster/pulumi/common/src/ratelimit/rateLimitSchema.test.ts
+++ b/cluster/pulumi/common/src/ratelimit/rateLimitSchema.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test } from '@jest/globals';
+
+import { RateLimitSchema } from './rateLimitSchema';
+
+const validConfig = {
+  globalLimits: {
+    maxTokens: 1000,
+    tokensPerFill: 1000,
+    fillInterval: '60s',
+  },
+  rateLimits: {
+    '/registry/metadata/v1/info': {
+      name: 'registry-metadata-info',
+      type: 'limited',
+      maxTokens: 720,
+      tokensPerFill: 720,
+      fillInterval: '60s',
+      perIpLimits: {
+        maxTokens: 120,
+        tokensPerFill: 120,
+        fillInterval: '60s',
+      },
+    },
+  },
+};
+
+test('RateLimitSchema accepts config without overrides', () => {
+  expect(() => RateLimitSchema.parse(validConfig)).not.toThrow();
+});
+
+test('RateLimitSchema accepts named overrides with ips', () => {
+  const config = {
+    ...validConfig,
+    rateLimits: {
+      '/registry/metadata/v1/info': {
+        ...validConfig.rateLimits['/registry/metadata/v1/info'],
+        perIpLimits: {
+          ...validConfig.rateLimits['/registry/metadata/v1/info'].perIpLimits,
+          overrides: {
+            'single-validator': {
+              ips: ['192.68.78.50'],
+              maxTokens: 220,
+              tokensPerFill: 220,
+              fillInterval: '60s',
+            },
+            'multi-validators': {
+              ips: ['192.68.78.51', '192.68.78.52'],
+              maxTokens: 250,
+              tokensPerFill: 250,
+              fillInterval: '60s',
+            },
+          },
+        },
+      },
+    },
+  };
+  expect(() => RateLimitSchema.parse(config)).not.toThrow();
+});
+
+test('RateLimitSchema rejects override without ips', () => {
+  const config = {
+    ...validConfig,
+    rateLimits: {
+      '/registry/metadata/v1/info': {
+        ...validConfig.rateLimits['/registry/metadata/v1/info'],
+        perIpLimits: {
+          ...validConfig.rateLimits['/registry/metadata/v1/info'].perIpLimits,
+          overrides: {
+            '192.68.78.50': {
+              maxTokens: 220,
+              tokensPerFill: 220,
+              fillInterval: '60s',
+            },
+          },
+        },
+      },
+    },
+  };
+  expect(() => RateLimitSchema.parse(config)).toThrow();
+});
+
+test('RateLimitSchema rejects non-IPv4 addresses in ips', () => {
+  const config = {
+    ...validConfig,
+    rateLimits: {
+      '/registry/metadata/v1/info': {
+        ...validConfig.rateLimits['/registry/metadata/v1/info'],
+        perIpLimits: {
+          ...validConfig.rateLimits['/registry/metadata/v1/info'].perIpLimits,
+          overrides: {
+            'multi-validators': {
+              ips: ['2001:db8::1'],
+              maxTokens: 250,
+              tokensPerFill: 250,
+              fillInterval: '60s',
+            },
+          },
+        },
+      },
+    },
+  };
+  expect(() => RateLimitSchema.parse(config)).toThrow();
+});
+
+test('RateLimitSchema rejects empty override ips array', () => {
+  const config = {
+    ...validConfig,
+    rateLimits: {
+      '/registry/metadata/v1/info': {
+        ...validConfig.rateLimits['/registry/metadata/v1/info'],
+        perIpLimits: {
+          ...validConfig.rateLimits['/registry/metadata/v1/info'].perIpLimits,
+          overrides: {
+            'empty-group': {
+              ips: [],
+              maxTokens: 250,
+              tokensPerFill: 250,
+              fillInterval: '60s',
+            },
+          },
+        },
+      },
+    },
+  };
+  expect(() => RateLimitSchema.parse(config)).toThrow();
+});

--- a/cluster/pulumi/common/src/ratelimit/rateLimitSchema.ts
+++ b/cluster/pulumi/common/src/ratelimit/rateLimitSchema.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { isIP } from 'net';
 import { z } from 'zod';
 
 export const BucketRateLimitSchema = z.object({
@@ -8,9 +9,21 @@ export const BucketRateLimitSchema = z.object({
   fillInterval: z.string(),
 });
 
+const Ipv4AddressSchema = z.string().refine(ip => isIP(ip) === 4, {
+  message: 'Expected IPv4 address',
+});
+
+const OverrideSchema = BucketRateLimitSchema.extend({
+  ips: z.array(Ipv4AddressSchema).min(1),
+});
+
+export const PerIpLimitsSchema = BucketRateLimitSchema.extend({
+  overrides: z.record(z.string().min(1), OverrideSchema).optional(),
+});
+
 const BucketMatchedRateLimitSchema = BucketRateLimitSchema.extend({
   type: z.literal('limited'),
-  perIpLimits: BucketRateLimitSchema.optional(),
+  perIpLimits: PerIpLimitsSchema.optional(),
 });
 
 export const BannedSchema = z.object({


### PR DESCRIPTION
Fixes https://github.com/canton-network/splice/issues/6599

This PR adds:
- per IP rate limits
- validation for the schema

example usage:
```
perIpLimits:
  maxTokens: 120
  tokensPerFill: 120
  fillInterval: 60s
  overrides:
    test:
      ips:
        - 192.68.78.50
      maxTokens: 220
      tokensPerFill: 220
      fillInterval: 60s
```

Note: the change is backwards-compatible.
Relevant doc: [link](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter#using-rate-limit-descriptors-for-local-rate-limiting)
Example config change: [link](https://github.com/canton-network/splice/pull/6631/changes/0dc6baf444fa541f2a2d470fff38c4dad33e55a4)