### PR TITLE
Remove Scan app `enableAppActivityRecordAndTrafficIngestion` and `serveAppActivityRecordsAndTraffic` config options

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/DistributedDomainIntegrationTest.scala
@@ -117,7 +117,7 @@ class DistributedDomainIntegrationTest
 
     // Check that things work for external validators
     clue("Alice can tap") {
-      onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
+      eventuallySucceeds()(onboardWalletUser(aliceWalletClient, aliceValidatorBackend))
       aliceWalletClient.tap(1000)
     }
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualSignatureIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/ManualSignatureIntegrationTest.scala
@@ -6,7 +6,6 @@ import com.digitalasset.canton.crypto.SigningPublicKey
 import com.digitalasset.canton.topology.Namespace
 import com.digitalasset.canton.topology.admin.grpc.TopologyStoreId
 import com.digitalasset.canton.topology.store.TimeQuery
-import org.lfdecentralizedtrust.splice.config.ConfigTransforms.updateAllScanAppConfigs
 import org.lfdecentralizedtrust.splice.integration.EnvironmentDefinition
 import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.IntegrationTest
 import org.lfdecentralizedtrust.splice.util.WalletTestUtil
@@ -25,12 +24,6 @@ class ManualSignatureIntegrationTest
       .withManualStart
       .withoutAliceValidatorConnectingToSplitwell
       .withSequencerConnectionsFromScanDisabled()
