### PR TITLE
Fix GCP log-based upgrade alerts

### DIFF
--- a/cluster/expected/observability/expected.json
+++ b/cluster/expected/observability/expected.json
@@ -697,7 +697,7 @@
     "id": "",
     "inputs": {
       "description": "Logs with ClusterUpdate events",
-      "filter": "\nresource.labels.cluster_name=\"cn-mocknet\"\nresource.type=~\"(gke_cluster|gke_nodepool)\"\njsonPayload.state=~\"STARTED\"",
+      "filter": "\nresource.labels.cluster_name=\"cn-mocknet\"\nresource.type=~\"(gke_cluster|gke_nodepool)\"\njsonPayload.@type=~\"UpgradeEvent\"",
       "labelExtractors": {
         "cluster": "EXTRACT(resource.labels.cluster_name)"
       },

--- a/cluster/pulumi/observability/src/gcpAlerts.ts
+++ b/cluster/pulumi/observability/src/gcpAlerts.ts
@@ -210,7 +210,7 @@ export function installClusterMaintenanceUpdateAlerts(
     filter: `
 resource.labels.cluster_name="${CLUSTER_NAME}"
 resource.type=~"(gke_cluster|gke_nodepool)"
-jsonPayload.state=~"STARTED"`,
+jsonPayload.@type=~"UpgradeEvent"`,
     labelExtractors: {
       cluster: 'EXTRACT(resource.labels.cluster_name)',
     },


### PR DESCRIPTION
[static]

Apparently they changed something and the old query doesn't give signal anymore.

I picked the new query based on looking at logs... and looking at historic data it looks right and not too spammy:

- [TestNet](https://console.cloud.google.com/logs/query;query=resource.labels.cluster_name%3D%22cn-testzrhnet%22%0Aresource.type%3D~%22%2528gke_cluster%7Cgke_nodepool%2529%22%0AjsonPayload.@type%3D~%22UpgradeEvent%22;cursorTimestamp=2026-08-12T09:33:42.232659497Z;duration=P30D?project=da-cn-devnet) (where we noticed)
- [DevNet](https://console.cloud.google.com/logs/query;query=resource.labels.cluster_name%3D%22cn-devnet%22%0Aresource.type%3D~%22%2528gke_cluster%7Cgke_nodepool%2529%22%0AjsonPayload.@type%3D~%22UpgradeEvent%22;cursorTimestamp=2026-08-12T09:18:57.712491097Z;duration=P30D?project=da-cn-devnet)
- [MainNet](https://console.cloud.google.com/logs/query;query=resource.type%3D~%22%2528gke_cluster%7Cgke_nodepool%2529%22%0AjsonPayload.@type%3D~%22UpgradeEvent%22%0Aresource.labels.cluster_name%3D%22cn-mainzrhnet%22;cursorTimestamp=2026-08-04T09:04:15.210198007Z;duration=P30D?project=da-cn-mainnet)

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>



### Pull Request Checklist

#### Cluster Testing
- [ ] If a cluster test is required, comment `/cluster_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If an upgrade test is required, comment `/upgrade_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a hard-migration test is required (from the latest release), comment `/hdm_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.
- [ ] If a logical synchronizer upgrade test is required (from canton-3.5), comment `/lsu_test` on this PR to request it, and ping someone with access to the DA-internal system to approve it.

#### PR Guidelines
- [ ] Include any change that might be observable by our partners or affect their deployment in the [release notes](https://github.com/canton-network/splice/blob/main/docs/src/release_notes.rst).
- [ ] Specify fixed issues with `Fixes #n`, and mention issues worked on using `#n`
- [ ] Include a screenshot for frontend-related PRs - see [README](https://github.com/canton-network/splice/blob/main/TESTING.md#running-and-debugging-integration-tests) or use your favorite screenshot tool


#### Merge Guidelines
- [ ] Make the git commit message look sensible when squash-merging on GitHub (most likely: just copy your PR description).
