### PR TITLE
Make Pulumi pass the correct migrationId for Validator-stable-old 

### DIFF
--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -1,6 +1,12 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DeployValidatorRunbook, EnvVarConfigSchema, K8sResourceSchema, KmsConfigSchema, LogLevelSchema } from '@canton-network/splice-pulumi-common/src/config';
+import {
+  DeployValidatorRunbook,
+  EnvVarConfigSchema,
+  K8sResourceSchema,
+  KmsConfigSchema,
+  LogLevelSchema
+} from '@canton-network/splice-pulumi-common/src/config';
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { z } from 'zod';
 

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -1,14 +1,18 @@
 // Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-  DeployValidatorRunbook,
-  EnvVarConfigSchema,
-  K8sResourceSchema,
-  KmsConfigSchema,
-  LogLevelSchema,
-} from '@canton-network/splice-pulumi-common/src/config';
+import { DeployValidatorRunbook, EnvVarConfigSchema, K8sResourceSchema, KmsConfigSchema, LogLevelSchema } from '@canton-network/splice-pulumi-common/src/config';
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { z } from 'zod';
+
+
+
+
+
+
+
+
+
+
 
 export const SynchronizerConfigSchema = z.union([
   z
@@ -134,6 +138,7 @@ export const ValidatorConfigSchema = z
     onboardingSecret: z.string().optional(),
     partyAllocator: PartyAllocatorConfigSchema.prefault({ enable: false }),
     version: z.string().optional(),
+    migrationId: z.number().optional(),
   })
   .and(ValidatorNodeConfigSchema);
 

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -5,7 +5,7 @@ import {
   EnvVarConfigSchema,
   K8sResourceSchema,
   KmsConfigSchema,
-  LogLevelSchema
+  LogLevelSchema,
 } from '@canton-network/splice-pulumi-common/src/config';
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { z } from 'zod';

--- a/cluster/pulumi/common-validator/src/config.ts
+++ b/cluster/pulumi/common-validator/src/config.ts
@@ -4,16 +4,6 @@ import { DeployValidatorRunbook, EnvVarConfigSchema, K8sResourceSchema, KmsConfi
 import { clusterSubConfig } from '@canton-network/splice-pulumi-common/src/config/config';
 import { z } from 'zod';
 
-
-
-
-
-
-
-
-
-
-
 export const SynchronizerConfigSchema = z.union([
   z
     .object({

--- a/cluster/pulumi/validator-runbook/src/installNode.ts
+++ b/cluster/pulumi/validator-runbook/src/installNode.ts
@@ -218,7 +218,9 @@ async function installValidator(
     ...loadYamlFromFile(
       `${SPLICE_ROOT}/apps/app/src/pack/examples/sv-helm/standalone-validator-values.yaml`,
       {
-        MIGRATION_ID: DecentralizedSynchronizerUpgradeConfig.activeMigrationId.toString(),
+        MIGRATION_ID: (
+          validatorConfig.migrationId ?? DecentralizedSynchronizerUpgradeConfig.activeMigrationId
+        ).toString(),
         SPONSOR_SV_URL: `https://sv.sv-2.${CLUSTER_HOSTNAME}`,
         YOUR_VALIDATOR_NODE_NAME: validatorConfig.nodeIdentifier || validatorConfig.partyHint,
         TRUSTED_SCAN_URL: `https://scan.sv-2.${CLUSTER_HOSTNAME}`,


### PR DESCRIPTION
Fix https://github.com/DACH-NY/canton-network-internal/issues/6411