### PR TITLE
Fix runbooks' deployments

### DIFF
--- a/cluster/expected/validator-runbook/expected.json
+++ b/cluster/expected/validator-runbook/expected.json
@@ -915,7 +915,7 @@
           },
           "persistence": {
             "host": "postgres",
-            "postgresName": "postgres",
+            "postgresName": "postgres-helmless",
             "secretName": "postgres-secrets"
           },
           "pvc": {

--- a/cluster/pulumi/sv-runbook/src/postgres.ts
+++ b/cluster/pulumi/sv-runbook/src/postgres.ts
@@ -45,6 +45,11 @@ export async function installPostgres(
       xns,
       name,
       parent => installPasswordWithParent(parent, xns, name, secretName),
+      // No need to support legacy chart
+      {
+        deployment: 'docker-image',
+        postgresImage: valuesFromFile.db.postgresImage || 'postgres:18',
+      },
       values,
       undefined,
       supportsSvRunbookReset

--- a/cluster/pulumi/sv-runbook/src/postgres.ts
+++ b/cluster/pulumi/sv-runbook/src/postgres.ts
@@ -51,8 +51,8 @@ export async function installPostgres(
         postgresImage: valuesFromFile.db.postgresImage || 'postgres:18',
       },
       values,
-      undefined,
-      supportsSvRunbookReset
+      undefined, // overrideDbSizeFromValues
+      supportsSvRunbookReset // disableProtection
     );
   }
 }

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -254,7 +254,7 @@ async function installValidator(
     ...(participantBootstrapDumpSecret ? { nodeIdentifier: newParticipantIdentifier } : {}),
     persistence: {
       ...validatorValuesFromYamlFiles.persistence,
-      postgresName: 'postgres',
+      postgresName: postgres.instanceName,
     },
     pvc: {
       volumeStorageClass: standardStorageClassName,


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9456

- Validator runbook had a hardcoded name of postgres which is now changed, so it couldn't connect to it
- SV runbook had an `any` being passed as the incorrect value, causing a missing imageName, with every parameter after that being optional