-      .addConfigTransforms((_, config) =>
-        updateAllScanAppConfigs((_, config) =>
-          // Sequencer is returning TRAFFIC_CONTROL_DISABLED when looking up traffic summaries.
-          config.copy(enableAppActivityRecordAndTrafficIngestion = false)
-        )(config)
-      )
   }
 
   "synchronizer" should {

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/TrafficBasedRewardsSvAppTimeBasedIntegrationTest.scala
@@ -227,7 +227,7 @@ class TrafficBasedRewardsSvAppTimeBasedIntegrationTest
 
           clue("CalculateRewardsV2 contracts are also visible in scan rewards reference store") {
             eventually() {
-              val v2s = sv1ScanBackend.appState.rewardsReferenceStoreO.value
+              val v2s = sv1ScanBackend.appState.rewardsReferenceStore
                 .listActiveCalculateRewardsV2()
                 .futureValue
               v2s.map(c =>

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanApp.scala
@@ -144,16 +144,12 @@ class ScanApp(
         nodeMetrics.grpcClientMetrics,
         retryProvider,
       ),
-      if (config.enableAppActivityRecordAndTrafficIngestion) {
-        Some(
-          new SequencerTrafficClient(
-            syncConfig.sequencer,
-            retryProvider,
-            nodeMetrics.grpcClientMetrics,
-            loggerFactory,
-          )
-        )
-      } else None,
+      new SequencerTrafficClient(
+        syncConfig.sequencer,
+        retryProvider,
+        nodeMetrics.grpcClientMetrics,
+        loggerFactory,
+      ),
     )
 
   override def initialize(
@@ -273,30 +269,22 @@ class ScanApp(
           loggerFactory,
         )
       )
-      // Conditionally create traffic summary ingestion dependencies
-      appActivityRecordStoreO =
-        if (config.enableAppActivityRecordAndTrafficIngestion) {
-          Some(
-            new DbAppActivityRecordStore(
-              storage,
-              updateHistory,
-              DbAppActivityRecordStore.IngestionVersions(
-                AppActivityComputation.ActivityIngestionCodeVersion,
-                config.activityIngestionUserVersion.fold(0)(_.toInt),
-              ),
-              config.isFirstSv,
-              loggerFactory,
-            )
-          )
-        } else None
-      appRewardsStoreO = appActivityRecordStoreO.map(appActivityRecordStore =>
-        new DbScanAppRewardsStore(
-          storage,
-          updateHistory,
-          appActivityRecordStore,
-          config.rewardMintingAllowanceTolerance,
-          loggerFactory,
-        )
+      appActivityRecordStore = new DbAppActivityRecordStore(
+        storage,
+        updateHistory,
+        DbAppActivityRecordStore.IngestionVersions(
+          AppActivityComputation.ActivityIngestionCodeVersion,
+          config.activityIngestionUserVersion.fold(0)(_.toInt),
+        ),
+        config.isFirstSv,
+        loggerFactory,
+      )
+      appRewardsStore = new DbScanAppRewardsStore(
+        storage,
+        updateHistory,
+        appActivityRecordStore,
+        config.rewardMintingAllowanceTolerance,
+        loggerFactory,
       )
       synchronizerId <-
         retryProvider.getValueWithRetries(
@@ -319,8 +307,8 @@ class ScanApp(
         loggerFactory,
         store,
         updateHistory,
-        appRewardsStoreO,
-        appActivityRecordStoreO,
+        appRewardsStore,
+        appActivityRecordStore,
         storage,
         acsSnapshotStore,
         serviceUserPrimaryParty,
@@ -331,7 +319,7 @@ class ScanApp(
       scanVerdictStore = DbScanVerdictStore(
         storage,
         updateHistory,
-        appActivityRecordStoreO,
+        appActivityRecordStore,
         loggerFactory,
       )(ec)
       scanEventStore = new ScanEventStore(
@@ -360,25 +348,24 @@ class ScanApp(
         dsoParty,
         config.spliceInstanceNames.nameServiceNameAcronym.toLowerCase(),
       )
-      rewardsReferenceStoreO =
-        if (config.enableAppActivityRecordAndTrafficIngestion) {
-          val rewardsStore = ScanRewardsReferenceStore(
-            key = ScanRewardsReferenceStore.Key(
-              dsoParty = dsoParty,
-              synchronizerId = synchronizerId,
-            ),
-            storage,
-            loggerFactory,
-            retryProvider,
-            domainMigrationId,
-            participantId,
-            config.automation.ingestion,
-            config.parameters.defaultLimit,
-          )
-          automation.registerRewardsReferenceStoreIngestion(rewardsStore)
-          automation.registerRewardComputationTrigger(rewardsStore)
-          Some(rewardsStore)
-        } else None
+      rewardsReferenceStore = {
+        val rewardsStore = ScanRewardsReferenceStore(
+          key = ScanRewardsReferenceStore.Key(
+            dsoParty = dsoParty,
+            synchronizerId = synchronizerId,
+          ),
+          storage,
+          loggerFactory,
+          retryProvider,
+          domainMigrationId,
+          participantId,
+          config.automation.ingestion,
+          config.parameters.defaultLimit,
+        )
+        automation.registerRewardsReferenceStoreIngestion(rewardsStore)
+        automation.registerRewardComputationTrigger(rewardsStore)
+        rewardsStore
+      }
       verdictAutomation = new ScanVerdictAutomationService(
         config,
         syncNodes,
@@ -390,7 +377,7 @@ class ScanApp(
         domainMigrationId,
         synchronizerId,
         nodeMetrics.verdictIngestion,
-        rewardsReferenceStoreO,
+        rewardsReferenceStore,
       )
       scanHandler = new HttpScanHandler(
         serviceUserPrimaryParty,
@@ -400,15 +387,14 @@ class ScanApp(
         syncService,
         automation,
         updateHistory,
-        appRewardsStoreO,
-        appActivityRecordStoreO,
+        appRewardsStore,
+        appActivityRecordStore,
         acsSnapshotStore,
         scanEventStore,
         bulkStorage.map(_.reader),
         dsoAnsResolver,
         config.miningRoundsCacheTimeToLiveOverride,
         config.enableForcedAcsSnapshots,
-        config.serveAppActivityRecordsAndTraffic,
         clock,
         loggerFactory,
         packageVersionSupport,
@@ -548,7 +534,7 @@ class ScanApp(
         bulkStorage,
         verdictAutomation,
         scanEventStore,
-        rewardsReferenceStoreO,
+        rewardsReferenceStore,
         loggerFactory.getTracedLogger(ScanApp.State.getClass),
         timeouts,
         bftSequencersWithAdminConnections.map(_._1),
@@ -622,7 +608,7 @@ object ScanApp {
       bulkStorage: Option[BulkStorage],
       verdictAutomation: ScanVerdictAutomationService,
       eventStore: ScanEventStore,
-      rewardsReferenceStoreO: Option[ScanRewardsReferenceStore],
+      rewardsReferenceStore: ScanRewardsReferenceStore,
       logger: TracedLogger,
       timeouts: ProcessingTimeout,
       bftSequencersAdminConnections: Seq[SequencerAdminConnection],
@@ -643,9 +629,7 @@ object ScanApp {
             automation,
             verdictAutomation,
             store,
-          ) ++
-          rewardsReferenceStoreO.toList ++
-          Seq(
+            rewardsReferenceStore,
             storage,
             synchronizerNodes.current,
             participantAdminConnection,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanSynchronizerNode.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/ScanSynchronizerNode.scala
@@ -8,7 +8,7 @@ import org.lfdecentralizedtrust.splice.scan.sequencer.SequencerTrafficClient
 
 final class ScanSynchronizerNode(
     override val sequencerAdminConnection: SequencerAdminConnection,
-    val sequencerTrafficClient: Option[SequencerTrafficClient],
+    val sequencerTrafficClient: SequencerTrafficClient,
 ) extends SynchronizerNode(sequencerAdminConnection)
     with AutoCloseable {
   override def close(): Unit = {

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/admin/http/HttpScanHandler.scala
@@ -147,15 +147,14 @@ class HttpScanHandler(
     synchronizerNodeService: SynchronizerNodeService[ScanSynchronizerNode],
     protected val storeWithIngestion: AppStoreWithIngestion[ScanStore],
     updateHistory: UpdateHistory,
-    appRewardsStoreO: Option[DbScanAppRewardsStore],
-    appActivityStoreO: Option[AppActivityStore],
+    appRewardsStore: DbScanAppRewardsStore,
+    appActivityStore: AppActivityStore,
     snapshotStore: AcsSnapshotStore,
     eventStore: ScanEventStore,
     bulkStorage: Option[BulkStorageReader],
     dsoAnsResolver: DsoAnsResolver,
     miningRoundsCacheTimeToLiveOverride: Option[NonNegativeFiniteDuration],
     enableForcedAcsSnapshots: Boolean,
-    serveAppActivityRecordsAndTraffic: Boolean,
     clock: Clock,
     protected val loggerFactory: NamedLoggerFactory,
     protected val packageVersionSupport: PackageVersionSupport,
@@ -831,14 +830,11 @@ class HttpScanHandler(
         case Some((verdictWithViewsO, updateO)) =>
           val verdictRowIdO = verdictWithViewsO.map { case (v, _) => v.rowId }
           for {
-            appActivityRecordO <-
-              if (serveAppActivityRecordsAndTraffic)
-                verdictRowIdO match {
-                  case Some(rowId) =>
-                    eventStore.getAppActivityRecords(Seq(rowId)).map(_.get(rowId))
-                  case None => Future.successful(None)
-                }
-              else Future.successful(None)
+            appActivityRecordO <- verdictRowIdO match {
+              case Some(rowId) =>
+                eventStore.getAppActivityRecords(Seq(rowId)).map(_.get(rowId))
+              case None => Future.successful(None)
+            }
           } yield {
             val encodedUpdateV2 = updateO
               .map(
@@ -853,12 +849,9 @@ class HttpScanHandler(
             val verdictEncoded = verdictWithViewsO.map { case (v, views) =>
               ScanHttpEncodings.encodeVerdict(v, views)
             }
-            val trafficSummaryEncoded =
-              if (serveAppActivityRecordsAndTraffic)
-                verdictWithViewsO.flatMap { case (v, _) =>
-                  v.trafficSummaryO.map(ScanHttpEncodings.encodeTrafficSummary)
-                }
-              else None
+            val trafficSummaryEncoded = verdictWithViewsO.flatMap { case (v, _) =>
+              v.trafficSummaryO.map(ScanHttpEncodings.encodeTrafficSummary)
+            }
             val appActivityRecordEncoded = appActivityRecordO.map(
               ScanHttpEncodings.encodeAppActivityRecord
             )
@@ -915,9 +908,7 @@ class HttpScanHandler(
         verdictRowIds = events.flatMap { case (verdictWithViewsO, _) =>
           verdictWithViewsO.map { case (v, _) => v.rowId }
         }
-        appActivityRecordMap <-
-          if (serveAppActivityRecordsAndTraffic) eventStore.getAppActivityRecords(verdictRowIds)
-          else Future.successful(Map.empty[Long, eventStore.AppActivityRecordT])
+        appActivityRecordMap <- eventStore.getAppActivityRecords(verdictRowIds)
       } yield events.map { case (verdictWithViewsO, updateO) =>
         val encodedUpdateV2 = updateO
           .map(
@@ -932,12 +923,9 @@ class HttpScanHandler(
         val verdictEncoded = verdictWithViewsO.map { case (v, views) =>
           ScanHttpEncodings.encodeVerdict(v, views)
         }
-        val trafficSummaryEncoded =
-          if (serveAppActivityRecordsAndTraffic)
-            verdictWithViewsO.flatMap { case (v, _) =>
-              v.trafficSummaryO.map(ScanHttpEncodings.encodeTrafficSummary)
-            }
-          else None
+        val trafficSummaryEncoded = verdictWithViewsO.flatMap { case (v, _) =>
+          v.trafficSummaryO.map(ScanHttpEncodings.encodeTrafficSummary)
+        }
         val appActivityRecordEncoded = verdictWithViewsO.flatMap { case (v, _) =>
           appActivityRecordMap.get(v.rowId).map(ScanHttpEncodings.encodeAppActivityRecord)
         }
@@ -2706,23 +2694,14 @@ class HttpScanHandler(
   ] = {
     implicit val tc = extracted
     withSpan(s"$workflowId.getRewardAccountingEarliestAvailableRound") { _ => _ =>
-      appActivityStoreO match {
-        case Some(appActivityStore) =>
-          appActivityStore.earliestRoundWithCompleteAppActivity().map {
-            case Some(round) =>
-              ScanResource.GetRewardAccountingEarliestAvailableRoundResponse.OK(
-                definitions.GetRewardAccountingEarliestAvailableRoundResponse(round)
-              )
-            case None =>
-              ScanResource.GetRewardAccountingEarliestAvailableRoundResponse.NotFound(
-                ErrorResponse("No reward accounting data available yet")
-              )
-          }
+      appActivityStore.earliestRoundWithCompleteAppActivity().map {
+        case Some(round) =>
+          ScanResource.GetRewardAccountingEarliestAvailableRoundResponse.OK(
+            definitions.GetRewardAccountingEarliestAvailableRoundResponse(round)
+          )
         case None =>
-          Future.successful(
-            ScanResource.GetRewardAccountingEarliestAvailableRoundResponse.NotFound(
-              ErrorResponse("Reward accounting is not enabled")
-            )
+          ScanResource.GetRewardAccountingEarliestAvailableRoundResponse.NotFound(
+            ErrorResponse("No reward accounting data available yet")
           )
       }
     }
@@ -2745,44 +2724,38 @@ class HttpScanHandler(
       )
     )
     withSpan(s"$workflowId.getRewardAccountingActivityTotals") { _ => _ =>
-      (appRewardsStoreO, appActivityStoreO) match {
-        case (Some(appRewardsStore), Some(appActivityStore)) =>
-          appRewardsStore.getAppActivityRoundTotalByRound(roundNumber).flatMap {
-            case Some(activityTotal) =>
-              appRewardsStore.getAppRewardRoundTotalByRound(roundNumber).map {
-                case Some(rewardTotal) =>
-                  ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
-                    definitions.GetRewardAccountingActivityTotalsResponse(
-                      definitions.RewardAccountingActivityTotalsOk(
-                        status = "Ok",
-                        roundNumber = activityTotal.roundNumber,
-                        totalAppActivityWeight = activityTotal.totalRoundAppActivityWeight,
-                        activePartiesCount = activityTotal.activeAppProviderPartiesCount,
-                        activityRecordsCount = activityTotal.activityRecordsCount,
-                        totalAppRewardMintingAllowance =
-                          rewardTotal.totalAppRewardMintingAllowance.toString,
-                        totalAppRewardThresholded = rewardTotal.totalAppRewardThresholded.toString,
-                        totalAppRewardUnclaimed = rewardTotal.totalAppRewardUnclaimed.toString,
-                        rewardedAppProviderPartiesCount =
-                          rewardTotal.rewardedAppProviderPartiesCount,
-                      )
-                    )
+      appRewardsStore.getAppActivityRoundTotalByRound(roundNumber).flatMap {
+        case Some(activityTotal) =>
+          appRewardsStore.getAppRewardRoundTotalByRound(roundNumber).map {
+            case Some(rewardTotal) =>
+              ScanResource.GetRewardAccountingActivityTotalsResponse.OK(
+                definitions.GetRewardAccountingActivityTotalsResponse(
+                  definitions.RewardAccountingActivityTotalsOk(
+                    status = "Ok",
+                    roundNumber = activityTotal.roundNumber,
+                    totalAppActivityWeight = activityTotal.totalRoundAppActivityWeight,
+                    activePartiesCount = activityTotal.activeAppProviderPartiesCount,
+                    activityRecordsCount = activityTotal.activityRecordsCount,
+                    totalAppRewardMintingAllowance =
+                      rewardTotal.totalAppRewardMintingAllowance.toString,
+                    totalAppRewardThresholded = rewardTotal.totalAppRewardThresholded.toString,
+                    totalAppRewardUnclaimed = rewardTotal.totalAppRewardUnclaimed.toString,
+                    rewardedAppProviderPartiesCount = rewardTotal.rewardedAppProviderPartiesCount,
                   )
-                case None =>
-                  // We should never hit this, as both activity totals and round
-                  // totals are added in a single DB Tx
-                  undetermined
-              }
+                )
+              )
             case None =>
-              appActivityStore.earliestIngestedRound().map {
-                case Some(earliestIngested) if roundNumber <= earliestIngested =>
-                  cannotProvide
-                case _ =>
-                  undetermined
-              }
+              // We should never hit this, as both activity totals and round
+              // totals are added in a single DB Tx
+              undetermined
           }
-        case _ =>
-          Future.successful(cannotProvide)
+        case None =>
+          appActivityStore.earliestIngestedRound().map {
+            case Some(earliestIngested) if roundNumber <= earliestIngested =>
+              cannotProvide
+            case _ =>
+              undetermined
+          }
       }
     }
   }
@@ -2804,31 +2777,26 @@ class HttpScanHandler(
       )
     )
     withSpan(s"$workflowId.getRewardAccountingRootHash") { _ => _ =>
-      (appRewardsStoreO, appActivityStoreO) match {
-        case (Some(appRewardsStore), Some(appActivityStore)) =>
-          appRewardsStore.getAppRewardRootHashByRound(roundNumber).flatMap {
-            case Some(rootHash) =>
-              Future.successful(
-                ScanResource.GetRewardAccountingRootHashResponse.OK(
-                  definitions.GetRewardAccountingRootHashResponse(
-                    definitions.RewardAccountingRootHashOk(
-                      status = "Ok",
-                      roundNumber = rootHash.roundNumber,
-                      rootHash = rootHash.rootHash.toHex,
-                    )
-                  )
+      appRewardsStore.getAppRewardRootHashByRound(roundNumber).flatMap {
+        case Some(rootHash) =>
+          Future.successful(
+            ScanResource.GetRewardAccountingRootHashResponse.OK(
+              definitions.GetRewardAccountingRootHashResponse(
+                definitions.RewardAccountingRootHashOk(
+                  status = "Ok",
+                  roundNumber = rootHash.roundNumber,
+                  rootHash = rootHash.rootHash.toHex,
                 )
               )
-            case None =>
-              appActivityStore.earliestIngestedRound().map {
-                case Some(earliestIngested) if roundNumber <= earliestIngested =>
-                  cannotProvide
-                case _ =>
-                  undetermined
-              }
+            )
+          )
+        case None =>
+          appActivityStore.earliestIngestedRound().map {
+            case Some(earliestIngested) if roundNumber <= earliestIngested =>
+              cannotProvide
+            case _ =>
+              undetermined
           }
-        case _ =>
-          Future.successful(cannotProvide)
       }
     }
   }
@@ -2840,50 +2808,41 @@ class HttpScanHandler(
   ] = {
     implicit val tc = extracted
     withSpan(s"$workflowId.getRewardAccountingBatch") { _ => _ =>
-      appRewardsStoreO match {
-        case None =>
-          Future.successful(
+      appRewardsStore
+        .lookupBatchByHash(roundNumber, DbScanAppRewardsStore.RewardHash.fromHex(batchHash))
+        .map {
+          case None =>
             ScanResource.GetRewardAccountingBatchResponse.NotFound(
-              ErrorResponse("Reward accounting is not enabled on this node")
+              ErrorResponse(
+                s"Batch not (yet) found for round $roundNumber with hash $batchHash"
+              )
             )
-          )
-        case Some(appRewardsStore) =>
-          appRewardsStore
-            .lookupBatchByHash(roundNumber, DbScanAppRewardsStore.RewardHash.fromHex(batchHash))
-            .map {
-              case None =>
-                ScanResource.GetRewardAccountingBatchResponse.NotFound(
-                  ErrorResponse(
-                    s"Batch not (yet) found for round $roundNumber with hash $batchHash"
-                  )
+          case Some(batch: DbScanAppRewardsStore.BatchOfBatches) =>
+            ScanResource.GetRewardAccountingBatchResponse.OK(
+              definitions.GetRewardAccountingBatchResponse(
+                definitions.RewardAccountingBatchOfBatches(
+                  batchType = "BatchOfBatches",
+                  childHashes = batch.childHashes.map(_.toHex).toVector,
                 )
-              case Some(batch: DbScanAppRewardsStore.BatchOfBatches) =>
-                ScanResource.GetRewardAccountingBatchResponse.OK(
-                  definitions.GetRewardAccountingBatchResponse(
-                    definitions.RewardAccountingBatchOfBatches(
-                      batchType = "BatchOfBatches",
-                      childHashes = batch.childHashes.map(_.toHex).toVector,
+              )
+            )
+          case Some(batch: DbScanAppRewardsStore.BatchOfMintingAllowances) =>
+            ScanResource.GetRewardAccountingBatchResponse.OK(
+              definitions.GetRewardAccountingBatchResponse(
+                definitions.RewardAccountingBatchOfMintingAllowances(
+                  batchType = "BatchOfMintingAllowances",
+                  mintingAllowances = batch.allowances
+                    .map(a =>
+                      definitions.RewardAccountingMintingAllowance(
+                        provider = a.provider,
+                        amount = a.amount.toString,
+                      )
                     )
-                  )
+                    .toVector,
                 )
-              case Some(batch: DbScanAppRewardsStore.BatchOfMintingAllowances) =>
-                ScanResource.GetRewardAccountingBatchResponse.OK(
-                  definitions.GetRewardAccountingBatchResponse(
-                    definitions.RewardAccountingBatchOfMintingAllowances(
-                      batchType = "BatchOfMintingAllowances",
-                      mintingAllowances = batch.allowances
-                        .map(a =>
-                          definitions.RewardAccountingMintingAllowance(
-                            provider = a.provider,
-                            amount = a.amount.toString,
-                          )
-                        )
-                        .toVector,
-                    )
-                  )
-                )
-            }
-      }
+              )
+            )
+        }
     }
   }
 }

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanAutomationService.scala
@@ -47,8 +47,8 @@ class ScanAutomationService(
     protected val loggerFactory: NamedLoggerFactory,
     store: ScanStore,
     val updateHistory: UpdateHistory,
-    appRewardsStoreO: Option[DbScanAppRewardsStore],
-    appActivityStoreO: Option[AppActivityStore],
+    appRewardsStore: DbScanAppRewardsStore,
+    appActivityStore: AppActivityStore,
     storage: DbStorage,
     snapshotStore: AcsSnapshotStore,
     svParty: PartyId,
@@ -79,10 +79,7 @@ class ScanAutomationService(
   def registerRewardComputationTrigger(
       rewardsReferenceStore: ScanRewardsReferenceStore
   ): Unit =
-    for {
-      appRewardsStore <- appRewardsStoreO
-      appActivityStore <- appActivityStoreO
-    } registerTrigger(
+    registerTrigger(
       new RewardComputationTrigger(
         appRewardsStore,
         appActivityStore,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictAutomationService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictAutomationService.scala
@@ -34,7 +34,7 @@ class ScanVerdictAutomationService(
     migrationId: Long,
     synchronizerId: SynchronizerId,
     ingestionMetrics: ScanMediatorVerdictIngestionMetrics,
-    rewardsReferenceStoreO: Option[ScanRewardsReferenceStore],
+    rewardsReferenceStore: ScanRewardsReferenceStore,
 )(implicit
     ec: ExecutionContextExecutor,
     mat: Materializer,
@@ -49,10 +49,8 @@ class ScanVerdictAutomationService(
 
   override def companion: AutomationServiceCompanion = ScanVerdictAutomationService
 
-  private val appActivityComputationO: Option[AppActivityComputation] =
-    rewardsReferenceStoreO.map { store =>
-      new AppActivityComputation(store, loggerFactory)
-    }
+  private val appActivityComputation: AppActivityComputation =
+    new AppActivityComputation(rewardsReferenceStore, loggerFactory)
 
   registerService(
     new ScanVerdictIngestionService(
@@ -63,7 +61,7 @@ class ScanVerdictAutomationService(
       migrationId = migrationId,
       synchronizerId = synchronizerId,
       ingestionMetrics = ingestionMetrics,
-      appActivityComputationO = appActivityComputationO,
+      appActivityComputation = appActivityComputation,
       backoffClock = triggerContext.pollingClock,
       retryProvider = triggerContext.retryProvider,
       loggerFactory = triggerContext.loggerFactory,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/ScanVerdictIngestionService.scala
@@ -74,7 +74,7 @@ class ScanVerdictIngestionService(
     migrationId: Long,
     synchronizerId: SynchronizerId,
     ingestionMetrics: ScanMediatorVerdictIngestionMetrics,
-    appActivityComputationO: Option[AppActivityComputation],
+    appActivityComputation: AppActivityComputation,
     backoffClock: Clock,
     override protected val retryProvider: RetryProvider,
     override protected val loggerFactory: NamedLoggerFactory,
@@ -107,10 +107,7 @@ class ScanVerdictIngestionService(
   private def waitForStores(): Future[Unit] =
     for {
       _ <- store.waitUntilInitialized
-      _ <- appActivityComputationO match {
-        case Some(appActivityComputation) => appActivityComputation.waitUntilInitialized
-        case None => Future.unit
-      }
+      _ <- appActivityComputation.waitUntilInitialized
     } yield ()
 
   /** When starting a fresh stream, the record time from which to start streaming */
@@ -130,7 +127,7 @@ class ScanVerdictIngestionService(
         streamVerdictsAndBatchWithTraffic(
           ingestionStart,
           currentMediatorClient,
-          synchronizerNodes.current.sequencerTrafficClient,
+          Some(synchronizerNodes.current.sequencerTrafficClient),
         )
       val completedWithCompleteF = Promise[Option[v30.VerdictsResponse.Complete]]()
       val source = currentSource
@@ -157,7 +154,7 @@ class ScanVerdictIngestionService(
                         streamVerdictsAndBatchWithTraffic(
                           successorIngestionStart,
                           successorMediatorClient,
-                          synchronizerNodes.successor.flatMap(_.sequencerTrafficClient),
+                          synchronizerNodes.successor.map(_.sequencerTrafficClient),
                         )
                           .mapMaterializedValue(_ => NotUsed)
                       case None =>
@@ -243,30 +240,27 @@ class ScanVerdictIngestionService(
           // Compute app activity records (before DB transaction).
           // Records have verdictRowId = DUMMY_VERDICT_ROW_ID
           // the store resolves actual row_ids during insertion.
-          (appActivityRecords, firstActiveRoundO, lastArchivedRoundO) <-
-            appActivityComputationO match {
-              case Some(appActivityComputation) =>
-                val recordTimes =
-                  verdicts.map(v => CantonTimestamp.tryFromProtoTimestamp(v.getRecordTime))
-                for {
-                  records <- appActivityComputation.computeActivities(summariesWithVerdicts).map {
-                    _.flatMap { case (summary, _, recordO) =>
-                      recordO.map(summary.sequencingTime -> _)
-                    }
-                  }
-                  firstActiveRoundO <- recordTimes.minOption match {
-                    case Some(minRecordTime) =>
-                      appActivityComputation.lookupActiveOpenMiningRound(minRecordTime)
-                    case None => Future.successful(None)
-                  }
-                  lastArchivedRoundO <- recordTimes.maxOption match {
-                    case Some(maxRecordTime) =>
-                      appActivityComputation.lookupLatestArchivedOpenMiningRound(maxRecordTime)
-                    case None => Future.successful(None)
-                  }
-                } yield (records, firstActiveRoundO, lastArchivedRoundO)
-              case None => Future.successful((Seq.empty, None, None))
-            }
+          (appActivityRecords, firstActiveRoundO, lastArchivedRoundO) <- {
+            val recordTimes =
+              verdicts.map(v => CantonTimestamp.tryFromProtoTimestamp(v.getRecordTime))
+            for {
+              records <- appActivityComputation.computeActivities(summariesWithVerdicts).map {
+                _.flatMap { case (summary, _, recordO) =>
+                  recordO.map(summary.sequencingTime -> _)
+                }
+              }
+              firstActiveRoundO <- recordTimes.minOption match {
+                case Some(minRecordTime) =>
+                  appActivityComputation.lookupActiveOpenMiningRound(minRecordTime)
+                case None => Future.successful(None)
+              }
+              lastArchivedRoundO <- recordTimes.maxOption match {
+                case Some(maxRecordTime) =>
+                  appActivityComputation.lookupLatestArchivedOpenMiningRound(maxRecordTime)
+                case None => Future.successful(None)
+              }
+            } yield (records, firstActiveRoundO, lastArchivedRoundO)
+          }
 
           _ <- ensureVerdictsHaveTrafficSummaries(verdicts, summaryByTime)
           _ <- store.insertVerdictsWithAppActivityRecords(
@@ -362,10 +356,7 @@ class ScanVerdictIngestionService(
       verdicts: Seq[v30.Verdict],
       summaryByTime: Map[CantonTimestamp, DbScanVerdictStore.TrafficSummaryT],
   )(implicit tc: TraceContext): Future[Unit] =
-    (store.appActivityRecordStoreO match {
-      case None => Future.successful(None)
-      case Some(s) => s.startedIngestingAt
-    }).map { startO =>
+    store.appActivityRecordStore.startedIngestingAt.map { startO =>
       val missingTimes = ScanVerdictIngestionService.findMissingTrafficSummaries(
         verdicts.map(v => CantonTimestamp.tryFromProtoTimestamp(v.getRecordTime)),
         summaryByTime.keySet,

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala
@@ -61,8 +61,6 @@ case class ScanAppBackendConfig(
     synchronizerNodes: ScanSynchronizerNodesConfig,
     override val automation: AutomationConfig = AutomationConfig(),
     mediatorVerdictIngestion: MediatorVerdictIngestionConfig = MediatorVerdictIngestionConfig(),
-    enableAppActivityRecordAndTrafficIngestion: Boolean = true,
-    serveAppActivityRecordsAndTraffic: Boolean = true,
     isFirstSv: Boolean = false,
     // Max rounding error tolerated wrt actual total of minting allowances
     // and the per-round minting allowance from the CC whitepaper.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStore.scala
@@ -125,10 +125,7 @@ class ScanEventStore(
   def getAppActivityRecords(verdictRowIds: Seq[Long])(implicit
       tc: TraceContext
   ): Future[Map[Long, AppActivityRecordT]] =
-    verdictStore.appActivityRecordStoreO match {
-      case Some(store) => store.getRecordsByVerdictRowIds(verdictRowIds)
-      case None => Future.successful(Map.empty)
-    }
+    verdictStore.appActivityRecordStore.getRecordsByVerdictRowIds(verdictRowIds)
 
   // Get values from in-memory refs, fallsback to DB read
   private def resolveCurrentMigrationCap(

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/db/DbScanVerdictStore.scala
@@ -237,13 +237,13 @@ object DbScanVerdictStore {
   def apply(
       storage: com.digitalasset.canton.resource.DbStorage,
       updateHistory: UpdateHistory,
-      appActivityRecordStoreO: Option[DbAppActivityRecordStore],
+      appActivityRecordStore: DbAppActivityRecordStore,
       loggerFactory: NamedLoggerFactory,
   )(implicit ec: ExecutionContext): DbScanVerdictStore =
     new DbScanVerdictStore(
       storage,
       updateHistory,
-      appActivityRecordStoreO,
+      appActivityRecordStore,
       loggerFactory,
     )
 }
@@ -251,7 +251,7 @@ object DbScanVerdictStore {
 class DbScanVerdictStore(
     storage: DbStorage,
     updateHistory: UpdateHistory,
-    val appActivityRecordStoreO: Option[DbAppActivityRecordStore],
+    val appActivityRecordStore: DbAppActivityRecordStore,
     override protected val loggerFactory: NamedLoggerFactory,
 )(implicit
     ec: ExecutionContext
@@ -556,17 +556,13 @@ class DbScanVerdictStore(
       firstActiveRoundO: Option[Long],
       lastArchivedRoundO: Option[Long],
   )(implicit tc: TraceContext): DBIO[Unit] =
-    appActivityRecordStoreO match {
-      case None => DBIO.successful(())
-      case Some(s) =>
-        s.insertAppActivityRecordsDBIO(
-          items,
-          firstRecordTimeMicros,
-          hasTrafficSummaries,
-          firstActiveRoundO,
-          lastArchivedRoundO,
-        )
-    }
+    appActivityRecordStore.insertAppActivityRecordsDBIO(
+      items,
+      firstRecordTimeMicros,
+      hasTrafficSummaries,
+      firstActiveRoundO,
+      lastArchivedRoundO,
+    )
 
   private def afterFilters(
       afterO: Option[(Long, CantonTimestamp)],

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/DbAppActivityRecordStoreTest.scala
@@ -1143,7 +1143,7 @@ class DbAppActivityRecordStoreTest
       val verdictStore = new DbScanVerdictStore(
         storage.underlying,
         updateHistory,
-        Some(appStore),
+        appStore,
         loggerFactory,
       )
       (appStore, verdictStore)

--- a/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
+++ b/apps/scan/src/test/scala/org/lfdecentralizedtrust/splice/scan/store/ScanEventStoreTest.scala
@@ -11,7 +11,7 @@ import org.lfdecentralizedtrust.splice.store.{
   StoreTestBase,
   UpdateHistory,
 }
-import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore
+import org.lfdecentralizedtrust.splice.scan.store.db.{DbAppActivityRecordStore, DbScanVerdictStore}
 import org.lfdecentralizedtrust.splice.scan.store.db.DbScanVerdictStore.{TrafficSummaryT, EnvelopeT}
 import org.lfdecentralizedtrust.splice.store.db.SplicePostgresTest
 import com.digitalasset.canton.resource.DbStorage
@@ -880,7 +880,18 @@ class ScanEventStoreTest extends StoreTestBase with HasExecutionContext with Spl
   }
 
   private def newVerdictStore(updateHistory: UpdateHistory) =
-    new DbScanVerdictStore(storage.underlying, updateHistory, None, loggerFactory)
+    new DbScanVerdictStore(
+      storage.underlying,
+      updateHistory,
+      new DbAppActivityRecordStore(
+        storage.underlying,
+        updateHistory,
+        DbAppActivityRecordStore.IngestionVersions(1, 0),
+        false,
+        loggerFactory,
+      ),
+      loggerFactory,
+    )
 
   private def insertUpdate(
       updateHistory: UpdateHistory,

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -6,3 +6,10 @@
 .. NOTE: add your upcoming release notes below this line. They are included in the `release_notes.rst`.
 
 release-notes:: Upcoming
+
+    - Scan app
+
+        - The ``enable-app-activity-record-and-traffic-ingestion`` and
+          ``serve-app-activity-records-and-traffic`` configuration options have been removed. App
+          activity records and sequencer traffic are now always ingested, and app activity is
+          always computed and served on the corresponding HTTP endpoints.


### PR DESCRIPTION
Fixes #6594

Changes are best viewed with whitespace ignored: https://github.com/canton-network/splice/pull/6643/changes?w=1

This removes the `enableAppActivityRecordAndTrafficIngestion` and `serveAppActivityRecordsAndTraffic` config options and the optionality proliferation that they resulted in.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
