### PR TITLE
Bump aws_version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2087,6 +2087,7 @@ def mergeStrategy(oldStrategy: String => MergeStrategy): String => MergeStrategy
     case path if path.endsWith("scala-collection-compat.properties") => MergeStrategy.first
     // Don't really care about the notice file so just take any.
     case "META-INF/FastDoubleParser-NOTICE" => MergeStrategy.first
+    case "META-INF/FastDoubleParser-LICENSE" => MergeStrategy.first
     case "META-INF/license/LICENSE.boringssl.txt" => MergeStrategy.first
     case path if path.endsWith("/OSGI-INF/MANIFEST.MF") => MergeStrategy.first
     case x =>

--- a/project/CantonDependencies.scala
+++ b/project/CantonDependencies.scala
@@ -332,7 +332,7 @@ object CantonDependencies {
     "com.google.protobuf" % "protobuf-java-util" % protobuf_version
 
   // AWS SDK for Java API to encrypt/decrypt keys using AWS KMS
-  lazy val aws_version = "2.29.5"
+  lazy val aws_version = "2.49.4"
   lazy val aws_kms = "software.amazon.awssdk" % "kms" % aws_version
   lazy val aws_sts = "software.amazon.awssdk" % "sts" % aws_version
 


### PR DESCRIPTION
The AWS SDK pulls in netty as a dependency, which triggers some vulnerability warnings. Even though they do not apply in practice, they cause noise.

This PR bumps `aws_version` to the same version as Canton.