### PR TITLE
Ingest ProcessRewardsV2 in ScanRewardsReferenceStore

### DIFF
--- a/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
+++ b/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/store/ScanRewardsReferenceStore.scala
@@ -189,6 +189,17 @@ object ScanRewardsReferenceStore {
             round = Some(contract.payload.round.number),
           )
         },
+        mkFilter(splice.amulet.rewardaccountingv2.ProcessRewardsV2.COMPANION)(
+          co => co.payload.dso == dso,
+          versionGuard = { case (pkgVersionSupport, now) =>
+            (tc) => pkgVersionSupport.supportsTrafficBasedAppRewards(Seq(key.dsoParty), now)(tc)
+          },
+        ) { contract =>
+          ScanRewardsReferenceStoreRowData(
+            contract = contract,
+            round = Some(contract.payload.round.number),
+          )
+        },
       ),
       interfaceFilters = Map.empty,
       synchronizerFilter = Some(key.synchronizerId),


### PR DESCRIPTION
We need the `ProcessRewardsV2` info for doing the #6136 . This PR adds the ingestion of this without a store version bump, as we could in principle enable the pruning of older data based on the reward processing metrics, ie confirming that no rounds are left unprocessed.
and only rely on the data in store for the recently processed rounds.

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
