### PR TITLE
Demote `Failed to read bft sequencers list from scan` to INFO

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
@@ -90,9 +90,7 @@ class BftScanConnectionIntegrationTest
         ) or
           include("Encountered 4 consecutive transient failures") or include(
             "Failed to connect to scan of FAILED Seed URL #0 (http://localhost:5112)."
-          ) or include(
-            "Failed to read bft sequencers list from scan http://localhost:5112"
-          ))
+          )
       ),
     )
 

--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/BftScanConnectionIntegrationTest.scala
@@ -90,7 +90,7 @@ class BftScanConnectionIntegrationTest
         ) or
           include("Encountered 4 consecutive transient failures") or include(
             "Failed to connect to scan of FAILED Seed URL #0 (http://localhost:5112)."
-          )
+          ))
       ),
     )
 

--- a/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
+++ b/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/onboarding/SequencerBftPeerReconciler.scala
@@ -138,7 +138,8 @@ abstract class SequencerBftPeerReconciler(
         scan
           .listSvBftSequencers()
           .recover { case NonFatal(ex) =>
-            logger.warn(s"Failed to read bft sequencers list from scan ${scan.url}", ex)
+            // not a warn because short-term failures are benign and longer-term outages should be covered by other monitoring
+            logger.info(s"Failed to read bft sequencers list from scan ${scan.url}", ex)
             Seq.empty
           }
       }

--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -107,10 +107,6 @@ Splice unsafe shutdown future
 # SV UI polls cometbft status endpoint even when there's no cometBFT (we have this in the full network docker compose test)
 .*CometBFT is not configured for this app.*
 
-# Expected during SV onboarding as we start scan and the sv app concurrently
-# TODO(#893) maybe remove this again
-Failed to read bft sequencers list from scan
-
 Failed to connect to scan of Digital-Asset-Eng-3.*AppUpgradeIntegrationTest
 
 # Ignore scan issues in disaster recovery tests as we don't start scan there


### PR DESCRIPTION
Fixes https://github.com/DACH-NY/cn-test-failures/issues/9485

Alerting now covered via https://github.com/canton-network/splice/pull/6675

I contemplated making the logging smarter (only warn if stays failed for N minutes), but somehow I'm not convinced that this is worth the effort and added complexity.

[ci]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
