### PR TITLE
Auto-enable session signing keys on KMS participants

### DIFF
--- a/apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/kms-participant-aws-values.yaml
@@ -23,3 +23,8 @@ additionalEnvVars:
       secretKeyRef:
         name: aws-credentials
         key: secretAccessKey
+  # Session signing keys reduce KMS load and cost on KMS-backed participants by signing
+  # most messages with short-lived in-memory keys instead of calling the KMS each time.
+  # This config setting only works on KMS participants.
+  - name: ADDITIONAL_CONFIG_SESSION_SIGNING_KEYS
+    value: canton.participants.participant.crypto.session-signing-keys.enabled = true

--- a/apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml
+++ b/apps/app/src/pack/examples/sv-helm/kms-participant-gcp-values.yaml
@@ -19,6 +19,11 @@ kms:
 additionalEnvVars:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: "/app/gcp-credentials.json"
+  # Session signing keys reduce KMS load and cost on KMS-backed participants by signing
+  # most messages with short-lived in-memory keys instead of calling the KMS each time.
+  # This config setting only works on KMS participants.
+  - name: ADDITIONAL_CONFIG_SESSION_SIGNING_KEYS
+    value: canton.participants.participant.crypto.session-signing-keys.enabled = true
 extraVolumeMounts:
   - name: gcp-credentials
     mountPath: "/app/gcp-credentials.json"

--- a/cluster/expected/sv/expected.json
+++ b/cluster/expected/sv/expected.json
@@ -5138,6 +5138,10 @@
             "value": "/app/gcp-credentials.json"
           },
           {
+            "name": "ADDITIONAL_CONFIG_SESSION_SIGNING_KEYS",
+            "value": "canton.participants.participant.crypto.session-signing-keys.enabled = true"
+          },
+          {
             "name": "ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
             "value": "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
           },

--- a/cluster/expected/validator1/expected.json
+++ b/cluster/expected/validator1/expected.json
@@ -708,6 +708,10 @@
             "value": "/app/gcp-credentials.json"
           },
           {
+            "name": "ADDITIONAL_CONFIG_SESSION_SIGNING_KEYS",
+            "value": "canton.participants.participant.crypto.session-signing-keys.enabled = true"
+          },
+          {
             "name": "ADDITIONAL_CONFIG_PARTICIPANT_PRUNING",
             "value": "# Ignore missing ACS commitment and commitment mismatches\ncanton.participants.participant.parameters.stores.safe-to-prune-commitment-state = \"all\"\n"
           }


### PR DESCRIPTION
[static]

Part of #5135

Not doing a cluster test because these value files are not used there anyway. Some proof the config works: it's 1:1 the same from https://github.com/DACH-NY/canton-network-internal/blob/893fed686731036d394f3f9424d4d11d7a600504/cluster/configs/shared-internal/prod-like/participant_session_signing_keys.yaml (in use on CILR and DevNet)

Will follow up with cf-docs PR and cleanups on internal.

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
