### PR TITLE
Disable circuit breakers for all sv4 apps in LSU test

### DIFF
--- a/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
+++ b/apps/app/src/test/scala/org/lfdecentralizedtrust/splice/integration/tests/LsuIntegrationTest.scala
@@ -109,10 +109,11 @@ class LsuIntegrationTest
                   physicalSynchronizerExpiration = NonNegativeFiniteDuration.ofSeconds(1)
                 ),
                 // sv-4 is intentionally a late-joining node in this test, which means the
-                // sequencer spends some time catching up. This can cause the sv-app's
+                // sequencer spends some time catching up. This can cause the sv-4 apps'
                 // circuit breakers to trip, which makes annoying logs and delays init.
                 // The circuit breakers tripping a bit during catchup would be just fine
-                // IRL, so as a simple fix to this test we disable them for sv-4.
+                // IRL, so as a simple fix to this test we disable them for all sv-4 apps
+                // (see also the scan and validator app transforms below).
                 circuitBreakers =
                   if (name == "sv4") CircuitBreakersConfig.never
                   else config.parameters.circuitBreakers,
@@ -121,7 +122,7 @@ class LsuIntegrationTest
           }
           .andThen(
             ConfigTransforms
-              .updateAllScanAppConfigs { (_, config) =>
+              .updateAllScanAppConfigs { (name, config) =>
                 config.copy(
                   synchronizerNodes = config.synchronizerNodes.copy(
                     successor = Some(config.synchronizerNodes.current)
@@ -129,8 +130,23 @@ class LsuIntegrationTest
                   parameters = config.parameters.copy(
                     spliceCachingConfigs = config.parameters.spliceCachingConfigs.copy(
                       physicalSynchronizerExpiration = NonNegativeFiniteDuration.ofSeconds(1)
-                    )
+                    ),
+                    circuitBreakers =
+                      if (name == "sv4Scan") CircuitBreakersConfig.never
+                      else config.parameters.circuitBreakers,
                   ),
+                )
+              }
+          )
+          .andThen(
+            ConfigTransforms
+              .updateAllValidatorAppConfigs { (name, config) =>
+                config.copy(
+                  parameters = config.parameters.copy(
+                    circuitBreakers =
+                      if (name == "sv4Validator") CircuitBreakersConfig.never
+                      else config.parameters.circuitBreakers
+                  )
                 )
               }
           )(config)


### PR DESCRIPTION
fixes DACH-NY/cn-test-failures#9487

Previous fix (#5587) only covered the sv app; DACH-NY/cn-test-failures#9487 shows the same trip (sequencer backpressure during sv4 catchup) from the sv4 validator app

### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
