### PR TITLE
Fix WebSocket JWT extraction dropping tokens due to unstrimmed whitespace

### DIFF
--- a/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/Endpoints.scala
+++ b/canton/community/ledger/ledger-json-api/src/main/scala/com/digitalasset/canton/http/json/v2/Endpoints.scala
@@ -434,6 +434,21 @@ object Endpoints {
   val wsSubprotocol: Header =
     sttp.model.Header("Sec-WebSocket-Protocol", "daml.ws.auth")
 
+  private val wsJwtTokenPrefix = "jwt.token."
+
+  // Extracts the JWT from a `Sec-WebSocket-Protocol` header value such as
+  // "daml.ws.auth, jwt.token.<TOKEN>" (RFC 6455 clients join subprotocols with ", ").
+  // Elements must be trimmed before matching the prefix, since the leading space on
+  // every element but the first would otherwise make `startsWith` fail to find the token.
+  def extractWsJwtToken(headerValue: Option[String]): Option[Jwt] =
+    headerValue
+      .map(_.split(",").toSeq.map(_.trim))
+      .getOrElse(Seq.empty)
+      .filter(_.startsWith(wsJwtTokenPrefix))
+      .map(_.substring(wsJwtTokenPrefix.length))
+      .headOption
+      .map(Jwt.apply)
+
   lazy val baseEndpoint: Endpoint[CallerContext, Unit, Unit, Unit, Any] = endpoint
     .securityIn(
       auth
@@ -445,16 +460,7 @@ object Endpoints {
         .and(
           auth
             .apiKey(header[Option[String]]("Sec-WebSocket-Protocol"))
-            .map { bearer =>
-              val tokenPrefix = "jwt.token." // TODO (i21030) test this
-              bearer
-                .map(_.split(",").toSeq)
-                .getOrElse(Seq.empty)
-                .filter(_.startsWith(tokenPrefix))
-                .map(_.substring(tokenPrefix.length))
-                .headOption
-                .map(Jwt.apply)
-            }(_.map(_.token))
+            .map(extractWsJwtToken)(_.map(_.token))
             .description("Ledger API standard JWT token (websocket)")
         )
         .and(

--- a/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/json/v2/EndpointsTest.scala
+++ b/canton/community/ledger/ledger-json-api/src/test/scala/com/digitalasset/canton/http/json/v2/EndpointsTest.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.canton.http.json.v2
+
+import com.digitalasset.canton.http.json.v2.Endpoints.{Jwt, extractWsJwtToken}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EndpointsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Endpoints.extractWsJwtToken"
+
+  it should "extract the JWT when the header has no extra whitespace" in {
+    extractWsJwtToken(Some("daml.ws.auth,jwt.token.abc123")) shouldBe Some(Jwt("abc123"))
+  }
+
+  it should "extract the JWT when the subprotocols are comma-space separated, as sent by browsers and " +
+    "standard WebSocket clients (RFC 6455)" in {
+      extractWsJwtToken(Some("daml.ws.auth, jwt.token.abc123")) shouldBe Some(Jwt("abc123"))
+    }
+
+  it should "extract the JWT regardless of subprotocol order" in {
+    extractWsJwtToken(Some("jwt.token.abc123, daml.ws.auth")) shouldBe Some(Jwt("abc123"))
+  }
+
+  it should "extract the JWT when it is the only requested subprotocol" in {
+    extractWsJwtToken(Some("jwt.token.abc123")) shouldBe Some(Jwt("abc123"))
+  }
+
+  it should "tolerate extra surrounding and internal whitespace around subprotocols" in {
+    extractWsJwtToken(Some("  daml.ws.auth  ,   jwt.token.abc123  ")) shouldBe Some(Jwt("abc123"))
+  }
+
+  it should "return None when the header is absent" in {
+    extractWsJwtToken(None) shouldBe None
+  }
+
+  it should "return None when no subprotocol carries a JWT" in {
+    extractWsJwtToken(Some("daml.ws.auth")) shouldBe None
+  }
+
+  it should "return None for an empty header value" in {
+    extractWsJwtToken(Some("")) shouldBe None
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6776.

`Sec-WebSocket-Protocol` is a comma-**space** separated list per RFC 6455 (`"daml.ws.auth, jwt.token.<TOKEN>"`). The JWT extraction in `Endpoints.scala` split on `,` but never trimmed the resulting elements, so every element after the first kept a leading space and failed the `startsWith("jwt.token.")` check. The JWT was silently dropped and the ledger API call was rejected as `UNAUTHENTICATED` (grpc code 16), even though the same token works fine via the standard `Authorization` header.

- Extracts the parsing logic into `Endpoints.extractWsJwtToken` and trims each element after splitting.
- Resolves the outstanding `// TODO (i21030) test this`.
- Adds `EndpointsTest.scala` covering: RFC 6455 comma-space form, no-space form, token-first ordering, token-only, extra surrounding/internal whitespace, absent header, no matching subprotocol, and empty header value.

## Test plan

- [x] New unit tests in `EndpointsTest.scala` (`extractWsJwtToken`) cover the reported case and related edge cases.
- [ ] CI
