### PR TITLE
Add advisory lock to `SqlIndexInitializationTrigger`

### DIFF
--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
@@ -13,7 +13,7 @@ import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.automation.SqlIndexInitializationTrigger.IndexAction
-import org.lfdecentralizedtrust.splice.store.db.AdvisoryLockIds
+import org.lfdecentralizedtrust.splice.store.db.AdvisoryLocks
 import org.lfdecentralizedtrust.splice.util.PrettyInstances.*
 import slick.dbio.{DBIOAction, Effect, NoStream}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
@@ -113,39 +113,6 @@ class SqlIndexInitializationTrigger(
     Future.successful(false)
   }
 
-  private[automation] val acquireIndexDdlLock: DBIOAction[Boolean, NoStream, Effect.Read] =
-    sql"select pg_try_advisory_lock(${AdvisoryLockIds.sqlIndexInitialization})"
-      .as[Boolean]
-      .head
-
-  private[automation] val releaseIndexDdlLock: DBIOAction[Boolean, NoStream, Effect.Read] =
-    sql"select pg_advisory_unlock(${AdvisoryLockIds.sqlIndexInitialization})"
-      .as[Boolean]
-      .head
-
-  /** Wraps the given index DDL in an advisory lock, so that only one process at a time executes
-    * index DDL against this database.
-    *
-    * Apps sharing a database would otherwise issue concurrent DDL for the same index and fail with
-    * "tuple concurrently updated". `if [not] exists` does not prevent this, since it's evaluated
-    * before any of the concurrent statements has committed its catalog changes.
-    *
-    * Note: we cannot use a transaction-scoped lock here, because `create index concurrently` and
-    * `drop index concurrently` must not run inside a transaction block. We therefore use a
-    * session-scoped lock and pin the session, so that acquire, DDL, and release all run on the
-    * same connection without a transaction.
-    */
-  private def withIndexDdlLock[T, E <: Effect](
-      action: DBIOAction[T, NoStream, E]
-  ): DBIOAction[T, NoStream, Effect.Read & E] =
-    (for {
-      lockAcquired <- acquireIndexDdlLock
-      result <- lockAcquired match {
-        case true => action.andFinally(releaseIndexDdlLock)
-        case false => DBIOAction.failed(FailedToAcquireIndexLockException())
-      }
-    } yield result).withPinnedSession
-
   override protected def completeTask(task: SqlIndexInitializationTrigger.Task)(implicit
       tc: TraceContext
   ): Future[TaskOutcome] = (task match {
@@ -153,7 +120,7 @@ class SqlIndexInitializationTrigger(
       logger.info(s"Dropping index $indexName")
       storage
         .queryAndUpdate(
-          withIndexDdlLock(sqlu"drop index concurrently if exists #$indexName"),
+          AdvisoryLocks.withDdlLock(sqlu"drop index concurrently if exists #$indexName"),
           "drop_" + indexName,
         )
         .unwrap
@@ -165,7 +132,7 @@ class SqlIndexInitializationTrigger(
     case Task.ExecuteAction(IndexAction.Create(indexName, createAction)) =>
       logger.info(s"Creating index $indexName")
       storage
-        .queryAndUpdate(withIndexDdlLock(createAction), "create_" + indexName)
+        .queryAndUpdate(AdvisoryLocks.withDdlLock(createAction), "create_" + indexName)
         .unwrap
         .map { _ =>
           logger.info(s"Finished creating index $indexName")
@@ -180,7 +147,7 @@ class SqlIndexInitializationTrigger(
       logger.info(s"Confirmed action completed for index ${action.indexName}")
       Future.successful(TaskSuccess(s"Confirmed action completed for index ${action.indexName}"))
   }).transform {
-    case Failure(e: FailedToAcquireIndexLockException) =>
+    case Failure(e: AdvisoryLocks.FailedToAcquireAdvisoryLockException) =>
       // There was a concurrent DDL statement running.
       // The action stays in `remainingActions`, so we retry it on the next poll.
       logger.info(s"Skipping $task, another DDL statement was running currently", e)
@@ -206,11 +173,6 @@ object SqlIndexInitializationTrigger {
       indexActions,
     )
   }
-
-  final case class FailedToAcquireIndexLockException()
-      extends RuntimeException(
-        "Failed to acquire the advisory lock guarding SQL index DDL."
-      )
 
   sealed trait IndexStatus
   object IndexStatus {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
@@ -181,9 +181,9 @@ class SqlIndexInitializationTrigger(
       Future.successful(TaskSuccess(s"Confirmed action completed for index ${action.indexName}"))
   }).transform {
     case Failure(e: FailedToAcquireIndexLockException) =>
-      // Another process is executing index DDL. This is expected whenever multiple apps share a
-      // database. The action stays in `remainingActions`, so we retry it on the next poll.
-      logger.info(s"Skipping $task, another process is currently executing index DDL", e)
+      // There was a concurrent DDL statement running.
+      // The action stays in `remainingActions`, so we retry it on the next poll.
+      logger.info(s"Skipping $task, another DDL statement was running currently", e)
       Success(TaskNoop)
     case other => other
   }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
@@ -13,12 +13,14 @@ import com.digitalasset.canton.tracing.TraceContext
 import io.opentelemetry.api.trace.Tracer
 import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.automation.SqlIndexInitializationTrigger.IndexAction
+import org.lfdecentralizedtrust.splice.store.db.AdvisoryLockIds
 import org.lfdecentralizedtrust.splice.util.PrettyInstances.*
 import slick.dbio.{DBIOAction, Effect, NoStream}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
+import scala.util.{Failure, Success}
 
 /** A trigger that asynchronously creates or drops SQL indexes at application startup.
   *
@@ -111,14 +113,47 @@ class SqlIndexInitializationTrigger(
     Future.successful(false)
   }
 
+  private[automation] val acquireIndexDdlLock: DBIOAction[Boolean, NoStream, Effect.Read] =
+    sql"select pg_try_advisory_lock(${AdvisoryLockIds.sqlIndexInitialization})"
+      .as[Boolean]
+      .head
+
+  private[automation] val releaseIndexDdlLock: DBIOAction[Boolean, NoStream, Effect.Read] =
+    sql"select pg_advisory_unlock(${AdvisoryLockIds.sqlIndexInitialization})"
+      .as[Boolean]
+      .head
+
+  /** Wraps the given index DDL in an advisory lock, so that only one process at a time executes
+    * index DDL against this database.
+    *
+    * Apps sharing a database would otherwise issue concurrent DDL for the same index and fail with
+    * "tuple concurrently updated". `if [not] exists` does not prevent this, since it's evaluated
+    * before any of the concurrent statements has committed its catalog changes.
+    *
+    * Note: we cannot use a transaction-scoped lock here, because `create index concurrently` and
+    * `drop index concurrently` must not run inside a transaction block. We therefore use a
+    * session-scoped lock and pin the session, so that acquire, DDL, and release all run on the
+    * same connection without a transaction.
+    */
+  private def withIndexDdlLock[T, E <: Effect](
+      action: DBIOAction[T, NoStream, E]
+  ): DBIOAction[T, NoStream, Effect.Read & E] =
+    (for {
+      lockAcquired <- acquireIndexDdlLock
+      result <- lockAcquired match {
+        case true => action.andFinally(releaseIndexDdlLock)
+        case false => DBIOAction.failed(FailedToAcquireIndexLockException())
+      }
+    } yield result).withPinnedSession
+
   override protected def completeTask(task: SqlIndexInitializationTrigger.Task)(implicit
       tc: TraceContext
-  ): Future[TaskOutcome] = task match {
+  ): Future[TaskOutcome] = (task match {
     case Task.ExecuteAction(IndexAction.Drop(indexName)) =>
       logger.info(s"Dropping index $indexName")
       storage
-        .update(
-          sqlu"drop index concurrently if exists #$indexName",
+        .queryAndUpdate(
+          withIndexDdlLock(sqlu"drop index concurrently if exists #$indexName"),
           "drop_" + indexName,
         )
         .unwrap
@@ -130,7 +165,7 @@ class SqlIndexInitializationTrigger(
     case Task.ExecuteAction(IndexAction.Create(indexName, createAction)) =>
       logger.info(s"Creating index $indexName")
       storage
-        .update(createAction, "create_" + indexName)
+        .queryAndUpdate(withIndexDdlLock(createAction), "create_" + indexName)
         .unwrap
         .map { _ =>
           logger.info(s"Finished creating index $indexName")
@@ -144,6 +179,13 @@ class SqlIndexInitializationTrigger(
       }
       logger.info(s"Confirmed action completed for index ${action.indexName}")
       Future.successful(TaskSuccess(s"Confirmed action completed for index ${action.indexName}"))
+  }).transform {
+    case Failure(e: FailedToAcquireIndexLockException) =>
+      // Another process is executing index DDL. This is expected whenever multiple apps share a
+      // database. The action stays in `remainingActions`, so we retry it on the next poll.
+      logger.info(s"Skipping $task, another process is currently executing index DDL", e)
+      Success(TaskNoop)
+    case other => other
   }
 }
 
@@ -164,6 +206,11 @@ object SqlIndexInitializationTrigger {
       indexActions,
     )
   }
+
+  final case class FailedToAcquireIndexLockException()
+      extends RuntimeException(
+        "Failed to acquire the advisory lock guarding SQL index DDL."
+      )
 
   sealed trait IndexStatus
   object IndexStatus {

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTrigger.scala
@@ -147,7 +147,7 @@ class SqlIndexInitializationTrigger(
       logger.info(s"Confirmed action completed for index ${action.indexName}")
       Future.successful(TaskSuccess(s"Confirmed action completed for index ${action.indexName}"))
   }).transform {
-    case Failure(e: AdvisoryLocks.FailedToAcquireAdvisoryLockException) =>
+    case Failure(e: AdvisoryLocks.FailedToAcquireLockException) =>
       // There was a concurrent DDL statement running.
       // The action stays in `remainingActions`, so we retry it on the next poll.
       logger.info(s"Skipping $task, another DDL statement was running currently", e)

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
@@ -16,4 +16,5 @@ object AdvisoryLockIds {
   private val base: Long = 0x73706c00
 
   final val acsSnapshotDataInsert: Long = base + 1
+  final val sqlIndexInitialization: Long = base + 2
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLockIds.scala
@@ -16,5 +16,5 @@ object AdvisoryLockIds {
   private val base: Long = 0x73706c00
 
   final val acsSnapshotDataInsert: Long = base + 1
-  final val sqlIndexInitialization: Long = base + 2
+  final val ddlStatement: Long = base + 2
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.store.db
+
+import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
+
+import scala.concurrent.ExecutionContext
+
+object AdvisoryLocks {
+  final case class FailedToAcquireAdvisoryLockException(lockId: Long)
+      extends RuntimeException(s"Failed to acquire advisory lock $lockId.")
+
+  private[db] def acquireSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
+    sql"select pg_try_advisory_lock($lockId)".as[Boolean].head
+
+  private[db] def releaseSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
+    sql"select pg_advisory_unlock($lockId)".as[Boolean].head
+
+  /** Wraps the given action in a session-scoped advisory lock; useful for acquiring locks for
+    * queries like DDL that can't run in a transaction.
+    */
+  def withSessionLock[T, E <: Effect](lockId: Long, action: DBIOAction[T, NoStream, E])(implicit
+      ec: ExecutionContext
+  ): DBIOAction[T, NoStream, Effect.Read & E] =
+    (for {
+      lockAcquired <- acquireSessionLock(lockId)
+      result <- lockAcquired match {
+        case true => action.andFinally(releaseSessionLock(lockId))
+        case false => DBIOAction.failed(FailedToAcquireAdvisoryLockException(lockId))
+      }
+    } yield result).withPinnedSession
+
+  def withDdlLock[T, E <: Effect](action: DBIOAction[T, NoStream, E])(implicit
+      ec: ExecutionContext
+  ): DBIOAction[T, NoStream, Effect.Read & E] =
+    withSessionLock(AdvisoryLockIds.ddlStatement, action)
+}

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
@@ -4,13 +4,25 @@
 package org.lfdecentralizedtrust.splice.store.db
 
 import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.jdbc.JdbcProfile
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 import scala.concurrent.ExecutionContext
 
 object AdvisoryLocks {
-  final case class FailedToAcquireAdvisoryLockException(lockId: Long)
-      extends RuntimeException(s"Failed to acquire advisory lock $lockId.")
+  final case class FailedToAcquireLockException(
+      lockType: String,
+      lockId: Long,
+  ) extends RuntimeException(s"Failed to acquire $lockType advisory lock $lockId.")
+
+  private def withLock[T, E <: Effect](lockType: String, lockId: Long)(
+      acquire: DBIOAction[Boolean, NoStream, Effect.Read],
+      onAcquired: DBIOAction[T, NoStream, E],
+  )(implicit ec: ExecutionContext): DBIOAction[T, NoStream, Effect.Read & E] =
+    acquire.flatMap(acquired =>
+      if (acquired) onAcquired
+      else DBIOAction.failed(FailedToAcquireLockException(lockType, lockId))
+    )
 
   private[db] def acquireSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
     sql"select pg_try_advisory_lock($lockId)".as[Boolean].head
@@ -24,16 +36,28 @@ object AdvisoryLocks {
   def withSessionLock[T, E <: Effect](lockId: Long, action: DBIOAction[T, NoStream, E])(implicit
       ec: ExecutionContext
   ): DBIOAction[T, NoStream, Effect.Read & E] =
-    (for {
-      lockAcquired <- acquireSessionLock(lockId)
-      result <- lockAcquired match {
-        case true => action.andFinally(releaseSessionLock(lockId))
-        case false => DBIOAction.failed(FailedToAcquireAdvisoryLockException(lockId))
-      }
-    } yield result).withPinnedSession
+    withLock("session-scoped", lockId)(
+      acquireSessionLock(lockId),
+      action.andFinally(releaseSessionLock(lockId)),
+    ).withPinnedSession
 
   def withDdlLock[T, E <: Effect](action: DBIOAction[T, NoStream, E])(implicit
       ec: ExecutionContext
   ): DBIOAction[T, NoStream, Effect.Read & E] =
     withSessionLock(AdvisoryLockIds.ddlStatement, action)
+
+  private def acquireTransactionalLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
+    sql"SELECT pg_try_advisory_xact_lock($lockId)".as[Boolean].head
+
+  /** Wraps the given action in a transactional advisory lock. */
+  def withTransactionalLock[T, E <: Effect](
+      profile: JdbcProfile,
+      lockId: Long,
+      action: DBIOAction[T, NoStream, E],
+  )(implicit
+      ec: ExecutionContext
+  ): DBIOAction[T, NoStream, Effect.Read & Effect.Transactional & E] = {
+    import profile.api.jdbcActionExtensionMethods
+    withLock("transactional", lockId)(acquireTransactionalLock(lockId), action).transactionally
+  }
 }

--- a/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
+++ b/apps/common/src/main/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocks.scala
@@ -24,10 +24,10 @@ object AdvisoryLocks {
       else DBIOAction.failed(FailedToAcquireLockException(lockType, lockId))
     )
 
-  private[db] def acquireSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
+  private def acquireSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
     sql"select pg_try_advisory_lock($lockId)".as[Boolean].head
 
-  private[db] def releaseSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
+  private def releaseSessionLock(lockId: Long): DBIOAction[Boolean, NoStream, Effect.Read] =
     sql"select pg_advisory_unlock($lockId)".as[Boolean].head
 
   /** Wraps the given action in a session-scoped advisory lock; useful for acquiring locks for

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -4,6 +4,7 @@ import com.daml.metrics.api.noop.NoOpMetricsFactory
 import org.lfdecentralizedtrust.splice.config.AutomationConfig
 import org.lfdecentralizedtrust.splice.environment.RetryProvider
 import org.lfdecentralizedtrust.splice.store.{StoreErrors, StoreTestBase}
+import org.lfdecentralizedtrust.splice.store.db.AdvisoryLocksTestHelper
 import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.SuppressionRule
@@ -34,7 +35,8 @@ class SqlIndexInitializationTriggerStoreTest
     with SplicePostgresTest
     with AcsJdbcTypes
     with AcsTables
-    with FutureHelpers {
+    with FutureHelpers
+    with AdvisoryLocksTestHelper {
 
   private val expectedIndexNames = Seq(
     "updt_hist_crea_hi_mi_ci_import_updates",
@@ -362,7 +364,7 @@ class SqlIndexInitializationTriggerStoreTest
         ),
       )
       val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdIndexDdlLock(releaseLock.future)
+      val (lockAcquired, lockReleased) = holdLock(AdvisoryLocks.withDdlLock, releaseLock.future)
 
       for {
         _ <- lockAcquired
@@ -377,30 +379,6 @@ class SqlIndexInitializationTriggerStoreTest
       } yield indexNamesAfter should contain("test_index")
     }
 
-  }
-
-  /** Acquires the DDL advisory lock on a separate database session and holds it until `release`
-    * completes.
-    *
-    * Returns a future that completes once the lock is held, and a future that completes once the
-    * lock has been released again.
-    */
-  private def holdIndexDdlLock(release: Future[Unit]): (Future[Unit], Future[Unit]) = {
-    val acquired = Promise[Unit]()
-    val released = storage.underlying
-      .query(
-        AdvisoryLocks.withDdlLock(
-          DBIOAction
-            .successful(())
-            .map(_ => acquired.success(()))
-            .flatMap(_ => DBIOAction.from(release))
-        ),
-        "hold DDL lock",
-      )
-      .failOnShutdown
-    // Make sure the test fails rather than hangs if the lock-holding session dies.
-    released.failed.foreach(acquired.tryFailure)
-    (acquired.future, released)
   }
 
   private def listIndexNames(): Future[Seq[String]] = {

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -362,16 +362,9 @@ class SqlIndexInitializationTriggerStoreTest
 
       for {
         _ <- lockAcquired
-
-        // While another process holds the lock, the trigger must not execute any DDL,
-        // and must not log at warn level or above
-        _ <- loggerFactory.assertLoggedWarningsAndErrorsSeq(
-          within = trigger.runOnce(),
-          assertion = _ shouldBe empty,
-        )
+        _ <- trigger.runOnce()
         indexNamesWhileLocked <- listIndexNames()
         _ = indexNamesWhileLocked should not contain "test_index"
-
         // The contended action is still pending and succeeds once the lock is released
         _ = releaseLock.success(())
         _ <- lockReleased
@@ -383,24 +376,19 @@ class SqlIndexInitializationTriggerStoreTest
     "not collide when several triggers share a database" in {
       // Sets up several triggers that will all run the same index DDL against the same tables.
       // Without the advisory lock, the concurrent DDL statements compete either failing or
-      // leaving behind invalid indexes. Both are logged as warnings, so we assert that the whole
-      // run is free of warnings.
+      // leaving behind invalid indexes.
       val triggers = (1 to 8).map(_ =>
         SqlIndexInitializationTrigger(
           storage = storage,
           triggerContext = fastPollingTriggerContext,
         )
       )
-      val indexNames = loggerFactory
-        .assertLoggedWarningsAndErrorsSeq(
-          within = Future
-            .sequence(triggers.map(runTriggerUntilAllTasksDone))
-            // Unlike the SimClock-based tests, these polling loops keep running on the wall clock,
-            // so they have to be stopped before the test ends.
-            .map(_ => triggers.foreach(_.close()))
-            .flatMap(_ => listIndexNames()),
-          assertion = _ shouldBe empty,
-        )
+      val indexNames = Future
+        .sequence(triggers.map(runTriggerUntilAllTasksDone))
+        // Unlike the SimClock-based tests, these polling loops keep running on the wall clock,
+        // so they have to be stopped before the test ends.
+        .map(_ => triggers.foreach(_.close()))
+        .flatMap(_ => listIndexNames())
         .futureValue
       indexNames should contain allElementsOf expectedIndexNames
       indexNames should not contain "scan_txlog_store_sid_en_vot"

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -8,13 +8,17 @@ import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.resource.DbStorage
-import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.time.SimClock
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.canton.{FutureHelpers, HasActorSystem, HasExecutionContext}
 import org.lfdecentralizedtrust.splice.automation.SqlIndexInitializationTrigger.IndexAction
-import org.lfdecentralizedtrust.splice.store.db.{AcsJdbcTypes, AcsTables, SplicePostgresTest}
+import org.lfdecentralizedtrust.splice.store.db.{
+  AcsJdbcTypes,
+  AcsTables,
+  AdvisoryLocks,
+  SplicePostgresTest,
+}
 import org.slf4j.event.Level
 import slick.dbio.DBIOAction
 import slick.jdbc.{GetResult, PositionedResult}
@@ -358,7 +362,7 @@ class SqlIndexInitializationTriggerStoreTest
         ),
       )
       val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdIndexDdlLock(trigger, releaseLock.future)
+      val (lockAcquired, lockReleased) = holdIndexDdlLock(releaseLock.future)
 
       for {
         _ <- lockAcquired
@@ -373,80 +377,25 @@ class SqlIndexInitializationTriggerStoreTest
       } yield indexNamesAfter should contain("test_index")
     }
 
-    "not collide when several triggers share a database" in {
-      // Sets up several triggers that will all run the same index DDL against the same tables.
-      // Without the advisory lock, the concurrent DDL statements compete either failing or
-      // leaving behind invalid indexes.
-      val triggers = (1 to 8).map(_ =>
-        SqlIndexInitializationTrigger(
-          storage = storage,
-          triggerContext = fastPollingTriggerContext,
-        )
-      )
-      val indexNames = Future
-        .sequence(triggers.map(runTriggerUntilAllTasksDone))
-        // Unlike the SimClock-based tests, these polling loops keep running on the wall clock,
-        // so they have to be stopped before the test ends.
-        .map(_ => triggers.foreach(_.close()))
-        .flatMap(_ => listIndexNames())
-        .futureValue
-      indexNames should contain allElementsOf expectedIndexNames
-      indexNames should not contain "scan_txlog_store_sid_en_vot"
-    }
-
-    "release the advisory lock after executing index DDL" in {
-      val trigger = SqlIndexInitializationTrigger(
-        storage = storage,
-        triggerContext = triggerContext,
-        indexActions = List(
-          IndexAction.Create(
-            "test_index",
-            sqlu"create index concurrently if not exists test_index on update_history_creates (record_time)",
-          )
-        ),
-      )
-      for {
-        _ <- runTriggerUntilAllTasksDone(trigger)
-        indexNames <- listIndexNames()
-        _ = indexNames should contain("test_index")
-        lockIsFree <- storage.underlying
-          .query(
-            (for {
-              lockAcquired <- trigger.acquireIndexDdlLock
-              _ <- if (lockAcquired) trigger.releaseIndexDdlLock else DBIOAction.successful(false)
-            } yield lockAcquired).withPinnedSession,
-            "check index DDL lock",
-          )
-          .failOnShutdown
-      } yield lockIsFree shouldBe true
-    }
   }
 
-  /** Acquires the index DDL advisory lock on a separate database session and holds it until
-    * `release` completes.
+  /** Acquires the DDL advisory lock on a separate database session and holds it until `release`
+    * completes.
     *
     * Returns a future that completes once the lock is held, and a future that completes once the
     * lock has been released again.
     */
-  private def holdIndexDdlLock(
-      trigger: SqlIndexInitializationTrigger,
-      release: Future[Unit],
-  ): (Future[Unit], Future[Unit]) = {
+  private def holdIndexDdlLock(release: Future[Unit]): (Future[Unit], Future[Unit]) = {
     val acquired = Promise[Unit]()
     val released = storage.underlying
       .query(
-        (for {
-          lockAcquired <- trigger.acquireIndexDdlLock
-          _ =
-            if (lockAcquired) acquired.success(())
-            else
-              acquired.failure(
-                new RuntimeException("The test failed to acquire the index DDL advisory lock")
-              )
-          _ <- DBIOAction.from(release)
-          _ <- trigger.releaseIndexDdlLock
-        } yield ()).withPinnedSession,
-        "hold index DDL lock",
+        AdvisoryLocks.withDdlLock(
+          DBIOAction
+            .successful(())
+            .map(_ => acquired.success(()))
+            .flatMap(_ => DBIOAction.from(release))
+        ),
+        "hold DDL lock",
       )
       .failOnShutdown
     // Make sure the test fails rather than hangs if the lock-holding session dies.
@@ -525,13 +474,6 @@ class SqlIndexInitializationTriggerStoreTest
     RetryProvider(loggerFactory, timeouts, FutureSupervisor.Noop, NoOpMetricsFactory),
     loggerFactory,
     NoOpMetricsFactory,
-  )
-
-  // A trigger context whose polling loop actually makes progress over time. The default context
-  // uses a SimClock, which never advances, so a trigger that reports a no-op never polls again.
-  private lazy val fastPollingTriggerContext: TriggerContext = triggerContext.copy(
-    config = AutomationConfig(pollingInterval = NonNegativeFiniteDuration.ofMillis(100)),
-    pollingClock = wallClock,
   )
 
   override protected def cleanDb(

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -8,6 +8,7 @@ import com.digitalasset.canton.concurrent.{FutureSupervisor, Threading}
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.logging.SuppressionRule
 import com.digitalasset.canton.resource.DbStorage
+import com.digitalasset.canton.config.NonNegativeFiniteDuration
 import com.digitalasset.canton.time.SimClock
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MonadUtil
@@ -19,7 +20,7 @@ import slick.dbio.DBIOAction
 import slick.jdbc.{GetResult, PositionedResult}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 
 class SqlIndexInitializationTriggerStoreTest
     extends StoreTestBase
@@ -30,6 +31,13 @@ class SqlIndexInitializationTriggerStoreTest
     with AcsJdbcTypes
     with AcsTables
     with FutureHelpers {
+
+  private val expectedIndexNames = Seq(
+    "updt_hist_crea_hi_mi_ci_import_updates",
+    "updt_hist_tran_hi_eth",
+    "dso_acs_store_sid_mid_pn_tid_rbio",
+    "scan_txlog_store_sid_effat_en_vot",
+  )
 
   "SqlIndexInitializationTrigger" should {
 
@@ -56,12 +64,7 @@ class SqlIndexInitializationTriggerStoreTest
         indexNames <- listIndexNames()
         _ <- dumpIndexes()
       } yield {
-        indexNames should contain allElementsOf Seq(
-          "updt_hist_crea_hi_mi_ci_import_updates",
-          "updt_hist_tran_hi_eth",
-          "dso_acs_store_sid_mid_pn_tid_rbio",
-          "scan_txlog_store_sid_effat_en_vot",
-        )
+        indexNames should contain allElementsOf expectedIndexNames
         indexNames should not contain "scan_txlog_store_sid_en_vot"
       }
     }
@@ -342,6 +345,125 @@ class SqlIndexInitializationTriggerStoreTest
         tasksResult.value shouldBe empty
       }
     }
+
+    "skip index DDL quietly while another process holds the advisory lock" in {
+      val trigger = SqlIndexInitializationTrigger(
+        storage = storage,
+        triggerContext = triggerContext,
+        indexActions = List(
+          IndexAction.Create(
+            "test_index",
+            sqlu"create index concurrently if not exists test_index on update_history_creates (record_time)",
+          )
+        ),
+      )
+      val releaseLock = Promise[Unit]()
+      val (lockAcquired, lockReleased) = holdIndexDdlLock(trigger, releaseLock.future)
+
+      for {
+        _ <- lockAcquired
+
+        // While another process holds the lock, the trigger must not execute any DDL,
+        // and must not log at warn level or above
+        _ <- loggerFactory.assertLoggedWarningsAndErrorsSeq(
+          within = trigger.runOnce(),
+          assertion = _ shouldBe empty,
+        )
+        indexNamesWhileLocked <- listIndexNames()
+        _ = indexNamesWhileLocked should not contain "test_index"
+
+        // The contended action is still pending and succeeds once the lock is released
+        _ = releaseLock.success(())
+        _ <- lockReleased
+        _ <- runTriggerUntilAllTasksDone(trigger)
+        indexNamesAfter <- listIndexNames()
+      } yield indexNamesAfter should contain("test_index")
+    }
+
+    "not collide when several triggers share a database" in {
+      // Sets up several triggers that will all run the same index DDL against the same tables.
+      // Without the advisory lock, the concurrent DDL statements compete either failing or
+      // leaving behind invalid indexes. Both are logged as warnings, so we assert that the whole
+      // run is free of warnings.
+      val triggers = (1 to 8).map(_ =>
+        SqlIndexInitializationTrigger(
+          storage = storage,
+          triggerContext = fastPollingTriggerContext,
+        )
+      )
+      val indexNames = loggerFactory
+        .assertLoggedWarningsAndErrorsSeq(
+          within = Future
+            .sequence(triggers.map(runTriggerUntilAllTasksDone))
+            // Unlike the SimClock-based tests, these polling loops keep running on the wall clock,
+            // so they have to be stopped before the test ends.
+            .map(_ => triggers.foreach(_.close()))
+            .flatMap(_ => listIndexNames()),
+          assertion = _ shouldBe empty,
+        )
+        .futureValue
+      indexNames should contain allElementsOf expectedIndexNames
+      indexNames should not contain "scan_txlog_store_sid_en_vot"
+    }
+
+    "release the advisory lock after executing index DDL" in {
+      val trigger = SqlIndexInitializationTrigger(
+        storage = storage,
+        triggerContext = triggerContext,
+        indexActions = List(
+          IndexAction.Create(
+            "test_index",
+            sqlu"create index concurrently if not exists test_index on update_history_creates (record_time)",
+          )
+        ),
+      )
+      for {
+        _ <- runTriggerUntilAllTasksDone(trigger)
+        indexNames <- listIndexNames()
+        _ = indexNames should contain("test_index")
+        lockIsFree <- storage.underlying
+          .query(
+            (for {
+              lockAcquired <- trigger.acquireIndexDdlLock
+              _ <- if (lockAcquired) trigger.releaseIndexDdlLock else DBIOAction.successful(false)
+            } yield lockAcquired).withPinnedSession,
+            "check index DDL lock",
+          )
+          .failOnShutdown
+      } yield lockIsFree shouldBe true
+    }
+  }
+
+  /** Acquires the index DDL advisory lock on a separate database session and holds it until
+    * `release` completes.
+    *
+    * Returns a future that completes once the lock is held, and a future that completes once the
+    * lock has been released again.
+    */
+  private def holdIndexDdlLock(
+      trigger: SqlIndexInitializationTrigger,
+      release: Future[Unit],
+  ): (Future[Unit], Future[Unit]) = {
+    val acquired = Promise[Unit]()
+    val released = storage.underlying
+      .query(
+        (for {
+          lockAcquired <- trigger.acquireIndexDdlLock
+          _ =
+            if (lockAcquired) acquired.success(())
+            else
+              acquired.failure(
+                new RuntimeException("The test failed to acquire the index DDL advisory lock")
+              )
+          _ <- DBIOAction.from(release)
+          _ <- trigger.releaseIndexDdlLock
+        } yield ()).withPinnedSession,
+        "hold index DDL lock",
+      )
+      .failOnShutdown
+    // Make sure the test fails rather than hangs if the lock-holding session dies.
+    released.failed.foreach(acquired.tryFailure)
+    (acquired.future, released)
   }
 
   private def listIndexNames(): Future[Seq[String]] = {
@@ -416,6 +538,14 @@ class SqlIndexInitializationTriggerStoreTest
     loggerFactory,
     NoOpMetricsFactory,
   )
+
+  // A trigger context whose polling loop actually makes progress over time. The default context
+  // uses a SimClock, which never advances, so a trigger that reports a no-op never polls again.
+  private lazy val fastPollingTriggerContext: TriggerContext = triggerContext.copy(
+    config = AutomationConfig(pollingInterval = NonNegativeFiniteDuration.ofMillis(100)),
+    pollingClock = wallClock,
+  )
+
   override protected def cleanDb(
       storage: DbStorage
   )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] = for {

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/automation/SqlIndexInitializationTriggerStoreTest.scala
@@ -364,7 +364,8 @@ class SqlIndexInitializationTriggerStoreTest
         ),
       )
       val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdLock(AdvisoryLocks.withDdlLock, releaseLock.future)
+      val (lockAcquired, lockReleased) =
+        holdLock(AdvisoryLocks.withDdlLock, DBIOAction.unit, releaseLock.future)
 
       for {
         _ <- lockAcquired

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
@@ -3,13 +3,10 @@
 
 package org.lfdecentralizedtrust.splice.store.db
 
-import cats.Monad
-import com.digitalasset.canton.concurrent.Threading
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.resource.DbStorage
 import com.digitalasset.canton.store.db.DbTest
 import com.digitalasset.canton.tracing.TraceContext
-import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.canton.HasExecutionContext
 import org.lfdecentralizedtrust.splice.store.StoreTestBase
 import slick.dbio.{DBIOAction, Effect, NoStream}
@@ -24,18 +21,14 @@ trait AdvisoryLocksTestHelper { _: DbTest with StoreTestBase with HasExecutionCo
     * been released.
     */
   final def holdLock(
-      withLock: DBIOAction[Unit, NoStream, Effect] => DBIOAction[Unit, NoStream, Effect.All],
+      withLock: DBIOAction[Unit, NoStream, Effect.All] => DBIOAction[Unit, NoStream, Effect.All],
+      action: DBIOAction[Unit, NoStream, Effect.All],
       release: Future[Unit],
   ): (Future[Unit], Future[Unit]) = {
     val acquired = Promise[Unit]()
     val released = storage.underlying
       .queryAndUpdate(
-        withLock(
-          DBIOAction
-            .successful(())
-            .map(_ => acquired.success(()))
-            .flatMap(_ => DBIOAction.from(release))
-        ),
+        withLock(action.map(_ => acquired.success(())).flatMap(_ => DBIOAction.from(release))),
         "hold lock",
       )
       .failOnShutdown
@@ -52,27 +45,22 @@ class AdvisoryLocksTest
     with AcsTables
     with AdvisoryLocksTestHelper {
 
-  private val testIndexNames: Seq[String] = (1 to 8).map(i => s"test_index_$i")
+  private val testTable = "a"
 
-  "AdvisoryLocks.withSessionLock" should {
-
-    "not collide when several concurrent DDL statements run" in {
-      // Create several indexes concurrently. Without the advisory lock these would compete, either
-      // failing or leaving behind invalid indexes
-      for {
-        _ <- Future.sequence(testIndexNames.map(createIndexWithDdlLock))
-        invalidIndexes <- invalidIndexNames()
-        indexNames <- listIndexNames()
-      } yield {
-        invalidIndexes shouldBe empty
-        indexNames should contain allElementsOf testIndexNames
-      }
-    }
-
+  private def commonTests(
+      lockType: String,
+      lockId: Long,
+      withLock: (
+          Long,
+          DBIOAction[Unit, NoStream, Effect.All],
+      ) => DBIOAction[Unit, NoStream, Effect.All],
+  ) = {
     "release the lock after running an action" in {
       for {
-        _ <- createIndexWithDdlLock("test_index_1")
-        lockIsFree <- lockIsFree(AdvisoryLockIds.ddlStatement)
+        _ <- storage.underlying
+          .queryAndUpdate(withLock(lockId, DBIOAction.unit), "test lock")
+          .failOnShutdown
+        lockIsFree <- lockIsFree(lockId)
       } yield lockIsFree shouldBe true
     }
 
@@ -80,153 +68,44 @@ class AdvisoryLocksTest
       for {
         failure <- storage.underlying
           .queryAndUpdate(
-            AdvisoryLocks.withDdlLock(sqlu"create index on a_table_that_does_not_exist (bad)"),
-            "failing DDL",
+            withLock(lockId, DBIOAction.failed(new RuntimeException("error"))),
+            "test lock",
           )
           .failOnShutdown
           .failed
-        _ = failure shouldBe a[java.sql.SQLException]
-        lockIsFree <- lockIsFree(AdvisoryLockIds.ddlStatement)
+        _ = failure shouldBe a[RuntimeException]
+        lockIsFree <- lockIsFree(lockId)
       } yield lockIsFree shouldBe true
     }
 
     "fail fast while another session holds the lock" in {
       val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdLock(AdvisoryLocks.withDdlLock, releaseLock.future)
+      val createTable = sqlu"create table #$testTable (id int)".map(_ => ())
+      val (lockAcquired, lockReleased) =
+        holdLock(withLock(lockId, _), createTable, releaseLock.future)
       for {
         _ <- lockAcquired
         failure <- storage.underlying
-          .queryAndUpdate(
-            AdvisoryLocks.withDdlLock(
-              sqlu"create index concurrently if not exists test_index_1 on update_history_creates (record_time)"
-            ),
-            "contended DDL",
-          )
+          .queryAndUpdate(withLock(lockId, createTable), "contended query")
           .failOnShutdown
           .failed
-        indexNamesWhileLocked <- listIndexNames()
         _ = releaseLock.success(())
         _ <- lockReleased
-      } yield {
-        failure shouldBe AdvisoryLocks.FailedToAcquireLockException(
-          "session-scoped",
-          AdvisoryLockIds.ddlStatement,
-        )
-        indexNamesWhileLocked should not contain "test_index_1"
-      }
+      } yield failure shouldBe AdvisoryLocks.FailedToAcquireLockException(lockType, lockId)
     }
   }
 
-  "AdvisoryLocks.withTransactionalLock" should {
+  "AdvisoryLocks.withSessionLock" should commonTests(
+    "session-scoped",
+    AdvisoryLockIds.ddlStatement,
+    AdvisoryLocks.withSessionLock,
+  )
 
-    "release the lock when the transaction ends" in {
-      for {
-        _ <- storage.underlying
-          .queryAndUpdate(
-            AdvisoryLocks.withTransactionalLock(
-              profile,
-              AdvisoryLockIds.acsSnapshotDataInsert,
-              sqlu"insert into active_parties (store_id, party, closed_round) values (1, 'committed', 1)",
-            ),
-            "insert under transactional lock",
-          )
-          .failOnShutdown
-        lockIsFree <- lockIsFree(AdvisoryLockIds.acsSnapshotDataInsert)
-        committed <- countParties("committed")
-      } yield {
-        lockIsFree shouldBe true
-        committed shouldBe 1
-      }
-    }
-
-    "roll back the action and release the lock when the action fails" in {
-      for {
-        failure <- storage.underlying
-          .queryAndUpdate(
-            AdvisoryLocks.withTransactionalLock(
-              profile,
-              AdvisoryLockIds.acsSnapshotDataInsert,
-              DBIOAction.seq(
-                sqlu"insert into active_parties (store_id, party, closed_round) values (2, 'rolled_back', 1)",
-                sqlu"insert into a_table_that_does_not_exist values (1)",
-              ),
-            ),
-            "failing action under transactional lock",
-          )
-          .failOnShutdown
-          .failed
-        _ = failure shouldBe a[java.sql.SQLException]
-        lockIsFree <- lockIsFree(AdvisoryLockIds.acsSnapshotDataInsert)
-        rolledBack <- countParties("rolled_back")
-      } yield {
-        lockIsFree shouldBe true
-        rolledBack shouldBe 0
-      }
-    }
-
-    "fail fast while another transaction holds the lock" in {
-      val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdLock(
-        AdvisoryLocks.withTransactionalLock(profile, AdvisoryLockIds.acsSnapshotDataInsert, _),
-        releaseLock.future,
-      )
-      for {
-        _ <- lockAcquired
-        failure <- storage.underlying
-          .queryAndUpdate(
-            AdvisoryLocks.withTransactionalLock(
-              profile,
-              AdvisoryLockIds.acsSnapshotDataInsert,
-              sqlu"insert into active_parties (store_id, party, closed_round) values (3, 'contended', 1)",
-            ),
-            "contended action under transactional lock",
-          )
-          .failOnShutdown
-          .failed
-        contendedWhileLocked <- countParties("contended")
-        _ = releaseLock.success(())
-        _ <- lockReleased
-        // The same action succeeds once the holder's transaction has ended.
-        _ <- storage.underlying
-          .queryAndUpdate(
-            AdvisoryLocks.withTransactionalLock(
-              profile,
-              AdvisoryLockIds.acsSnapshotDataInsert,
-              sqlu"insert into active_parties (store_id, party, closed_round) values (3, 'contended', 1)",
-            ),
-            "retried action under transactional lock",
-          )
-          .failOnShutdown
-        contendedAfterRelease <- countParties("contended")
-      } yield {
-        failure shouldBe AdvisoryLocks.FailedToAcquireLockException(
-          "transactional",
-          AdvisoryLockIds.acsSnapshotDataInsert,
-        )
-        contendedWhileLocked shouldBe 0
-        contendedAfterRelease shouldBe 1
-      }
-    }
-  }
-
-  /** Runs `create index concurrently` with the DDL lock, retrying with a small sleep for as long
-    * as another session holds the lock.
-    */
-  private def createIndexWithDdlLock(indexName: String): Future[Unit] =
-    Monad[Future].tailRecM(())(_ =>
-      storage.underlying
-        .queryAndUpdate(
-          AdvisoryLocks.withDdlLock(
-            sqlu"create index concurrently if not exists #$indexName on update_history_creates (record_time)"
-          ),
-          s"create $indexName",
-        )
-        .failOnShutdown
-        .map(_ => Right(()))
-        .recoverWith { case _: AdvisoryLocks.FailedToAcquireLockException =>
-          Future(Threading.sleep(10)).map(_ => Left(()))
-        }
-    )
+  "AdvisoryLocks.withTransactionalLock" should commonTests(
+    "transactional",
+    AdvisoryLockIds.acsSnapshotDataInsert,
+    AdvisoryLocks.withTransactionalLock(profile, _, _),
+  )
 
   /** Whether [[lockId]] can be acquired, i.e. nothing is holding it. Session-scoped and
     * transactional locks share one lock space, so a session-scoped check also detects a
@@ -238,42 +117,8 @@ class AdvisoryLocksTest
       .failOnShutdown
       .recover { case _: AdvisoryLocks.FailedToAcquireLockException => false }
 
-  private def countParties(party: String): Future[Int] =
-    storage.underlying
-      .query(
-        sql"select count(*) from active_parties where party = $party".as[Int].head,
-        "countParties",
-      )
-      .failOnShutdown
-
-  private def listIndexNames(): Future[Seq[String]] =
-    storage.underlying
-      .query(
-        sql"select indexname from pg_indexes where schemaname = 'public'".as[String],
-        "listIndexes",
-      )
-      .failOnShutdown
-
-  private def invalidIndexNames(): Future[Seq[String]] =
-    storage.underlying
-      .query(
-        sql"""
-          select c.relname
-          from pg_class c
-          join pg_namespace n on n.oid = c.relnamespace
-          join pg_index i on i.indexrelid = c.oid
-          where n.nspname = current_schema and c.relkind = 'i' and not i.indisvalid
-        """.as[String],
-        "invalidIndexes",
-      )
-      .failOnShutdown
-
   override protected def cleanDb(
       storage: DbStorage
-  )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] = for {
-    _ <- resetAllAppTables(storage)
-    _ <- MonadUtil.sequentialTraverse(testIndexNames) { indexName =>
-      storage.update(sqlu"drop index if exists #$indexName", s"drop index $indexName")
-    }
-  } yield ()
+  )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] =
+    storage.update(sqlu"drop table if exists #$testTable", s"drop $testTable")
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
@@ -7,25 +7,54 @@ import cats.Monad
 import com.digitalasset.canton.concurrent.Threading
 import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
 import com.digitalasset.canton.resource.DbStorage
+import com.digitalasset.canton.store.db.DbTest
 import com.digitalasset.canton.tracing.TraceContext
 import com.digitalasset.canton.util.MonadUtil
 import com.digitalasset.canton.HasExecutionContext
 import org.lfdecentralizedtrust.splice.store.StoreTestBase
-import slick.dbio.DBIOAction
+import slick.dbio.{DBIOAction, Effect, NoStream}
 import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
 
 import scala.concurrent.{Future, Promise}
+
+trait AdvisoryLocksTestHelper { _: DbTest with StoreTestBase with HasExecutionContext =>
+
+  /** Acquires a lock by calling [[withLock]] and holds it until `release` completes. Returns a
+    * future that completes once the lock is held, and a future that completes once the lock has
+    * been released.
+    */
+  final def holdLock(
+      withLock: DBIOAction[Unit, NoStream, Effect] => DBIOAction[Unit, NoStream, Effect.All],
+      release: Future[Unit],
+  ): (Future[Unit], Future[Unit]) = {
+    val acquired = Promise[Unit]()
+    val released = storage.underlying
+      .queryAndUpdate(
+        withLock(
+          DBIOAction
+            .successful(())
+            .map(_ => acquired.success(()))
+            .flatMap(_ => DBIOAction.from(release))
+        ),
+        "hold lock",
+      )
+      .failOnShutdown
+    released.failed.foreach(acquired.tryFailure)
+    (acquired.future, released)
+  }
+}
 
 class AdvisoryLocksTest
     extends StoreTestBase
     with HasExecutionContext
     with SplicePostgresTest
     with AcsJdbcTypes
-    with AcsTables {
+    with AcsTables
+    with AdvisoryLocksTestHelper {
 
   private val testIndexNames: Seq[String] = (1 to 8).map(i => s"test_index_$i")
 
-  "AdvisoryLocks" should {
+  "AdvisoryLocks.withSessionLock" should {
 
     "not collide when several concurrent DDL statements run" in {
       // Create several indexes concurrently. Without the advisory lock these would compete, either
@@ -43,7 +72,7 @@ class AdvisoryLocksTest
     "release the lock after running an action" in {
       for {
         _ <- createIndexWithDdlLock("test_index_1")
-        lockIsFree <- ddlLockIsFree()
+        lockIsFree <- lockIsFree(AdvisoryLockIds.ddlStatement)
       } yield lockIsFree shouldBe true
     }
 
@@ -57,13 +86,13 @@ class AdvisoryLocksTest
           .failOnShutdown
           .failed
         _ = failure shouldBe a[java.sql.SQLException]
-        lockIsFree <- ddlLockIsFree()
+        lockIsFree <- lockIsFree(AdvisoryLockIds.ddlStatement)
       } yield lockIsFree shouldBe true
     }
 
     "fail fast while another session holds the lock" in {
       val releaseLock = Promise[Unit]()
-      val (lockAcquired, lockReleased) = holdDdlLock(releaseLock.future)
+      val (lockAcquired, lockReleased) = holdLock(AdvisoryLocks.withDdlLock, releaseLock.future)
       for {
         _ <- lockAcquired
         failure <- storage.underlying
@@ -79,10 +108,103 @@ class AdvisoryLocksTest
         _ = releaseLock.success(())
         _ <- lockReleased
       } yield {
-        failure shouldBe AdvisoryLocks.FailedToAcquireAdvisoryLockException(
-          AdvisoryLockIds.ddlStatement
+        failure shouldBe AdvisoryLocks.FailedToAcquireLockException(
+          "session-scoped",
+          AdvisoryLockIds.ddlStatement,
         )
         indexNamesWhileLocked should not contain "test_index_1"
+      }
+    }
+  }
+
+  "AdvisoryLocks.withTransactionalLock" should {
+
+    "release the lock when the transaction ends" in {
+      for {
+        _ <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withTransactionalLock(
+              profile,
+              AdvisoryLockIds.acsSnapshotDataInsert,
+              sqlu"insert into active_parties (store_id, party, closed_round) values (1, 'committed', 1)",
+            ),
+            "insert under transactional lock",
+          )
+          .failOnShutdown
+        lockIsFree <- lockIsFree(AdvisoryLockIds.acsSnapshotDataInsert)
+        committed <- countParties("committed")
+      } yield {
+        lockIsFree shouldBe true
+        committed shouldBe 1
+      }
+    }
+
+    "roll back the action and release the lock when the action fails" in {
+      for {
+        failure <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withTransactionalLock(
+              profile,
+              AdvisoryLockIds.acsSnapshotDataInsert,
+              DBIOAction.seq(
+                sqlu"insert into active_parties (store_id, party, closed_round) values (2, 'rolled_back', 1)",
+                sqlu"insert into a_table_that_does_not_exist values (1)",
+              ),
+            ),
+            "failing action under transactional lock",
+          )
+          .failOnShutdown
+          .failed
+        _ = failure shouldBe a[java.sql.SQLException]
+        lockIsFree <- lockIsFree(AdvisoryLockIds.acsSnapshotDataInsert)
+        rolledBack <- countParties("rolled_back")
+      } yield {
+        lockIsFree shouldBe true
+        rolledBack shouldBe 0
+      }
+    }
+
+    "fail fast while another transaction holds the lock" in {
+      val releaseLock = Promise[Unit]()
+      val (lockAcquired, lockReleased) = holdLock(
+        AdvisoryLocks.withTransactionalLock(profile, AdvisoryLockIds.acsSnapshotDataInsert, _),
+        releaseLock.future,
+      )
+      for {
+        _ <- lockAcquired
+        failure <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withTransactionalLock(
+              profile,
+              AdvisoryLockIds.acsSnapshotDataInsert,
+              sqlu"insert into active_parties (store_id, party, closed_round) values (3, 'contended', 1)",
+            ),
+            "contended action under transactional lock",
+          )
+          .failOnShutdown
+          .failed
+        contendedWhileLocked <- countParties("contended")
+        _ = releaseLock.success(())
+        _ <- lockReleased
+        // The same action succeeds once the holder's transaction has ended.
+        _ <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withTransactionalLock(
+              profile,
+              AdvisoryLockIds.acsSnapshotDataInsert,
+              sqlu"insert into active_parties (store_id, party, closed_round) values (3, 'contended', 1)",
+            ),
+            "retried action under transactional lock",
+          )
+          .failOnShutdown
+        contendedAfterRelease <- countParties("contended")
+      } yield {
+        failure shouldBe AdvisoryLocks.FailedToAcquireLockException(
+          "transactional",
+          AdvisoryLockIds.acsSnapshotDataInsert,
+        )
+        contendedWhileLocked shouldBe 0
+        contendedAfterRelease shouldBe 1
       }
     }
   }
@@ -106,40 +228,21 @@ class AdvisoryLocksTest
         }
     )
 
-  /** Acquires the DDL lock on a separate database session and holds it until `release` completes.
-    *
-    * Returns a future that completes once the lock is held, and a future that completes once the
-    * lock has been released again.
+  /** Whether [[lockId]] can be acquired, i.e. nothing is holding it. Session-scoped and
+    * transactional locks share one lock space, so a session-scoped check also detects a
+    * detects a transactional holder.
     */
-  private def holdDdlLock(release: Future[Unit]): (Future[Unit], Future[Unit]) = {
-    val acquired = Promise[Unit]()
-    val released = storage.underlying
-      .query(
-        AdvisoryLocks.withDdlLock(
-          DBIOAction
-            .successful(())
-            .map(_ => acquired.success(()))
-            .flatMap(_ => DBIOAction.from(release))
-        ),
-        "hold DDL lock",
-      )
+  private def lockIsFree(lockId: Long): Future[Boolean] =
+    storage.underlying
+      .query(AdvisoryLocks.withSessionLock(lockId, DBIOAction.successful(true)), "check lock")
       .failOnShutdown
-    // Make sure the test fails rather than hangs if the lock-holding session dies.
-    released.failed.foreach(acquired.tryFailure)
-    (acquired.future, released)
-  }
+      .recover { case _: AdvisoryLocks.FailedToAcquireLockException => false }
 
-  /** Whether the DDL lock can be acquired from another session, i.e. nothing is holding it. */
-  private def ddlLockIsFree(): Future[Boolean] =
+  private def countParties(party: String): Future[Int] =
     storage.underlying
       .query(
-        (for {
-          acquired <- AdvisoryLocks.acquireSessionLock(AdvisoryLockIds.ddlStatement)
-          _ <-
-            if (acquired) AdvisoryLocks.releaseSessionLock(AdvisoryLockIds.ddlStatement)
-            else DBIOAction.successful(false)
-        } yield acquired).withPinnedSession,
-        "check DDL lock",
+        sql"select count(*) from active_parties where party = $party".as[Int].head,
+        "countParties",
       )
       .failOnShutdown
 
@@ -167,8 +270,10 @@ class AdvisoryLocksTest
 
   override protected def cleanDb(
       storage: DbStorage
-  )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] =
-    MonadUtil.sequentialTraverse(testIndexNames) { indexName =>
+  )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] = for {
+    _ <- resetAllAppTables(storage)
+    _ <- MonadUtil.sequentialTraverse(testIndexNames) { indexName =>
       storage.update(sqlu"drop index if exists #$indexName", s"drop index $indexName")
     }
+  } yield ()
 }

--- a/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
+++ b/apps/common/src/test/scala/org/lfdecentralizedtrust/splice/store/db/AdvisoryLocksTest.scala
@@ -1,0 +1,174 @@
+// Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package org.lfdecentralizedtrust.splice.store.db
+
+import cats.Monad
+import com.digitalasset.canton.concurrent.Threading
+import com.digitalasset.canton.lifecycle.FutureUnlessShutdown
+import com.digitalasset.canton.resource.DbStorage
+import com.digitalasset.canton.tracing.TraceContext
+import com.digitalasset.canton.util.MonadUtil
+import com.digitalasset.canton.HasExecutionContext
+import org.lfdecentralizedtrust.splice.store.StoreTestBase
+import slick.dbio.DBIOAction
+import slick.jdbc.canton.ActionBasedSQLInterpolation.Implicits.actionBasedSQLInterpolationCanton
+
+import scala.concurrent.{Future, Promise}
+
+class AdvisoryLocksTest
+    extends StoreTestBase
+    with HasExecutionContext
+    with SplicePostgresTest
+    with AcsJdbcTypes
+    with AcsTables {
+
+  private val testIndexNames: Seq[String] = (1 to 8).map(i => s"test_index_$i")
+
+  "AdvisoryLocks" should {
+
+    "not collide when several concurrent DDL statements run" in {
+      // Create several indexes concurrently. Without the advisory lock these would compete, either
+      // failing or leaving behind invalid indexes
+      for {
+        _ <- Future.sequence(testIndexNames.map(createIndexWithDdlLock))
+        invalidIndexes <- invalidIndexNames()
+        indexNames <- listIndexNames()
+      } yield {
+        invalidIndexes shouldBe empty
+        indexNames should contain allElementsOf testIndexNames
+      }
+    }
+
+    "release the lock after running an action" in {
+      for {
+        _ <- createIndexWithDdlLock("test_index_1")
+        lockIsFree <- ddlLockIsFree()
+      } yield lockIsFree shouldBe true
+    }
+
+    "release the lock after an action fails" in {
+      for {
+        failure <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withDdlLock(sqlu"create index on a_table_that_does_not_exist (bad)"),
+            "failing DDL",
+          )
+          .failOnShutdown
+          .failed
+        _ = failure shouldBe a[java.sql.SQLException]
+        lockIsFree <- ddlLockIsFree()
+      } yield lockIsFree shouldBe true
+    }
+
+    "fail fast while another session holds the lock" in {
+      val releaseLock = Promise[Unit]()
+      val (lockAcquired, lockReleased) = holdDdlLock(releaseLock.future)
+      for {
+        _ <- lockAcquired
+        failure <- storage.underlying
+          .queryAndUpdate(
+            AdvisoryLocks.withDdlLock(
+              sqlu"create index concurrently if not exists test_index_1 on update_history_creates (record_time)"
+            ),
+            "contended DDL",
+          )
+          .failOnShutdown
+          .failed
+        indexNamesWhileLocked <- listIndexNames()
+        _ = releaseLock.success(())
+        _ <- lockReleased
+      } yield {
+        failure shouldBe AdvisoryLocks.FailedToAcquireAdvisoryLockException(
+          AdvisoryLockIds.ddlStatement
+        )
+        indexNamesWhileLocked should not contain "test_index_1"
+      }
+    }
+  }
+
+  /** Runs `create index concurrently` with the DDL lock, retrying with a small sleep for as long
+    * as another session holds the lock.
+    */
+  private def createIndexWithDdlLock(indexName: String): Future[Unit] =
+    Monad[Future].tailRecM(())(_ =>
+      storage.underlying
+        .queryAndUpdate(
+          AdvisoryLocks.withDdlLock(
+            sqlu"create index concurrently if not exists #$indexName on update_history_creates (record_time)"
+          ),
+          s"create $indexName",
+        )
+        .failOnShutdown
+        .map(_ => Right(()))
+        .recoverWith { case _: AdvisoryLocks.FailedToAcquireLockException =>
+          Future(Threading.sleep(10)).map(_ => Left(()))
+        }
+    )
+
+  /** Acquires the DDL lock on a separate database session and holds it until `release` completes.
+    *
+    * Returns a future that completes once the lock is held, and a future that completes once the
+    * lock has been released again.
+    */
+  private def holdDdlLock(release: Future[Unit]): (Future[Unit], Future[Unit]) = {
+    val acquired = Promise[Unit]()
+    val released = storage.underlying
+      .query(
+        AdvisoryLocks.withDdlLock(
+          DBIOAction
+            .successful(())
+            .map(_ => acquired.success(()))
+            .flatMap(_ => DBIOAction.from(release))
+        ),
+        "hold DDL lock",
+      )
+      .failOnShutdown
+    // Make sure the test fails rather than hangs if the lock-holding session dies.
+    released.failed.foreach(acquired.tryFailure)
+    (acquired.future, released)
+  }
+
+  /** Whether the DDL lock can be acquired from another session, i.e. nothing is holding it. */
+  private def ddlLockIsFree(): Future[Boolean] =
+    storage.underlying
+      .query(
+        (for {
+          acquired <- AdvisoryLocks.acquireSessionLock(AdvisoryLockIds.ddlStatement)
+          _ <-
+            if (acquired) AdvisoryLocks.releaseSessionLock(AdvisoryLockIds.ddlStatement)
+            else DBIOAction.successful(false)
+        } yield acquired).withPinnedSession,
+        "check DDL lock",
+      )
+      .failOnShutdown
+
+  private def listIndexNames(): Future[Seq[String]] =
+    storage.underlying
+      .query(
+        sql"select indexname from pg_indexes where schemaname = 'public'".as[String],
+        "listIndexes",
+      )
+      .failOnShutdown
+
+  private def invalidIndexNames(): Future[Seq[String]] =
+    storage.underlying
+      .query(
+        sql"""
+          select c.relname
+          from pg_class c
+          join pg_namespace n on n.oid = c.relnamespace
+          join pg_index i on i.indexrelid = c.oid
+          where n.nspname = current_schema and c.relkind = 'i' and not i.indisvalid
+        """.as[String],
+        "invalidIndexes",
+      )
+      .failOnShutdown
+
+  override protected def cleanDb(
+      storage: DbStorage
+  )(implicit traceContext: TraceContext): FutureUnlessShutdown[?] =
+    MonadUtil.sequentialTraverse(testIndexNames) { indexName =>
+      storage.update(sqlu"drop index if exists #$indexName", s"drop index $indexName")
+    }
+}

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerBase.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/automation/AcsSnapshotTriggerBase.scala
@@ -26,6 +26,7 @@ import org.apache.pekko.stream.Materializer
 import org.lfdecentralizedtrust.splice.scan.config.ScanStorageConfig
 import org.lfdecentralizedtrust.splice.store.UpdateHistory
 import org.lfdecentralizedtrust.splice.store.HistoryMetrics.AcsSnapshotsMetrics
