### PR TITLE
Allow voting after effectivity date

### DIFF
--- a/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
+++ b/apps/sv/frontend/src/__tests__/governance/proposal-details-content.test.tsx
@@ -1242,3 +1242,127 @@ describe('Proposal Details > Votes & Voting', () => {
     expect(rejectButton).not.toBeDisabled();
   });
 });
+
+describe('Open vote request whose effectivity has passed', () => {
+  const pastEffectivity = {
+    requester: 'sv1',
+    requesterIsYou: true,
+    votingThresholdDeadline: '2024-01-01 13:00',
+    voteTakesEffect: '2024-01-02 13:00',
+    status: 'In Progress',
+  } as ProposalVotingInformation;
+
+  test('shows the vote form to an SV that has not voted', () => {
+    const votes: ProposalVote[] = [
+      { sv: 'sv1', isYou: true, vote: 'no-vote' },
+      { sv: 'sv3', vote: 'accepted', reason: { url: 'https://example.com', body: 'Reason' } },
+    ];
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId="sv1"
+          contractId={voteRequest.contractId}
+          proposalDetails={voteRequest.proposalDetails}
+          votingInformation={pastEffectivity}
+          votes={votes}
+        />
+      </Wrapper>
+    );
+
+    const votingForm = screen.getByTestId('your-vote-form');
+    expect(votingForm).toBeInTheDocument();
+    expect(within(votingForm).getByTestId('your-vote-accept')).toBeInTheDocument();
+    expect(within(votingForm).getByTestId('your-vote-reject')).toBeInTheDocument();
+  });
+
+  test('shows the change-vote control to an SV that has already voted', async () => {
+    const user = userEvent.setup();
+    const votes: ProposalVote[] = [
+      {
+        sv: 'sv1',
+        isYou: true,
+        vote: 'accepted',
+        reason: { url: 'https://example.com', body: 'Reason' },
+      },
+      { sv: 'sv3', vote: 'accepted', reason: { url: 'https://example.com', body: 'Reason' } },
+    ];
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId="sv1"
+          contractId={voteRequest.contractId}
+          proposalDetails={voteRequest.proposalDetails}
+          votingInformation={pastEffectivity}
+          votes={votes}
+        />
+      </Wrapper>
+    );
+
+    // An SV that has voted sees the Edit control rather than the form, until it starts editing.
+    expect(screen.queryByTestId('your-vote-form')).not.toBeInTheDocument();
+
+    const editButton = screen.getByTestId('your-vote-edit-button');
+    expect(editButton).toBeInTheDocument();
+
+    await user.click(editButton);
+
+    const votingForm = screen.getByTestId('your-vote-form');
+    expect(votingForm).toBeInTheDocument();
+    expect(within(votingForm).getByTestId('your-vote-reject')).toBeInTheDocument();
+  });
+
+  test('shows SVs that have not voted as awaiting a response', () => {
+    const votes: ProposalVote[] = [
+      {
+        sv: 'sv1',
+        isYou: true,
+        vote: 'accepted',
+        reason: { url: 'https://example.com', body: 'Reason' },
+      },
+      { sv: 'sv3', vote: 'no-vote' },
+    ];
+
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId="sv1"
+          contractId={voteRequest.contractId}
+          proposalDetails={voteRequest.proposalDetails}
+          votingInformation={pastEffectivity}
+          votes={votes}
+        />
+      </Wrapper>
+    );
+
+    const noVoteTab = screen.getByTestId('no-vote-votes-tab');
+    expect(noVoteTab.textContent).toMatch(/Awaiting Response/);
+    expect(noVoteTab.textContent).not.toMatch(/Did not Vote/);
+
+    const statuses = screen
+      .getAllByTestId('proposal-details-vote-status-value')
+      .map(s => s.textContent);
+    expect(statuses).toContain('Awaiting Response');
+    expect(statuses).not.toContain('No Vote');
+  });
+});
+
+describe('Closed proposal', () => {
+  test('does not show the vote form or the change-vote control', () => {
+    render(
+      <Wrapper>
+        <ProposalDetailsContent
+          currentSvPartyId={voteResult.votingInformation.requester}
+          contractId={voteResult.contractId}
+          proposalDetails={voteResult.proposalDetails}
+          votingInformation={voteResult.votingInformation}
+          votes={voteResult.votes}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('your-vote-form')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('your-vote-edit-button')).not.toBeInTheDocument();
+  });
+});

--- a/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
+++ b/apps/sv/frontend/src/components/governance/ProposalDetailsContent.tsx
@@ -60,18 +60,13 @@ export interface ProposalDetailsContentProps {
 
 type VoteTab = Extract<VoteStatus, 'accepted' | 'rejected' | 'no-vote'> | 'all';
 
-const now = () => dayjs();
-
 export const ProposalDetailsContent: React.FC<ProposalDetailsContentProps> = props => {
   const { contractId, proposalDetails, votingInformation, votes, currentSvPartyId } = props;
 
   const votesHooks = useVotesHooks();
   const dsoInfoQuery = useDsoInfos();
 
-  const isEffective =
-    votingInformation.voteTakesEffect && dayjs(votingInformation.voteTakesEffect).isBefore(now());
-  const isClosed =
-    !proposalDetails.isVoteRequest || isEffective || votingInformation.status === 'Rejected';
+  const isClosed = !proposalDetails.isVoteRequest || votingInformation.status === 'Rejected';
 
   const dsoConfigToCompareWith = useMemo(() => {
     if (proposalDetails.action === 'SRARC_SetConfig') {

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -16,3 +16,8 @@
           By upgrading to this version, SVs agree to change this parameter to 2 minutes (unless they override the new SV app config value).
           The change takes effect once a sufficient number of SVs have upgraded.
 
+        - The governance UI no longer stops an SV from casting or changing its vote once a
+          proposal's target effective time has passed. Votes are now accepted for as long as the
+          vote request is open, matching what the ledger allows. This makes it possible to reject a
+          proposal whose action fails to execute and which would otherwise remain in flight
+          indefinitely.


### PR DESCRIPTION
Fixes #6636

This updates the UI to allow voting after the effectivity date but before the action is taken by removing the `isEffective` check.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
