### PR TITLE
Ignore expired preapprovals in AcceptTransferPreapprovalProposalTrigger

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTimeBasedIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/WalletTimeBasedIntegrationTest.scala
@@ -1,5 +1,7 @@
 package org.lfdecentralizedtrust.splice.integration.tests
 
+import org.lfdecentralizedtrust.splice.codegen.java.splice.wallet.transferpreapproval.TransferPreapprovalProposal
+import org.lfdecentralizedtrust.splice.config.ConfigTransforms
 import org.lfdecentralizedtrust.splice.config.ConfigTransforms.{
   ConfigurableApp,
   updateAutomationConfig,
@@ -10,6 +12,7 @@ import org.lfdecentralizedtrust.splice.integration.tests.SpliceTests.Integration
 import org.lfdecentralizedtrust.splice.sv.automation.delegatebased.{
   AnsSubscriptionRenewalPaymentTrigger,
   ExpiredLockedAmuletTrigger,
+  ExpireTransferPreapprovalsTrigger,
 }
 import org.lfdecentralizedtrust.splice.sv.automation.singlesv.ReceiveSvRewardCouponTrigger
 import org.lfdecentralizedtrust.splice.util.{
@@ -18,8 +21,13 @@ import org.lfdecentralizedtrust.splice.util.{
   TriggerTestUtil,
   WalletTestUtil,
 }
-import org.lfdecentralizedtrust.splice.validator.automation.ReceiveFaucetCouponTrigger
+import org.lfdecentralizedtrust.splice.validator.automation.{
+  ReceiveFaucetCouponTrigger,
+  RenewTransferPreapprovalTrigger,
+}
 import org.lfdecentralizedtrust.splice.wallet.admin.api.client.commands.HttpWalletAppClient
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
+import monocle.macros.syntax.lens.*
 
 import java.time.Duration
 
@@ -29,6 +37,9 @@ class WalletTimeBasedIntegrationTest
     with TimeTestUtil
     with SplitwellTestUtil
     with TriggerTestUtil {
+
+  // reduce for expiry test
+  private val preapprovalLifetime = NonNegativeFiniteDuration.ofMinutes(1)
 
   override def environmentDefinition: SpliceEnvironmentDefinition =
     EnvironmentDefinition
@@ -48,6 +59,11 @@ class WalletTimeBasedIntegrationTest
         updateAutomationConfig(ConfigurableApp.Sv)(
           // without this, alice's validator gets AppRewardCoupons that complicate testing
           _.withPausedTrigger[ReceiveSvRewardCouponTrigger]
+        )(config)
+      )
+      .addConfigTransforms((_, config) =>
+        ConfigTransforms.updateAllValidatorConfigs_(
+          _.focus(_.transferPreapproval.preapprovalLifetime).replace(preapprovalLifetime)
         )(config)
       )
 
@@ -219,6 +235,58 @@ class WalletTimeBasedIntegrationTest
             )
           }
         }
+    }
+
+    "create a new TransferPreapproval if the existing one has expired" in { implicit env =>
+      val aliceUserParty = onboardWalletUser(aliceWalletClient, aliceValidatorBackend)
+      val aliceValidatorParty = aliceValidatorBackend.getValidatorPartyId()
+
+      def alicePreapprovals =
+        aliceValidatorBackend
+          .listTransferPreapprovals()
+          .filter(_.payload.receiver == aliceUserParty.toProtoPrimitive)
+
+      // disable renew and expiry automation so the expired one does not get archived.
+      setTriggersWithin(
+        triggersToPauseAtStart = Seq(
+          aliceValidatorBackend.validatorAutomation.trigger[RenewTransferPreapprovalTrigger]
+        ) ++ activeSvs.map(_.dsoDelegateBasedAutomation.trigger[ExpireTransferPreapprovalsTrigger])
+      ) {
+        val initial = clue("Alice creates a TransferPreapproval") {
+          createTransferPreapprovalEnsuringItExists(aliceWalletClient, aliceValidatorBackend)
+          alicePreapprovals.loneElement
+        }
+
+        clue("The TransferPreapproval expires without being renewed or archived") {
+          advanceTime(preapprovalLifetime.asJava.plusSeconds(1))
+          val expired = alicePreapprovals.loneElement
+          expired.contract.contractId shouldBe initial.contract.contractId
+          expired.payload.expiresAt should be < getLedgerTime.toInstant
+        }
+
+        actAndCheck(
+          "Alice creates another TransferPreapprovalProposal",
+          aliceValidatorBackend.participantClientWithAdminToken.ledger_api_extensions.commands
+            .submitWithResult(
+              userId = aliceValidatorBackend.config.ledgerApiUser,
+              actAs = Seq(aliceUserParty),
+              readAs = Seq(aliceUserParty),
+              update = TransferPreapprovalProposal.create(
+                aliceUserParty.toProtoPrimitive,
+                aliceValidatorParty.toProtoPrimitive,
+                java.util.Optional.of(dsoParty.toProtoPrimitive),
+              ),
+            ),
+        )(
+          "Validator automation creates a new TransferPreapproval",
+          _ => {
+            val fresh = alicePreapprovals
+              .filterNot(_.contract.contractId == initial.contract.contractId)
+              .loneElement
+            fresh.payload.expiresAt should be > getLedgerTime.toInstant
+          },
+        )
+      }
     }
   }
 

--- a/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/AcceptTransferPreapprovalProposalTrigger.scala
+++ b/apps/validator/src/main/scala/org/lfdecentralizedtrust/splice/validator/automation/AcceptTransferPreapprovalProposalTrigger.scala
@@ -110,11 +110,20 @@ class AcceptTransferPreapprovalProposalTrigger(
       for {
         validatorWallet <- ValidatorUtil.getValidatorWallet(store, walletManager)
         result <- store.lookupTransferPreapprovalByReceiverPartyWithOffset(receiverParty) flatMap {
-          case QueryResult(_, Some(_)) =>
+          // Expired pre-approvals are ignored: the receiver cannot be paid through them anymore
+          // and they may stick around for a while until the SV automation archives them.
+          case QueryResult(_, Some(existing))
+              if existing.payload.expiresAt.isAfter(clock.now.toInstant) =>
             Future.successful(
               TaskSuccess(show"TransferPreapproval for receiver $receiverParty already exists")
             )
-          case QueryResult(offset, None) =>
+          case QueryResult(offset, existing) =>
+            existing.foreach(expired =>
+              logger.info(
+                s"Accepting proposal for receiver $receiverParty as its existing TransferPreapproval " +
+                  s"${expired.contractId.contractId} expired at ${expired.payload.expiresAt}"
+              )
+            )
             validatorWallet.treasury
               .enqueueAmuletOperation(
                 operation,

--- a/docs/src/release_notes_upcoming.rst
+++ b/docs/src/release_notes_upcoming.rst
@@ -15,6 +15,8 @@
           accepted command id receives a 200 response with the same result as the first.
           Concurrent duplicates, where no submission has completed yet, are still rejected.
 
+        - ``TransferPreapprovalProposal`` s are now accepted if there is an existing one but it has expired.
+
     - CantonBft
 
          - Increase the default segment length by 4x to reduce performance impact from epoch switches.


### PR DESCRIPTION
[ci]

fixes #6610

Signed-off-by: Moritz Kiefer <moritz.kiefer@purelyfunctional.org



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