+import org.lfdecentralizedtrust.splice.store.db.AdvisoryLocks
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -126,7 +127,7 @@ abstract class AcsSnapshotTriggerBase(
     case Success(result) =>
       snapshotMetrics.waitingForLock.updateValue(0)
       Success(result)
-    case Failure(e: AcsSnapshotStore.FailedToAcquireLockException) =>
+    case Failure(e: AdvisoryLocks.FailedToAcquireLockException) =>
       // It is expected that we sometimes fail to acquire the lock on the snapshot table.
       // The time until the lock is released is typically much larger than our task retry timeouts,
       // so we can just silently skip the task and try again later.

--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/AcsSnapshotStore.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.javaapi.data.CreatedEvent
 import org.lfdecentralizedtrust.splice.codegen.java.splice.amulet.{Amulet, LockedAmulet}
 import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.{
   AcsSnapshot,
-  FailedToAcquireLockException,
   IncrementalAcsSnapshot,
   IncrementalAcsSnapshotTable,
   QueryAcsSnapshotResult,
@@ -17,7 +16,12 @@ import org.lfdecentralizedtrust.splice.scan.store.AcsSnapshotStore.{
 }
 import org.lfdecentralizedtrust.splice.store.UpdateHistory.SelectFromCreateEvents
 import org.lfdecentralizedtrust.splice.store.{HardLimit, Limit, LimitHelpers, UpdateHistory}
-import org.lfdecentralizedtrust.splice.store.db.{AcsJdbcTypes, AcsQueries, AdvisoryLockIds}
+import org.lfdecentralizedtrust.splice.store.db.{
+  AcsJdbcTypes,
+  AcsQueries,
+  AdvisoryLocks,
+  AdvisoryLockIds,
+}
 import org.lfdecentralizedtrust.splice.util.{Contract, HoldingsSummary, PackageQualifiedName}
 import com.digitalasset.canton.data.CantonTimestamp
 import com.digitalasset.canton.lifecycle.{CloseContext, FutureUnlessShutdown}
@@ -220,22 +224,7 @@ class AcsSnapshotStore(
   private def withExclusiveSnapshotDataLock[T, E <: Effect](
       action: DBIOAction[T, NoStream, E]
   ): DBIOAction[T, NoStream, Effect.Read & Effect.Transactional & E] =
-    (for {
-      lockResult <- sql"SELECT pg_try_advisory_xact_lock(${AdvisoryLockIds.acsSnapshotDataInsert})"
-        .as[Boolean]
-        .head
-      result <- lockResult match {
-        case true => action
-        // Lock conflicts can happen:
-        // - In production, if the application crashes while writing a snapshot and then restarts
-        //   and tries to write another snapshot before the database has closed the connection and released the lock.
-        // - In production, if two triggers (ingesting and backfilling) happen to write a snapshot at the same time.
-        // - In testing, where multiple scan instances write to the same app database.
-        // In all cases, we want to fail immediately, and rely on the caller's infrastructure to retry.
-        case false =>
-          DBIOAction.failed(FailedToAcquireLockException())
-      }
-    } yield result).transactionally
+    AdvisoryLocks.withTransactionalLock(profile, AdvisoryLockIds.acsSnapshotDataInsert, action)
 
   def deleteSnapshot(
       snapshot: AcsSnapshot
@@ -798,11 +787,6 @@ class AcsSnapshotStore(
 }
 
 object AcsSnapshotStore {
-
-  case class FailedToAcquireLockException()
-      extends RuntimeException(
-        "Failed to acquire advisory lock for writing to the acs snapshot table."
-      )
 
   sealed trait IncrementalAcsSnapshotTable { def tableName: String }
   object IncrementalAcsSnapshotTable {

--- a/project/ignore-patterns/canton_network_test_log.ignore.txt
+++ b/project/ignore-patterns/canton_network_test_log.ignore.txt
@@ -129,10 +129,6 @@ Circuit breaker .* tripped after .* failures.*(Command|Splice)CircuitBreakerTest
 # This is more likely in test code where we run multiple apps against the same database, all trying to create the same index.
 Index .* should be created and is invalid, dropping it
 
-# TODO(#4738) - remove this
-processTaskWithRetry failed with an unknown exception, not retrying.*SqlIndexInitializationTrigger.*PSQLException: ERROR: tuple concurrently updated
-Skipping processing of.*due to unexpected failure.*SqlIndexInitializationTrigger.*PSQLException: ERROR: tuple concurrently updated
-
 # Injected errors in s3Mock
 Simulated S3 error
 

--- a/test-full-class-names-non-integration.log
+++ b/test-full-class-names-non-integration.log
@@ -37,6 +37,7 @@ org.lfdecentralizedtrust.splice.store.TxLogBackfillingStoreTest
 org.lfdecentralizedtrust.splice.store.UpdateHistoryBackfillingTest
 org.lfdecentralizedtrust.splice.store.UpdateHistoryTest
 org.lfdecentralizedtrust.splice.store.db.AcsSnapshotStoreTest
+org.lfdecentralizedtrust.splice.store.db.AdvisoryLocksTest
 org.lfdecentralizedtrust.splice.store.db.DbExternalPartyWalletStoreTest
 org.lfdecentralizedtrust.splice.store.db.DbMultiDomainAcsStoreTest
 org.lfdecentralizedtrust.splice.store.db.DbScanRewardsReferenceStoreTest


### PR DESCRIPTION
Fixes #4738

This adds an advisory lock around the index DDL statements in `SqlIndexInitializationTrigger`. When a trigger fails to acquire the lock, the task will be retried.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
