### PR TITLE
Fix rewardWeightBps specified with '_'  breaking js_yaml >= 4.2

### DIFF
--- a/cluster/configs/configs/configs/TestNet/approved-sv-id-values.yaml
+++ b/cluster/configs/configs/configs/TestNet/approved-sv-id-values.yaml
@@ -1,13 +1,13 @@
 approvedSvIdentities:
   - name: Digital-Asset-2
     publicKey: PUBKEY_0==
-    rewardWeightBps: 100000
+    rewardWeightBps: 100_000
   - name: SV1
     publicKey: PUBLIC_KEY_1==
-    rewardWeightBps: 1000000
+    rewardWeightBps: 1_000_000
   - name: SV2
     publicKey: PUBLIC_KEY_2==
-    rewardWeightBps: 150000
+    rewardWeightBps: 150_000
     extraBeneficiaries:
       - beneficiary: "mock-validator-1::123456789012345678901234567890123456789012234567890123456789012345678"
         weight: 100000
@@ -16,4 +16,4 @@ approvedSvIdentities:
   - name: Digital-Asset-1
     publicKey: THIS_IS_THE_WRONG_KEY
     # this is the right reward weight though
-    rewardWeightBps: 150000
+    rewardWeightBps: 150_000

--- a/cluster/expected/sv-runbook/expected.json
+++ b/cluster/expected/sv-runbook/expected.json
@@ -221,7 +221,7 @@
             },
             "approvedSvIdentities": {
               "type": "md5",
-              "value": "5871224b744b45122540483fddbd550f"
+              "value": "6c876b92df2d92fe7ba83e883d031386"
             }
           },
           "network": "test",
@@ -1413,16 +1413,6 @@
             "rewardWeightBps": 1000000
           },
           {
-            "extraBeneficiaries": [
-              {
-                "beneficiary": "mock-validator-1::123456789012345678901234567890123456789012234567890123456789012345678",
-                "weight": 100000
-              },
-              {
-                "beneficiary": "Broadridge-validator-1::1220c89a73e7b47f16dfb48a521eeedfe2a8620ea1b19b815ab427388d9f5427faa5",
-                "weight": 50000
-              }
-            ],
             "name": "SV2",
             "publicKey": "PUBLIC_KEY_2==",
             "rewardWeightBps": 150000

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -2559,7 +2559,7 @@
             },
             "approvedSvIdentities": {
               "type": "md5",
-              "value": "5871224b744b45122540483fddbd550f"
+              "value": "6c876b92df2d92fe7ba83e883d031386"
             }
           },
           "network": "test",
@@ -4192,16 +4192,6 @@
               "rewardWeightBps": 1000000
             },
             {
-              "extraBeneficiaries": [
-                {
-                  "beneficiary": "mock-validator-1::123456789012345678901234567890123456789012234567890123456789012345678",
-                  "weight": 100000
-                },
-                {
-                  "beneficiary": "Broadridge-validator-1::1220c89a73e7b47f16dfb48a521eeedfe2a8620ea1b19b815ab427388d9f5427faa5",
-                  "weight": 50000
-                }
-              ],
               "name": "SV2",
               "publicKey": "PUBLIC_KEY_2==",
               "rewardWeightBps": 150000
@@ -4874,7 +4864,7 @@
             },
             "approvedSvIdentities": {
               "type": "md5",
-              "value": "5871224b744b45122540483fddbd550f"
+              "value": "6c876b92df2d92fe7ba83e883d031386"
             }
           },
           "network": "test",
@@ -6537,16 +6527,6 @@
               "rewardWeightBps": 1000000
             },
             {
-              "extraBeneficiaries": [
-                {
-                  "beneficiary": "mock-validator-1::123456789012345678901234567890123456789012234567890123456789012345678",
-                  "weight": 100000
-                },
-                {
-                  "beneficiary": "Broadridge-validator-1::1220c89a73e7b47f16dfb48a521eeedfe2a8620ea1b19b815ab427388d9f5427faa5",
-                  "weight": 50000
-                }
-              ],
               "name": "SV2",
               "publicKey": "PUBLIC_KEY_2==",
               "rewardWeightBps": 150000

--- a/cluster/pulumi/common-sv/src/approvedIdentities.ts
+++ b/cluster/pulumi/common-sv/src/approvedIdentities.ts
@@ -19,11 +19,20 @@ export type ApprovedSvIdentity = {
   rewardWeightBps: number;
 };
 
+export type ApprovedSvIdentityFromYamlFile = {
+  name: string;
+  publicKey: string | pulumi.Output<string>;
+  // js-yaml after 4.2 doesn't support specifying numbers with separating underscores (e.g. 100_000),
+  // which means that it will parse that as a string and break the on Helm schema validation.
+  // For normal numbers (e.g 100000), it still gets parsed as a number.
+  rewardWeightBps: string | number;
+};
+
 export function approvedSvIdentitiesFile(): string | undefined {
   return getPathToPublicConfigFile('approved-sv-id-values.yaml');
 }
 
-function approvedSvIdentitiesFromFile(): ApprovedSvIdentity[] {
+function approvedSvIdentitiesFromFile(): ApprovedSvIdentityFromYamlFile[] {
   const file = approvedSvIdentitiesFile();
   return file ? loadYamlFromFile(file).approvedSvIdentities : [];
 }
@@ -48,7 +57,12 @@ function approvedSvIdentitiesFromConfig(): ApprovedSvIdentity[] {
 }
 
 export function approvedSvIdentities(): ApprovedSvIdentity[] {
-  const fromFile = approvedSvIdentitiesFromFile();
+  const rawFromFile = approvedSvIdentitiesFromFile();
+  const fromFile: ApprovedSvIdentity[] = rawFromFile.map(identity => ({
+    name: identity.name,
+    rewardWeightBps: parseInt(String(identity.rewardWeightBps).replace('_', ''), 10),
+    publicKey: identity.publicKey,
+  }));
   const fromConfig = approvedSvIdentitiesFromConfig();
 
   // We override public keys to the locally configured one,
@@ -60,7 +74,8 @@ export function approvedSvIdentities(): ApprovedSvIdentity[] {
   );
 
   return _.uniqBy([...fromFile, ...fromConfig], 'name').map(identity => ({
-    ...identity,
+    name: identity.name,
+    rewardWeightBps: identity.rewardWeightBps,
     publicKey: configuredPublicKeys[identity.name] ?? identity.publicKey,
   }));
 }

--- a/cluster/pulumi/common-sv/src/approvedIdentities.ts
+++ b/cluster/pulumi/common-sv/src/approvedIdentities.ts
@@ -24,6 +24,7 @@ export type ApprovedSvIdentityFromYamlFile = {
   publicKey: string | pulumi.Output<string>;
   // js-yaml after 4.2 doesn't support specifying numbers with separating underscores (e.g. 100_000),
   // which means that it will parse that as a string and break the on Helm schema validation.
+  // This is compliant with the yaml spec, which doesn't define numbers with underscores as possible.
   // For normal numbers (e.g 100000), it still gets parsed as a number.
   rewardWeightBps: string | number;
 };


### PR DESCRIPTION
Running a test on a scratch with https://github.com/canton-network/splice/pull/6726/changes reapplied in https://github.com/canton-network/splice/pull/6750
[link](https://app.circleci.com/pipelines/github/DACH-NY/canton-network-internal/77928/details?workflowId=768a7467-3416-442f-925b-e55897ea398a)