### PR TITLE
Prevent page_token=123 false alert

### DIFF
--- a/cluster/configs/shared/base.yaml
+++ b/cluster/configs/shared/base.yaml
@@ -209,7 +209,8 @@ monitoring:
       (
         (
           jsonPayload.message=~"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+" AND
-          -jsonPayload.message=~"(?i)(secret|token|(private|secret)(-)?key|password)=(\"\*\*\*\*\"|hidden)"
+          -jsonPayload.message=~"(?i)(secret|token|(private|secret)(-)?key|password)=(\"\*\*\*\*\"|hidden)" AND
+          -jsonPayload.message=~"(?i)page(_|-)?token=[^, ]+"
         ) OR
         jsonPayload.message=~"eyJhbGc[A-Za-z0-9_-]{2,}\.[A-Za-z0-9_-]{2,}\.[A-Za-z0-9_-]{2,}" OR
         jsonPayload.message=~"Bearer\s+eyJ[A-Za-z0-9_-]{2,}"

--- a/cluster/deployment/scratchneta/config.resolved.yaml
+++ b/cluster/deployment/scratchneta/config.resolved.yaml
@@ -122,7 +122,7 @@ monitoring:
       walletSweep:
         tolerance: 1.5
     enableNoDataAlerts: false
-    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
     muteTimeIntervals: []
   enableGrafanaServiceAccountToken: true
 multiValidator:

--- a/cluster/deployment/scratchnetb/config.resolved.yaml
+++ b/cluster/deployment/scratchnetb/config.resolved.yaml
@@ -122,7 +122,7 @@ monitoring:
       walletSweep:
         tolerance: 1.5
     enableNoDataAlerts: false
-    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
     muteTimeIntervals: []
   enableGrafanaServiceAccountToken: true
 multiValidator:

--- a/cluster/deployment/scratchnetc/config.resolved.yaml
+++ b/cluster/deployment/scratchnetc/config.resolved.yaml
@@ -122,7 +122,7 @@ monitoring:
       walletSweep:
         tolerance: 1.5
     enableNoDataAlerts: false
-    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
     muteTimeIntervals: []
   enableGrafanaServiceAccountToken: true
 multiValidator:

--- a/cluster/deployment/scratchnetd/config.resolved.yaml
+++ b/cluster/deployment/scratchnetd/config.resolved.yaml
@@ -122,7 +122,7 @@ monitoring:
       walletSweep:
         tolerance: 1.5
     enableNoDataAlerts: false
-    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
     muteTimeIntervals: []
   enableGrafanaServiceAccountToken: true
 multiValidator:

--- a/cluster/deployment/scratchnete/config.resolved.yaml
+++ b/cluster/deployment/scratchnete/config.resolved.yaml
@@ -122,7 +122,7 @@ monitoring:
       walletSweep:
         tolerance: 1.5
     enableNoDataAlerts: false
-    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
+    loggedSecretsFilter: "(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n"
     muteTimeIntervals: []
   enableGrafanaServiceAccountToken: true
 multiValidator:

--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -800,7 +800,7 @@
     "id": "",
     "inputs": {
       "description": "Logs containing secrets (JWTs, Bearer tokens, passwords, etc.)",
-      "filter": "resource.labels.cluster_name=\"cn-mocknet\"\n(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n",
+      "filter": "resource.labels.cluster_name=\"cn-mocknet\"\n(\n  (\n    jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=[^, ]+\" AND\n    -jsonPayload.message=~\"(?i)(secret|token|(private|secret)(-)?key|password)=(\\\"\\*\\*\\*\\*\\\"|hidden)\" AND\n    -jsonPayload.message=~\"(?i)page(_|-)?token=[^, ]+\"\n  ) OR\n  jsonPayload.message=~\"eyJhbGc[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\\.[A-Za-z0-9_-]{2,}\" OR\n  jsonPayload.message=~\"Bearer\\s+eyJ[A-Za-z0-9_-]{2,}\"\n)\n",
       "labelExtractors": {
         "cluster": "EXTRACT(resource.labels.cluster_name)",
         "namespace": "EXTRACT(resource.labels.namespace_name)"


### PR DESCRIPTION
[before](https://console.cloud.google.com/logs/query;query=resource.labels.cluster_name%3D%22cn-mainzrhnet%22%0A%2528%0A%20%20%2528%0A%20%20%20%20jsonPayload.message%3D~%22%2528%3Fi%2529%2528secret%7Ctoken%7C%2528private%7Csecret%2529%2528-%2529%3Fkey%7Cpassword%2529%3D%5B%5E,%20%5D%2B%22%20AND%0A%20%20%20%20-jsonPayload.message%3D~%22%2528%3Fi%2529%2528secret%7Ctoken%7C%2528private%7Csecret%2529%2528-%2529%3Fkey%7Cpassword%2529%3D%2528%5C%22%5C*%5C*%5C*%5C*%5C%22%7Chidden%2529%22%0A%20%20%2529%20OR%0A%20%20jsonPayload.message%3D~%22eyJhbGc%5BA-Za-z0-9_-%5D%7B2,%7D%5C.%5BA-Za-z0-9_-%5D%7B2,%7D%5C.%5BA-Za-z0-9_-%5D%7B2,%7D%22%20OR%0A%20%20jsonPayload.message%3D~%22Bearer%5Cs%2BeyJ%5BA-Za-z0-9_-%5D%7B2,%7D%22%0A%2529%0A;cursorTimestamp=2026-08-06T09:20:56.341Z;startTime=2026-08-06T08:33:47.000Z;endTime=2026-08-06T09:42:00.000Z?project=da-cn-mainnet) vs [now](https://console.cloud.google.com/logs/query;query=resource.labels.cluster_name%3D%22cn-mainzrhnet%22%0A%2528%0A%20%20%2528%0A%20%20%20%20jsonPayload.message%3D~%22%2528%3Fi%2529%2528secret%7Ctoken%7C%2528private%7Csecret%2529%2528-%2529%3Fkey%7Cpassword%2529%3D%5B%5E,%20%5D%2B%22%20AND%0A%20%20%20%20%20%20%20%20%20%20-jsonPayload.message%3D~%22%2528%3Fi%2529%2528secret%7Ctoken%7C%2528private%7Csecret%2529%2528-%2529%3Fkey%7Cpassword%2529%3D%2528%5C%22%5C*%5C*%5C*%5C*%5C%22%7Chidden%2529%22%20AND%0A%20%20%20%20%20%20%20%20%20%20-jsonPayload.message%3D~%22%2528%3Fi%2529page%2528_%7C-%2529%3Ftoken%3D%5B%5E,%20%5D%2B%22%0A%20%20%2529%20OR%0A%20%20jsonPayload.message%3D~%22eyJhbGc%5BA-Za-z0-9_-%5D%7B2,%7D%5C.%5BA-Za-z0-9_-%5D%7B2,%7D%5C.%5BA-Za-z0-9_-%5D%7B2,%7D%22%20OR%0A%20%20jsonPayload.message%3D~%22Bearer%5Cs%2BeyJ%5BA-Za-z0-9_-%5D%7B2,%7D%22%0A%2529%0A;cursorTimestamp=2026-08-06T09:22:55.646Z;startTime=2026-08-06T08:33:47.000Z;endTime=2026-08-06T09:26:50.000Z?project=da-cn-mainnet)

apparently GCP doesn't support negative lookbehind