### PR TITLE
Show diff of `dars.lock` if it's out of date

### DIFF
--- a/build-tools/dar-lock-checker/src/main/scala/org/lfdecentralizedtrust/splice/build_tools/DarLockChecker.scala
+++ b/build-tools/dar-lock-checker/src/main/scala/org/lfdecentralizedtrust/splice/build_tools/DarLockChecker.scala
@@ -121,15 +121,7 @@ object DarLockChecker {
             val currentHashes = File(outputFilename).contentAsString
             val lockStr = getLockStr(checkedInDarMap ++ darMap)
             if (currentHashes != lockStr)
-              sys.error(
-                Seq(
-                  "Error: daml lockfile is not up-to-date",
-                  "Expected:",
-                  lockStr,
-                  "Actual:",
-                  currentHashes,
-                ).mkString(System.lineSeparator())
-              )
+              sys.error(lockOutOfDateMessage(outputFilename, lockStr))
           case "update" =>
             // Check that the freshly built packages either match the
             // last release or have a different version number.
@@ -262,6 +254,33 @@ object DarLockChecker {
       .toSeq
       .sorted
       .mkString(System.lineSeparator())
+
+  private[build_tools] def lockOutOfDateMessage(
+      currentLockFile: String,
+      expectedLockStr: String,
+      diffColor: String = if (sys.env.contains("CI")) "never" else "always",
+  ): String =
+    File.temporaryFile(prefix = "expected-dars", suffix = ".lock") { expectedFile =>
+      val _ = expectedFile.write(expectedLockStr)
+
+      val out = new StringBuilder("")
+      def appendToOut(s: String): Unit = out ++= s + System.lineSeparator()
+      val _ = Seq(
+        "diff",
+        s"--color=$diffColor",
+        "--unified=0",
+        s"--label=$currentLockFile",
+        "--label=expected-dars.lock",
+        currentLockFile,
+        expectedFile.toString,
+      ).!(ProcessLogger(appendToOut, appendToOut))
+
+      Seq(
+        "Error: daml lockfile is not up-to-date",
+        "",
+        out.toString,
+      ).mkString(System.lineSeparator())
+    }
 
   private def getCheckedInDarMap(): Map[(PackageName, PackageVersion), String] = {
     val checkedInDars = File("daml/dars").list(_.extension == Some(".dar")).toSeq

--- a/build-tools/dar-lock-checker/src/test/scala/org/lfdecentralizedtrust/splice/build_tools/DarLockCheckerTest.scala
+++ b/build-tools/dar-lock-checker/src/test/scala/org/lfdecentralizedtrust/splice/build_tools/DarLockCheckerTest.scala
@@ -3,6 +3,7 @@
 
 package org.lfdecentralizedtrust.splice.build_tools
 
+import better.files.*
 import com.digitalasset.daml.lf.data.Ref.{PackageName, PackageVersion}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -12,6 +13,52 @@ class DarLockCheckerTest extends AnyWordSpec with Matchers {
   private def pkg(name: String): PackageName = PackageName.assertFromString(name)
   private def ver(v: String): PackageVersion = PackageVersion.assertFromString(v)
   private def key(name: String, v: String) = (pkg(name), ver(v))
+
+  "lockOutOfDateMessage" should {
+    def lock(entries: String*): String = entries.mkString(System.lineSeparator())
+
+    def messageFor(currentLockContent: String, expectedLockStr: String): String =
+      File.temporaryFile(prefix = "current-dars", suffix = ".lock").apply { currentFile =>
+        val _ = currentFile.write(currentLockContent)
+        DarLockChecker.lockOutOfDateMessage(currentFile.toString, expectedLockStr, "never")
+      }
+
+    // The `-`/`+` lines of the diff embedded in the message
+    def changedLines(message: String): Seq[String] =
+      message.linesIterator
+        .filterNot(line => line.startsWith("---") || line.startsWith("+++"))
+        .filter(line => line.startsWith("-") || line.startsWith("+"))
+        .toSeq
+
+    "report only the entries whose package id changed" in {
+      val current = lock(
+        "splice-amulet 0.1.0 hash0",
+        "splice-amulet 0.1.1 hash1",
+        "splice-amulet 0.1.2 hash2",
+      )
+      val expected = lock(
+        "splice-amulet 0.1.0 hash0",
+        "splice-amulet 0.1.1 rebuiltHash1",
+        "splice-amulet 0.1.2 hash2",
+      )
+      changedLines(messageFor(current, expected)) shouldBe Seq(
+        "-splice-amulet 0.1.1 hash1",
+        "+splice-amulet 0.1.1 rebuiltHash1",
+      )
+    }
+
+    "report entries missing from the lock file" in {
+      val current = lock()
+      val expected = lock("splice-amulet 0.1.0 hash0")
+      changedLines(messageFor(current, expected)) shouldBe Seq("+splice-amulet 0.1.0 hash0")
+    }
+
+    "report entries that are no longer expected" in {
+      val current = lock("splice-amulet 0.1.0 hash0")
+      val expected = lock()
+      changedLines(messageFor(current, expected)) shouldBe Seq("-splice-amulet 0.1.0 hash0")
+    }
+  }
 
   "detectBumps" should {
     "return empty when branch and compare base match exactly" in {

--- a/project/ignore-patterns/sbt-output.ignore.txt
+++ b/project/ignore-patterns/sbt-output.ignore.txt
@@ -43,7 +43,7 @@ protoc-jar: caught exception, retrying: java\.io\.IOException: Cannot run progra
 .*no longer exists at.*
 
 # sbt 1.4 onwards logs GC warnings
-.*\[.*warn.*\].* of the last .* were spent in garbage collection\.
+.*\[.*warn.*\].* of the last .* were spent in GC\.
 
 # During release bundling, the copy of the Canton OS repo emits a bunch of warnings
 .*\[.*warn.*\].*Negative time


### PR DESCRIPTION
Fixes #5899

This updates `DarLockChecker.scala` to shell out to `diff` to get the difference between the current lock file and its expected contents, and includes the output in the error message.

@meiersi-da let me know if you'd prefer an approach that doesn't shell out to `diff`.

![error](https://github.com/user-attachments/assets/4bb43125-a222-4cb8-a49d-de1e9d991f8b)

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
