### PR TITLE
Fix cncluster psql for participants

### DIFF
--- a/build-tools/cncluster
+++ b/build-tools/cncluster
@@ -2336,23 +2336,36 @@ function subcmd_psql() {
   local APPLICATION="$2"
 
   _info "Retrieving DB connection info from pod description..."
-  local DB_INIT_COMMAND
-  DB_INIT_COMMAND=$(
+  local DB_INIT_SCRIPT
+  DB_INIT_SCRIPT=$(
     kubectl get deployment \
       --namespace "${NAMESPACE}" \
       --selector "app=${APPLICATION}" \
       -o 'jsonpath={..spec.template.spec.initContainers[0].command}' \
-    | jq 'join(" ")' \
-    | grep -i psql \
-    | sed -nE 's/^.*(psql.?*) 2>&1.*$/\1/p'
+    | jq -r 'join("\n")'
   )
+
+  # There can be multiple psql invocations, pick the one that contains create database.
+  local DB_INIT_COMMAND
+  DB_INIT_COMMAND=$(
+    grep -F 'create database' <<< "${DB_INIT_SCRIPT}" \
+      | sed -nE 's/^.*(psql .*) 2>&1.*$/\1/p' \
+      | tail -n 1
+  ) || true
 
   if [ -z "${DB_INIT_COMMAND}" ]; then
     _error "Application ${APPLICATION} in namespace ${NAMESPACE} does not have an associated database."
     exit 1
   fi
 
-  eval "set -- $DB_INIT_COMMAND"
+  # The participant does not directly inline the db name so we resolve things here.
+  local DB_INIT_VARS
+  DB_INIT_VARS=$(
+    sed -nE "s/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*='[^']*')[[:space:]]*$/local \1/p" <<< "${DB_INIT_SCRIPT}"
+  ) || true
+
+  eval "${DB_INIT_VARS}
+        set -- ${DB_INIT_COMMAND}"
   while [ $# -gt 0 ]; do
     case "$1" in
       -h|--host)


### PR DESCRIPTION
Tested on CILR that it works for sv participant, sequencer and sv-app and for validator1 participant.

Fixes #6693



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
