### PR TITLE
SV: use AmuletAllocation expiresAt for early expiry (#5743)

### DIFF
--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/StoreTestBase.scala
@@ -428,6 +428,7 @@ abstract class StoreTestBase
       requestedAt: Instant,
       allocateBefore: Instant,
       settleBefore: Instant,
+      expiresAt: Option[Instant] = None,
       contractId: String = nextCid(),
   ): Contract[
     AmuletAllocation.ContractId,
@@ -462,7 +463,7 @@ abstract class StoreTestBase
     val template = new AmuletAllocation(
       new LockedAmulet.ContractId(nextCid()),
       allocationSpec,
-      java.util.Optional.empty(),
+      expiresAt.toJava,
     )
 
     contract(

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/store/SvDsoStore.scala
@@ -1635,7 +1635,13 @@ object SvDsoStore {
       ) { contract =>
         DsoAcsStoreRowData(
           contract,
-          // TODO(#5743): use the more precise `expiresAt` time once the minimal `splice-amulet` version contains that field
+          // `AmuletTransferInstruction` has no separate stored expiry:
+          // `executeBefore` is already capped to `tokenStandardMaxTTL` at
+          // creation (see Splice.ExternalPartyAmuletRules), so it *is* the
+          // early expiry:
+          //
+          // transferLifetime = executeBefore - requestedAt
+          // require $ transferLifetime <= tokenStandardMaxTTL
           contractExpiresAt =
             Some(Timestamp.assertFromInstant(contract.payload.transfer.executeBefore)),
         )
@@ -1645,9 +1651,13 @@ object SvDsoStore {
       ) { contract =>
         DsoAcsStoreRowData(
           contract,
-          // TODO(#5743): use the more precise `expiresAt` time once the minimal `splice-amulet` version contains that field
-          contractExpiresAt =
-            Some(Timestamp.assertFromInstant(contract.payload.allocation.settlement.settleBefore)),
+          contractExpiresAt = Some(
+            Timestamp.assertFromInstant(
+              contract.payload.expiresAt.orElse(
+                contract.payload.allocation.settlement.settleBefore
+              )
+            )
+          ),
         )
       },
       mkFilter(splice.amuletallocationv2.AmuletAllocationV2.COMPANION)(

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
@@ -598,7 +598,7 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
           requestedAt = now,
           allocateBefore = now.plusSeconds(1800),
           settleBefore = future,
-          expiresAt = Some(now.plusSeconds(1800))
+          expiresAt = Some(now.plusSeconds(1800)),
         )
 
         val ignoredCid = amuletAllocation(
@@ -625,9 +625,15 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
           store <- mkStore()
           _ <- dummyDomain.create(dsoRules())(store.multiDomainAcsStore)
           _ <- MonadUtil.sequentialTraverse(
-            Seq(expiredCid, earlyExpiredCid,
-              activeCid, activeWithExiresAtCid,
-              ignoredCid, ignoredEarlyExpiredCid))(
+            Seq(
+              expiredCid,
+              earlyExpiredCid,
+              activeCid,
+              activeWithExiresAtCid,
+              ignoredCid,
+              ignoredEarlyExpiredCid,
+            )
+          )(
             dummyDomain.create(_)(store.multiDomainAcsStore)
           )
 

--- a/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
+++ b/apps/sv/src/test/scala/org/lfdecentralizedtrust/splice/store/db/SvDsoStoreTest.scala
@@ -556,6 +556,7 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
         val future = now.plusSeconds(3600)
         val amount = new java.math.BigDecimal("10.0").setScale(10)
 
+        // Expires on `settleBefore`
         val expiredCid = amuletAllocation(
           sender = userParty(1),
           receiver = userParty(3),
@@ -564,6 +565,19 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
           requestedAt = past.minusSeconds(3600),
           allocateBefore = past.minusSeconds(1800),
           settleBefore = past,
+        )
+
+        // Early-expired: settlement deadline is still in the future, but the
+        // `expiresAt` is in the past.
+        val earlyExpiredCid = amuletAllocation(
+          sender = userParty(1),
+          receiver = userParty(3),
+          executor = userParty(4),
+          amount = amount,
+          requestedAt = past.minusSeconds(3600),
+          allocateBefore = past.minusSeconds(1800),
+          settleBefore = future,
+          expiresAt = Some(past),
         )
 
         val activeCid = amuletAllocation(
@@ -576,7 +590,28 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
           settleBefore = future,
         )
 
+        val activeWithExiresAtCid = amuletAllocation(
+          sender = userParty(1),
+          receiver = userParty(2),
+          executor = userParty(4),
+          amount = amount,
+          requestedAt = now,
+          allocateBefore = now.plusSeconds(1800),
+          settleBefore = future,
+          expiresAt = Some(now.plusSeconds(1800))
+        )
+
         val ignoredCid = amuletAllocation(
+          sender = userParty(2),
+          receiver = userParty(1),
+          executor = userParty(4),
+          amount = amount,
+          requestedAt = past.minusSeconds(3600),
+          allocateBefore = past.minusSeconds(1800),
+          settleBefore = past,
+        )
+
+        val ignoredEarlyExpiredCid = amuletAllocation(
           sender = userParty(2),
           receiver = userParty(1),
           executor = userParty(4),
@@ -589,7 +624,10 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
         for {
           store <- mkStore()
           _ <- dummyDomain.create(dsoRules())(store.multiDomainAcsStore)
-          _ <- MonadUtil.sequentialTraverse(Seq(expiredCid, activeCid, ignoredCid))(
+          _ <- MonadUtil.sequentialTraverse(
+            Seq(expiredCid, earlyExpiredCid,
+              activeCid, activeWithExiresAtCid,
+              ignoredCid, ignoredEarlyExpiredCid))(
             dummyDomain.create(_)(store.multiDomainAcsStore)
           )
 
@@ -615,18 +653,27 @@ abstract class SvDsoStoreTest extends StoreTestBase with HasExecutionContext {
         } yield {
           val allContracts = resultAll.map(_.contract)
           allContracts should contain(expiredCid)
+          allContracts should contain(earlyExpiredCid)
           allContracts should contain(ignoredCid)
+          allContracts should contain(ignoredEarlyExpiredCid)
           allContracts should not contain activeCid
+          allContracts should not contain activeWithExiresAtCid
 
           val filteredContracts = resultFiltered.map(_.contract)
           filteredContracts should contain(expiredCid)
+          filteredContracts should contain(earlyExpiredCid)
           filteredContracts should not contain ignoredCid
+          filteredContracts should not contain ignoredEarlyExpiredCid
           filteredContracts should not contain activeCid
+          filteredContracts should not contain activeWithExiresAtCid
 
           val filteredTwoPartiesContracts = resultFilteredTwoParties.map(_.contract)
           filteredTwoPartiesContracts should not contain expiredCid
+          filteredTwoPartiesContracts should not contain earlyExpiredCid
           filteredTwoPartiesContracts should not contain ignoredCid
+          filteredTwoPartiesContracts should not contain ignoredEarlyExpiredCid
           filteredTwoPartiesContracts should not contain activeCid
+          filteredTwoPartiesContracts should not contain activeWithExiresAtCid
         }
       }
     }

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -26,6 +26,12 @@
           MainNet/TestNet/DevNet/ScratchNet from the cluster subdomain, LocalNet for localhost, and a
           capitalized fallback otherwise (Unknown Network when no scan URL is available).
 
+        - ``AmuletAllocation`` ingestion by ``SvDsoStore`` now honour the earlier
+          ``expiresAt`` deadline instead of the coarser settlement deadline, so
+          locked amulet is released sooner. This only affects newly ingested
+          contracts; contracts already in the SV store keep their previous expiry
+          unless reingestion is forced via a store version bump.
+
     - SV UI
 
         - During the creation of ``AmuletRules_SetConfig`` proposal, for the ``rewardConfig``


### PR DESCRIPTION
SvDsoStore now honours the earlier `expiresAt` deadline when ingesting `AmuletAllocation` contracts, falling back to the coarser settlement `settleBefore` when it is not set. This releases locked amulet sooner.

Also replace the TODO(#5743) on `AmuletTransferInstruction` with a note explaining that its `executeBefore` is already capped to `tokenStandardMaxTTL` at creation, so no separate stored expiry exists.

Add store tests covering early-expired and active-with-expiresAt allocations, and a release note.

Fixes #5743 

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [x] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [x] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
